### PR TITLE
remove several compile warnings

### DIFF
--- a/src/cinnamon-app.c
+++ b/src/cinnamon-app.c
@@ -1083,6 +1083,7 @@ cinnamon_app_launch (CinnamonApp     *app,
   gboolean ret;
   CinnamonGlobal *global;
   MetaScreen *screen;
+  GdkDisplay *gdisplay;
 
   if (startup_id)
     *startup_id = NULL;
@@ -1101,6 +1102,7 @@ cinnamon_app_launch (CinnamonApp     *app,
 
   global = cinnamon_global_get ();
   screen = cinnamon_global_get_screen (global);
+  gdisplay = gdk_screen_get_display (cinnamon_global_get_gdk_screen (global));
 
   if (timestamp == 0)
     timestamp = cinnamon_global_get_current_time (global);
@@ -1108,7 +1110,7 @@ cinnamon_app_launch (CinnamonApp     *app,
   if (workspace < 0)
     workspace = meta_screen_get_active_workspace_index (screen);
 
-  context = gdk_app_launch_context_new ();
+  context = gdk_display_get_app_launch_context (gdisplay);
   gdk_app_launch_context_set_timestamp (context, timestamp);
   gdk_app_launch_context_set_desktop (context, workspace);
 

--- a/src/cinnamon-gtk-embed.c
+++ b/src/cinnamon-gtk-embed.c
@@ -136,10 +136,11 @@ cinnamon_gtk_embed_get_preferred_width (ClutterActor *actor,
   if (embed->priv->window
       && gtk_widget_get_visible (GTK_WIDGET (embed->priv->window)))
     {
-      GtkRequisition requisition;
-      gtk_widget_size_request (GTK_WIDGET (embed->priv->window), &requisition);
+      GtkRequisition min_req, natural_req;
+      gtk_widget_get_preferred_size (GTK_WIDGET (embed->priv->window), &min_req, &natural_req);
 
-      *min_width_p = *natural_width_p = requisition.width;
+      *min_width_p = min_req.width;
+      *natural_width_p = natural_req.width;
     }
   else
     *min_width_p = *natural_width_p = 0;
@@ -156,10 +157,11 @@ cinnamon_gtk_embed_get_preferred_height (ClutterActor *actor,
   if (embed->priv->window
       && gtk_widget_get_visible (GTK_WIDGET (embed->priv->window)))
     {
-      GtkRequisition requisition;
-      gtk_widget_size_request (GTK_WIDGET (embed->priv->window), &requisition);
+      GtkRequisition min_req, natural_req;
+      gtk_widget_get_preferred_size (GTK_WIDGET (embed->priv->window), &min_req, &natural_req);
 
-      *min_height_p = *natural_height_p = requisition.height;
+      *min_height_p = min_req.height;
+      *natural_height_p = natural_req.height;
     }
   else
     *min_height_p = *natural_height_p = 0;

--- a/src/st/st-texture-cache.c
+++ b/src/st/st-texture-cache.c
@@ -1659,7 +1659,7 @@ st_texture_cache_load_icon_name (StTextureCache    *cache,
     case ST_ICON_FADED:
       themed = g_themed_icon_new_with_default_fallbacks (name);
       cache_key = g_strdup_printf ("faded-icon:%s,size=%d", name, size);
-      data.name = name;
+      data.name = g_strdup (name);
       data.size = size;
       cogltexture = st_texture_cache_load (st_texture_cache_get_default (),
                                       cache_key,
@@ -1667,6 +1667,7 @@ st_texture_cache_load_icon_name (StTextureCache    *cache,
                                       create_faded_icon_cpu,
                                       &data,
                                       NULL);
+      g_free (data.name);
       g_free (cache_key);
 
       if (cogltexture != COGL_INVALID_HANDLE)


### PR DESCRIPTION
- removed several gtk/gdk deprecation warnings
- removed one warning concerning a const string pointer assigned to a non-const string pointer

NEEDS TESTING on Linux Mint 13 and Debian Edition (works on Fedora 17)
