### PR TITLE
code cleanup for a little less CPU usage

### DIFF
--- a/src/st/st-widget.c
+++ b/src/st/st-widget.c
@@ -1899,12 +1899,12 @@ st_widget_sync_hover (StWidget *widget)
   ClutterDeviceManager *device_manager;
   ClutterInputDevice *pointer;
   ClutterActor *pointer_actor;
-
-  device_manager = clutter_device_manager_get_default ();
-  pointer = clutter_device_manager_get_core_device (device_manager,
-                                                    CLUTTER_POINTER_DEVICE);
-  pointer_actor = clutter_input_device_get_pointer_actor (pointer);
+  
   if (widget->priv->track_hover) {
+    device_manager = clutter_device_manager_get_default ();
+    pointer = clutter_device_manager_get_core_device (device_manager,
+                                                      CLUTTER_POINTER_DEVICE);
+    pointer_actor = clutter_input_device_get_pointer_actor (pointer);
     if (pointer_actor)
       st_widget_set_hover (widget, clutter_actor_contains (CLUTTER_ACTOR (widget), pointer_actor));
     else


### PR DESCRIPTION
We don't need to fetch the pointer actor, if track_hover is not set.
