### PR TITLE
Menu search, change sorting to match application name first

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1251,18 +1251,46 @@ MyApplet.prototype = {
        var res;
        if (pattern){
           res = new Array();
-          resext = new Array()
+          var found;
+          var reswrd = new Array();
+          var resfrg = new Array();
+          var resetc = new Array();
+          var wordloc;
+          for (var i in applist){
              let app = applist[i];
-             if (app.get_name().toLowerCase().indexOf(pattern)!=-1 ) res.push(app);
-             if ((app.get_description() && app.get_description().toLowerCase().indexOf(pattern)!=-1) || (app.get_id() && app.get_id().slice(0, -8).toLowerCase().indexOf(pattern)!=-1)) resext.push(app);
+             var n;
+             found = false;
+             wordloc = new Array();
+             wordloc.push(0);
+             while ((n = app.get_name().toLowerCase().substr(wordloc[wordloc.length-1]).indexOf(" "))!=-1){
+                wordloc.push((n+1)+wordloc[wordloc.length-1]);
+             }
+             for (var index in wordloc){
+                if(!found && (app.get_name().toLowerCase().substr(wordloc[index], pattern.length) == pattern)){
+                   reswrd.push(app);
+                   found = true;
+                } 
+             }
+             if (!found && (app.get_name().toLowerCase().indexOf(pattern)!=-1)){
+                resfrg.push(app);
+                found = true;
+             }
+             if (!found && ((app.get_description() && app.get_description().toLowerCase().indexOf(pattern)!=-1) || (app.get_id() && app.get_id().slice(0, -8).toLowerCase().indexOf(pattern)!=-1))){
+                resetc.push(app);
+             }
           }
-          res.sort(function(a,b){
+          reswrd.sort(function(a,b){
              return a.get_name().toLowerCase() > b.get_name().toLowerCase();
           });
-          resext.sort(function(a,b){
+          resfrg.sort(function(a,b){
              return a.get_name().toLowerCase() > b.get_name().toLowerCase();
           });
-          res.push.apply(res, resext);
+          resetc.sort(function(a,b){
+             return a.get_name().toLowerCase() > b.get_name().toLowerCase();
+          });
+          res = res.concat(reswrd);
+          res = res.concat(resfrg);
+          res = res.concat(resetc);
        }
        else{ 
           res = applist;
@@ -1270,7 +1298,7 @@ MyApplet.prototype = {
              return a.get_name().toLowerCase() > b.get_name().toLowerCase();
           });
        }
-       
+
        return res;
     },
     


### PR DESCRIPTION
This changes the sorting of the menu search function to search the apps by name-word first, next name-fragment, then description/id. This makes it easier to search the app by name and gives a lesser priority secondary information. However, it still returns the full list of apps that would have been originally found.

e.g.
Search: "la"
Keyboard "La"yout   name-word
"La"nguage support   name-word
Calcu"la"tor   name-fragment
Disp"la"ys   name-fragment
...
APTon CD   description/id
...

I think this makes sense because if you know the name of your app you can get to it quickly, yet it still displays the other apps based on other information.
