### PR TITLE
Fix two issues with dnd and themes using different background for hovering

### DIFF
--- a/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
@@ -279,7 +279,7 @@ MyApplet.prototype = {
 
     _init: function(orientation, panel_height) {
         Applet.Applet.prototype._init.call(this, orientation, panel_height);
-
+        this.actor.set_track_hover(false);
         try {
             this.orientation = orientation;
             this._dragPlaceholder = null;

--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -700,7 +700,7 @@ MyApplet.prototype = {
 
     _init: function(orientation, panel_height) {        
         Applet.Applet.prototype._init.call(this, orientation, panel_height);
-        
+        this.actor.set_track_hover(false);
         try {                    
             this.orientation = orientation;
             this.dragInProgress = false;

--- a/src/st/st-widget.c
+++ b/src/st/st-widget.c
@@ -1904,10 +1904,12 @@ st_widget_sync_hover (StWidget *widget)
   pointer = clutter_device_manager_get_core_device (device_manager,
                                                     CLUTTER_POINTER_DEVICE);
   pointer_actor = clutter_input_device_get_pointer_actor (pointer);
-  if (pointer_actor)
-    st_widget_set_hover (widget, clutter_actor_contains (CLUTTER_ACTOR (widget), pointer_actor));
-  else
-    st_widget_set_hover (widget, FALSE);
+  if (widget->priv->track_hover) {
+    if (pointer_actor)
+      st_widget_set_hover (widget, clutter_actor_contains (CLUTTER_ACTOR (widget), pointer_actor));
+    else
+      st_widget_set_hover (widget, FALSE);
+  }
 }
 
 /**


### PR DESCRIPTION
This fixes two issues with Drag'n'Drop in panel applets in combination with themes that set a different background for hovered items.

1) When trying to drop an item on an applet that doesn't accept it, that applet's actor gets css pseudo class "hover" assigned, even if it's not supposed to get it (neither was track_hover set, nor was checked whether track_hover was set, when syncing the hover states after the drop).

2) When an actor was dropped to its own old position in window-list and panel-launchers, the same hovering problem occured.

This fix sets track_hover = false for both window-list and panel-launchers applet's container actors and makes sure that track_hover is checked when syncing hover states.
