### PR TITLE
Ensure that the expo workspace thumbnail title is removed from the parent container before destruction.

### DIFF
--- a/js/ui/expoThumbnail.js
+++ b/js/ui/expoThumbnail.js
@@ -422,7 +422,6 @@ ExpoWorkspaceThumbnail.prototype = {
     },
 
     destroy : function() {            
-        this.title.destroy();
         this.actor.destroy();        
     },
 
@@ -440,10 +439,7 @@ ExpoWorkspaceThumbnail.prototype = {
             }
             this._windows[i].destroy();
         }
-
-        this._windows = [];
-        this.title = null;
-        this.actor = null;        
+        this._windows = null;
     },
 
     // Tests if @win belongs to this workspace and monitor
@@ -861,8 +857,14 @@ ExpoThumbnailsBox.prototype = {
             thumbnail.setPorthole(this._porthole.x, this._porthole.y,
                                   this._porthole.width, this._porthole.height);
             this._thumbnails.push(thumbnail);
-            if (metaWorkspace == global.screen.get_active_workspace())
+            if (metaWorkspace == global.screen.get_active_workspace()) {
                 this._lastActiveWorkspace = thumbnail;
+            }
+            thumbnail.actor.connect('destroy', Lang.bind(this, function(actor) {
+                this.actor.remove_actor(actor);
+                this.actor.remove_actor(thumbnail.title);
+                thumbnail.title.destroy();
+                }));
             this.actor.add_actor(thumbnail.actor);
             this.actor.add_actor(thumbnail.title);
 


### PR DESCRIPTION
I noticed that every time Expo is closed,  a few warning messages are printed to the console:

```
   Window manager warning: Log level 8: gtk_im_context_set_client_window: assertion `GTK_IS_IM_CONTEXT (context)' failed
```

I traced the warning to the workspace thumbnail title ("WORKSPACE 1", etc.), which is added to an actor but not removed when it is destroyed (the parent actor seems to have global lifetime). This patch remedies this. It also removes the thumbnail actor from the same container.
