### PR TITLE
Expo: Enable overview mode for the selected workspace on keyboard selection

### DIFF
--- a/js/ui/expoThumbnail.js
+++ b/js/ui/expoThumbnail.js
@@ -272,8 +272,10 @@ ExpoWorkspaceThumbnail.prototype = {
         this.title.name = selected ? "selected" : "";
         if (selected) {
             this._highlight();
+            this._overviewModeOn();
         }
         else {
+            this._overviewModeOff();
             this._shade(true);
         }
     },


### PR DESCRIPTION
This enables overview mode for the selected workspace as keyboard selection moves through the workspaces (just like mouse hover does).
