### PR TITLE
Reduce log spam from the workspace-switcher applet

### DIFF
--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
@@ -49,7 +49,7 @@ MyApplet.prototype = {
         var index = global.screen.get_active_workspace_index();
         index += incremental;
         if(global.screen.get_workspace_by_index(index) != null) {
-            global.screen.get_workspace_by_index(index).activate(false);
+            global.screen.get_workspace_by_index(index).activate(global.get_current_time());
         }
     },
     


### PR DESCRIPTION
If the time stamp of the activation of a workspace is set to "false" a warning is printed. Using the current time, the behaviour is the same but no warning in the log.
