### PR TITLE
[RFT] Alt-Tab: Fade the switcher's icon bar while showing previews.

### DIFF
--- a/js/ui/altTab.js
+++ b/js/ui/altTab.js
@@ -503,6 +503,12 @@ AltTabPopup.prototype = {
             childBox.y1 = Math.round(or.y -diffY);
             childBox.y2 = Math.round(or.y + or.height + diffY);
             clone.allocate(childBox, 0);
+            clone.opacity = 127;
+            Tweener.addTween(clone,
+                             { opacity: 255,
+                               time: PREVIEW_SWITCHER_FADEOUT_TIME/2,
+                               transition: 'linear'
+                             });
 
             Tweener.addTween(this._appSwitcher.actor,
                              { opacity: 200,


### PR DESCRIPTION
This lowers the Alt-tab icon bar's opacity while a preview is shown. "Icons and window preview" must be the selected Alt-tab mode for this effect to be enabled.

Update: This now also fades in the preview, to make the visual experience less straining on the eye.

Current status: Ready for test.
