### PR TITLE
Let "Advanced options" in background sidepage scroll independent of wallpaper pane

### DIFF
--- a/files/usr/lib/cinnamon-settings/cinnamon-settings.py
+++ b/files/usr/lib/cinnamon-settings/cinnamon-settings.py
@@ -644,9 +644,13 @@ class BackgroundSidePage (SidePage):
         
         self.content_box.pack_start(Gtk.HSeparator(), False, False, 2)
         
+        scrolled_window = Gtk.ScrolledWindow();
+        scrolled_window.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.NEVER)
+
         expander = Gtk.Expander()
         expander.set_label(_("Advanced options"))
-        self.content_box.pack_start(expander, False, False, 0)
+        scrolled_window.add_with_viewport(expander);
+        self.content_box.pack_start(scrolled_window, False, True, 0)
         
         advanced_options_box = Gtk.HBox()
         expander.add(advanced_options_box)


### PR DESCRIPTION
Prevent the occurrence of this:
http://imagebin.org/228478
