### PR TITLE
Give _themeFontSize a value before use.

### DIFF
--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -782,13 +782,13 @@ Panel.prototype = {
             panelHeight = global.settings.get_int("panel-top-height");
         }
         if (global.settings.get_boolean("panel-scale-text-icons")) {
+            let textheight = (panelHeight / Applet.DEFAULT_PANEL_HEIGHT) * Applet.PANEL_FONT_DEFAULT_HEIGHT;
+            this.actor.set_style('font-size: ' + textheight + 'px;');
+        } else {
             if (!this._themeFontSize) {
                 let themeNode = this.actor.get_theme_node();
                 this._themeFontSize = themeNode.get_length("font-size");
             }
-            let textheight = (panelHeight / Applet.DEFAULT_PANEL_HEIGHT) * Applet.PANEL_FONT_DEFAULT_HEIGHT;
-            this.actor.set_style('font-size: ' + textheight + 'px;');
-        } else {
             this.actor.set_style('font-size: ' + this._themeFontSize + 'px;');
         }
         this.actor.set_height(panelHeight);
@@ -832,13 +832,13 @@ Panel.prototype = {
             panelHeight = global.settings.get_int("panel-top-height");
         }
         if (global.settings.get_boolean("panel-scale-text-icons")) {
+            let textheight = (panelHeight / Applet.DEFAULT_PANEL_HEIGHT) * Applet.PANEL_FONT_DEFAULT_HEIGHT;
+            this.actor.set_style('font-size: ' + textheight + 'px;');
+        } else {
             if (!this._themeFontSize) {
                 let themeNode = this.actor.get_theme_node();
                 this._themeFontSize = themeNode.get_length("font-size");
             }
-            let textheight = (panelHeight / Applet.DEFAULT_PANEL_HEIGHT) * Applet.PANEL_FONT_DEFAULT_HEIGHT;
-            this.actor.set_style('font-size: ' + textheight + 'px;');
-        } else {
             this.actor.set_style('font-size: ' + this._themeFontSize + 'px;');
         }
         AppletManager.updateAppletPanelHeights(true);


### PR DESCRIPTION
Unless I'm badly mistaken, this._themeFontSize will most often be null when accessed. This patch gives it a value before it is accessed.
