### PR TITLE
Expo: dropping on same workspace is accepted although it is prohibited

### DIFF
--- a/js/ui/expoThumbnail.js
+++ b/js/ui/expoThumbnail.js
@@ -711,31 +711,27 @@ ExpoWorkspaceThumbnail.prototype = {
     },
 
     acceptDrop : function(source, actor, x, y, time) {
-        if (this.state > ThumbnailState.NORMAL)
+        if (this.handleDragOver(source, actor, x, y, time) === DND.DragMotionResult.CONTINUE) {
             return false;
-        this.metaWorkspace.activate(time);
-        if (source.realWindow) {
-            let win = source.realWindow;
-            if (this._isMyWindow(win))
-                return false;
-
-            let metaWindow = win.get_meta_window();
-
-            // We need to move the window before changing the workspace, because
-            // the move itself could cause a workspace change if the window enters
-            // the primary monitor
-            if (metaWindow.get_monitor() != this.monitorIndex)
-                metaWindow.move_to_monitor(this.monitorIndex);
-
-            metaWindow.change_workspace_by_index(this.metaWorkspace.index(),
-                                                 false, // don't create workspace
-                                                 time);
-
-
-            this._overviewModeOn();
-            return true;
         }
-        return false;
+
+        this.metaWorkspace.activate(time);
+        let win = source.realWindow;
+        let metaWindow = win.get_meta_window();
+
+        // We need to move the window before changing the workspace, because
+        // the move itself could cause a workspace change if the window enters
+        // the primary monitor
+        if (metaWindow.get_monitor() != this.monitorIndex) {
+            metaWindow.move_to_monitor(this.monitorIndex);
+        }
+
+        metaWindow.change_workspace_by_index(this.metaWorkspace.index(),
+                                                false, // don't create workspace
+                                                time);
+
+        this._overviewModeOn();
+        return true;
     }
 };
 


### PR DESCRIPTION
Dragging a window within the same workspace shows the prohibited icon, but dropping is accepted anyway.
This patch fixes that by making acceptDrop use handleDragOver to decide whether to accept a drop.
