### PR TITLE
fix systray icon gaps

### DIFF
--- a/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
@@ -23,14 +23,6 @@ MyApplet.prototype = {
                           redisplay: null };
 
         this.actor.style="spacing: 5px;";
-        try {
-            Main.statusIconDispatcher.connect('status-icon-added', Lang.bind(this, this._onTrayIconAdded));
-            Main.statusIconDispatcher.connect('status-icon-removed', Lang.bind(this, this._onTrayIconRemoved));
-            Main.statusIconDispatcher.connect('before-redisplay', Lang.bind(this, this._onBeforeRedisplay));
-        }
-        catch (e) {
-            global.logError(e);
-        }
     },
 
     on_applet_clicked: function(event) {


### PR DESCRIPTION
Addressing #1106, this patch cleans up a problem probably caused by simultanous development.
