### PR TITLE
menu applet: fix #1237

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -144,7 +144,6 @@ ApplicationContextMenuItem.prototype = {
                 AppFavorites.getAppFavorites().removeFavorite(this._appButton.app.get_id());
                 break;
         }
-        this._appButton.actor.grab_key_focus();
         this._appButton.toggleMenu();
         return false;
     }


### PR DESCRIPTION
fix #1237 - get_key_focus was triggering a changed signal on the search text box, which was resetting categories (thinking a search was being performed).
