### PR TITLE
Simple fix to regression caused by pull request #1186

### DIFF
--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -282,8 +282,8 @@ IconApplet.prototype = {
         this.__icon_name = icon_name;
     },
 
-    set_applet_icon_symbolic_name: function (icon_name) {
-        if (this.__icon_name === icon_name) {
+    set_applet_icon_symbolic_name: function (icon_name, forceUpdate) {
+        if (!forceUpdate && this.__icon_name === icon_name) {
             return;
         }
 
@@ -325,7 +325,7 @@ IconApplet.prototype = {
                 this.set_applet_icon_name(this.__icon_name);
                 break;
             case St.IconType.SYMBOLIC:
-                this.set_applet_icon_symbolic_name(this.__icon_name);
+                this.set_applet_icon_symbolic_name(this.__icon_name, true);
                 break;
             case -1:
                 this.set_applet_icon_path(this.__icon_name);


### PR DESCRIPTION
Pull request #1186 causes a regression which makes some applet icons invisible after switching between scalable and fixed size icons. This fixes the issue by adding an optional forceUpdate parameter to force an icon update even if the icon is the same as the current, to be used internally in the applet's base class.

Update: I have an alternative fix ready, which reverts the change to the applet base class and instead does the caching solely in the network-manager applet: https://github.com/autarkper/Cinnamon/compare/applet-redraw-regression-fix2. This fix is arguably safer as the resulting impact is limited to one single applet.
