### PR TITLE
Changed notification's motion to be smaller, more pleasant and uniform

### DIFF
--- a/js/ui/messageTray.js
+++ b/js/ui/messageTray.js
@@ -1572,7 +1572,7 @@ MessageTray.prototype = {
         this._notificationBin.child = this._notification.actor;
         this._notificationBin.opacity = 0;        
         let monitor = Main.layoutManager.primaryMonitor;
-        this._notificationBin.y = monitor.height; // Notifications appear from here (for the animation)
+        this._notificationBin.y = this._notification._table.get_theme_node().get_length('margin-from-top-edge-of-screen') * 2; // Notifications appear from here (for the animation)
         let margin = this._notification._table.get_theme_node().get_length('margin-from-right-edge-of-screen');                
         this._notificationBin.x = monitor.width - this._notification._table.width - margin;
         this._notificationBin.show();


### PR DESCRIPTION
Currently the notification appears from the bottom of the screen goes really fast to its normal position, making the animating look a little weird (in low powered systems, as my pc, the frame rate isn't good enough to make it look fluid). I have changed it to make it travel when appearing the same distance that it does when disappearing.
