### PR TITLE
Allow dragging of shortcuts from menu to desktop

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -164,7 +164,7 @@ ApplicationButton.prototype = {
         this.addActor(this.icon);
         this.label = new St.Label({ text: this.app.get_name(), style_class: 'menu-application-button-label' });
         this.addActor(this.label);
-        
+        this.actor._app = app; // backreference
         this._draggable = DND.makeDraggable(this.actor);
         this.isDraggableApp = true;
     },
@@ -233,6 +233,7 @@ if (category){
         this.actor = new St.Button({ reactive: true, label: label, style_class: 'menu-category-button', x_align: St.Align.START });
         this.actor._delegate = this;
         this.buttonbox = new St.BoxLayout();
+        
         this.label = new St.Label({ text: label, style_class: 'menu-category-button-label' });
         if (category && this.icon_name){
            this.icon = new St.Icon({icon_name: this.icon_name, icon_size: CATEGORY_ICON_SIZE, icon_type: St.IconType.FULLCOLOR});


### PR DESCRIPTION
This is in reference to #836.

Drag to desktop is implemented by checking to see if no valid drop targets were found, and then looking for windows at the destination coordinates. Figuring out the user intent from there is pretty easy, albeit not completely 100%.

I'd like it if a Mint dev would look at this and see if it can be improved. As it stands, neither gnome-shell nor cinnamon are able to drag icons to the desktop. This might be considered a hack job, but it does add immediate usability without needing to modify nautilus or any external libraries. I should note I have been using this for several days now and have not seen any issues arise.

I also looked at implementing dragging icons to Docky, and can do so, but it requires restarting Docky for the icon to appear, and so isn't a possibility at this point.
