### PR TITLE
Clean up move workspace code and fix inconsistencies

### DIFF
--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -862,36 +862,18 @@ WindowManager.prototype = {
     },
 
     actionMoveWorkspaceLeft: function() {
-        let index = this._getWorkspaceLeft();
-        if (index != global.screen.get_active_workspace_index()) {
-            global.screen.get_workspace_by_index(index).activate(global.get_current_time()); 
-        }       
+        global.screen.get_active_workspace().get_neighbor(Meta.MotionDirection.LEFT).activate(global.get_current_time());
     },
 
     actionMoveWorkspaceRight: function() {
-        let index = this._getWorkspaceRight();
-        if (index != global.screen.get_active_workspace_index()) {
-            global.screen.get_workspace_by_index(index).activate(global.get_current_time()); 
-        }      
+        global.screen.get_active_workspace().get_neighbor(Meta.MotionDirection.RIGHT).activate(global.get_current_time());
     },
 
     actionMoveWorkspaceUp: function() {
-        let activeWorkspaceIndex = global.screen.get_active_workspace_index();
-        let indexToActivate = activeWorkspaceIndex;
-        if (activeWorkspaceIndex > 0)
-            indexToActivate--;
-
-        if (indexToActivate != activeWorkspaceIndex)
-            global.screen.get_workspace_by_index(indexToActivate).activate(global.get_current_time());        
+        global.screen.get_active_workspace().get_neighbor(Meta.MotionDirection.UP).activate(global.get_current_time());
     },
 
     actionMoveWorkspaceDown: function() {
-        let activeWorkspaceIndex = global.screen.get_active_workspace_index();
-        let indexToActivate = activeWorkspaceIndex;
-        if (activeWorkspaceIndex < global.screen.n_workspaces - 1)
-            indexToActivate++;
-
-        if (indexToActivate != activeWorkspaceIndex)
-            global.screen.get_workspace_by_index(indexToActivate).activate(global.get_current_time());        
+        global.screen.get_active_workspace().get_neighbor(Meta.MotionDirection.DOWN).activate(global.get_current_time());
     }
 };


### PR DESCRIPTION
Fixes #548

With this code, it no longer wraps around when switching workspaces: i.e. no longer go to the last workspace, if you go to the left from the first one. Ctrl-Shift-Alt-Left/Right never did this.
If we want to introduce wrap around for everything, we should patch meta_workspace_get_neighbor() in muffin/src/core/workspace.c instead of doing it in an inconsistent Cinnamon-only way: Ctrl-Shift-Alt-Left/Right is handled in Muffin.
