### PR TITLE
Allows dragging of applications from menu to desktop

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -164,7 +164,7 @@ ApplicationButton.prototype = {
         this.addActor(this.icon);
         this.label = new St.Label({ text: this.app.get_name(), style_class: 'menu-application-button-label' });
         this.addActor(this.label);
-        
+        this.actor._app = app; // backreference
         this._draggable = DND.makeDraggable(this.actor);
         this.isDraggableApp = true;
     },
@@ -233,6 +233,7 @@ if (category){
         this.actor = new St.Button({ reactive: true, label: label, style_class: 'menu-category-button', x_align: St.Align.START });
         this.actor._delegate = this;
         this.buttonbox = new St.BoxLayout();
+        
         this.label = new St.Label({ text: label, style_class: 'menu-category-button-label' });
         if (category && this.icon_name){
            this.icon = new St.Icon({icon_name: this.icon_name, icon_size: CATEGORY_ICON_SIZE, icon_type: St.IconType.FULLCOLOR});

--- a/files/usr/share/nautilus-python/extensions/windowinfo.py
+++ b/files/usr/share/nautilus-python/extensions/windowinfo.py
@@ -1,0 +1,170 @@
+import os.path
+import subprocess
+import urllib
+import weakref
+
+from gi.repository import Nautilus, GObject, Gio, Gtk, GdkX11
+import dbus.service
+from dbus.mainloop.glib import DBusGMainLoop
+DBusGMainLoop(set_as_default=True)
+
+dbusbusname = 'org.gnome.Nautilus.WindowInfo'
+dbuspath = '/org/gnome/Nautilus/windows/%#x'
+dbusinterface_posix = 'org.gnome.Nautilus.WindowInfo.posix' # posix file system (this was previously called Window.fs)
+dbusinterface_gvfs = 'org.gnome.Nautilus.WindowInfo.gvfs' # posix file system (this was previously called Window.fs)
+
+def posix_shell_escape(string):
+    assert "\n" not in string, "I don't know how to represent a newline character in POSIX escaped arguments."
+    escape = "\\|&;<>()$`\"' \t\n*?[#~=%" # \\ has to be first. see http://www.opengroup.org/austin/mailarchives/ag/msg09377.html for the rest
+    for c in escape:
+        string = string.replace(c,"\\"+c)
+    return string
+
+def gvfs2posix(string):
+    """Convert a gvfs path to a posix path, raising an exception if there is none"""
+    f = Gio.file_new_for_path(string)
+    p = f.get_path()
+    if not f:
+        raise Exception("There is no POSIX path for this GVFS path.")
+    return p
+
+def renaming(rename_to):
+    """decorator to rename a function object before it is passed to other decorators"""
+    def decorate(func):
+        func.__name__ = rename_to
+        return func
+    return decorate
+
+class RemoteWindow(dbus.service.Object):
+    """Objects attached to windows that serve as their remote controls. Windows
+    get these created and attached as their .remotecontrol properties by the
+    bus_RemoteControlPseudomenus plugin's ._make_known() method."""
+    def __init__(self, window):
+        self.selection = []
+        self.currentPath = None
+        self._window = weakref.ref(window)
+        
+        bus_path = dbuspath%self.window.get_window().get_xid()
+        print "Claiming DBus path %r"%bus_path
+        bus_name = dbus.service.BusName(dbusbusname, bus = dbus.SessionBus())
+        
+        try:
+           dbus.service.Object.__init__(self, bus_name, bus_path)
+           window.connect('loading-uri', self.uri_changed_cb)
+        except Exception:
+           print "We're already listening!"
+
+    window = property(lambda self: self._window())
+
+    def select(self, files):
+        self.selection = files
+        #print self.selection
+    
+    def updatePath(self, path):
+        #print "Path updated to %s"%path
+        self.currentPath = path
+
+    @dbus.service.method(dbus_interface=dbusinterface_gvfs, out_signature='as')
+    def getSelection(self):
+        return self.selection
+
+    @dbus.service.method(dbus_interface=dbusinterface_gvfs, out_signature='s')
+    def getCwd(self):
+        return self.currentPath
+
+    @dbus.service.signal(dbus_interface=dbusinterface_gvfs, signature='s')
+    def cwdChanged(self, path): pass
+    
+    
+
+class PosixRemoteWindow(RemoteWindow):
+    """RemoteControlWindow that additionally provides the methods and signals
+    on a .posix interface, with all gio/gvfs paths mapped to real filesystem
+    paths"""
+    # has to be in another class: the dbus.service._method_lookup method looks
+    # through the whole mro looking for a method that has the right name (can't
+    # be two in one class (!)) and the right dbus interface (can't be two in
+    # one function). from a python point of view, the overwritten methods are
+    # only accessible via RemoteControlWindow.the_function(self, ...)!
+
+    @dbus.service.method(dbus_interface=dbusinterface_posix, out_signature='as')
+    def getSelection(self):
+        return [gvfs2posix(x) for x in self.selection]
+
+    @dbus.service.method(dbus_interface=dbusinterface_posix, out_signature='s')
+    def getSelectionShelljoint(self):
+        return " ".join([posix_shell_escape(x) for x in PosixRemoteWindow.get_selection(self)]) # while self.get_selection would work as well, i don't think it's wise because both functions of the same name stay in active use, and if some wise guy decides to split GvfsRemoteControlWindow out of RemotecontrolWindow, the sequence of inheritance might make this call the wrong get_selection
+
+    @dbus.service.method(dbus_interface=dbusinterface_posix, out_signature='s')
+    def getCwd(self):
+        return gvfs2posix(self.currentPath)
+    
+    @dbus.service.signal(dbus_interface=dbusinterface_posix, signature='s')
+    def cwdChanged(self, path): 
+        pass
+
+
+class RemoteWindowMenuProvider(GObject.GObject, Nautilus.MenuProvider):
+    def __init__(self):
+        pass
+
+    def get_file_items(self, window, files):
+        # called when files get selected from the gui
+        #pp = pprint.PrettyPrinter(indent=4)
+        #x = dir(window.get_window())
+        #pp.pprint(x)
+        try:
+            self._make_known(window)
+        except Exception:
+            if not files:
+                return
+            else:
+                raise
+        
+        window.remoteinfo.select([f.get_uri() for f in files])
+    
+    def get_background_items(self, window, folder):
+        if 'x-nautilus-desktop' in folder.get_uri_scheme():
+            # doesn't work in Python <2.7 :(
+            # directory = subprocess.check_output(['/usr/bin/xdg-user-dir', 'DESKTOP']).strip()
+            directory = subprocess.Popen(['/usr/bin/xdg-user-dir', 'DESKTOP'], stdout=subprocess.PIPE).communicate()[0].strip()
+        elif 'file' in folder.get_uri_scheme():
+            directory = folder.get_location().get_path()
+        
+        if not self.valid_uri(directory):
+            directory = gvfs2posix(directory)
+        
+        print "background path is %s"%directory
+        if hasattr(window, "remoteinfo"):
+            window.remoteinfo.updatePath(unicode(directory, "utf-8"))
+        else:
+            try:
+                self._make_known(window)
+                window.remoteinfo.updatePath(unicode(directory, "utf-8"))
+            except Exception:
+                return
+    
+    def valid_uri(self, uri):
+        if not uri.startswith("file://"): return False
+        return True
+        
+    def get_toolbar_items(self, window, file):
+        # set up window even before a file is selected
+        try:
+            self._make_known(window)
+        except Exception:
+            print "ignoring:", window, type(window).__name__
+            pass # hope for another event to fire up when the window is ready or that the window is not so important anyway
+
+    def _make_known(self, window):
+        if type(window).__name__ == '__main__.NautilusSpatialWindow':
+            raise Exception("Spatial windowows not yet supported") # selection stuff would work, but there is no directory changing in spatial windows
+        elif type(window).__name__ != "__main__.NautilusWindow" and type(window).__name__ != "__main__.NautilusDesktopWindow":
+            raise Exception("Window is unexpected %r"%type(window))
+        
+        if window.get_window() is None:
+            raise Exception("Window not yet ready (no X id), ignoring")
+        
+        if not hasattr(window, "remoteinfo"):
+            window.remoteinfo = PosixRemoteWindow(window)
+            self.window = window

--- a/js/ui/dnd.js
+++ b/js/ui/dnd.js
@@ -11,6 +11,13 @@ const Main = imports.ui.main;
 
 const Params = imports.misc.params;
 
+// For dragging to desktop / file manager:
+const FileUtils = imports.misc.fileUtils;
+const USER_DESKTOP_PATH = FileUtils.getUserDesktopDir();
+const Gio = imports.gi.Gio;
+const Util = imports.misc.util;
+const FileManagerDBus = imports.ui.fileManagerDBus;
+
 // Time to scale down to maxDragActorSize
 const SCALE_ANIMATION_TIME = 0.25;
 // Time to animate to original position on cancel
@@ -425,7 +432,6 @@ _Draggable.prototype = {
         let [dropX, dropY] = event.get_coords();
         let target = this._dragActor.get_stage().get_actor_at_pos(Clutter.PickMode.ALL,
                                                                   dropX, dropY);
-
         // We call observers only once per motion with the innermost
         // target actor. If necessary, the observer can walk the
         // parent itself.
@@ -445,8 +451,10 @@ _Draggable.prototype = {
                         continue;
                 }
         }
-
+        
+        let cinnWindows = new Array();
         while (target) {
+            cinnWindows.push(target);
             if (target._delegate && target._delegate.acceptDrop) {
                 let [r, targX, targY] = target.transform_stage_point(dropX, dropY);
                 if (target._delegate.acceptDrop(this.actor._delegate,
@@ -475,12 +483,147 @@ _Draggable.prototype = {
             }
             target = target.get_parent();
         }
+        
+        // No Cinnamon actors have accepted drag-and-drop. Usually we'd
+        // revert the drag here, but let's try identifying user intent
+        // based on the Cinnamon actors and windows at our cursor's 
+        // location. If we find a Nautilus window, we may use DBus to
+        // interact with it and copy over the item if that's what we
+        // determine user intent to be.
+        
+        // Define a single post-drag function we can call no matter how
+        // we end up completing the action.
+        let fnCompleted = function(self, event) {
+            self._dragActor.destroy();
+            self._dragInProgress = false;
+            global.unset_cursor();
+            self.emit('drag-end', event.get_time(), true);
+            self._dragComplete();
+            
+            // @todo Close all popup menus
+            global.display.emit('overlay-key');
+            return true;
+        };
+        
+        cinnWindows.pop();
+        
+        // If we have no target it's because we're trying to drop on an
+        // actor that does not accept DnD.
+        if (target === null && this.actor['_app'])
+        {
+            let onlyNautilus = true;
+            // Get a list of windows which we could be dropping it on
+            let windows = global.get_window_actors();
+            let [stageWidth, stageHeight] = event.get_source().get_stage().get_size();
+            
+            // Filter out all Cinnamon actors that aren't at our mouse
+            // coordinates. A resulting empty array suggests the user
+            // is trying to drag to a non-Cinnamon window.
+            cinnWindows = cinnWindows.filter(function(cw) {
+                let [_w, _h] = cw.get_size();
+                let [_x, _y] = cw.get_position();
+                // For a cinnamon window to be considered, it must be
+                // visible, must not be the exact size of our stage,
+                // and must overlap our drop coordinates.
+                return (cw.visible && _h>0 && _w>0 
+                  && (_h!=stageHeight && _w!=stageWidth) 
+                  && _x <= dropX && _x+_w >= dropX && _y <= dropY && _y+_h >= dropY);
+            });
+            
+            // User released on a Cinnamon element, so we won't respond.
+            if (cinnWindows.length > 0) {
+                this._cancelDrag(event.get_time());
+                return true;
+            }
+            
+            // Now we need to filter out windows that are either not
+            // visible or do not overlap our drop coordinates.
+            windows = windows.filter(function(w) {
+               let [_w, _h] = w.get_size();
+               let [_x, _y] = w.get_position();
+               
+               return (w.visible && _x <= dropX && _x+_w >= dropX && _y <= dropY && _y+_h >= dropY);
+            });
+
+            // Not really a filter, just check whether we are only
+            // dealing with Nautilus windows at the drop target.
+            // If we have multiple windows stacked beneath the cursor,
+            // we can't safely assume the user's intent (at least not
+            // with some sort of visual feedback).
+            windows = windows.filter(function(w) {
+                if (!w['get_meta_window'] || w.get_meta_window().get_wm_class() != 'Nautilus') 
+                  onlyNautilus = false;
+                return true;
+            });
+            
+            // Debug
+            /*let titles = windows.map(function(w) {
+                if (w['get_meta_window'])
+                    return '[' + w.get_meta_window().get_layer() + '] ' 
+                        + w.meta_window.get_wm_class() + ' - '
+                        + w.meta_window.get_title();
+                else
+                    return 'Unknown Cinnamon container';
+            });*/
+            
+            // Sort windows by layer
+            windows.sort(function(a, b) {
+                return a['get_meta_window'] && b['get_meta_window'] 
+                  && a.get_meta_window().get_layer() <= b.get_meta_window().get_layer();
+            });
+            
+            // Maybe accept this as an intent to drag and drop to file manager:
+            // One file manager window at drop location OK (desktop)
+            // Two file manager windows at drop location OK (desktop + one open folder)
+            // More than two file managers NOT OK (they could be overlapping)
+            // More than one unique application NOT OK (same)
+            if (windows.length > 0 && windows[0].meta_window.get_wm_class() == 'Nautilus'
+                && (windows.length == 1 || windows.length == 2 && onlyNautilus))
+            {
+                let filename, sourceFile, destFile;
+                filename = this.actor._app.get_id();
+                sourceFile = Gio.file_new_for_path(this.actor._app.get_tree_entry().get_desktop_file_path());
+                
+                try {
+                    // Get the X window ID. This relies on Muffin's continued 
+                    // exposing of window ID in the window description.
+                    let xWindowId = windows[0].meta_window.get_description().split(' ')[0];
+                    
+                    // Connect to file manager handling the target window, if possible
+                    //let fileMan = new FileManagerDBus.FileManager(xWindowId);
+                    let fileMan = FileManagerDBus.GetForWindow(xWindowId);
+                    let self = this;
+                    fileMan.getCwd(function(path) {
+                        if (path) {
+                            destFile = Gio.file_new_for_path(path+"/"+filename);
+                            FileManagerDBus.Copy(sourceFile, destFile);
+                            FileManagerDBus.MakeExecutable(path+"/"+filename);
+                            return fnCompleted(self, event);
+                        }
+                        else {
+                            self._cancelDrag(event.get_time());
+                        }
+                    });
+                    
+                    return true;
+                    
+                } catch (e) {
+                    if (windows[0].meta_window.get_title() == _('Desktop')) {
+                        destFile = Gio.file_new_for_path(USER_DESKTOP_PATH+"/"+filename);
+                        FileManagerDBus.Copy(sourceFile, destFile);
+                        FileManagerDBus.MakeExecutable(USER_DESKTOP_PATH+"/"+filename);
+                        return fnCompleted(this, event);
+                    }
+                }
+            }
+         }
 
         this._cancelDrag(event.get_time());
 
         return true;
     },
-
+    
+    
     _getRestoreLocation: function() {
         let x, y, scale;
 

--- a/js/ui/fileManagerDBus.js
+++ b/js/ui/fileManagerDBus.js
@@ -1,0 +1,79 @@
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+const Signals = imports.signals;
+const DBus = imports.dbus;
+const Main = imports.ui.main;
+const Gio = imports.gi.Gio;
+const Util = imports.misc.util;
+
+const FILEMAN_BUS_NAME = 'org.gnome.Nautilus.WindowInfo';
+const FILEMAN_INTERFACE_NAME = 'org.gnome.Nautilus.WindowInfo.posix'; // interface
+const FILEMAN_SERVICE_PATH_PREFIX = '/org/gnome/Nautilus/windows/';
+
+const FileManagerIface = {
+    name: FILEMAN_INTERFACE_NAME,
+    methods: [
+                { name: 'getCwd', inSignature: '', outSignature: 's' },
+                { name: 'getSelection', inSignature: '', outSignature: 'as' }
+             ],
+    signals: [],
+    properties: []
+};
+
+function CinnamonFileManager(windowId) {
+    this._init(windowId);
+}
+
+CinnamonFileManager.prototype = {
+    _init: function(windowId) {
+        let WINDOW_SERVICE_PATH = FILEMAN_SERVICE_PATH_PREFIX + windowId;
+        DBus.session.exportObject(WINDOW_SERVICE_PATH, this);
+        DBus.session.proxifyObject(this, FILEMAN_BUS_NAME, WINDOW_SERVICE_PATH);
+    }
+};
+
+DBus.proxifyPrototype(CinnamonFileManager.prototype, FileManagerIface);
+
+function FileManager(windowId) {
+    this._init(windowId);
+}
+
+FileManager.prototype = {
+    _init: function(windowId) {
+        this._fm = new CinnamonFileManager(windowId);
+    },
+    getCwd: function(fn) {
+        if (!fn) fn = function(v) {
+            global.log(v);
+        }
+        
+        this._fm.getCwdRemote(fn);
+    },
+    getSelection: function(fn) {
+        if (!fn) fn = function(v) {
+            global.log(v);
+        }
+        
+        this._fm.getSelectionRemote(fn);
+    }
+};
+Signals.addSignalMethods(FileManager.prototype);
+
+DBus.conformExport(FileManager.prototype, FileManagerIface);
+
+let fileManagerBusses = {};
+
+function GetForWindow(windowId) {
+    if (!fileManagerBusses[windowId]) {
+        fileManagerBusses[windowId] = new FileManager(windowId);
+    }
+    
+    return fileManagerBusses[windowId];
+}
+
+function Copy(sourceFile, destFile) {
+    sourceFile.copy(destFile, 0, null, function(){});
+}
+
+function MakeExecutable(filePath) {
+    Util.spawnCommandLine("chmod +x \""+filePath+"\"");
+}

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -32,6 +32,7 @@ const CinnamonDBus = imports.ui.cinnamonDBus;
 const WindowManager = imports.ui.windowManager;
 const ThemeManager = imports.ui.themeManager;
 const Magnifier = imports.ui.magnifier;
+const FileManagerDBus = imports.ui.fileManagerDBus;
 const XdndHandler = imports.ui.xdndHandler;
 const StatusIconDispatcher = imports.ui.statusIconDispatcher;
 const Util = imports.misc.util;


### PR DESCRIPTION
#836. Previous thread [here](https://github.com/linuxmint/Cinnamon/pull/842). Adds DBus interface to Nautilus windows, fixes bugs in selection of drop window, keeps simple fallback method of copying to desktop.

A python-nautilus extension hooks into Nautilus windows to provide DBus methods to get file selection and current working directory. I believe this is an automatic install as it is in the `files/` directory. Once nautilus is restarted it begins providing the DBus session bus interfaces.

A new `fileManagerDBus.js` provides the connection and is now called by `dnd.js` when it is determined that the destination drop coordinates match either:
- Only a single file manager window (desktop)
- Two file manager windows (desktop + one open folder)

When there are more than two file manager windows at the drop coordinates, no action is taken and the action is reverted (we could drop it anyway but I've kept it simple since we have no visual feedback).
Likewise when there are more than one unique applications with windows at the drop coordinates no action is taken.

Cinnamon actors are examined for a possible match, and if one is found (e.g. user picks up app icon and lets it go again) no action is taken.

Meta windows are examined as they were before but now exclude those that are not visible.

If the DBus service can be reached, it will get the current working directory of the file manager window and copy the shortcut to it.
If the DBus service cannot be reached and the meta window title matches `_("Desktop")` it will copy the file to the user's home folder.
