### PR TITLE
[RFT] Close modal dialog on press of Escape button

### DIFF
--- a/js/ui/modalDialog.js
+++ b/js/ui/modalDialog.js
@@ -160,7 +160,14 @@ ModalDialog.prototype = {
     },
 
     _onKeyPressEvent: function(object, keyPressEvent) {
+        let modifiers = Cinnamon.get_event_state(keyPressEvent);
+        let ctrlAltMask = Clutter.ModifierType.CONTROL_MASK | Clutter.ModifierType.MOD1_MASK;
         let symbol = keyPressEvent.get_key_symbol();
+        if (symbol === Clutter.Escape && !(modifiers & ctrlAltMask)) {
+            this.close();
+            return;
+        }
+
         let action = this._actionKeys[symbol];
 
         if (action)


### PR DESCRIPTION
This makes Cinnamon's modal dialogs close automatically when the user presses the Escape key. No  action is performed, of course.

How to test: One of the few modal dialogs in Cinnamon is the one presented when Troubleshoot -> "Restore all settings to default" is selected from the panel's context menu. Please note that due to some strange phenomenon, the menu option has to be invoked using the keyboard; if the mouse is used the dialog does not respond to keyboard input at all.

Current status: Ready for test.
