### PR TITLE
Enable the keyboard layout applet's flag icon...

### DIFF
--- a/files/usr/share/cinnamon/applets/keyboard@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/keyboard@cinnamon.org/applet.js
@@ -132,7 +132,7 @@ MyApplet.prototype = {
             let icon_name = this._config.get_group_name(i);
             let actor;
             if (this._showFlags)
-                actor = new St.Icon({ icon_name: icon_name, icon_type: St.IconType.SYMBOLIC, style_class: 'popup-menu-icon' });
+                actor = new St.Icon({ icon_name: icon_name, icon_type: St.IconType.FULLCOLOR, style_class: 'popup-menu-icon' });
             else
                 actor = new St.Label({ text: short_names[i] });
             let item = new LayoutMenuItem(this._config, i, actor, groups[i]);


### PR DESCRIPTION
... be visible in the menu by using FULLCOLOR as icon type for the menu
