### PR TITLE
[Expo, WIP] Tone down the thumbnails' desktop background.

### DIFF
--- a/js/ui/expoThumbnail.js
+++ b/js/ui/expoThumbnail.js
@@ -232,6 +232,7 @@ ExpoWorkspaceThumbnail.prototype = {
         
         this._background = Meta.BackgroundActor.new_for_screen(global.screen);
         this._contents.add_actor(this._background);
+        this._background.dim_factor = 0.4;
 
         let porthole = Main.layoutManager.getPorthole();
         this.setPorthole(porthole);


### PR DESCRIPTION
This tones down the expo thumbnail backgrounds. If they are too toned down, that can easily be changed..

Screenhots:
- Before: http://www.autark.se/dump/expo-current-2012-09-28-09:01:37.png
- After: http://www.autark.se/dump/expo-faded-background4-2012-09-29-10:09:09.png

Current status: Work In Progress.

Update 1: my first iteration produced a background that was too dark (http://www.autark.se/dump/expo-faded-background-2012-09-27%2018:25:49.png).
Update 2: the latest iteration uses a dim_factor of 0.4, which is the same as in Scale.
