### PR TITLE
Fix a crash when canceling closure after using middle mouse button

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -334,7 +334,6 @@ AppMenuButton.prototype = {
             this._windowHandle(false);
         } else if (Cinnamon.get_event_state(event) & Clutter.ModifierType.BUTTON2_MASK) {
             this.metaWindow.delete(global.get_current_time());
-            this.rightClickMenu.destroy();
         } else if (Cinnamon.get_event_state(event) & Clutter.ModifierType.BUTTON3_MASK) {
             this.rightClickMenu.mouseEvent = event;
             this.rightClickMenu.toggle();   


### PR DESCRIPTION
When you close a program on the panel with the middle mouse button, the program asks for confirmation, the right click menu is destroyed anyway. Any attempt to open the destroyed popup menu when the window is not yet closed crashes Cinnamon.
