### PR TITLE
Ensure that getTabList does not return a list having duplicates.

### DIFF
--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -1078,13 +1078,18 @@ function getTabList(workspaceOpt, screenOpt) {
     // the correct tab order.
     let allwindows = display.get_tab_list(Meta.TabList.NORMAL_ALL, screen,
                                        workspace);
+    let registry = {}; // to avoid duplicates
     let tracker = Cinnamon.WindowTracker.get_default();
     for (let i = 0; i < allwindows.length; ++i) {
         let window = allwindows[i];
+        let seqno = window.get_stable_sequence();
         // Add "normal" windows and those that don't have an "app".
-        if (normalLookup[window.get_stable_sequence()] === 1 || !tracker.get_window_app(window))
+        if (normalLookup[seqno] === 1 || !tracker.get_window_app(window))
         {
-            windows.push(window);
+            if (!registry[seqno]) {
+                windows.push(window);
+                registry[seqno] = true;
+            }
         }
     }
     return windows;


### PR DESCRIPTION
Works around a possible bug in display.get_tab_list, which under some circumstances (app-less, on-all-workspaces dialog on another workspace) can produce duplicates.

One thing I have noted after my pull request #838 was merged is that is possible for Expo to show duplicates. It's a very rare occurrence, but it should be worked around anyway.

How to reproduce the issue:
1) Switch to an empty workspace.
2) Click the desktop to make sure it has input focus.
3) Press CTRL+ALT+DEL to bring up the logout dialog. It should not have input focus.
4) Switch to another workspace.
5) Bring up Expo.
6) Mouse over your workspaces.

Expected behavior: There should only be one instance of the logout dialog on each workspace.
Actual behavior: There will be two instances of the logout dialog on some workspaces.
