### PR TITLE
Only show "remove from panel" context menu item when in panel edit mode.

### DIFF
--- a/files/usr/lib/cinnamon-settings/cinnamon-settings.py
+++ b/files/usr/lib/cinnamon-settings/cinnamon-settings.py
@@ -505,10 +505,12 @@ class GSettingsCheckButton(Gtk.CheckButton):
         self.settings = Gio.Settings.new(schema)        
         self.set_active(self.settings.get_boolean(self.key))
         self.settings.connect("changed::"+self.key, self.on_my_setting_changed)
-        self.connect('toggled', self.on_my_value_changed)            
+        self.connectorId = self.connect('toggled', self.on_my_value_changed)
     
     def on_my_setting_changed(self, settings, key):
-        self.set_active(self.settings.get_boolean(self.key))
+        self.disconnect(self.connectorId)                     #  panel-edit-mode can trigger changed:: twice in certain instances,
+        self.set_active(self.settings.get_boolean(self.key))  #  so disconnect temporarily when we're simply updating the widget state
+        self.connectorId = self.connect('toggled', self.on_my_value_changed)
         
     def on_my_value_changed(self, widget):
         self.settings.set_boolean(self.key, self.get_active())

--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -967,6 +967,7 @@ PopupMenuBase.prototype = {
             }
             if (menuItem == this._activeMenuItem)
                 this._activeMenuItem = null;
+            this.length--;
         }));
     },
 


### PR DESCRIPTION
Implements #507

Conflicts with #1036, but I think it probably fixes the same problem.
