### PR TITLE
Keep Cinnamon from crashing if systray applet is removed

### DIFF
--- a/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
@@ -21,7 +21,7 @@ MyApplet.prototype = {
     on_applet_clicked: function(event) {
     },
 
-    _destroy: function () {
+    on_applet_removed_from_panel: function () {
         Main.statusIconDispatcher.disconnect(this._signals.added);
         Main.statusIconDispatcher.disconnect(this._signals.removed);
         Main.statusIconDispatcher.disconnect(this._signals.redisplay);

--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -167,7 +167,7 @@ Applet.prototype = {
     on_applet_added_to_panel: function() {       
     },
 
-    _destroy: function() {
+    on_applet_removed_from_panel: function() {
         // Implemented by Applets, called by appletManager
         // handles things that might cause a crash once the applet is
         // no longer on the stage

--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -87,9 +87,10 @@ function onEnabledAppletsChanged() {
                         if (directory != null) {
                             let applet = loadApplet(uuid, directory, orientation);
                             try {
-                                applet._destroy();
+                                applet.on_applet_removed_from_panel();
                             } catch (e) {
-                                global.logError("Problem with applet: " + uuid + " _destroy method: " + e);
+                                global.logError("Problem with applet: " + uuid +
+                                                " on_applet_removed_from_panel method: " + e);
                             }
                             if (applet._panelLocation != null) {
                                 applet._panelLocation.remove_actor(applet.actor);


### PR DESCRIPTION
- Shuffled code around in applet
- Added '_destroy' method to applets, that is called from appletManager
  allows applet to perform some cleanup before it's removed from the stage.
- Removed the systray refresh call from appletManager and moved it to the applet
  itself.

Addresses #563
