### PR TITLE
Better theme manipulation (added fallback)

### DIFF
--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -538,12 +538,10 @@ function setThemeStylesheet(cssStylesheet)
 function loadTheme() {
     let themeContext = St.ThemeContext.get_for_stage (global.stage);
 
-    let cssStylesheet = _defaultCssStylesheet;
-    if (_cssStylesheet != null)
-        cssStylesheet = _cssStylesheet;
+    let theme = St.Theme.new ('', '', _defaultCssStylesheet);
 
-    let theme = new St.Theme ();
-    theme.load_stylesheet(cssStylesheet);
+    if (_cssStylesheet != null)
+        theme = St.Theme.new ('', _cssStylesheet, _defaultCssStylesheet);
     
     themeContext.set_theme (theme);
 }


### PR DESCRIPTION
St.Theme has three levels of themes (default, theme and application). I've set the cinnamon's default theme to default and other themes are set to theme (higher priority). Only if an element is not specified in theme, it will use default.

IMPORTANT: This will break older themes, but it works fine with new (1.4) and well done themes, like Ambiance themes. This should be tested before merge.

Edit.: This fixes issue #532
