### PR TITLE
Relieve Expo and Scale of panel-hiding-and-showing duties

### DIFF
--- a/js/ui/expo.js
+++ b/js/ui/expo.js
@@ -233,8 +233,8 @@ Expo.prototype = {
         let primary = Main.layoutManager.primaryMonitor;
         let rtl = (St.Widget.get_default_direction () == St.TextDirection.RTL);
 
-        let contentY = Main.panel.actor.height;
-        let contentHeight = primary.height - contentY - Main.panel.actor.height;
+        let contentY = 0;
+        let contentHeight = primary.height - contentY;
 
         this._group.set_position(primary.x, primary.y);
         this._group.set_size(primary.width, primary.height);
@@ -361,24 +361,9 @@ Expo.prototype = {
         this.allocateID = this.activeWorkspace.connect('allocated', Lang.bind(this, this._animateVisible2));
 
         this._createClone(activeWorkspaceActor);
-        if (global.settings.get_string("desktop-layout") != 'traditional' && !global.settings.get_boolean("panel-autohide"))
-            this.clone.set_position(0, Main.panel.actor.height); 
-
         this.clone.show();
 
         this._gradient.show();
-        
-        if (Main.panel)
-            Tweener.addTween(Main.panel.actor, {    opacity: 0, 
-                                                    time: ANIMATION_TIME, 
-                                                    transition: 'easeOutQuad', 
-                                                    onComplete: function(){Main.panel.actor.hide();}});
-        if (Main.panel2)
-            Tweener.addTween(Main.panel2.actor, {   opacity: 0, 
-                                                    time: ANIMATION_TIME, 
-                                                    transition: 'easeOutQuad', 
-                                                    onComplete: function(){Main.panel2.actor.hide();}});
-        
         this._background.dim_factor = 1;
         Tweener.addTween(this._background,
                             { dim_factor: 0.4,
@@ -518,15 +503,6 @@ Expo.prototype = {
                 maximizedWindow = true;
         }
 
-        if (Main.panel){
-            Main.panel.actor.show();
-            Tweener.addTween(Main.panel.actor, {opacity: 255, time: ANIMATION_TIME, transition: 'easeOutQuad'});
-        }
-        if (Main.panel2){
-            Main.panel2.actor.show();
-            Tweener.addTween(Main.panel2.actor, {opacity: 255, time: ANIMATION_TIME, transition: 'easeOutQuad'});
-        }
-
         Tweener.addTween(this._background,
                          { dim_factor: 1,
                            time: ANIMATION_TIME,
@@ -544,8 +520,6 @@ Expo.prototype = {
         this.clone.set_scale(activeWorkspaceActor.get_scale()[0], activeWorkspaceActor.get_scale()[1]);
         this.clone.show();
         let y = 0;
-        if (global.settings.get_string("desktop-layout") != 'traditional' && !global.settings.get_boolean("panel-autohide"))
-            y = Main.panel.actor.height; 
         Tweener.addTween(this.clone, {  x: 0, 
                                         y: y, 
                                         scale_x: 1 , 

--- a/js/ui/expoThumbnail.js
+++ b/js/ui/expoThumbnail.js
@@ -810,25 +810,11 @@ ExpoThumbnailsBox.prototype = {
             this._stateCounts[ThumbnailState[key]] = 0;
 
         // The "porthole" is the portion of the screen that we show in the workspaces
-        let panelHeight = Main.panel.actor.height;
         let monitor = Main.layoutManager.primaryMonitor;
-        let autohide = global.settings.get_boolean("panel-autohide");
-        let desktop_layout = global.settings.get_string("desktop-layout");
         let portholeY = null;
         let portholeHeight = null;
-        if (autohide){
-            portholeY = 0;
-            portholeHeight = monitor.height;
-        } else if (desktop_layout == "traditional"){
-            portholeY = 0;
-            portholeHeight = monitor.height - panelHeight;        
-        } else if (desktop_layout == "flipped"){
-            portholeY = panelHeight;
-            portholeHeight = monitor.height - panelHeight;     
-        } else {
-            portholeY = panelHeight;
-            portholeHeight = monitor.height - (panelHeight * 2);         
-        }
+        portholeY = 0;
+        portholeHeight = monitor.height;
         this._porthole = {
             x: monitor.x,
             y: portholeY,

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -286,6 +286,20 @@ function start() {
         layoutManager.panelBox2.add(panel2.actor);   
         layoutManager._updateBoxes();
     }
+    
+    function enablePanels() {
+        if (panel) panel.enable();
+        if (panel2) panel2.enable();
+    }
+    function disablePanels() {
+        if (panel) panel.disable();
+        if (panel2) panel2.disable();
+    }
+    
+    expo.connect('showing', disablePanels);
+    expo.connect('hiding', enablePanels);
+    overview.connect('showing', disablePanels);
+    overview.connect('hiding', enablePanels);
                 
     wm = new WindowManager.WindowManager();
     messageTray = new MessageTray.MessageTray();

--- a/js/ui/overview.js
+++ b/js/ui/overview.js
@@ -544,17 +544,6 @@ Overview.prototype = {
 
         this._workspacesDisplay.show();
 
-        if (Main.panel)
-            Tweener.addTween(Main.panel.actor, {    opacity: 0, 
-                                                    time: ANIMATION_TIME, 
-                                                    transition: 'easeOutQuad', 
-                                                    onComplete: function(){Main.panel.actor.hide();}});
-        if (Main.panel2)
-            Tweener.addTween(Main.panel2.actor, {   opacity: 0, 
-                                                    time: ANIMATION_TIME, 
-                                                    transition: 'easeOutQuad', 
-                                                    onComplete: function(){Main.panel2.actor.hide();}});
-
         this.workspaces = this._workspacesDisplay.workspacesView;
         global.overlay_group.add_actor(this.workspaces.actor);
 
@@ -695,15 +684,6 @@ Overview.prototype = {
 
         this.animationInProgress = true;
         this._hideInProgress = true;
-
-        if (Main.panel){
-            Main.panel.actor.show();
-            Tweener.addTween(Main.panel.actor, {opacity: 255, time: ANIMATION_TIME, transition: 'easeOutQuad'});
-        }
-        if (Main.panel2){
-            Main.panel2.actor.show();
-            Tweener.addTween(Main.panel2.actor, {opacity: 255, time: ANIMATION_TIME, transition: 'easeOutQuad'});
-        }
 
         if (!this.workspaces.getActiveWorkspace().hasMaximizedWindows()) {
             this._desktopFade.opacity = 0;


### PR DESCRIPTION
This moves the responsibility of hiding and showing the panel (or panels) from Scale and Expo to higher authority (Main). In passing, it fixes issue #951. It also does away with a lot of code duplication in panels.js.

Currently, there is a slight regression in smoothness when Expo is being hidden. Hopefully somebody could fix that.
