### PR TITLE
Move to left/right workspace buttons when right-clicking a window on the windowlist

### DIFF
--- a/js/ui/windowList.js
+++ b/js/ui/windowList.js
@@ -577,14 +577,6 @@ WindowList.prototype = {
                     menuReference.itemMinimizeWindow.label.set_text(_("Minimize"));
                     
                     return;
-                } else if (state == 'maximize') {
-                    if (actor.get_meta_window().get_maximized()) {
-                        menuReference.itemMaximizeWindow.label.set_text(_("Unmaximize"));
-                    } else {
-                        menuReference.itemMaximizeWindow.label.set_text(_("Maximize"));
-                    }
-                    
-                    return;
                 }
             }
         }


### PR DESCRIPTION
It's finally ready!

For LTR/RTL differences I have copied the Muffin behaviour in my last commit. I have not tested RTL but I suppose it works well.
