### PR TITLE
Fix a memory leak created by right click menu not getting properly destroyed

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -314,6 +314,7 @@ AppMenuButton.prototype = {
     _onDestroy: function() {
         this.metaWindow.disconnect(this._updateCaptionId);
         this._tooltip.destroy();
+        this.rightClickMenu.destroy();
     },
     
     doFocus: function() {


### PR DESCRIPTION
I've already talked about this with Clem this morning.
