### PR TITLE
Last unused import from js/ui/ removed

### DIFF
--- a/js/ui/appFavorites.js
+++ b/js/ui/appFavorites.js
@@ -4,8 +4,6 @@ const Cinnamon = imports.gi.Cinnamon;
 const Lang = imports.lang;
 const Signals = imports.signals;
 
-const Main = imports.ui.main;
-
 function AppFavorites() {
     this._init();
 }


### PR DESCRIPTION
appFavorites.js had one unused import. This was the last one I could find in the js/ui/ folder. (Haven't checked other folders, however)
