### PR TITLE
[Expo, RFT] Make the icons a bit smaller.

### DIFF
--- a/js/ui/expoThumbnail.js
+++ b/js/ui/expoThumbnail.js
@@ -20,7 +20,7 @@ const SLIDE_ANIMATION_TIME = 0.3;
 const INACTIVE_OPACITY = 120;
 const REARRANGE_TIME = 0.3;
 const ICON_OPACITY = 192;
-const ICON_SIZE = 128;
+const ICON_SIZE = 96;
 
 function ExpoWindowClone(realWindow) {
     this._init(realWindow);


### PR DESCRIPTION
This makes the icons that symbolize minimized windows on a workspace a little smaller, so they aren't so prominent.

Screenshots:
- Before: http://www.autark.se/dump/expo-current-icons-2012-09-27-18:58:33.png
- After: http://www.autark.se/dump/expo-smaller-icons-2012-09-27-18:59:17.png

Current status: Ready For Test
