### PR TITLE
Special handling of "sticky" windows

### DIFF
--- a/files/usr/share/cinnamon/applets/windows-quick-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/windows-quick-list@cinnamon.org/applet.js
@@ -103,7 +103,7 @@ MyApplet.prototype = {
 	},
 
 	activateWindow: function(metaWorkspace, metaWindow) {
-		metaWorkspace.activate(global.get_current_time());
+		if(!metaWindow.is_on_all_workspaces()) { metaWorkspace.activate(global.get_current_time()); }
 		metaWindow.unminimize(global.get_current_time());
 		metaWindow.activate(global.get_current_time());
 	},


### PR DESCRIPTION
This patch makes sure sticky windows are listed first and that switching to them doesn't cause a workspace switch.
