### PR TITLE
appletManager: avoid access of undefined object

### DIFF
--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -451,9 +451,11 @@ function updateAppletPanelHeights(force_recalc) {
             if (elements[0] == "panel2") {
                 panel = Main.panel2;
             }
-            let newheight = panel.actor.get_height();
-            if (appletObj[uuid]._panelHeight != newheight || force_recalc) {
-                appletObj[uuid].setPanelHeight(newheight);
+            if (appletObj[uuid]) {
+                let newheight = panel.actor.get_height();
+                if (appletObj[uuid]._panelHeight != newheight || force_recalc) {
+                    appletObj[uuid].setPanelHeight(newheight);
+                }
             }
         }
     }


### PR DESCRIPTION
I've lately been seeing the following console output on restarting cinnamon:

```
JS ERROR: !!!   Exception was: TypeError: appletObj[uuid] is undefined
JS ERROR: !!!     lineNumber = '455'
JS ERROR: !!!     fileName = '"/usr/share/cinnamon/js/ui/appletManager.js"'
JS ERROR: !!!     stack = '"updateAppletPanelHeights()@/usr/share/cinnamon/js/ui/appletManager.js:455
([object _private_Cinnamon_GenericContainer])@/usr/share/cinnamon/js/ui/panel.js:808
"'
JS ERROR: !!!     message = '"appletObj[uuid] is undefined"'
```
