### PR TITLE
Fix mysterious error messages caused by destroy_children in Window List

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -725,7 +725,14 @@ MyApplet.prototype = {
     },
     
     _refreshItems: function() {
-        this.myactor.destroy_children();
+        /* "this.myactor.destroy_children()" produces mysterious warnings:
+        "Clutter-CRITICAL **: clutter_actor_unmap: assertion `CLUTTER_IS_ACTOR (self)' failed",
+        one for each child actor, so let's use a loop instead. */
+
+        for ( let i = 0; i < this._windows.length; ++i ) {
+            this.myactor.remove_actor(this._windows[i].actor);
+            this._windows[i].actor.destroy();
+        }
         this._windows = new Array();
 
         let metaWorkspace = global.screen.get_active_workspace();


### PR DESCRIPTION
I have found that Window List, when the user switches workspaces, will cause mysterious error messages (one for each button in the window list) to be printed to the console:

```
 "Clutter-CRITICAL **: clutter_actor_unmap: assertion `CLUTTER_IS_ACTOR (self)' failed"
```

After some debugging I find that it is the line "this.myactor.destroy_children();" that produces the error messages, although it does the job of destroying the children.

This patch replaces the call to destroy_children with a loop to destroy each child individually, to get rid of the confusion until the root cause is fixed.

See also: #822.
