### PR TITLE
Add 'window-marked-urgent' to the signals listened for in the window-list applet

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -782,6 +782,7 @@ MyApplet.prototype = {
             global.screen.connect('notify::n-workspaces',
                                     Lang.bind(this, this._changeWorkspaces));
             global.display.connect('window-demands-attention', Lang.bind(this, this._onWindowDemandsAttention));
+            global.display.connect('window-marked-urgent', Lang.bind(this, this._onWindowDemandsAttention));
                                     
             // this._container.connect('allocate', Lang.bind(Main.panel, this._allocateBoxes)); 
             


### PR DESCRIPTION
Tries to address #1072

The good news:

Fixes window-list alerts for XChat, Empathy.

The bad:

Does not fix Pidgin - I believe this to be a Pidgin issue, not Cinnamon/Muffin.
