### PR TITLE
[1.6] prevent non-gtk-systray-icons from disappearing on redisplay

### DIFF
--- a/src/cinnamon-gtk-embed.c
+++ b/src/cinnamon-gtk-embed.c
@@ -212,8 +212,9 @@ static void
 cinnamon_gtk_embed_unrealize (ClutterActor *actor)
 {
   CinnamonGtkEmbed *embed = CINNAMON_GTK_EMBED (actor);
-
-  _cinnamon_embedded_window_unrealize (embed->priv->window);
+  
+  if (embed->priv->window)
+    _cinnamon_embedded_window_unrealize (embed->priv->window);
 
   CLUTTER_ACTOR_CLASS (cinnamon_gtk_embed_parent_class)->unrealize (actor);
 }

--- a/src/cinnamon-tray-manager.c
+++ b/src/cinnamon-tray-manager.c
@@ -350,10 +350,12 @@ cinnamon_tray_manager_child_redisplay (gpointer socket_pointer, gpointer child_p
   CinnamonTrayManagerChild *child = child_pointer;
   
   g_return_if_fail(child != NULL);
-  g_return_if_fail(GTK_IS_WIDGET(child->window));
   
-  gtk_widget_unrealize(child->window);
-  gtk_widget_realize(child->window);
+  if (child->actor && CLUTTER_IS_ACTOR(child->actor)) {
+    clutter_actor_destroy(child->actor);
+  }
+  
+  on_plug_added(socket_pointer, child->manager);
 }
 
 void cinnamon_tray_manager_redisplay (CinnamonTrayManager *manager)


### PR DESCRIPTION
When changing panel settings or adding/removing/shuffling applets, systray icons of non-GTK applications disappeared.

When the redisplay was triggered, the actor was destroyed, but only recreated on the icon's application's request. Non-GTK applications don't trigger that request, so we do it for them. For GTK-applications, this does not mean that it is triggered twice.

This adresses and fixes #1073 and (partially) #481.
