### PR TITLE
Battery time remaining display on battery applet

### DIFF
--- a/data/org.cinnamon.gschema.xml
+++ b/data/org.cinnamon.gschema.xml
@@ -259,8 +259,8 @@
   </schema>
 
   <schema path="/org/cinnamon/power/" id="org.cinnamon.power" gettext-domain="@GETTEXT_PACKAGE">
-      <key type="b" name="power-show-percentage">
-          <default>true</default>
+      <key type="s" name="power-label">
+          <default>'percent'</default>
           <summary>Display percentage in power applet</summary>
           <description>Display battery remaining as percentage or time in power applet.</description>
     </key>


### PR DESCRIPTION
As requested in #106, I've add an option to show battery (or charge if AC power is plugged in) time remaining in battery applet instead of only percentage. The display setting can be switched in the pop-up menu.
