### PR TITLE
Fixed #606 - Implement Spotify in Cinnamon's Volume Popup

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -97,8 +97,8 @@ const MediaServer2PlayerIFace = {
 
 /* global values */
 let icon_path = "/usr/share/cinnamon/theme/";
-let compatible_players = [ "clementine", "mpd", "exaile", "banshee", "rhythmbox", "rhythmbox3", "pragha", "quodlibet", "guayadeque", "amarok", "googlemusicframe", "xbmc", "xnoise", "gmusicbrowser" ];
-let support_seek = [ "clementine", "banshee", "rhythmbox", "rhythmbox3", "quodlibet", "amarok", "xnoise", "gmusicbrowser" ];
+let compatible_players = [ "clementine", "mpd", "exaile", "banshee", "rhythmbox", "rhythmbox3", "pragha", "quodlibet", "guayadeque", "amarok", "googlemusicframe", "xbmc", "xnoise", "gmusicbrowser", "spotify" ];
+let support_seek = [ "clementine", "banshee", "rhythmbox", "rhythmbox3", "quodlibet", "amarok", "xnoise", "gmusicbrowser", "spotify" ];
 /* dummy vars for translation */
 let x = _("Playing");
 x = _("Paused");
@@ -327,7 +327,7 @@ TextImageMenuItem.prototype = {
          let icon_file = icon_path + icon_name + ".svg";
          let file = Gio.file_new_for_path(icon_file);
          let icon_uri = file.get_uri();
- 
+
          return St.TextureCache.get_default().load_uri_async(icon_uri, 16, 16);
     },
 }
@@ -338,7 +338,7 @@ function Player() {
 
 Player.prototype = {
     __proto__: PopupMenu.PopupMenuSection.prototype,
-    
+
     _init: function(system_status_button, owner) {
         PopupMenu.PopupMenuSection.prototype._init.call(this);
 
@@ -352,6 +352,7 @@ Player.prototype = {
         this._playerInfo = new TextImageMenuItem(this._getName(), false, "player-stopped", "left", "popup-menu-item");
         this.addMenuItem(this._playerInfo);
 
+        this._trackCoverFile = this._trackCoverFileTmp = false;
         this._trackCover = new St.Bin({style_class: 'sound-track-cover', x_align: St.Align.MIDDLE});
         this._trackCover.set_child(new St.Icon({icon_name: "media-optical-cd-audio", icon_size: 100, icon_type: St.IconType.FULLCOLOR}));
         this._trackInfos = new St.Bin({style_class: 'sound-track-infos', y_align: St.Align.MIDDLE});
@@ -382,7 +383,7 @@ Player.prototype = {
             Lang.bind(this, function () { this._mediaServerPlayer.StopRemote(); }));
         this._nextButton = new ControlButton('media-skip-forward',
             Lang.bind(this, function () { this._mediaServerPlayer.NextRemote(); }));
-        
+
         this.controls = new St.BoxLayout();
         this.controls.add_actor(this._prevButton.getActor());
         this.controls.add_actor(this._playButton.getActor());
@@ -390,7 +391,7 @@ Player.prototype = {
         this.controls.add_actor(this._nextButton.getActor());
         this._trackControls.set_child(this.controls);
         this.addActor(this._trackControls);
-        
+
         this._mediaServer.getRaise(Lang.bind(this, function(sender, raise) {
             if (raise) {
                 this._raiseButton = new ControlButton('go-up',
@@ -398,15 +399,15 @@ Player.prototype = {
                 this.controls.add_actor(this._raiseButton.getActor());
             }
         }));
-        
+
         this._mediaServer.getQuit(Lang.bind(this, function(sender, quit) {
             if (quit) {
                 this._quitButton = new ControlButton('window-close',
                     Lang.bind(this, function () { this._mediaServer.QuitRemote(); }));
                 this.controls.add_actor(this._quitButton.getActor());
             }
-        }));      
-       
+        }));
+
         /* this players don't support seek */
         if (support_seek.indexOf(this._name) == -1)
             this._time.hide();
@@ -426,7 +427,7 @@ Player.prototype = {
         this._mediaServerPlayer.connect('Seeked', Lang.bind(this, function(sender, value) {
             this._setPosition(sender, value);
         }));
-        
+
         Mainloop.timeout_add(1000, Lang.bind(this, this._getPosition));
     },
 
@@ -456,7 +457,7 @@ Player.prototype = {
     },
 
     _getPosition: function() {
-        this._mediaServerPlayer.getPosition(Lang.bind(this, 
+        this._mediaServerPlayer.getPosition(Lang.bind(this,
             this._setPosition
         ));
         Mainloop.timeout_add(1000, Lang.bind(this, this._getPosition));
@@ -498,23 +499,38 @@ Player.prototype = {
             }
         }*/
 
+        let change = false;
         if (metadata["mpris:artUrl"]) {
-            let cover = metadata["mpris:artUrl"].toString();
-            cover = decodeURIComponent(cover.substr(7));
-            if (! GLib.file_test(cover, GLib.FileTest.EXISTS))
-                this._trackCover.set_child(new St.Icon({icon_name: "media-optical-cd-audio", icon_size: 100, icon_type: St.IconType.FULLCOLOR}));
-            else {
-                let l = new Clutter.BinLayout();
-                let b = new Clutter.Box();
-                let c = new Clutter.Texture({height: 100, keep_aspect_ratio: true, filter_quality: 2, filename: cover});
-                b.set_layout_manager(l);
-                b.set_width(120);
-                b.add_actor(c);
-                this._trackCover.set_child(b);
+            if (this._trackCoverFile != metadata["mpris:artUrl"].toString()) {
+                this._trackCoverFile = metadata["mpris:artUrl"].toString();
+                change = true;
             }
         }
-        else
-            this._trackCover.set_child(new St.Icon({icon_name: "media-optical-cd-audio", icon_size: 100, icon_type: St.IconType.FULLCOLOR}));
+        else {
+            if (this._trackCoverFile != false) {
+                this._trackCoverFile = false;
+                change = true;
+            }
+        }
+
+        if (change) {
+            if (this._trackCoverFile) {
+                let cover_path = "";
+                if (this._trackCoverFile.match(/^http/)) {
+                    this._hideCover();
+                    let cover = Gio.file_new_for_uri(decodeURIComponent(this._trackCoverFile));
+                    if (!this._trackCoverFileTmp)
+                        this._trackCoverFileTmp = Gio.file_new_tmp('XXXXXX.mediaplayer-cover')[0];
+                    cover.read_async(null, null, Lang.bind(this, this._onReadCover));
+                }
+                else {
+                    cover_path = decodeURIComponent(this._trackCoverFile.substr(7));
+                    this._showCover(cover_path);
+                }
+            }
+            else
+                this._showCover(false);
+        }
     },
 
     _getMetadata: function() {
@@ -531,7 +547,7 @@ Player.prototype = {
         }
         else if (status == "Paused") {
             this._playButton.setIcon("media-playback-start");
-            this._pauseTimer(); 
+            this._pauseTimer();
         }
         else if (status == "Stopped") {
             this._playButton.setIcon("media-playback-start");
@@ -594,7 +610,51 @@ Player.prototype = {
             numHours = "";
         return numHours + numMins.toString() + ":" + numSecs.toString();
     },
-    
+
+    _onReadCover: function(cover, result) {
+        let inStream = cover.read_finish(result);
+        let outStream = this._trackCoverFileTmp.replace(null, false, Gio.FileCreateFlags.REPLACE_DESTINATION, null, null);
+        outStream.splice_async(inStream, Gio.OutputStreamSpliceFlags.CLOSE_TARGET, 0, null, Lang.bind(this, this._onSavedCover));
+    },
+
+    _onSavedCover: function(outStream, result) {
+        outStream.splice_finish(result, null);
+        let cover_path = this._trackCoverFileTmp.get_path();
+        this._showCover(cover_path);
+    },
+
+    _hideCover: function() {
+        /*Tweener.addTween(this.trackCoverContainer, { opacity: 0,
+            time: 0.3,
+            transition: 'easeOutCubic',
+        });*/
+    },
+
+    _showCover: function(cover_path) {
+        /*Tweener.addTween(this._trackCover, { opacity: 0,
+            time: 0.3,
+            transition: 'easeOutCubic',
+            onComplete: Lang.bind(this, function() {*/
+                if (! cover_path || ! GLib.file_test(cover_path, GLib.FileTest.EXISTS)) {
+                    this._trackCover.set_child(new St.Icon({icon_name: "media-optical-cd-audio", icon_size: 100, icon_type: St.IconType.FULLCOLOR}));
+                }
+                else {
+                    let l = new Clutter.BinLayout();
+                    let b = new Clutter.Box();
+                    let c = new Clutter.Texture({height: 100, keep_aspect_ratio: true, filter_quality: 2, filename: cover_path});
+                    b.set_layout_manager(l);
+                    b.set_width(120);
+                    b.add_actor(c);
+                    this._trackCover.set_child(b);
+                }
+                /*Tweener.addTween(this._trackCover, { opacity: 255,
+                    time: 0.3,
+                    transition: 'easeInCubic'
+                });
+            })
+        });*/
+    },
+
     setIcon: function(icon) {
        if (this._system_status_button._nbPlayers()==0)
          this._system_status_button.setIcon(icon);
@@ -624,7 +684,7 @@ MediaPlayerLauncher.prototype = {
 
     activate: function (event) {
     	this._menu.actor.hide();
-        this._app.activate_full(-1, event.get_time());        
+        this._app.activate_full(-1, event.get_time());
         return true;
     }
 
@@ -637,16 +697,16 @@ function MyApplet(orientation) {
 MyApplet.prototype = {
     __proto__: Applet.IconApplet.prototype,
 
-    _init: function(orientation) {        
+    _init: function(orientation) {
         Applet.IconApplet.prototype._init.call(this, orientation);
-        
-        try {                                
+
+        try {
             this.menuManager = new PopupMenu.PopupMenuManager(this);
             this.menu = new Applet.AppletPopupMenu(this, orientation);
-            this.menuManager.addMenu(this.menu);            
-            
+            this.menuManager.addMenu(this.menu);
+
             this.set_applet_icon_symbolic_name('audio-x-generic');
-            
+
             // menu not showed by default
             this._players = {};
             // watch players
@@ -656,7 +716,7 @@ MyApplet.prototype = {
                     Lang.bind(this, this._removePlayer)
                 );
             }
-            
+
             this._control = new Gvc.MixerControl({ name: 'Cinnamon Volume Control' });
             this._control.connect('state-changed', Lang.bind(this, this._onControlStateChanged));
             this._control.connect('default-sink-changed', Lang.bind(this, this._readOutput));
@@ -664,7 +724,7 @@ MyApplet.prototype = {
             this._control.connect('stream-added', Lang.bind(this, this._maybeShowInput));
             this._control.connect('stream-removed', Lang.bind(this, this._maybeShowInput));
             this._volumeMax = 1.5*this._control.get_vol_max_norm();
-            
+
             this._output = null;
             this._outputVolumeId = 0;
             this._outputMutedId = 0;
@@ -672,28 +732,28 @@ MyApplet.prototype = {
             this._input = null;
             this._inputVolumeId = 0;
             this._inputMutedId = 0;
-            
+
             this._icon_name = '';
-            
+
             this.actor.connect('scroll-event', Lang.bind(this, this._onScrollEvent));
-            
+
             this._control.open();
-            
+
             this._volumeControlShown = false;
-            
+
             this._showFixedElements();
-            
-            
+
+
         }
         catch (e) {
             global.logError(e);
         }
     },
-    
+
     on_applet_clicked: function(event) {
-        this.menu.toggle();        
+        this.menu.toggle();
     },
-    
+
     _onScrollEvent: function(actor, event) {
         let direction = event.get_scroll_direction();
         let currentVolume = this._output.volume;
@@ -716,7 +776,7 @@ MyApplet.prototype = {
 
         this._notifyVolumeChange();
     },
-    
+
     setIconName: function(icon) {
        this._icon_name = icon;
        if (this._nbPlayers()==0)
@@ -736,11 +796,11 @@ MyApplet.prototype = {
         this._players[owner] = new Player(this, owner);
         this.menu.addMenuItem(this._players[owner]);
         this.menu.emit('players-loaded', true);
-        
+
         this._showFixedElements();
-        
+
         this.setIconName(this._icon_name);
-        
+
         this._readOutput();
     },
 
@@ -748,18 +808,18 @@ MyApplet.prototype = {
         delete this._players[owner];
         this._cleanup();
         this._volumeControlShown = false;
-        for (owner in this._players) { 
+        for (owner in this._players) {
             this._addPlayer(owner);
         }
         this.menu.emit('players-loaded', true);
-        
+
         this._showFixedElements();
-        
+
         this.setIconName(this._icon_name);
-        
+
         this._readOutput();
     },
-    
+
     _cleanup: function() {
         if (this._outputTitle) this._outputTitle.destroy();
         if (this._outputSlider) this._outputSlider.destroy();
@@ -767,11 +827,11 @@ MyApplet.prototype = {
         if (this._inputSlider) this._inputSlider.destroy();
         this.menu.removeAll();
      },
-    
+
     _showFixedElements: function() {
         if (this._volumeControlShown) return;
         this._volumeControlShown = true;
-        
+
         if (this._nbPlayers()==0){
         	this._availablePlayers = new Array();
             let appsys = Cinnamon.AppSystem.get_default();
@@ -783,27 +843,27 @@ MyApplet.prototype = {
             	let path = entry.get_desktop_file_path();
             	for (var p=0; p<compatible_players.length; p++) {
                     let desktopFile = compatible_players[p]+".desktop";
-            		if (path.indexOf(desktopFile) != -1 && listedDesktopFiles.indexOf(desktopFile) == -1) {            		
+            		if (path.indexOf(desktopFile) != -1 && listedDesktopFiles.indexOf(desktopFile) == -1) {
                 		this._availablePlayers.push(app);
                         listedDesktopFiles.push(desktopFile);
             		}
-           		}            	        
-            }                                   
-            
+           		}
+            }
+
             if (this._availablePlayers.length > 0){
                 this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
                 this._launchPlayerItem = new PopupMenu.PopupSubMenuMenuItem(_("Launch player..."));
-                
+
                 for (var p=0; p<this._availablePlayers.length; p++){
                     let playerApp = this._availablePlayers[p];
                     let menuItem = new MediaPlayerLauncher(playerApp, this._launchPlayerItem.menu);
                     this._launchPlayerItem.menu.addMenuItem(menuItem);
                 }
-                
+
                 this.menu.addMenuItem(this._launchPlayerItem);
             }
         }
-        
+
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
         this._outputTitle = new TextImageMenuItem(_("Volume"), "audio-volume-high", false, "right", "sound-volume-menu-item");
         this._outputSlider = new PopupMenu.PopupSliderMenuItem(0);
@@ -818,12 +878,12 @@ MyApplet.prototype = {
         this._inputSlider.connect('drag-end', Lang.bind(this, this._notifyVolumeChange));
         this.menu.addMenuItem(this._inputTitle);
         this.menu.addMenuItem(this._inputSlider);
-        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());               
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
         this.menu.addSettingsAction(_("Sound Settings"), 'gnome-sound-panel.desktop');
-        
+
         this._selectDeviceItem = new PopupMenu.PopupSubMenuMenuItem(_("Output device..."));
-        this.menu.addMenuItem(this._selectDeviceItem);     
-        
+        this.menu.addMenuItem(this._selectDeviceItem);
+
         if (this._showInput){
            this._inputTitle.actor.show();
            this._inputSlider.actor.show();
@@ -831,11 +891,11 @@ MyApplet.prototype = {
            this._inputTitle.actor.hide();
            this._inputSlider.actor.hide();
         }
-        
+
         this._volumeChanged (null, null, '_output');
         this._volumeChanged (null, null, '_input');
     },
-    
+
     _sliderChanged: function(slider, value, property) {
         if (this[property] == null) {
             log ('Volume slider changed for %s, but %s does not exist'.format(property, property));
@@ -878,7 +938,7 @@ MyApplet.prototype = {
             this._outputTitle.setIcon("audio-volume-muted");
         if (this[property].volume / this._volumeMax > 0)
             this._outputTitle.setIcon("audio-volume-low");
-        if (this[property].volume / this._volumeMax > 0.30) 
+        if (this[property].volume / this._volumeMax > 0.30)
             this._outputTitle.setIcon("audio-volume-medium");
         if (this[property].volume / this._volumeMax > 0.80)
             this._outputTitle.setIcon("audio-volume-high");
@@ -886,7 +946,7 @@ MyApplet.prototype = {
         if (property == '_output' && !this._output.is_muted)
             this.setIconName(this._volumeToIcon(this._output.volume));
     },
-    
+
     _volumeToIcon: function(volume) {
         if (volume <= 0) {
             return 'audio-volume-muted';
@@ -899,7 +959,7 @@ MyApplet.prototype = {
             return 'audio-volume-medium';
         }
     },
-    
+
     _onControlStateChanged: function() {
         if (this._control.get_state() == Gvc.MixerControlState.READY) {
             this._readOutput();
@@ -909,7 +969,7 @@ MyApplet.prototype = {
             this.actor.hide();
         }
     },
-    
+
     _readOutput: function() {
         if (this._outputVolumeId) {
             this._output.disconnect(this._outputVolumeId);
@@ -923,8 +983,8 @@ MyApplet.prototype = {
             this._outputVolumeId = this._output.connect('notify::volume', Lang.bind(this, this._volumeChanged, '_output'));
             this._mutedChanged (null, null, '_output');
             this._volumeChanged (null, null, '_output');
-            let sinks = this._control.get_sinks();           
-	        this._selectDeviceItem.menu.removeAll();                
+            let sinks = this._control.get_sinks();
+	        this._selectDeviceItem.menu.removeAll();
 	        for (let i = 0; i < sinks.length; i++) {
 	        	let sink = sinks[i];
 	        	let menuItem = new PopupMenu.PopupMenuItem(sink.get_description());
@@ -934,15 +994,15 @@ MyApplet.prototype = {
 	        	menuItem.connect('activate', Lang.bind(this, function() {
 	        		log('Changing default sink to ' + sink.get_description());
 	                this._control.set_default_sink(sink);
-	            }));        	        	       
-	            this._selectDeviceItem.menu.addMenuItem(menuItem);             
-	        }            
+	            }));
+	            this._selectDeviceItem.menu.addMenuItem(menuItem);
+	        }
         } else {
             this._outputSlider.setValue(0);
             this.setIconName('audio-volume-muted-symbolic');
-        }        
+        }
     },
-            
+
     _readInput: function() {
         if (this._inputVolumeId) {
             this._input.disconnect(this._inputVolumeId);
@@ -961,7 +1021,7 @@ MyApplet.prototype = {
             this._inputSlider.actor.hide();
         }
     },
-    
+
     _maybeShowInput: function() {
         // only show input widgets if any application is recording audio
         this._showInput = false;
@@ -986,10 +1046,10 @@ MyApplet.prototype = {
             this._inputSlider.actor.hide();
         }
     }
-    
+
 };
 
-function main(metadata, orientation) {  
+function main(metadata, orientation) {
     let myApplet = new MyApplet(orientation);
-    return myApplet;      
+    return myApplet;
 }

--- a/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
@@ -10,47 +10,47 @@ function MyApplet(orientation) {
 MyApplet.prototype = {
     __proto__: Applet.Applet.prototype,
 
-    _init: function(orientation) {        
+    _init: function(orientation) {
         Applet.Applet.prototype._init.call(this, orientation);
         this.actor.remove_style_class_name("applet-box");
-        try {                   
+        try {
             Main.statusIconDispatcher.connect('status-icon-added', Lang.bind(this, this._onTrayIconAdded));
-            Main.statusIconDispatcher.connect('status-icon-removed', Lang.bind(this, this._onTrayIconRemoved));    
-            Main.statusIconDispatcher.connect('before-redisplay', Lang.bind(this, this._onBeforeRedisplay));    
+            Main.statusIconDispatcher.connect('status-icon-removed', Lang.bind(this, this._onTrayIconRemoved));
+            Main.statusIconDispatcher.connect('before-redisplay', Lang.bind(this, this._onBeforeRedisplay));
         }
         catch (e) {
             global.logError(e);
         }
     },
-    
+
     on_applet_clicked: function(event) {
-    
+
     },
-    
+
     _onBeforeRedisplay: function() {
         let children = this.actor.get_children();
         for (var i = 0; i < children.length; i++) {
             children[i].destroy();
         }
     },
-    
+
     _onTrayIconAdded: function(o, icon, role) {
-        try {                          
-            let hiddenIcons = ["network", "power", "keyboard", "gnome-settings-daemon", "volume", "bluetooth", "bluetooth-manager", "battery", "a11y"];
-            
-            if (hiddenIcons.indexOf(role) != -1 ) {  
-                // We've got an applet for that          
+        try {
+            let hiddenIcons = ["network", "power", "keyboard", "gnome-settings-daemon", "volume", "bluetooth", "bluetooth-manager", "battery", "a11y", "spotify"];
+
+            if (hiddenIcons.indexOf(role) != -1 ) {
+                // We've got an applet for that
                 return;
             }
-            
+
             global.log("Adding systray: " + role);
-            
+
             let buttonBox = new PanelMenu.ButtonBox({ style_class: 'panel-status-button', reactive: true, track_hover: true  });
             let box = buttonBox.actor;
             box.add_actor(icon);
 
             this._insertStatusItem(box, -1);
-            
+
             let themeNode = buttonBox.actor.get_theme_node();
             if (!themeNode.get_length('width')) icon.width = 22;
             else icon.width = themeNode.get_length('width');
@@ -67,7 +67,7 @@ MyApplet.prototype = {
         if (box && box._delegate instanceof PanelMenu.ButtonBox)
             box.destroy();
     },
-    
+
     _insertStatusItem: function(actor, position) {
         let children = this.actor.get_children();
         let i;
@@ -84,11 +84,11 @@ MyApplet.prototype = {
         }
         actor._rolePosition = position;
     },
-    
-    
+
+
 };
 
-function main(metadata, orientation) {  
+function main(metadata, orientation) {
     let myApplet = new MyApplet(orientation);
-    return myApplet;      
+    return myApplet;
 }


### PR DESCRIPTION
This changes would fix #606.

There are still two bugs in Spotify App for Linux:
- Running time can't be displayed, because property "Position" always returns 0:
  http://community.spotify.com/t5/Desktop-Linux/Spotify-DBus-position-property-always-returns-0/td-p/54107
- Can't raise Spotify when closed (minimized to systray):
  http://community.spotify.com/t5/Desktop-Linux/Raise-player-DBus-action-not-working/m-p/48613
