### PR TITLE
Expo: Direct keyboard selection of workspaces 1 to 9

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,7 @@ New features:
  - Workspace OSD
  - Keyboard navigation in Scale (close windows with CTRL+W or mouse middle-click)
  - Keyboard navigation in Expo
+ - Direct keyboard activation of workspaces 1 through 9 in Expo
  - Configurable panel height
  - Workspaces and Menu pages in Cinnamon Settings
  - Logging (Looking Glass output)


### PR DESCRIPTION
This enables the keyboard user to directly switch to the desired workspace in the Expo view by pressing the corresponding number key: 1 for the first workspace, etc., up to workspace 9. The activation of the chosen workspace will be accompanied by a brief workspace-shifting OSD.
