### PR TITLE
ALT+Tab: Fix "Clutter-CRITICAL **: clutter_actor_unmap: assertion `CLUTTER_IS_ACTOR (self)' failed".

### DIFF
--- a/js/ui/altTab.js
+++ b/js/ui/altTab.js
@@ -413,19 +413,22 @@ AltTabPopup.prototype = {
     },
 
     destroy : function() {
+        var doDestroy = Lang.bind(this, function() {
+           Main.uiGroup.remove_actor(this.actor);
+           this.actor.destroy();
+        });
+        
         this._popModal();
         if (this.actor.visible) {
             Tweener.addTween(this.actor,
                              { opacity: 0,
                                time: POPUP_FADE_OUT_TIME,
                                transition: 'easeOutQuad',
-                               onComplete: Lang.bind(this,
-                                   function() {
-                                       this.actor.destroy();
-                                   })
+                               onComplete: doDestroy
                              });
-        } else
-            this.actor.destroy();
+        } else {
+            doDestroy();
+        }
     },
 
     _onDestroy : function() {


### PR DESCRIPTION
If you are monitoring stderr you will find that whenever you are finished ALT-tabbing, something like the following will be printed:

(cinnamon:2867): Clutter-CRITICAL *_: clutter_actor_unmap: assertion CLUTTER_IS_ACTOR (self)' failed
(cinnamon:2867): Clutter-CRITICAL *_: clutter_actor_unmap: assertionCLUTTER_IS_ACTOR (self)' failed

The warning is due to an actor being destroyed while it is still part of Main.uiGroup. This patch remedies this.
