### PR TITLE
[startup performance; RFT] Don't default-load theme on startup

### DIFF
--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -218,9 +218,7 @@ function start() {
         applet_side = St.Side.TOP;        
     }
     
-    _defaultCssStylesheet = global.datadir + '/theme/cinnamon.css';
-    loadTheme();
-    
+    _defaultCssStylesheet = global.datadir + '/theme/cinnamon.css';    
     themeManager = new ThemeManager.ThemeManager();
 
     // Set up stage hierarchy to group all UI actors under one container.


### PR DESCRIPTION
This patch removes the initial load of the default theme on startup; the theme manager will load the user's chosen theme in its initialization. This should make for slightly improved Cinnamon startup performance.

Current status: Ready For Test.
