### PR TITLE
Set a suitable icon size of 16px for control buttons

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -266,6 +266,7 @@ ControlButton.prototype = {
         this.icon = new St.Icon({
             icon_type: St.IconType.SYMBOLIC,
             icon_name: icon,
+            icon_size: 16,
             style_class: 'sound-button-icon',
         });
         this.button.set_child(this.icon);


### PR DESCRIPTION
St.Icon has a default size of 48px, which is much bigger than the button on which the icon is placed.
