### PR TITLE
Cannot delete workspace using keyboard if NumLock is on

### DIFF
--- a/js/ui/expoThumbnail.js
+++ b/js/ui/expoThumbnail.js
@@ -760,13 +760,15 @@ ExpoThumbnailsBox.prototype = {
 
     handleKeyPressEvent: function(actor, event) {
         let modifiers = Cinnamon.get_event_state(event);
+        let ctrlAltMask = Clutter.ModifierType.CONTROL_MASK | Clutter.ModifierType.MOD1_MASK;
         let symbol = event.get_key_symbol();
         if (symbol === Clutter.Return || symbol === Clutter.KEY_space) {
             this.activateSelectedWorkspace();
             return true;
         }
-        if ((symbol === Clutter.Delete && (modifiers & Clutter.ModifierType.MODIFIER_MASK) === 0)
-            || symbol === Clutter.w && modifiers & Clutter.ModifierType.CONTROL_MASK) {
+        if ((symbol === Clutter.Delete && (modifiers & ctrlAltMask) !== ctrlAltMask)
+            || symbol === Clutter.w && modifiers & Clutter.ModifierType.CONTROL_MASK)
+        {
             this.removeSelectedWorkspace();
             return true;
         }


### PR DESCRIPTION
A follow-up to #792. Apparently, the NumLock key is a modifier, so one needs to be more specific about which modifiers are allowed or not.
