### PR TITLE
missing break statement, missing pointer derefence, missing pair of curly braces

### DIFF
--- a/src/cinnamon-global.c
+++ b/src/cinnamon-global.c
@@ -652,6 +652,7 @@ cinnamon_global_set_cursor (CinnamonGlobal *global,
           break;
         case CINNAMON_CURSOR_POINTING_HAND:
           cursor_type = GDK_HAND2;
+          break;
         case CINNAMON_CURSOR_DND_UNSUPPORTED_TARGET:
           cursor_type = GDK_X_CURSOR;
           break;
@@ -1455,7 +1456,7 @@ cinnamon_global_get_memory_info (CinnamonGlobal        *global,
   JSContext *context;
   gint64 now;
 
-  memset (meminfo, 0, sizeof (meminfo));
+  memset (meminfo, 0, sizeof (*meminfo));
 #ifdef HAVE_MALLINFO
   {
     struct mallinfo info = mallinfo ();

--- a/src/st/st-box-layout.c
+++ b/src/st/st-box-layout.c
@@ -797,10 +797,11 @@ st_box_layout_allocate (ClutterActor          *actor,
       else if (shrink_amount > 0)
         child_allocated -= shrinks[i].shrink_amount;
 
-      if (flip)
+      if (flip) {
         next_position = position - child_allocated;
         if (xalign == ST_ALIGN_CENTER_SPECIAL && next_position < content_box.x1)
           next_position = content_box.x1;
+      }
       else {
         next_position = position + child_allocated;
         if (xalign == ST_ALIGN_CENTER_SPECIAL && next_position > content_box.x2)


### PR DESCRIPTION
Cleans up a gcc v4.6.3 -Werror=uninitialized warning and two cppcheck v1.55 warnings.  All 3 appear to be inadvertant programming errors.

gcc:
(missing curley braces, discussed in #922)
st/st-box-layout.c: In function 'st_box_layout_allocate':
st/st-box-layout.c:802:64: error: 'next_position' may be used uninitialized in this function [-Werror=uninitialized]

cppcheck:
(missing break statement & missing pointer dereference)
[src/cinnamon-global.c:654]: (warning) Redundant assignment of "cursor_type" in switch
[src/cinnamon-global.c:1458]: (warning, inconclusive) Using size of pointer meminfo instead of size of its data.

cppcheck is [available here](http://cppcheck.sourceforge.net/). 
