### PR TITLE
Changed AltTab preview delay to 200 ms

### DIFF
--- a/js/ui/altTab.js
+++ b/js/ui/altTab.js
@@ -24,6 +24,8 @@ const THUMBNAIL_DEFAULT_SIZE = 256;
 const THUMBNAIL_POPUP_TIME = 500; // milliseconds
 const THUMBNAIL_FADE_TIME = 0.1; // seconds
 
+const PREVIEW_DELAY_TIMEOUT = 200; // milliseconds
+
 const iconSizes = [96, 64, 48, 32, 22];
 
 function mod(a, b) {
@@ -506,7 +508,7 @@ AltTabPopup.prototype = {
         if (this._displayPreviewTimeoutId) {
             Mainloop.source_remove(this._displayPreviewTimeoutId);
         }
-        this._displayPreviewTimeoutId = Mainloop.timeout_add(100, Lang.bind(this, showPreview));
+        this._displayPreviewTimeoutId = Mainloop.timeout_add(PREVIEW_DELAY_TIMEOUT, Lang.bind(this, showPreview));
     },
     
     /**


### PR DESCRIPTION
Made the preview timeout a bit longer so that the previews don't "flash" switching between windows fast. Experimented with different values and 200 seemed to be the best. Feel free to try it yourself. (For best results, please test by pressing "tab" twice only since you usually get faster if you have a lot of "tab"s to press)
