### PR TITLE
Fix display of correct status icons when connected.

### DIFF
--- a/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
@@ -1949,7 +1949,7 @@ MyApplet.prototype = {
             }
         }
 
-        this._mainConnection = activating || default_ip4 || default_ip6 || this._activeConnections[0] || null;
+        this._mainConnection = this._activeConnections[0] || activating || default_ip4 || default_ip6 || null;
     },
 
     _notifyActivated: function(activeConnection) {


### PR DESCRIPTION
This is a fix for #906 - could use further testing - I tested with a VPN connection and the icon properly shows a 'locked' connection, but cannot test with wifi at this time, would like others to confirm.  You can simply copy the applet.js file into your applet folder to test out.
