### PR TITLE
Thorough theme cleanup

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -12,18 +12,6 @@ stage {
 .cinnamon-link:hover {
 	color: #0000e0;
 }
-#Tooltip {
-	border: 1px solid rgba(212,185,67,1.0);
-	border-radius: 4px;
-	padding: 2px 12px;
-	background-gradient-end: rgba(251,234,159,0.9);
-	background-gradient-start: rgba(254,245,198,0.9);
-	background-gradient-direction: vertical;
-	color: #000000;
-	font-size: 8.5pt;
-	font-weight: normal;
-	text-align: center;
-}
 /* ===================================================================
  * PopupMenu (popupMenu.js) 
  * ===================================================================*/
@@ -270,6 +258,19 @@ StScrollBar StButton#vhandle:hover {
 }
 .system-status-icon {
 	icon-size: 1.14em;
+}
+/* Panel applet tooltips*/
+#Tooltip {
+	border: 1px solid rgba(212,185,67,1.0);
+	border-radius: 4px;
+	padding: 2px 12px;
+	background-gradient-end: rgba(251,234,159,0.9);
+	background-gradient-start: rgba(254,245,198,0.9);
+	background-gradient-direction: vertical;
+	color: #000000;
+	font-size: 8.5pt;
+	font-weight: normal;
+	text-align: center;
 }
 /* ===================================================================
  * Overview 
@@ -1296,7 +1297,7 @@ StScrollBar StButton#vhandle:hover {
 	icon-shadow: white 0px 0px 3px;
 }
 /* ===================================================================
- * Workspace OSD
+ * Workspace OSD and Workspace Expo
  * ===================================================================*/
 .workspace-osd {
 	color: #ffffff;


### PR DESCRIPTION
All Gnome Shell only code removed, a little reordering and some general tidying up, and a few small bugfixes. The result should be easier for newcomers to navigate, e.g. the corner ripple is under the overview section rather than the alt tab section and so on - don't think the gnome devs always put too much thought into where they put what. 

Not sure what to do with the whole end session bit, it is not currently used in Cinnamon on either fedora 17, Maya or Pangolin but it may be in other distros? Commented out, not deleted.

The following files in the theme folder can be deleted as well:
- close.svg (?)
- dash-placeholder.svg (used when drag'n'drop reordering icons in Gnome Shell's dash - could be used in Cinnamon drag'n'drop reordering favourites in the menu but currently isn't)
- filter-selected-ltr/rtl.svg (used in the GS overview application filter, not in Cinnamon)
- gdm.css (not used)
- panel-border.svg (gnome shell theme left-over)
- source-button-border.svg (same)
- ws-switch-arrow-down.svg + ws-switch-arrow-up.svg (displays in Gnome Shell on Alt-Ctrl+Up/Down, not used in Cinnamon)
