### PR TITLE
fix links in manpage

### DIFF
--- a/man/cinnamon.1
+++ b/man/cinnamon.1
@@ -82,7 +82,7 @@ Display help and exit
 
 .SH BUGS
 The bug tracker can be reached by visiting the website
-\fIhttps://bugzilla.gnome.org/buglist.cgi?product=cinnamon\fR
+\fIhttps://github.com/linuxmint/Cinnamon/issues\fR
 
 Before sending a bug report, please verify that you have the latest
 version of cinnamon. Many bugs (major and minor) are fixed at each
@@ -91,4 +91,4 @@ been solved.
 
 .SH ADDITIONAL INFORMATION
 
-For further information, visit the website \fIhttp://live.gnome.org/Cinnamon\fR
+For further information, visit the website \fIhttp://cinnamon.linuxmint.com\fR


### PR DESCRIPTION
cinnamon(1) references gnome.org
