### PR TITLE
Make Expo show minimized windows as icons

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,7 @@ New features:
  - Workspace OSD
  - Keyboard navigation in Scale (close windows with CTRL+W or mouse middle-click)
  - Keyboard navigation in Expo
+ - Display of minimized windows as icons in Expo
  - Configurable panel height
  - Workspaces and Menu pages in Cinnamon Settings
  - Logging (Looking Glass output)


### PR DESCRIPTION
This set of commits addresses issue #86, namely that it is not possible to see which workspaces contain minimized windows without having to mouse over each and every one of them.

Screen shot: http://www.autark.se/dump/expo-show-minimized-20120715.jpg
