### PR TITLE
Added tooltip for bluetooth applet

### DIFF
--- a/files/usr/share/cinnamon/applets/bluetooth@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/bluetooth@cinnamon.org/applet.js
@@ -202,7 +202,8 @@ MyApplet.prototype = {
             this.menu = new Applet.AppletPopupMenu(this, orientation);
             this.menuManager.addMenu(this.menu);            
             
-            this.set_applet_icon_symbolic_name('bluetooth-disabled');       
+            this.set_applet_icon_symbolic_name('bluetooth-disabled');
+            this.set_applet_tooltip(_("Bluetooth"));
                         
             GLib.spawn_command_line_sync ('pkill -f "^bluetooth-applet$"');
             this._applet = new GnomeBluetoothApplet.Applet();


### PR DESCRIPTION
Every applet has a tooltip, now bluetooth does have one, too.
