### PR TITLE
Workspace OSD enhancements

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -72,6 +72,8 @@ THEME CHANGES SINCE 1.4
 
 .workspace-osd {
 }
+.workspace-osd#failed {
+}
 
 .expo-workspaces-name-entry {
 }

--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -1636,6 +1636,10 @@ StScrollBar StButton#vhandle:hover {
 	font-weight: bold;
 	font-size: 48pt;	
 }
+.workspace-osd#failed {
+	color: #ff0000;
+}
+
 
 .expo-workspaces-name-entry {
 	padding: 5px;

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -751,26 +751,30 @@ WindowManager.prototype = {
         cinnamonwm.completed_switch_workspace();                        
     },
     
-    showWorkspaceOSD : function() {
+    showWorkspaceOSD : function(failed) {
         if (global.settings.get_boolean("workspace-osd-visible")) {            
             let current_workspace_index = global.screen.get_active_workspace_index();
-            if (current_workspace_index < Main.workspace_names.length) {
-                let monitor = Main.layoutManager.primaryMonitor;                
-                let label = new St.Label({style_class:'workspace-osd'});
-                label.set_text(Main.workspace_names[current_workspace_index]);            
-                label.set_opacity = 0;                             
-                Main.layoutManager.addChrome(label, { visibleInFullscreen: false });    
-                let workspace_osd_x = global.settings.get_int("workspace-osd-x");
-                let workspace_osd_y = global.settings.get_int("workspace-osd-y");
-                let x = (monitor.width * workspace_osd_x /100 - label.width/2);
-                let y = (monitor.height * workspace_osd_y /100 - label.height/2);
-                label.set_position(x, y);  
-                let duration = global.settings.get_int("workspace-osd-duration") / 1000;                
-                Tweener.addTween(label, { opacity: 255,                                                        
-                       time: duration,                   
-                       transition: 'linear',                                       
-                       onComplete: function() { Main.layoutManager.removeChrome(label); } });            
-            } 
+            let monitor = Main.layoutManager.primaryMonitor;                
+            let label = new St.Label({style_class:'workspace-osd'});
+            if (failed) {
+                label.name = "failed";
+            }
+            let wsName = current_workspace_index < Main.workspace_names.length ?
+                Main.workspace_names[current_workspace_index] :
+                "?";
+            label.set_text((current_workspace_index + 1).toString() +  ": " + wsName);            
+            label.set_opacity = 0;                             
+            Main.layoutManager.addChrome(label, { visibleInFullscreen: false });    
+            let workspace_osd_x = global.settings.get_int("workspace-osd-x");
+            let workspace_osd_y = global.settings.get_int("workspace-osd-y");
+            let x = (monitor.width * workspace_osd_x /100 - label.width/2);
+            let y = (monitor.height * workspace_osd_y /100 - label.height/2);
+            label.set_position(x, y);  
+            let duration = global.settings.get_int("workspace-osd-duration") / 1000;                
+            Tweener.addTween(label, { opacity: 255,                                                        
+                    time: duration,                   
+                    transition: 'linear',                                       
+                    onComplete: function() { Main.layoutManager.removeChrome(label); } });            
         }
     },
         
@@ -851,13 +855,16 @@ WindowManager.prototype = {
         if (screen.n_workspaces == 1)
             return;
 
+        let current_workspace_index = global.screen.get_active_workspace_index();
         if (binding.get_name() == 'switch-to-workspace-left') {
            this.actionMoveWorkspaceLeft();
-           this.showWorkspaceOSD();       
+           let failed = current_workspace_index === global.screen.get_active_workspace_index();
+           this.showWorkspaceOSD(failed)   
         }
         else if (binding.get_name() == 'switch-to-workspace-right') {
            this.actionMoveWorkspaceRight();
-           this.showWorkspaceOSD();       
+           let failed = current_workspace_index === global.screen.get_active_workspace_index();
+           this.showWorkspaceOSD(failed);
         }
     },
 


### PR DESCRIPTION
1) Make workspace OSD show the index of the switched-to workspace by prefixing the workspace name with the index and a colon, e.g., "1: Main", "2: Cinnamon dev", etc.
If you have a workspace whose name does not say which index it has, this helps to keep your sense of orientation. This also helps when your workspaces are out of sync with their default names, which can happen if you delete a workspace in the middle of the set of workspaces.

2) Indicate failure to switch workspace by changing the foreground color (controlled by CSS). If you are already at the left-most workspace and try to switch to the left, you will be subtly warned that you cannot move further in that direction. Vice versa for the right end.
