### PR TITLE
Fix issue #791 (CTRL+ALT+DEL in Expo removes selected workspace)

### DIFF
--- a/js/ui/expoThumbnail.js
+++ b/js/ui/expoThumbnail.js
@@ -778,7 +778,7 @@ ExpoThumbnailsBox.prototype = {
                 return true;
             }
         }
-        if (symbol === Clutter.Delete
+        if ((symbol === Clutter.Delete && (modifiers & Clutter.ModifierType.MODIFIER_MASK) === 0)
             || symbol === Clutter.w && modifiers & Clutter.ModifierType.CONTROL_MASK) {
             this.removeSelectedWorkspace();
             return true;


### PR DESCRIPTION
See issue #791.
