### PR TITLE
Use a timeout to abort long uneventful drag operations.

### DIFF
--- a/js/ui/dnd.js
+++ b/js/ui/dnd.js
@@ -174,7 +174,6 @@ _Draggable.prototype = {
     _grabEvents: function() {
         if (!this._eventsGrabbed) {
             Clutter.grab_pointer(_getEventHandlerActor());
-            Clutter.grab_keyboard(_getEventHandlerActor());
             this._eventsGrabbed = true;
         }
     },
@@ -182,16 +181,13 @@ _Draggable.prototype = {
     _ungrabEvents: function() {
         if (this._eventsGrabbed) {
             Clutter.ungrab_pointer();
-            Clutter.ungrab_keyboard();
             this._eventsGrabbed = false;
         }
     },
 
     _onEvent: function(actor, event) {
-        if (event.type() !== Clutter.EventType.KEY_PRESS && event.type() !== Clutter.EventType.KEY_RELEASE) {
-            // prevent the watchdog timer from firing, for a while
-            this._setTimer(true);
-        }
+        // prevent the watchdog timer from firing, for a while
+        this._setTimer(true);
         
         // Intercept BUTTON_PRESS to try to address a drag in progress condition 'dragging'
         // on interminably - you started dragging, went off the panels, released the mouse
@@ -226,14 +222,6 @@ _Draggable.prototype = {
                 return this._updateDragPosition(event);
             } else if (this._dragActor == null) {
                 return this._maybeStartDrag(event);
-            }
-        // We intercept KEY_PRESS event so that we can process Esc key press to cancel
-        // dragging and ignore all other key presses.
-        } else if (event.type() == Clutter.EventType.KEY_PRESS && this._dragInProgress) {
-            let symbol = event.get_key_symbol();
-            if (symbol == Clutter.Escape) {
-                this._cancelDrag(event.get_time());
-                return true;
             }
         } else if (event.type() == Clutter.EventType.LEAVE) {
             if (this._firstLeaveActor == null)


### PR DESCRIPTION
This is an attempt to work around issue #731, by setting a timeout that will cancel any drag-and-drop operation that does not produce any pointer-related events in five seconds. The timeout is continuously renewed as long as there are events. This means that as long as the pointer moves within the dropping area, the drag will continue, but if the pointer strays into the desktop, the events will stop coming and the drag will be aborted when the timeout strikes, unless the pointer comes back into the dropping area before the timeout.

Update: I have fixed a problem with the window list not being fully responsive immediately after an aborted DND operation.
Update 2: I have removed the grab of the keyboard, because it does not work, and it interferes with ALT+F2 command input.
