### PR TITLE
add function to return the cinnamon PID for debugging purposes

### DIFF
--- a/src/cinnamon-global.c
+++ b/src/cinnamon-global.c
@@ -90,7 +90,6 @@ struct _CinnamonGlobal {
   ca_context *sound_context;
 
   guint32 xdnd_timestamp;
-
   gint64 last_gc_end_time;
 };
 
@@ -1661,6 +1660,17 @@ cinnamon_global_get_current_time (CinnamonGlobal *global)
     return clutter_event_get_time (clutter_event);
   else
     return CLUTTER_CURRENT_TIME;
+}
+
+/**
+ * cinnamon_global_get_pid:
+ *
+ * Returns: the pid of the cinnamon process.
+ */
+pid_t
+cinnamon_global_get_pid ()
+{
+  return getpid();
 }
 
 /**

--- a/src/cinnamon-global.h
+++ b/src/cinnamon-global.h
@@ -36,7 +36,7 @@ MetaDisplay   *cinnamon_global_get_display               (CinnamonGlobal *global
 GList         *cinnamon_global_get_window_actors         (CinnamonGlobal *global);
 GSettings     *cinnamon_global_get_settings              (CinnamonGlobal *global);
 guint32        cinnamon_global_get_current_time          (CinnamonGlobal *global);
-
+pid_t          cinnamon_global_get_pid                      (void);
 
 /* Input/event handling */
 gboolean cinnamon_global_begin_modal            (CinnamonGlobal         *global,


### PR DESCRIPTION
This can be a useful number to have.  We can't retrieve the pid using glibtop in javascript.
