### PR TITLE
[default theme, Expo] Suggestion to harmonize Expo caption look with that of Scale

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -1637,10 +1637,10 @@ StScrollBar StButton#vhandle:hover {
 .expo-workspaces-name-entry {
 	padding: 5px;
 	border-radius: 4px;
-	color: rgb(128, 128, 128);
+	color: rgb(200, 200, 200);
 	border: 2px solid rgb(136,138,133);
-	background-gradient-start: rgb(200,200,200);
-	background-gradient-end: white;
+	background-gradient-start: rgb(128,128,128);
+	background-gradient-end: rgb(85,85,85);
 	background-gradient-direction: vertical;
 	selected-color: black;
 	caret-color: rgb(128, 128, 128);
@@ -1652,14 +1652,16 @@ StScrollBar StButton#vhandle:hover {
 }
 
 .expo-workspaces-name-entry#selected {
-	background-gradient-start: rgb(128,128,128);
-	background-gradient-end: black;
-	color: rgb(200, 200, 200);
+	background-gradient-start: rgb(200,200,200);
+	background-gradient-end: white;
+	font-weight: bold;
+	color: rgb(0, 0, 0);
 }
 
 .expo-workspaces-name-entry:focus {
-	color: rgb(64, 64, 64);
+	color: rgb(0, 0, 0);
 	font-weight: bold;
+	font-style: italic;
 	transition-duration: 300;
 }
 


### PR DESCRIPTION
The default theme uses very different color schemes in Expo and Scale to differentiate between selected and non-selected workspaces or windows, respectively. This is a suggestion on how to make Expo look more like Scale in that respect. I'm not a theme designer, so please feel free to come up with better suggestions.

Screenshots:
- Before: http://www.autark.se/dump/expo-styles-before-2012-10-01-09:53:13.png
- After: http://www.autark.se/dump/expo-styles-after-2012-10-01-09:54:27.png
