### PR TITLE
Fix rare Expo crash when a window is being created just as Expo is closing.

### DIFF
--- a/js/ui/expoThumbnail.js
+++ b/js/ui/expoThumbnail.js
@@ -398,10 +398,12 @@ ExpoWorkspaceThumbnail.prototype = {
             // the compositor finds out about them...
             Mainloop.idle_add(Lang.bind(this,
                                         function () {
-                                            if (this.actor &&
+                                            if (this._windows /*will be null if we're closing down*/ &&
                                                 metaWin.get_compositor_private() &&
                                                 metaWin.get_workspace() == this.metaWorkspace)
+                                            {
                                                 this._doAddWindow(metaWin);
+                                            }
                                             return false;
                                         }));
             return;


### PR DESCRIPTION
Fixes regression introduced by pull request #884.
