### PR TITLE
cinnamon-settings: space between "All Settings" button and the content

### DIFF
--- a/files/usr/lib/cinnamon-settings/cinnamon-settings.ui
+++ b/files/usr/lib/cinnamon-settings/cinnamon-settings.ui
@@ -23,29 +23,17 @@
         <property name="orientation">vertical</property>
         <property name="spacing">10</property>
         <child>
-          <object class="GtkVBox" id="vbox1">
-            <property name="visible">True</property>
+          <object class="GtkButtonBox" id="top_button_box">
             <property name="can_focus">False</property>
+            <property name="layout_style">start</property>
             <child>
-              <object class="GtkButtonBox" id="top_button_box">
-                <property name="can_focus">False</property>
-                <property name="layout_style">start</property>
-                <child>
-                  <object class="GtkButton" id="button_back">
-                    <property name="label">button</property>
-                    <property name="use_action_appearance">False</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <property name="use_action_appearance">False</property>
-                    <property name="image">image1</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
+              <object class="GtkButton" id="button_back">
+                <property name="label">button</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_action_appearance">False</property>
+                <property name="image">image1</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -53,6 +41,17 @@
                 <property name="position">0</property>
               </packing>
             </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkVBox" id="vbox1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <child>
               <object class="GtkScrolledWindow" id="side_view_sw">
                 <property name="height_request">125</property>
@@ -114,7 +113,7 @@
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="position">0</property>
+            <property name="position">1</property>
           </packing>
         </child>
         <child>
@@ -126,7 +125,6 @@
             <child>
               <object class="GtkButton" id="button_cancel">
                 <property name="label">gtk-close</property>
-                <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
@@ -145,7 +143,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>


### PR DESCRIPTION
Improved layout spacing by moving 'All Settings' button one level up from the
side_view VBox to the main VBox

![back button](http://i39.tinypic.com/qrgruv.png)
