### PR TITLE
Removes hidden label from power icon box

### DIFF
--- a/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
@@ -134,6 +134,8 @@ MyApplet.prototype = {
 
             let icon = this.actor.get_children()[0];
             this.actor.remove_actor(icon);
+            let label = this.actor.get_children()[0];
+            this.actor.remove_actor(label);
             let box = new St.BoxLayout({ name: 'batteryBox' });
             this.actor.add_actor(box);
             let iconBox = new St.Bin();


### PR DESCRIPTION
This removes the hidden label to the left of the battery icon, which was causing an unsightly padding in most themes.
