### PR TITLE
Let the theme handle expo background

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -406,6 +406,12 @@ StTooltip StLabel {
 	transition-duration: 100;
 	text-align: center;
 }
+
+.expo-background {
+	background-gradient-start: #000;
+	background-gradient-end: #AAA;
+	background-gradient-direction: vertical
+}
 /* ===================================================================
  * ViewSelector 
  * ===================================================================*/

--- a/js/ui/expo.js
+++ b/js/ui/expo.js
@@ -128,7 +128,7 @@ Expo.prototype = {
         // Dash elements, or mouseover handlers in the workspaces.
 
         this._gradient = new St.Button({reactive: false});
-        this._gradient.set_style("background-gradient-end: #AAA;background-gradient-start: #000;background-gradient-direction: vertical;");
+        this._gradient.set_style_class_name("expo-background");
         this._group.add_actor(this._gradient);
         this._coverPane = new Clutter.Rectangle({ opacity: 0,
                                                   reactive: true });


### PR DESCRIPTION
The new gradient background in expo doesn't look nice on resolutions like 1080p because of the color banding.

I created a new style class called "expo-background" so it's possible to style it via the theme file or keeping the desktop wallpaper by just leaving the style class blank within the theme file.
