### PR TITLE
#456 Lighten the next month in the calendar - fix for default theme

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -630,6 +630,7 @@ StTooltip StLabel {
 }
 .calendar-other-month-day {
 	color: #888888;
+    background-color: rgba(64, 64, 64, .5);
 }
 .calendar-day-with-events {
 	font-weight: bold;


### PR DESCRIPTION
Small change for default theme: http://imgur.com/HJ8Y3
