### PR TITLE
Add "Menu settings" to menu-applet popup menu

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -568,6 +568,10 @@ MyApplet.prototype = {
             
             this.edit_menu_item = new Applet.MenuItem(_("Edit menu"), Gtk.STOCK_EDIT, Lang.bind(this, this._launch_editor));
             this._applet_context_menu.addMenuItem(this.edit_menu_item);
+            let settings_menu_item = new Applet.MenuItem(_("Menu settings"), null, function() {
+                Util.spawnCommandLine("cinnamon-settings menu");
+            });
+            this._applet_context_menu.addMenuItem(settings_menu_item);
                                                                            
         }
         catch (e) {


### PR DESCRIPTION
This adds a "Menu settings" item to the menu-applet's popup menu.
