### PR TITLE
Send notifications directly to applet if applet is enabled and

### DIFF
--- a/js/ui/messageTray.js
+++ b/js/ui/messageTray.js
@@ -1591,7 +1591,6 @@ MessageTray.prototype = {
             if (canShowNotification)
                 this._showNotification();
             else if (!notificationsEnabled) {
-                global.logError("YES");
                 this._notification = this._notificationQueue.shift();
                 if (AppletManager.get_role_provider_exists(AppletManager.Roles.NOTIFICATIONS)) {
                     this.emit('notify-applet-update', this._notification);


### PR DESCRIPTION
notifications are disabled in Cinnamon Settings
