### PR TITLE
fix panels not being covered by fullscreen windows in certain situations

### DIFF
--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -966,18 +966,18 @@ Chrome.prototype = {
 
         for (let i = windows.length - 1; i > -1; i--) {
             let window = windows[i];
-            let layer = window.get_meta_window().get_layer();
+            let metaWindow = window.get_meta_window();
 
             // Skip minimized windows
             if (!window.showing_on_its_workspace())
                 continue;
 
-            if (layer == Meta.StackLayer.FULLSCREEN) {
+            if (metaWindow.is_fullscreen()) {
                 let monitor = this._findMonitorForWindow(window);
                 if (monitor)
                     monitor.inFullscreen = true;
             }
-            if (layer == Meta.StackLayer.OVERRIDE_REDIRECT) {
+            if (metaWindow.is_override_redirect()) {
                 // Check whether the window is screen sized
                 let isScreenSized =
                     (window.x == 0 && window.y == 0 &&


### PR DESCRIPTION
This adresses #733.

Changed the way layout.js checks for fullscreen (and override_redirect) windows. Panels are now covered by all fullscreen windows.
