### PR TITLE
Panel hide/show delays: Fix reading int setting as boolean.

### DIFF
--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -610,8 +610,8 @@ Panel.prototype = {
         this._hideable = global.settings.get_boolean("panel-autohide");
         this._hideTimer = false;
         this._showTimer = false;
-        this._showDelay = global.settings.get_boolean("panel-show-delay");
-        this._hideDelay = global.settings.get_boolean("panel-hide-delay");
+        this._onPanelShowDelayChanged();
+        this._onPanelHideDelayChanged();
 
         this.actor = new Cinnamon.GenericContainer({ name: 'panel',
                                                   reactive: true });


### PR DESCRIPTION
There is a problem with panel hide/show delays, that don't seem to be working until the timeout values are actively changed. The problem is due to the delay timeout values are read as booleans instead of ints on panel initialization.
