### PR TITLE
Fixed clutter warning from systray applet

### DIFF
--- a/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
@@ -72,6 +72,8 @@ MyApplet.prototype = {
             global.log("Adding systray: " + role + " (" + icon.get_width() + "x" + icon.get_height() + "px)");            
 
             let box = new St.Bin({ style_class: 'panel-status-button', reactive: true, track_hover: true});
+	    let iconParent = icon.get_parent();
+	    if (iconParent) iconParent.remove_actor(icon);
             box.add_actor(icon);
 
             this._insertStatusItem(box, -1);


### PR DESCRIPTION
Regression probably caused by https://github.com/linuxmint/Cinnamon/commit/97dedfd20b48dc3badec0fc7ad86e54f16ba7a2e

(cinnamon:4469): Clutter-WARNING **: Attempting to add actor of type 'CinnamonTrayIcon' to a container of type 'StBin', but the actor has already a parent of type 'StBin'.
