### PR TITLE
[Code Cleanup] Applet code cleanup

### DIFF
--- a/files/usr/share/cinnamon/applets/a11y@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/a11y@cinnamon.org/applet.js
@@ -36,66 +36,57 @@ function MyApplet(orientation, panel_height) {
 MyApplet.prototype = {
     __proto__: Applet.IconApplet.prototype,
 
-    _init: function(orientation, panel_height) {        
+    _init: function(orientation, panel_height) {
         Applet.IconApplet.prototype._init.call(this, orientation, panel_height);
-        
-        try {        
-            this.set_applet_icon_symbolic_name("preferences-desktop-accessibility");
-            this.set_applet_tooltip(_("Accessibility"));
-            
-            this.menuManager = new PopupMenu.PopupMenuManager(this);
-            this.menu = new Applet.AppletPopupMenu(this, orientation);
-            this.menuManager.addMenu(this.menu);            
-                                
-            let client = GConf.Client.get_default();
-            client.add_dir(KEY_META_DIR, GConf.ClientPreloadType.PRELOAD_ONELEVEL, null);
-            client.notify_add(KEY_META_DIR, Lang.bind(this, this._keyChanged), null, null);
 
-            let highContrast = this._buildHCItem();
-            this.menu.addMenuItem(highContrast);
+        this.set_applet_icon_symbolic_name("preferences-desktop-accessibility");
+        this.set_applet_tooltip(_("Accessibility"));
 
-            let magnifier = this._buildItem(_("Zoom"), APPLICATIONS_SCHEMA,
-                                                       'screen-magnifier-enabled');
-            this.menu.addMenuItem(magnifier);
+        this.menuManager = new PopupMenu.PopupMenuManager(this);
+        this.menu = new Applet.AppletPopupMenu(this, orientation);
+        this.menuManager.addMenu(this.menu);
 
-            let textZoom = this._buildFontItem();
-            this.menu.addMenuItem(textZoom);
+        let client = GConf.Client.get_default();
+        client.add_dir(KEY_META_DIR, GConf.ClientPreloadType.PRELOAD_ONELEVEL, null);
+        client.notify_add(KEY_META_DIR, Lang.bind(this, this._keyChanged), null, null);
 
-    //        let screenReader = this._buildItem(_("Screen Reader"), APPLICATIONS_SCHEMA,
-    //                                                               'screen-reader-enabled');
-    //        this.menu.addMenuItem(screenReader);
+        let highContrast = this._buildHCItem();
+        this.menu.addMenuItem(highContrast);
 
-            let screenKeyboard = this._buildItem(_("Screen Keyboard"), APPLICATIONS_SCHEMA,
+        let magnifier = this._buildItem(_("Zoom"), APPLICATIONS_SCHEMA,
+                                        'screen-magnifier-enabled');
+        this.menu.addMenuItem(magnifier);
+
+        let textZoom = this._buildFontItem();
+        this.menu.addMenuItem(textZoom);
+
+        let screenKeyboard = this._buildItem(_("Screen Keyboard"), APPLICATIONS_SCHEMA,
                                                                        'screen-keyboard-enabled');
-            this.menu.addMenuItem(screenKeyboard);
+        this.menu.addMenuItem(screenKeyboard);
 
-            let visualBell = this._buildItemGConf(_("Visual Alerts"), client, KEY_VISUAL_BELL);
-            this.menu.addMenuItem(visualBell);
+        let visualBell = this._buildItemGConf(_("Visual Alerts"), client, KEY_VISUAL_BELL);
+        this.menu.addMenuItem(visualBell);
 
-            let stickyKeys = this._buildItem(_("Sticky Keys"), A11Y_SCHEMA, KEY_STICKY_KEYS_ENABLED);
-            this.menu.addMenuItem(stickyKeys);
+        let stickyKeys = this._buildItem(_("Sticky Keys"), A11Y_SCHEMA, KEY_STICKY_KEYS_ENABLED);
+        this.menu.addMenuItem(stickyKeys);
 
-            let slowKeys = this._buildItem(_("Slow Keys"), A11Y_SCHEMA, KEY_SLOW_KEYS_ENABLED);
-            this.menu.addMenuItem(slowKeys);
+        let slowKeys = this._buildItem(_("Slow Keys"), A11Y_SCHEMA, KEY_SLOW_KEYS_ENABLED);
+        this.menu.addMenuItem(slowKeys);
 
-            let bounceKeys = this._buildItem(_("Bounce Keys"), A11Y_SCHEMA, KEY_BOUNCE_KEYS_ENABLED);
-            this.menu.addMenuItem(bounceKeys);
+        let bounceKeys = this._buildItem(_("Bounce Keys"), A11Y_SCHEMA, KEY_BOUNCE_KEYS_ENABLED);
+        this.menu.addMenuItem(bounceKeys);
 
-            let mouseKeys = this._buildItem(_("Mouse Keys"), A11Y_SCHEMA, KEY_MOUSE_KEYS_ENABLED);
-            this.menu.addMenuItem(mouseKeys);
+        let mouseKeys = this._buildItem(_("Mouse Keys"), A11Y_SCHEMA, KEY_MOUSE_KEYS_ENABLED);
+        this.menu.addMenuItem(mouseKeys);
 
-            this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-            this.menu.addSettingsAction(_("Universal Access Settings"), 'gnome-universal-access-panel.desktop');
-        }
-        catch (e) {
-            global.logError(e);
-        }
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+        this.menu.addSettingsAction(_("Universal Access Settings"), 'gnome-universal-access-panel.desktop');
     },
-    
+
     on_applet_clicked: function(event) {
-        this.menu.toggle();        
+        this.menu.toggle();
     },
-    
+
      _buildItemExtended: function(string, initial_value, writable, on_set) {
         let widget = new PopupMenu.PopupSwitchMenuItem(string, initial_value);
         if (!writable)
@@ -201,10 +192,10 @@ MyApplet.prototype = {
     _keyChanged: function() {
         this.emit('gconf-changed');
     }
-    
+
 };
 
-function main(metadata, orientation, panel_height) {  
+function main(metadata, orientation, panel_height) {
     let myApplet = new MyApplet(orientation, panel_height);
-    return myApplet;      
+    return myApplet;
 }

--- a/files/usr/share/cinnamon/applets/bluetooth@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/bluetooth@cinnamon.org/applet.js
@@ -204,90 +204,83 @@ function MyApplet(orientation, panel_height) {
 MyApplet.prototype = {
     __proto__: Applet.TextIconApplet.prototype,
 
-    _init: function(orientation, panel_height) {        
+    _init: function(orientation, panel_height) {
         Applet.TextIconApplet.prototype._init.call(this, orientation, panel_height);
-        
-        try {                                
-            this.menuManager = new PopupMenu.PopupMenuManager(this);
-            this.menu = new Applet.AppletPopupMenu(this, orientation);
-            this.menuManager.addMenu(this.menu);            
-            
-            this.set_applet_icon_symbolic_name('bluetooth-disabled');
-            this.set_applet_tooltip(_("Bluetooth"));
-                        
-            GLib.spawn_command_line_sync ('pkill -f "^bluetooth-applet$"');
-            this._applet = new Bluetooth.Applet();
 
-            this._killswitch = new PopupMenu.PopupSwitchMenuItem(_("Bluetooth"), false);
-            this._applet.connect('notify::killswitch-state', Lang.bind(this, this._updateKillswitch));
-            this._killswitch.connect('toggled', Lang.bind(this, function() {
-                let current_state = this._applet.killswitch_state;
-                if (current_state != Bluetooth.KillswitchState.HARD_BLOCKED &&
-                    current_state != Bluetooth.KillswitchState.NO_ADAPTER) {
-                    this._applet.killswitch_state = this._killswitch.state ?
-                        Bluetooth.KillswitchState.UNBLOCKED:
-                        Bluetooth.KillswitchState.SOFT_BLOCKED;
-                } else
-                    this._killswitch.setToggleState(false);
-            }));
+        this.menuManager = new PopupMenu.PopupMenuManager(this);
+        this.menu = new Applet.AppletPopupMenu(this, orientation);
+        this.menuManager.addMenu(this.menu);
 
-            this._discoverable = new PopupMenu.PopupSwitchMenuItem(_("Visibility"), this._applet.discoverable);
-            this._applet.connect('notify::discoverable', Lang.bind(this, function() {
-                this._discoverable.setToggleState(this._applet.discoverable);
-            }));
-            this._discoverable.connect('toggled', Lang.bind(this, function() {
-                this._applet.discoverable = this._discoverable.state;
-            }));
+        this.set_applet_icon_symbolic_name('bluetooth-disabled');
+        this.set_applet_tooltip(_("Bluetooth"));
 
-            this._updateKillswitch();
-            this.menu.addMenuItem(this._killswitch);
-            this.menu.addMenuItem(this._discoverable);
-            this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+        GLib.spawn_command_line_sync ('pkill -f "^bluetooth-applet$"');
+        this._applet = new Bluetooth.Applet();
 
-            this._fullMenuItems = [new PopupMenu.PopupSeparatorMenuItem(),
-                                   new PopupMenu.PopupMenuItem(_("Send Files to Device...")),
-                                   new PopupMenu.PopupMenuItem(_("Set up a New Device...")),
-                                   new PopupMenu.PopupSeparatorMenuItem()];
-            this._hasDevices = false;
+        this._killswitch = new PopupMenu.PopupSwitchMenuItem(_("Bluetooth"), false);
+        this._applet.connect('notify::killswitch-state', Lang.bind(this, this._updateKillswitch));
+        this._killswitch.connect('toggled', Lang.bind(this, function() {
+            let current_state = this._applet.killswitch_state;
+            if (current_state != Bluetooth.KillswitchState.HARD_BLOCKED &&
+                current_state != Bluetooth.KillswitchState.NO_ADAPTER) {
+                this._applet.killswitch_state = this._killswitch.state ?
+                    Bluetooth.KillswitchState.UNBLOCKED:
+                    Bluetooth.KillswitchState.SOFT_BLOCKED;
+            } else
+                this._killswitch.setToggleState(false);
+        }));
 
-            this._fullMenuItems[1].connect('activate', function() {
-                GLib.spawn_command_line_async('bluetooth-sendto');
-            });
-            this._fullMenuItems[2].connect('activate', function() {
-                GLib.spawn_command_line_async('bluetooth-wizard');
-            });
+        this._discoverable = new PopupMenu.PopupSwitchMenuItem(_("Visibility"), this._applet.discoverable);
+        this._applet.connect('notify::discoverable', Lang.bind(this, function() {
+                                                                   this._discoverable.setToggleState(this._applet.discoverable);
+                                                               }));
+        this._discoverable.connect('toggled', Lang.bind(this, function() {
+                                                            this._applet.discoverable = this._discoverable.state;
+                                                        }));
 
-            for (let i = 0; i < this._fullMenuItems.length; i++) {
-                let item = this._fullMenuItems[i];
-                this.menu.addMenuItem(item);
-            }
+        this._updateKillswitch();
+        this.menu.addMenuItem(this._killswitch);
+        this.menu.addMenuItem(this._discoverable);
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
-            this._deviceItemPosition = 3;
-            this._deviceItems = [];
-            this._applet.connect('devices-changed', Lang.bind(this, this._updateDevices));
-            this._updateDevices();
+        this._fullMenuItems = [new PopupMenu.PopupSeparatorMenuItem(),
+                               new PopupMenu.PopupMenuItem(_("Send Files to Device...")),
+                               new PopupMenu.PopupMenuItem(_("Set up a New Device...")),
+                               new PopupMenu.PopupSeparatorMenuItem()];
+        this._hasDevices = false;
 
-            this._applet.connect('notify::show-full-menu', Lang.bind(this, this._updateFullMenu));
-            this._updateFullMenu();
+        this._fullMenuItems[1].connect('activate', function() {
+                                           GLib.spawn_command_line_async('bluetooth-sendto');
+                                       });
+        this._fullMenuItems[2].connect('activate', function() {
+                                           GLib.spawn_command_line_async('bluetooth-wizard');
+                                       });
 
-            this.menu.addSettingsAction(_("Bluetooth Settings"), 'bluetooth-properties.desktop');
-
-            this._applet.connect('pincode-request', Lang.bind(this, this._pinRequest));
-            this._applet.connect('confirm-request', Lang.bind(this, this._confirmRequest));
-            this._applet.connect('auth-request', Lang.bind(this, this._authRequest));
-            this._applet.connect('cancel-request', Lang.bind(this, this._cancelRequest));     
-                      
+        for (let i = 0; i < this._fullMenuItems.length; i++) {
+            let item = this._fullMenuItems[i];
+            this.menu.addMenuItem(item);
         }
-        catch (e) {
-            global.logError(e);
-        }
+
+        this._deviceItemPosition = 3;
+        this._deviceItems = [];
+        this._applet.connect('devices-changed', Lang.bind(this, this._updateDevices));
+        this._updateDevices();
+
+        this._applet.connect('notify::show-full-menu', Lang.bind(this, this._updateFullMenu));
+        this._updateFullMenu();
+
+        this.menu.addSettingsAction(_("Bluetooth Settings"), 'bluetooth-properties.desktop');
+
+        this._applet.connect('pincode-request', Lang.bind(this, this._pinRequest));
+        this._applet.connect('confirm-request', Lang.bind(this, this._confirmRequest));
+        this._applet.connect('auth-request', Lang.bind(this, this._authRequest));
+        this._applet.connect('cancel-request', Lang.bind(this, this._cancelRequest));
     },
-    
+
     on_applet_clicked: function(event) {
-        this.menu.toggle();        
+        this.menu.toggle();
     },
-    
-   
+
     _updateKillswitch: function() {
         let current_state = this._applet.killswitch_state;
         let on = current_state == Bluetooth.KillswitchState.UNBLOCKED;
@@ -528,7 +521,7 @@ MyApplet.prototype = {
     }
 };
 
-function main(metadata, orientation, panel_height) {  
+function main(metadata, orientation, panel_height) {
     let myApplet = new MyApplet(orientation, panel_height);
-    return myApplet;      
+    return myApplet;
 }

--- a/files/usr/share/cinnamon/applets/brightness@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/brightness@cinnamon.org/applet.js
@@ -22,11 +22,11 @@ const PowerManagerInterface = {
             { name: 'GetPercentage', inSignature: '', outSignature: 'u' },
             { name: 'SetPercentage', inSignature: 'u', outSignature: 'u' },
             { name: 'StepUp', inSignature: '', outSignature: 'u' },
-            { name: 'StepDown', inSignature: '', outSignature: 'u' },
+            { name: 'StepDown', inSignature: '', outSignature: 'u' }
         ],
     signals:
         [
-            { name: 'Changed', inSignature: '', outSignature: '' },
+            { name: 'Changed', inSignature: '', outSignature: '' }
         ]
 };
 
@@ -83,10 +83,10 @@ TextImageMenuItem.prototype = {
          let icon_file = icon_path + icon_name + ".svg";
          let file = Gio.file_new_for_path(icon_file);
          let icon_uri = file.get_uri();
- 
+
          return St.TextureCache.get_default().load_uri_sync(1, icon_uri, 16, 16);
-    },
-}
+    }
+};
 /* end of TextImageMenuItem */
 
 function MyApplet(orientation, panel_height) {
@@ -96,106 +96,101 @@ function MyApplet(orientation, panel_height) {
 MyApplet.prototype = {
     __proto__: Applet.IconApplet.prototype,
 
-    _init: function(orientation, panel_height) {        
+    _init: function(orientation, panel_height) {
         Applet.IconApplet.prototype._init.call(this, orientation, panel_height);
-        
-        try {
-            this._proxy = new PowerManagerProxy(DBus.session, PowerBusName, PowerObjectPath);
-            
-            this.menuManager = new PopupMenu.PopupMenuManager(this);
-            this.menu = new Applet.AppletPopupMenu(this, orientation);
-            this.menuManager.addMenu(this.menu);            
-            
-            this.set_applet_icon_symbolic_name('display-brightness-symbolic');
 
-            //this is exactly the same type of label as in sound@cinnamon.org, it uses the same style.
-            this._brightnessTitle = new TextImageMenuItem(_("Brightness"), "display-brightness-symbolic", false, "right", "sound-volume-menu-item");
-            
-            this._brightnessSlider = new PopupMenu.PopupSliderMenuItem(100);
-            this._brightnessSlider.connect('value-changed', Lang.bind(this, this._sliderChanged));
-            
-            this._settingsMenu = new PopupMenu.PopupSubMenuMenuItem(_("Dimming settings"));
-            
-            let dimSwitchAc = this._buildItem(_("Dim screen on AC power"), DimSettingsSchema, DimSettingsAc);
-            this._settingsMenu.menu.addMenuItem(dimSwitchAc);
-            let dimSwitchBattery = this._buildItem(_("Dim screen on battery"), DimSettingsSchema, DimSettingsBattery);
-            this._settingsMenu.menu.addMenuItem(dimSwitchBattery);
-                      
-            //initial update.
-            //We have to wait until dbus calls back to decide whether to display brightness controls.
-            //Therefore, we will put that code into callback function.
-            //Since dbus should be quick, the user won't face an empty menu.
-            this._proxy.GetPercentageRemote(Lang.bind(this, function(b) {
-                if (b != undefined) {
-                    this._updateBrightnessLabel(b);
-                    this._brightnessSlider.setValue(b / 100);
-                    
-                    //add menu items to menu
-                    this.menu.addMenuItem(this._brightnessTitle);
-                    this.menu.addMenuItem(this._brightnessSlider);
-                    this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-                    this.menu.addMenuItem(this._settingsMenu);
-                
-                    //get notified
-                    this._proxy.connect('Changed', Lang.bind(this, this._getBrightness));
-                    this.actor.connect('scroll-event', Lang.bind(this, this._onScrollEvent));
-                } else {
-                    this.set_applet_tooltip(_("Brightness"));
-                    this.menu.addMenuItem(new PopupMenu.PopupMenuItem(_("Brightness not available"), { reactive: false }));
-                    this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-                }
-                
-                this.menu.addSettingsAction(_("Settings"), "gnome-screen-panel.desktop");
-		    }));
-        }
-        catch (e) {
-            global.logError(e);
-        }
+        this._proxy = new PowerManagerProxy(DBus.session, PowerBusName, PowerObjectPath);
+
+        this.menuManager = new PopupMenu.PopupMenuManager(this);
+        this.menu = new Applet.AppletPopupMenu(this, orientation);
+        this.menuManager.addMenu(this.menu);
+
+        this.set_applet_icon_symbolic_name('display-brightness-symbolic');
+
+        //this is exactly the same type of label as in sound@cinnamon.org, it uses the same style.
+        this._brightnessTitle = new TextImageMenuItem(_("Brightness"), "display-brightness-symbolic", false, "right", "sound-volume-menu-item");
+
+        this._brightnessSlider = new PopupMenu.PopupSliderMenuItem(100);
+        this._brightnessSlider.connect('value-changed', Lang.bind(this, this._sliderChanged));
+
+        this._settingsMenu = new PopupMenu.PopupSubMenuMenuItem(_("Dimming settings"));
+
+        let dimSwitchAc = this._buildItem(_("Dim screen on AC power"), DimSettingsSchema, DimSettingsAc);
+        this._settingsMenu.menu.addMenuItem(dimSwitchAc);
+        let dimSwitchBattery = this._buildItem(_("Dim screen on battery"), DimSettingsSchema, DimSettingsBattery);
+        this._settingsMenu.menu.addMenuItem(dimSwitchBattery);
+
+        //initial update.
+        //We have to wait until dbus calls back to decide whether to display brightness controls.
+        //Therefore, we will put that code into callback function.
+        //Since dbus should be quick, the user won't face an empty menu.
+        this._proxy.GetPercentageRemote(Lang.bind(this, function(b) {
+            if (b != undefined) {
+                this._updateBrightnessLabel(b);
+                this._brightnessSlider.setValue(b / 100);
+
+                //add menu items to menu
+                this.menu.addMenuItem(this._brightnessTitle);
+                this.menu.addMenuItem(this._brightnessSlider);
+                this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+                this.menu.addMenuItem(this._settingsMenu);
+
+                //get notified
+                this._proxy.connect('Changed', Lang.bind(this, this._getBrightness));
+                this.actor.connect('scroll-event', Lang.bind(this, this._onScrollEvent));
+            } else {
+                this.set_applet_tooltip(_("Brightness"));
+                this.menu.addMenuItem(new PopupMenu.PopupMenuItem(_("Brightness not available"), { reactive: false }));
+                this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+            }
+
+            this.menu.addSettingsAction(_("Settings"), "gnome-screen-panel.desktop");
+        }));
     },
 
     on_applet_clicked: function(event) {
         this._getBrightnessForcedUpdate();
-        this.menu.toggle();        
+        this.menu.toggle();
     },
-    
+
     /* taken from a11y@cinnamon.org */
     _buildItem: function(string, schema, key) {
         let settings = new Gio.Settings({ schema: schema });
         let widget = this._buildItemExtended(string,
-            settings.get_boolean(key),
-            settings.is_writable(key),
-            function(enabled) {
-                return settings.set_boolean(key, enabled);
-            });
+                                             settings.get_boolean(key),
+                                             settings.is_writable(key),
+                                             function(enabled) {
+                                                 return settings.set_boolean(key, enabled);
+                                             });
         settings.connect('changed::'+key, function() {
-            widget.setToggleState(settings.get_boolean(key));
-        });
+                             widget.setToggleState(settings.get_boolean(key));
+                         });
         return widget;
     },
-    
+
     _buildItemExtended: function(string, initial_value, writable, on_set) {
         let widget = new PopupMenu.PopupSwitchMenuItem(string, initial_value);
         if (!writable)
             widget.actor.reactive = false;
         else
             widget.connect('toggled', function(item) {
-                on_set(item.state);
-            });
+                               on_set(item.state);
+                           });
         return widget;
     },
     /* end taken from a11y@cinnamon.org */
-    
+
     _onScrollEvent: function(actor, event) {
         let direction = event.get_scroll_direction();
         if (direction == Clutter.ScrollDirection.UP) {
-                this._proxy.StepUpRemote(Lang.bind(this, function(b) {}));
+            this._proxy.StepUpRemote(Lang.bind(this, function(b) {}));
         }
         else if (direction == Clutter.ScrollDirection.DOWN) {
-                this._proxy.StepDownRemote(Lang.bind(this, function(b) {}));
+            this._proxy.StepDownRemote(Lang.bind(this, function(b) {}));
         }
         this._getBrightnessForcedUpdate();
     },
-   
+
     _sliderChanged: function(slider, value) {
         this._setBrightness(Math.floor(value * 100));
     },
@@ -205,25 +200,25 @@ MyApplet.prototype = {
         //Only update slider value when menu is NOT visible to prevent slider jumping
         if (!this.menu.isOpen) {
             this._getBrightnessForcedUpdate();
-		}
+        }
     },
-    
+
     _getBrightnessForcedUpdate: function() {
-            this._proxy.GetPercentageRemote(Lang.bind(this, function(b) {
-            this._updateBrightnessLabel(b);
-            this._brightnessSlider.setValue(b / 100);
-		}));
+        this._proxy.GetPercentageRemote(Lang.bind(this, function(b) {
+                                                      this._updateBrightnessLabel(b);
+                                                      this._brightnessSlider.setValue(b / 100);
+                                                  }));
     },
 
     _setBrightness: function(value) {
         this._proxy.SetPercentageRemote(value, Lang.bind(this, function(b) {
-            this._updateBrightnessLabel(b);
-        }));
+                                                             this._updateBrightnessLabel(b);
+                                                         }));
     },
 
     _updateBrightnessLabel: function(value) {
         this._brightnessTitle.setText(_("Brightness") + ": " + value + "%");
-        
+
         if (value != undefined)
             this.set_applet_tooltip(_("Brightness") + ": " + value + "%");
         else
@@ -231,8 +226,8 @@ MyApplet.prototype = {
     }
 };
 
-function main(metadata, orientation, panel_height) {  
+function main(metadata, orientation, panel_height) {
     let myApplet = new MyApplet(orientation, panel_height);
-    return myApplet;      
+    return myApplet;
 }
 

--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
@@ -32,79 +32,73 @@ function MyApplet(orientation, panel_height) {
 MyApplet.prototype = {
     __proto__: Applet.TextApplet.prototype,
 
-    _init: function(orientation, panel_height) {        
+    _init: function(orientation, panel_height) {
         Applet.TextApplet.prototype._init.call(this, orientation, panel_height);
-        
-        try {                 
-            this.menuManager = new PopupMenu.PopupMenuManager(this);
-            
-            this._orientation = orientation;
-            
-            this._initContextMenu();
-                                     
-            this._calendarArea = new St.BoxLayout({name: 'calendarArea' });
-            this.menu.addActor(this._calendarArea);
 
-            // Fill up the first column
+        this.menuManager = new PopupMenu.PopupMenuManager(this);
 
-            let vbox = new St.BoxLayout({vertical: true});
-            this._calendarArea.add(vbox);
+        this._orientation = orientation;
 
-            // Date
-            this._date = new St.Label();
-            this._date.style_class = 'datemenu-date-label';
-            vbox.add(this._date);
-           
-            this._eventSource = null;
-            this._eventList = null;
+        this._initContextMenu();
 
-            // Calendar
-            this._calendar = new Calendar.Calendar(this._eventSource);       
-            vbox.add(this._calendar.actor);
+        this._calendarArea = new St.BoxLayout({name: 'calendarArea' });
+        this.menu.addActor(this._calendarArea);
 
-            let item = new PopupMenu.PopupMenuItem(_("Date and Time Settings"))
-            item.connect("activate", Lang.bind(this, this._onLaunchSettings));
-            //this.menu.addMenuItem(item);
-            if (item) {
-                let separator = new PopupMenu.PopupSeparatorMenuItem();
-                separator.setColumnWidths(1);
-                vbox.add(separator.actor, {y_align: St.Align.END, expand: true, y_fill: false});
+        // Fill up the first column
 
-                item.actor.can_focus = false;
-                item.actor.reparent(vbox);
-            }
+        let vbox = new St.BoxLayout({vertical: true});
+        this._calendarArea.add(vbox);
 
-            // Done with hbox for calendar and event list
+        // Date
+        this._date = new St.Label();
+        this._date.style_class = 'datemenu-date-label';
+        vbox.add(this._date);
 
-            // Track changes to clock settings        
-            this._calendarSettings = new Gio.Settings({ schema: 'org.cinnamon.calendar' });
-            this._dateFormat = null;
-            this._dateFormatFull = null;
-            let getCalendarSettings = Lang.bind(this, function() {
-                this._dateFormat = this._calendarSettings.get_string('date-format');
-                this._dateFormatFull = this._calendarSettings.get_string('date-format-full');
-                this._updateClockAndDate();
-            });
-            this._calendarSettings.connect('changed', getCalendarSettings);
+        this._eventSource = null;
+        this._eventList = null;
 
-            // https://bugzilla.gnome.org/show_bug.cgi?id=655129
-            this._upClient = new UPowerGlib.Client();
-            this._upClient.connect('notify-resume', getCalendarSettings);
+        // Calendar
+        this._calendar = new Calendar.Calendar(this._eventSource);
+        vbox.add(this._calendar.actor);
 
-            // Start the clock
-            getCalendarSettings();
-            this._updateClockAndDatePeriodic();
-     
+        let item = new PopupMenu.PopupMenuItem(_("Date and Time Settings"));
+        item.connect("activate", Lang.bind(this, this._onLaunchSettings));
+        //this.menu.addMenuItem(item);
+        if (item) {
+            let separator = new PopupMenu.PopupSeparatorMenuItem();
+            separator.setColumnWidths(1);
+            vbox.add(separator.actor, {y_align: St.Align.END, expand: true, y_fill: false});
+
+            item.actor.can_focus = false;
+            item.actor.reparent(vbox);
         }
-        catch (e) {
-            global.logError(e);
-        }
+
+        // Done with hbox for calendar and event list
+
+        // Track changes to clock settings
+        this._calendarSettings = new Gio.Settings({ schema: 'org.cinnamon.calendar' });
+        this._dateFormat = null;
+        this._dateFormatFull = null;
+        let getCalendarSettings = Lang.bind(this, function() {
+                                                this._dateFormat = this._calendarSettings.get_string('date-format');
+                                                this._dateFormatFull = this._calendarSettings.get_string('date-format-full');
+                                                this._updateClockAndDate();
+                                            });
+        this._calendarSettings.connect('changed', getCalendarSettings);
+
+        // https://bugzilla.gnome.org/show_bug.cgi?id=655129
+        this._upClient = new UPowerGlib.Client();
+        this._upClient.connect('notify-resume', getCalendarSettings);
+
+        // Start the clock
+        getCalendarSettings();
+        this._updateClockAndDatePeriodic();
     },
-    
+
     on_applet_clicked: function(event) {
         this.menu.toggle();
     },
-    
+
     _onLaunchSettings: function() {
         this.menu.close();
         Util.spawnCommandLine("cinnamon-settings calendar");
@@ -125,7 +119,7 @@ MyApplet.prototype = {
         this._updateClockAndDate();
         this._periodicTimeoutId = Mainloop.timeout_add_seconds(1, Lang.bind(this, this._updateClockAndDatePeriodic));
     },
-    
+
     on_applet_removed_from_panel: function() {
         if (this._periodicTimeoutId){
             Mainloop.source_remove(this._periodicTimeoutId);
@@ -135,15 +129,15 @@ MyApplet.prototype = {
     _initContextMenu: function () {
         if (this._calendarArea) this._calendarArea.unparent();
         if (this.menu) this.menuManager.removeMenu(this.menu);
-        
+
         this.menu = new Applet.AppletPopupMenu(this, this._orientation);
         this.menuManager.addMenu(this.menu);
-        
+
         if (this._calendarArea){
             this.menu.addActor(this._calendarArea);
             this._calendarArea.show_all();
         }
-        
+
         // Whenever the menu is opened, select today
         this.menu.connect('open-state-changed', Lang.bind(this, function(menu, isOpen) {
             if (isOpen) {
@@ -167,15 +161,15 @@ MyApplet.prototype = {
             }
         }));
     },
-    
+
     on_orientation_changed: function (orientation) {
         this._orientation = orientation;
         this._initContextMenu();
     }
-    
+
 };
 
-function main(metadata, orientation, panel_height) {  
+function main(metadata, orientation, panel_height) {
     let myApplet = new MyApplet(orientation, panel_height);
-    return myApplet;      
+    return myApplet;
 }

--- a/files/usr/share/cinnamon/applets/expo@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/expo@cinnamon.org/applet.js
@@ -13,19 +13,14 @@ MyApplet.prototype = {
     _init: function(metadata, orientation, panel_height) {
         Applet.IconApplet.prototype._init.call(this, orientation, panel_height);
 
-        try {
-            Gtk.IconTheme.get_default().append_search_path(metadata.path);
-            this.set_applet_icon_symbolic_name("cinnamon-expo");
-            this.set_applet_tooltip(_("Expo"));
-            this._hover_activates = false;
-            global.settings.connect('changed::panel-edit-mode', Lang.bind(this, this.on_panel_edit_mode_changed));
-            global.settings.connect('changed::expo-applet-hover', Lang.bind(this, this._reload_settings));
-            this.actor.connect('enter-event', Lang.bind(this, this._onEntered));
-            this._reload_settings();
-        }
-        catch (e) {
-            global.logError(e);
-        }
+        Gtk.IconTheme.get_default().append_search_path(metadata.path);
+        this.set_applet_icon_symbolic_name("cinnamon-expo");
+        this.set_applet_tooltip(_("Expo"));
+        this._hover_activates = false;
+        global.settings.connect('changed::panel-edit-mode', Lang.bind(this, this.on_panel_edit_mode_changed));
+        global.settings.connect('changed::expo-applet-hover', Lang.bind(this, this._reload_settings));
+        this.actor.connect('enter-event', Lang.bind(this, this._onEntered));
+        this._reload_settings();
     },
 
     on_panel_edit_mode_changed: function () {

--- a/files/usr/share/cinnamon/applets/keyboard@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/keyboard@cinnamon.org/applet.js
@@ -39,56 +39,50 @@ function MyApplet(metadata, orientation, panel_height) {
 MyApplet.prototype = {
     __proto__: Applet.TextIconApplet.prototype,
 
-    _init: function(metadata, orientation, panel_height) {        
+    _init: function(metadata, orientation, panel_height) {
         Applet.TextIconApplet.prototype._init.call(this, orientation, panel_height);
-        
-        try {  
-            Gtk.IconTheme.get_default().append_search_path(metadata.path + "/flags");                              
-            this.menuManager = new PopupMenu.PopupMenuManager(this);
-            this.menu = new Applet.AppletPopupMenu(this, orientation);
-            this.menuManager.addMenu(this.menu);                            
 
-            this.actor.add_style_class_name('panel-status-button');            
+        Gtk.IconTheme.get_default().append_search_path(metadata.path + "/flags");
+        this.menuManager = new PopupMenu.PopupMenuManager(this);
+        this.menu = new Applet.AppletPopupMenu(this, orientation);
+        this.menuManager.addMenu(this.menu);
 
-            this._labelActors = [ ];
-            this._layoutItems = [ ];
+        this.actor.add_style_class_name('panel-status-button');
 
-            this._showFlags = global.settings.get_boolean("keyboard-applet-use-flags");
-            this._config = Gkbd.Configuration.get();
-            this._config.connect('changed', Lang.bind(this, this._syncConfig));
-            this._config.connect('group-changed', Lang.bind(this, this._syncGroup));
-            global.settings.connect('changed::keyboard-applet-use-flags', Lang.bind(this, this._reload_settings));
-            this._config.start_listen();
+        this._labelActors = [ ];
+        this._layoutItems = [ ];
 
-            this._syncConfig();
+        this._showFlags = global.settings.get_boolean("keyboard-applet-use-flags");
+        this._config = Gkbd.Configuration.get();
+        this._config.connect('changed', Lang.bind(this, this._syncConfig));
+        this._config.connect('group-changed', Lang.bind(this, this._syncGroup));
+        global.settings.connect('changed::keyboard-applet-use-flags', Lang.bind(this, this._reload_settings));
+        this._config.start_listen();
 
-            this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-            this.menu.addAction(_("Show Keyboard Layout"), Lang.bind(this, function() {
-                Main.overview.hide();
-                Util.spawn(['gkbd-keyboard-display', '-g', String(this._config.get_current_group() + 1)]);
-            }));                                
-            this.menu.addAction(_("Show Character Table"), Lang.bind(this, function() {
-                Main.overview.hide();
-                Util.spawn(['gucharmap']);
-            }));
-            this.menu.addSettingsAction(_("Region and Language Settings"), 'gnome-region-panel.desktop'); 
-            
-            this.show_flags_switch = new PopupMenu.PopupSwitchMenuItem(_("Show flags"), this._showFlags);
-            this._applet_context_menu.addMenuItem(this.show_flags_switch);            
-            this.show_flags_switch.connect('toggled', Lang.bind(this, this._toggle_flags));
-                      
-        }
-        catch (e) {
-            global.logError(e);
-        }
+        this._syncConfig();
+
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+        this.menu.addAction(_("Show Keyboard Layout"), Lang.bind(this, function() {
+                                                                     Main.overview.hide();
+                                                                     Util.spawn(['gkbd-keyboard-display', '-g', String(this._config.get_current_group() + 1)]);
+                                                                 }));
+        this.menu.addAction(_("Show Character Table"), Lang.bind(this, function() {
+                                                                     Main.overview.hide();
+                                                                     Util.spawn(['gucharmap']);
+                                                                 }));
+        this.menu.addSettingsAction(_("Region and Language Settings"), 'gnome-region-panel.desktop');
+
+        this.show_flags_switch = new PopupMenu.PopupSwitchMenuItem(_("Show flags"), this._showFlags);
+        this._applet_context_menu.addMenuItem(this.show_flags_switch);
+        this.show_flags_switch.connect('toggled', Lang.bind(this, this._toggle_flags));
     },
-    
+
     on_applet_clicked: function(event) {
-        this.menu.toggle();        
+        this.menu.toggle();
     },
-    
+
     _toggle_flags: function() {
-        if (this._showFlags) {            
+        if (this._showFlags) {
             this.show_flags_switch.setToggleState(false);
             global.settings.set_boolean("keyboard-applet-use-flags", false);
         } else {
@@ -96,12 +90,12 @@ MyApplet.prototype = {
             global.settings.set_boolean("keyboard-applet-use-flags", true);
         }
     },
-    
+
     _reload_settings: function() {
         this._showFlags = global.settings.get_boolean("keyboard-applet-use-flags");
         this._syncConfig();
     },
-    
+
    _adjustGroupNames: function(names) {
         // Disambiguate duplicate names with a subscript
         // This is O(N^2) to avoid sorting names
@@ -185,13 +179,13 @@ MyApplet.prototype = {
         } else {
             this.hide_applet_icon();
             this.set_applet_label(selectedLabel.text);
-        }       
+        }
 
         this._selectedLayout = item;
-    }    
+    }
 };
 
-function main(metadata, orientation, panel_height) {  
+function main(metadata, orientation, panel_height) {
     let myApplet = new MyApplet(metadata, orientation, panel_height);
-    return myApplet;      
+    return myApplet;
 }

--- a/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
@@ -263,7 +263,7 @@ NMWirelessSectionTitleMenuItem.prototype = {
     },
 
     updateForDevice: function(device) {
-		this._device = device;
+        this._device = device;
         // we show the switch
         // - if there not just one device
         // - if the switch is off
@@ -277,22 +277,22 @@ NMWirelessSectionTitleMenuItem.prototype = {
 
     activate: function(event) {
         PopupMenu.PopupSwitchMenuItem.prototype.activate.call(this, event);
-		log(this._setEnabledFunc);
+        log(this._setEnabledFunc);
         this._client[this._setEnabledFunc](this._switch.state);
-                        
+
         if (!this._device) {
             log('Section title activated when there is more than one device, should be non reactive');
             return;
         }
-        
+
         let newState = this._switch.state;
-       
+
         if (newState)
             this._device.activate();
         else
             this._device.deactivate();
-            
-        this.emit('enabled-changed', this._switch.state);        
+
+        this.emit('enabled-changed', this._switch.state);
     },
 
     _propertyChanged: function() {
@@ -388,8 +388,8 @@ NMDevice.prototype = {
         this.section.destroy();
     },
 
-    deactivate: function() {	
-		log("DISCONNECT");	
+    deactivate: function() {
+        log("DISCONNECT");
         this.device.disconnect(function() {});
     },
 
@@ -682,7 +682,7 @@ NMDevice.prototype = {
         let dev_product = this.device.get_product();
         let dev_vendor = this.device.get_vendor();
         if (!dev_product || !dev_vendor)
-	    return '';
+        return '';
 
         let product = Util.fixupPCIDescription(dev_product);
         let vendor = Util.fixupPCIDescription(dev_vendor);
@@ -1146,14 +1146,14 @@ NMDeviceWireless.prototype = {
         if (rsn_flags != NM80211ApSecurityFlags.NONE) {
             /* RSN check first so that WPA+WPA2 APs are treated as RSN/WPA2 */
             if (rsn_flags & NM80211ApSecurityFlags.KEY_MGMT_802_1X)
-	        type = NMAccessPointSecurity.WPA2_ENT;
-	    else if (rsn_flags & NM80211ApSecurityFlags.KEY_MGMT_PSK)
-	        type = NMAccessPointSecurity.WPA2_PSK;
+            type = NMAccessPointSecurity.WPA2_ENT;
+        else if (rsn_flags & NM80211ApSecurityFlags.KEY_MGMT_PSK)
+            type = NMAccessPointSecurity.WPA2_PSK;
         } else if (wpa_flags != NM80211ApSecurityFlags.NONE) {
             if (wpa_flags & NM80211ApSecurityFlags.KEY_MGMT_802_1X)
                 type = NMAccessPointSecurity.WPA_ENT;
             else if (wpa_flags & NM80211ApSecurityFlags.KEY_MGMT_PSK)
-	        type = NMAccessPointSecurity.WPA_PSK;
+            type = NMAccessPointSecurity.WPA_PSK;
         } else {
             if (flags & NM80211ApFlags.PRIVACY)
                 type = NMAccessPointSecurity.WEP;
@@ -1605,141 +1605,134 @@ function MyApplet(orientation, panel_height) {
 MyApplet.prototype = {
     __proto__: Applet.IconApplet.prototype,
 
-    _init: function(orientation, panel_height) {        
+    _init: function(orientation, panel_height) {
         Applet.IconApplet.prototype._init.call(this, orientation, panel_height);
-        
-        try {                                
-            this.menuManager = new PopupMenu.PopupMenuManager(this);
-            this.menu = new Applet.AppletPopupMenu(this, orientation);
-            this.menuManager.addMenu(this.menu);            
-            
-            this._currentIconName = undefined;
-            this._setIcon('network-offline');
 
-            this._client = NMClient.Client.new();
+        this.menuManager = new PopupMenu.PopupMenuManager(this);
+        this.menu = new Applet.AppletPopupMenu(this, orientation);
+        this.menuManager.addMenu(this.menu);
 
-            this._statusSection = new PopupMenu.PopupMenuSection();
-            this._statusItem = new PopupMenu.PopupMenuItem('', { style_class: 'popup-inactive-menu-item', reactive: false });
-            this._statusSection.addMenuItem(this._statusItem);
-            this._statusSection.addAction(_("Enable networking"), Lang.bind(this, function() {
-                this._client.networking_enabled = true;
-            }));
-            this._statusSection.actor.hide();
-            this.menu.addMenuItem(this._statusSection);
-            this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+        this._currentIconName = undefined;
+        this._setIcon('network-offline');
 
-            this._devices = { };
+        this._client = NMClient.Client.new();
 
-            this._devices.wired = {
-                section: new PopupMenu.PopupMenuSection(),
-                devices: [ ],
-                item: new NMWiredSectionTitleMenuItem(_("Wired"))
-            };
+        this._statusSection = new PopupMenu.PopupMenuSection();
+        this._statusItem = new PopupMenu.PopupMenuItem('', { style_class: 'popup-inactive-menu-item', reactive: false });
+        this._statusSection.addMenuItem(this._statusItem);
+        this._statusSection.addAction(_("Enable networking"), Lang.bind(this, function() {
+                                        this._client.networking_enabled = true;
+                                    }));
+        this._statusSection.actor.hide();
+        this.menu.addMenuItem(this._statusSection);
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
-            this._devices.wired.section.addMenuItem(this._devices.wired.item);
-            this._devices.wired.section.actor.hide();
-            this.menu.addMenuItem(this._devices.wired.section);
-            this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+        this._devices = { };
 
-            this._devices.wireless = {
-                section: new PopupMenu.PopupMenuSection(),
-                devices: [ ],
-                item: this._makeToggleItem('wireless', _("Wireless"))
-            };
-            this._devices.wireless.section.addMenuItem(this._devices.wireless.item);
-            this._devices.wireless.section.actor.hide();
-            this.menu.addMenuItem(this._devices.wireless.section);
-            this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+        this._devices.wired = {
+            section: new PopupMenu.PopupMenuSection(),
+            devices: [ ],
+            item: new NMWiredSectionTitleMenuItem(_("Wired"))
+        };
 
-            this._devices.wwan = {
-                section: new PopupMenu.PopupMenuSection(),
-                devices: [ ],
-                item: this._makeToggleItem('wwan', _("Mobile broadband"))
-            };
-            this._devices.wwan.section.addMenuItem(this._devices.wwan.item);
-            this._devices.wwan.section.actor.hide();
-            this.menu.addMenuItem(this._devices.wwan.section);
-            this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+        this._devices.wired.section.addMenuItem(this._devices.wired.item);
+        this._devices.wired.section.actor.hide();
+        this.menu.addMenuItem(this._devices.wired.section);
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
-            this._devices.vpn = {
-                section: new PopupMenu.PopupMenuSection(),
-                device: new NMDeviceVPN(this._client),
-                item: new NMWiredSectionTitleMenuItem(_("VPN Connections"))
-            };
-            this._devices.vpn.device.connect('active-connection-changed', Lang.bind(this, function() {
-                this._devices.vpn.item.updateForDevice(this._devices.vpn.device);
-            }));
-            this._devices.vpn.item.updateForDevice(this._devices.vpn.device);
-            this._devices.vpn.section.addMenuItem(this._devices.vpn.item);
-            this._devices.vpn.section.addMenuItem(this._devices.vpn.device.section);
-            this._devices.vpn.section.actor.hide();
-            this.menu.addMenuItem(this._devices.vpn.section);
-            this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-            this.menu.addSettingsAction(_("Network Settings"), 'gnome-network-panel.desktop');
+        this._devices.wireless = {
+            section: new PopupMenu.PopupMenuSection(),
+            devices: [ ],
+            item: this._makeToggleItem('wireless', _("Wireless"))
+        };
+        this._devices.wireless.section.addMenuItem(this._devices.wireless.item);
+        this._devices.wireless.section.actor.hide();
+        this.menu.addMenuItem(this._devices.wireless.section);
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
-            this._activeConnections = [ ];
-            this._connections = [ ];
+        this._devices.wwan = {
+            section: new PopupMenu.PopupMenuSection(),
+            devices: [ ],
+            item: this._makeToggleItem('wwan', _("Mobile broadband"))
+        };
+        this._devices.wwan.section.addMenuItem(this._devices.wwan.item);
+        this._devices.wwan.section.actor.hide();
+        this.menu.addMenuItem(this._devices.wwan.section);
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
-            this._mainConnection = null;
+        this._devices.vpn = {
+            section: new PopupMenu.PopupMenuSection(),
+            device: new NMDeviceVPN(this._client),
+            item: new NMWiredSectionTitleMenuItem(_("VPN Connections"))
+        };
+        this._devices.vpn.device.connect('active-connection-changed', Lang.bind(this, function() {
+                                            this._devices.vpn.item.updateForDevice(this._devices.vpn.device);
+                                        }));
+        this._devices.vpn.item.updateForDevice(this._devices.vpn.device);
+        this._devices.vpn.section.addMenuItem(this._devices.vpn.item);
+        this._devices.vpn.section.addMenuItem(this._devices.vpn.device.section);
+        this._devices.vpn.section.actor.hide();
+        this.menu.addMenuItem(this._devices.vpn.section);
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+        this.menu.addSettingsAction(_("Network Settings"), 'gnome-network-panel.desktop');
 
-            // Device types
-            this._dtypes = { };
-            this._dtypes[NetworkManager.DeviceType.ETHERNET] = NMDeviceWired;
-            this._dtypes[NetworkManager.DeviceType.WIFI] = NMDeviceWireless;
-            this._dtypes[NetworkManager.DeviceType.MODEM] = NMDeviceModem;
-            this._dtypes[NetworkManager.DeviceType.BT] = NMDeviceBluetooth;
-            // TODO: WiMax support
+        this._activeConnections = [ ];
+        this._connections = [ ];
 
-            // Connection types
-            this._ctypes = { };
-            this._ctypes[NetworkManager.SETTING_WIRELESS_SETTING_NAME] = NMConnectionCategory.WIRELESS;
-            this._ctypes[NetworkManager.SETTING_WIRED_SETTING_NAME] = NMConnectionCategory.WIRED;
-            this._ctypes[NetworkManager.SETTING_PPPOE_SETTING_NAME] = NMConnectionCategory.WIRED;
-            this._ctypes[NetworkManager.SETTING_PPP_SETTING_NAME] = NMConnectionCategory.WIRED;
-            this._ctypes[NetworkManager.SETTING_BLUETOOTH_SETTING_NAME] = NMConnectionCategory.WWAN;
-            this._ctypes[NetworkManager.SETTING_CDMA_SETTING_NAME] = NMConnectionCategory.WWAN;
-            this._ctypes[NetworkManager.SETTING_GSM_SETTING_NAME] = NMConnectionCategory.WWAN;
-            this._ctypes[NetworkManager.SETTING_VPN_SETTING_NAME] = NMConnectionCategory.VPN;
+        this._mainConnection = null;
 
-            this._settings = NMClient.RemoteSettings.new(null);
-            this._connectionsReadId = this._settings.connect('connections-read', Lang.bind(this, function() {
-                this._readConnections();
-                this._readDevices();
-                this._syncNMState();
+        // Device types
+        this._dtypes = { };
+        this._dtypes[NetworkManager.DeviceType.ETHERNET] = NMDeviceWired;
+        this._dtypes[NetworkManager.DeviceType.WIFI] = NMDeviceWireless;
+        this._dtypes[NetworkManager.DeviceType.MODEM] = NMDeviceModem;
+        this._dtypes[NetworkManager.DeviceType.BT] = NMDeviceBluetooth;
+        // TODO: WiMax support
 
-                // Connect to signals late so that early signals don't find in inconsistent state
-                // and connect only once (this signal handler can be called again if NetworkManager goes up and down)
-                if (!this._inited) {
-                    this._inited = true;
-                    this._client.connect('notify::manager-running', Lang.bind(this, this._syncNMState));
-                    this._client.connect('notify::networking-enabled', Lang.bind(this, this._syncNMState));
-                    this._client.connect('notify::state', Lang.bind(this, this._syncNMState));
-                    this._client.connect('notify::active-connections', Lang.bind(this, this._updateIcon));
-                    this._client.connect('device-added', Lang.bind(this, this._deviceAdded));
-                    this._client.connect('device-removed', Lang.bind(this, this._deviceRemoved));
-                    this._settings.connect('new-connection', Lang.bind(this, this._newConnection));
-                }
-            }));
-            
-            this._periodicUpdateIcon();
-            
-        }
-        catch (e) {
-            global.logError(e);
-        }
+        // Connection types
+        this._ctypes = { };
+        this._ctypes[NetworkManager.SETTING_WIRELESS_SETTING_NAME] = NMConnectionCategory.WIRELESS;
+        this._ctypes[NetworkManager.SETTING_WIRED_SETTING_NAME] = NMConnectionCategory.WIRED;
+        this._ctypes[NetworkManager.SETTING_PPPOE_SETTING_NAME] = NMConnectionCategory.WIRED;
+        this._ctypes[NetworkManager.SETTING_PPP_SETTING_NAME] = NMConnectionCategory.WIRED;
+        this._ctypes[NetworkManager.SETTING_BLUETOOTH_SETTING_NAME] = NMConnectionCategory.WWAN;
+        this._ctypes[NetworkManager.SETTING_CDMA_SETTING_NAME] = NMConnectionCategory.WWAN;
+        this._ctypes[NetworkManager.SETTING_GSM_SETTING_NAME] = NMConnectionCategory.WWAN;
+        this._ctypes[NetworkManager.SETTING_VPN_SETTING_NAME] = NMConnectionCategory.VPN;
+
+        this._settings = NMClient.RemoteSettings.new(null);
+        this._connectionsReadId = this._settings.connect('connections-read', Lang.bind(this, function() {
+           this._readConnections();
+           this._readDevices();
+           this._syncNMState();
+
+           // Connect to signals late so that early signals don't find in inconsistent state
+           // and connect only once (this signal handler can be called again if NetworkManager goes up and down)
+           if (!this._inited) {
+               this._inited = true;
+               this._client.connect('notify::manager-running', Lang.bind(this, this._syncNMState));
+               this._client.connect('notify::networking-enabled', Lang.bind(this, this._syncNMState));
+               this._client.connect('notify::state', Lang.bind(this, this._syncNMState));
+               this._client.connect('notify::active-connections', Lang.bind(this, this._updateIcon));
+               this._client.connect('device-added', Lang.bind(this, this._deviceAdded));
+               this._client.connect('device-removed', Lang.bind(this, this._deviceRemoved));
+               this._settings.connect('new-connection', Lang.bind(this, this._newConnection));
+           }
+        }));
+        this._periodicUpdateIcon();
     },
-    
+
     _setIcon: function(name) {
         if (this._currentIconName !== name) {
             this.set_applet_icon_symbolic_name(name);
             this._currentIconName = name;
         }
     },
-    
+
     on_applet_clicked: function(event) {
-        this.menu.toggle();        
+        this.menu.toggle();
     },
-    
+
     _ensureSource: function() {
         if (!this._source) {
             this._source = new NMMessageTraySource();
@@ -2102,8 +2095,8 @@ MyApplet.prototype = {
             let hasMobileIcon = false;
 
             if (!mc) {
-                this._setIcon('network-offline');         
-                this.set_applet_tooltip(_("No connection"));   
+                this._setIcon('network-offline');
+                this.set_applet_tooltip(_("No connection"));
             } else if (mc.state == NetworkManager.ActiveConnectionState.ACTIVATING) {
                 this._updateFrequencySeconds = FAST_PERIODIC_UPDATE_FREQUENCY_SECONDS;
                 switch (mc._section) {
@@ -2144,8 +2137,8 @@ MyApplet.prototype = {
                             }
                             this._setIcon('network-wireless-connected');
                             this.set_applet_tooltip(_("Connected to the wireless network"));
-                        } else {                          
-                            this._setIcon('network-wireless-signal-' + signalToIcon(ap.strength));                            
+                        } else {
+                            this._setIcon('network-wireless-signal-' + signalToIcon(ap.strength));
                             this.set_applet_tooltip(_("Wireless connection") + ": " + ap.get_ssid() + " ("+ ap.strength +"%)");
                             hasApIcon = true;
                         }
@@ -2186,13 +2179,12 @@ MyApplet.prototype = {
                     this.set_applet_tooltip(_("Connected to the network"));
                     break;
                 }
-            }            
-        }
-        catch (e) {
+            }
+        } catch (e) {
             global.logError(e);
-        }                        
+        }
     },
-    
+
     _periodicUpdateIcon: function() {
         this._updateIcon();
         this._updateFrequencySeconds = Math.max(2, this._updateFrequencySeconds);
@@ -2207,7 +2199,7 @@ MyApplet.prototype = {
 
 };
 
-function main(metadata, orientation, panel_height) {  
+function main(metadata, orientation, panel_height) {
     let myApplet = new MyApplet(orientation, panel_height);
-    return myApplet;      
+    return myApplet;
 }

--- a/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
@@ -280,27 +280,22 @@ MyApplet.prototype = {
     _init: function(orientation, panel_height) {
         Applet.Applet.prototype._init.call(this, orientation, panel_height);
         this.actor.set_track_hover(false);
-        try {
-            this.orientation = orientation;
-            this._dragPlaceholder = null;
-            this._dragPlaceholderPos = -1;
-            this._animatingPlaceholdersCount = 0;
+        this.orientation = orientation;
+        this._dragPlaceholder = null;
+        this._dragPlaceholderPos = -1;
+        this._animatingPlaceholdersCount = 0;
 
-            this.myactor = new St.BoxLayout({ name: 'panel-launchers-box',
-                                              style_class: 'panel-launchers-box' });
-            global.settings.connect('changed::' + PANEL_LAUNCHERS_KEY, Lang.bind(this, this._onSettingsChanged));
+        this.myactor = new St.BoxLayout({ name: 'panel-launchers-box',
+                                          style_class: 'panel-launchers-box' });
+        global.settings.connect('changed::' + PANEL_LAUNCHERS_KEY, Lang.bind(this, this._onSettingsChanged));
 
-            this._launchers = new Array();
+        this._launchers = new Array();
 
-            this.reload();
+        this.reload();
 
-            this.actor.add(this.myactor);
-            this.actor.reactive = global.settings.get_boolean(PANEL_EDIT_MODE_KEY);
-            global.settings.connect('changed::' + PANEL_EDIT_MODE_KEY, Lang.bind(this, this._onPanelEditModeChanged));
-        }
-        catch (e) {
-            global.logError(e);
-        }
+        this.actor.add(this.myactor);
+        this.actor.reactive = global.settings.get_boolean(PANEL_EDIT_MODE_KEY);
+        global.settings.connect('changed::' + PANEL_EDIT_MODE_KEY, Lang.bind(this, this._onPanelEditModeChanged));
     },
 
     _onPanelEditModeChanged: function() {
@@ -421,9 +416,9 @@ MyApplet.prototype = {
                     this._dragPlaceholder.animateOutAndDestroy();
                     this._animatingPlaceholdersCount++;
                     this._dragPlaceholder.actor.connect('destroy',
-							Lang.bind(this, function() {
-							    this._animatingPlaceholdersCount--;
-							}));
+                                                        Lang.bind(this, function() {
+                                                            this._animatingPlaceholdersCount--;
+                                                        }));
                 }
                 this._dragPlaceholder = null;
 

--- a/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
@@ -6,7 +6,7 @@ const St = imports.gi.St;
 const PopupMenu = imports.ui.popupMenu;
 const Pango = imports.gi.Pango;
 
-const POWER_SCHEMA = "org.cinnamon.power"
+const POWER_SCHEMA = "org.cinnamon.power";
 const SHOW_PERCENTAGE_KEY = "power-label";
 const BUS_NAME = 'org.gnome.SettingsDaemon';
 const OBJECT_PATH = '/org/gnome/SettingsDaemon/Power';
@@ -46,27 +46,27 @@ const PowerManagerInterface = {
     name: 'org.gnome.SettingsDaemon.Power',
     methods: [
         { name: 'GetDevices', inSignature: '', outSignature: 'a(susdut)' },
-        { name: 'GetPrimaryDevice', inSignature: '', outSignature: '(susdut)' },
+        { name: 'GetPrimaryDevice', inSignature: '', outSignature: '(susdut)' }
         ],
     signals: [
-        { name: 'PropertiesChanged', inSignature: 's,a{sv},a[s]' },
+        { name: 'PropertiesChanged', inSignature: 's,a{sv},a[s]' }
         ],
     properties: [
-        { name: 'Icon', signature: 's', access: 'read' },
+        { name: 'Icon', signature: 's', access: 'read' }
         ]
 };
 let PowerManagerProxy = DBus.makeProxyClass(PowerManagerInterface);
 
 const SettingsManagerInterface = {
-	name: 'org.freedesktop.DBus.Properties',
-	methods: [
-		{ name: 'Get', inSignature: 's,s', outSignature: 'v' },
-		{ name: 'GetAll', inSignature: 's', outSignature: 'a{sv}' },
-		{ name: 'Set', inSignature: 's,s,v', outSignature: '' }
-	],
-	signals: [
-	{name: 'PropertiesChanged', inSignature:'s,a{sv},a[s]', outSignature:''}
-	]
+        name: 'org.freedesktop.DBus.Properties',
+        methods: [
+                { name: 'Get', inSignature: 's,s', outSignature: 'v' },
+                { name: 'GetAll', inSignature: 's', outSignature: 'a{sv}' },
+                { name: 'Set', inSignature: 's,s,v', outSignature: '' }
+        ],
+        signals: [
+        {name: 'PropertiesChanged', inSignature:'s,a{sv},a[s]', outSignature:''}
+        ]
 };
 
 let SettingsManagerProxy = DBus.makeProxyClass(SettingsManagerInterface);
@@ -136,109 +136,104 @@ function MyApplet(orientation, panel_height) {
 MyApplet.prototype = {
     __proto__: Applet.TextIconApplet.prototype,
 
-    _init: function(orientation, panel_height) {        
+    _init: function(orientation, panel_height) {
         Applet.TextIconApplet.prototype._init.call(this, orientation, panel_height);
-        
-        try {                                
-            this.menuManager = new PopupMenu.PopupMenuManager(this);
-            this.menu = new Applet.AppletPopupMenu(this, orientation);
-            this.menuManager.addMenu(this.menu);            
-            
-            this.set_applet_icon_symbolic_name('battery-missing');            
-            this._proxy = new PowerManagerProxy(DBus.session, BUS_NAME, OBJECT_PATH);
-            this._smProxy = new SettingsManagerProxy(DBus.session, BUS_NAME, OBJECT_PATH);
-            
-            let icon = this.actor.get_children()[0];
-            this.actor.remove_actor(icon);
-            let box = new St.BoxLayout({ name: 'batteryBox' });
-            this.actor.add_actor(box);
-            let iconBox = new St.Bin();
-            box.add(iconBox, { y_align: St.Align.MIDDLE, y_fill: false });
-            this._mainLabel = new St.Label();
-            this._mainLabel.clutter_text.ellipsize = Pango.EllipsizeMode.NONE;
-            box.add(this._mainLabel, { y_align: St.Align.MIDDLE, y_fill: false });
-            iconBox.child = icon;
 
-            this._deviceItems = [ ];
-            this._hasPrimary = false;
-            this._primaryDeviceId = null;
-            
-            let settings = new Gio.Settings({ schema: POWER_SCHEMA }); 
-            this._labelDisplay = settings.get_string(SHOW_PERCENTAGE_KEY);
-            let applet = this;
-            settings.connect('changed::'+SHOW_PERCENTAGE_KEY, function() {
-                applet._switchLabelDisplay(settings.get_string(SHOW_PERCENTAGE_KEY));
-            });
+        this.menuManager = new PopupMenu.PopupMenuManager(this);
+        this.menu = new Applet.AppletPopupMenu(this, orientation);
+        this.menuManager.addMenu(this.menu);
 
-            this._batteryItem = new PopupMenu.PopupMenuItem('', { reactive: false });
-            this._primaryPercentage = new St.Label();
-            this._batteryItem.addActor(this._primaryPercentage, { align: St.Align.END });
-            this.menu.addMenuItem(this._batteryItem);
+        this.set_applet_icon_symbolic_name('battery-missing');
+        this._proxy = new PowerManagerProxy(DBus.session, BUS_NAME, OBJECT_PATH);
+        this._smProxy = new SettingsManagerProxy(DBus.session, BUS_NAME, OBJECT_PATH);
 
-            this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-            this._otherDevicePosition = 2;
-            
-            // Setup label display settings
-            this._displayItem = new PopupMenu.PopupSubMenuMenuItem(_("Display"));
-            this.menu.addMenuItem(this._displayItem);
-            this._displayPercentageItem = new PopupMenu.PopupMenuItem(_("Show percentage"));
-            this._displayPercentageItem.connect('activate', Lang.bind(this, function() {
-                settings.set_string(SHOW_PERCENTAGE_KEY, LabelDisplay.PERCENT);
-            }));
-            this._displayItem.menu.addMenuItem(this._displayPercentageItem);
-            this._displayTimeItem = new PopupMenu.PopupMenuItem(_("Show time remaining"));
-            this._displayTimeItem.connect('activate', Lang.bind(this, function() {
-                settings.set_string(SHOW_PERCENTAGE_KEY, LabelDisplay.TIME);
-            }));
-            this._displayItem.menu.addMenuItem(this._displayTimeItem);
-            this._displayNoneItem = new PopupMenu.PopupMenuItem(_("Hide label"));
-            this._displayNoneItem.connect('activate', Lang.bind(this, function() {
-                settings.set_string(SHOW_PERCENTAGE_KEY, LabelDisplay.NONE);
-            }));
-            this._displayItem.menu.addMenuItem(this._displayNoneItem);
-            this._switchLabelDisplay(this._labelDisplay);
+        let icon = this.actor.get_children()[0];
+        this.actor.remove_actor(icon);
+        let box = new St.BoxLayout({ name: 'batteryBox' });
+        this.actor.add_actor(box);
+        let iconBox = new St.Bin();
+        box.add(iconBox, { y_align: St.Align.MIDDLE, y_fill: false });
+        this._mainLabel = new St.Label();
+        this._mainLabel.clutter_text.ellipsize = Pango.EllipsizeMode.NONE;
+        box.add(this._mainLabel, { y_align: St.Align.MIDDLE, y_fill: false });
+        iconBox.child = icon;
 
-            this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-            this.menu.addSettingsAction(_("Power Settings"), 'gnome-power-panel.desktop');
+        this._deviceItems = [ ];
+        this._hasPrimary = false;
+        this._primaryDeviceId = null;
 
-            this._smProxy.connect('PropertiesChanged', Lang.bind(this, this._devicesChanged));
-            this._devicesChanged();            
-        }
-        catch (e) {
-            global.logError(e);
-        }
+        let settings = new Gio.Settings({ schema: POWER_SCHEMA });
+        this._labelDisplay = settings.get_string(SHOW_PERCENTAGE_KEY);
+        let applet = this;
+        settings.connect('changed::'+SHOW_PERCENTAGE_KEY, function() {
+                             applet._switchLabelDisplay(settings.get_string(SHOW_PERCENTAGE_KEY));
+                         });
+
+        this._batteryItem = new PopupMenu.PopupMenuItem('', { reactive: false });
+        this._primaryPercentage = new St.Label();
+        this._batteryItem.addActor(this._primaryPercentage, { align: St.Align.END });
+        this.menu.addMenuItem(this._batteryItem);
+
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+        this._otherDevicePosition = 2;
+
+        // Setup label display settings
+        this._displayItem = new PopupMenu.PopupSubMenuMenuItem(_("Display"));
+        this.menu.addMenuItem(this._displayItem);
+        this._displayPercentageItem = new PopupMenu.PopupMenuItem(_("Show percentage"));
+        this._displayPercentageItem.connect('activate', Lang.bind(this, function() {
+                                                                      settings.set_string(SHOW_PERCENTAGE_KEY, LabelDisplay.PERCENT);
+                                                                  }));
+        this._displayItem.menu.addMenuItem(this._displayPercentageItem);
+        this._displayTimeItem = new PopupMenu.PopupMenuItem(_("Show time remaining"));
+        this._displayTimeItem.connect('activate', Lang.bind(this, function() {
+                                                                settings.set_string(SHOW_PERCENTAGE_KEY, LabelDisplay.TIME);
+                                                            }));
+        this._displayItem.menu.addMenuItem(this._displayTimeItem);
+        this._displayNoneItem = new PopupMenu.PopupMenuItem(_("Hide label"));
+        this._displayNoneItem.connect('activate', Lang.bind(this, function() {
+                                                                settings.set_string(SHOW_PERCENTAGE_KEY, LabelDisplay.NONE);
+                                                            }));
+        this._displayItem.menu.addMenuItem(this._displayNoneItem);
+        this._switchLabelDisplay(this._labelDisplay);
+
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+        this.menu.addSettingsAction(_("Power Settings"), 'gnome-power-panel.desktop');
+
+        this._smProxy.connect('PropertiesChanged', Lang.bind(this, this._devicesChanged));
+        this._devicesChanged();
     },
-    
+
     on_applet_clicked: function(event) {
-        this.menu.toggle();        
+        this.menu.toggle();
     },
 
     _switchLabelDisplay: function(display) {
-            this._labelDisplay = display;
+        this._labelDisplay = display;
 
-            this._displayPercentageItem.setShowDot(false);
-            this._displayNoneItem.setShowDot(false);
-            this._displayTimeItem.setShowDot(false);
+        this._displayPercentageItem.setShowDot(false);
+        this._displayNoneItem.setShowDot(false);
+        this._displayTimeItem.setShowDot(false);
 
-            if (this._labelDisplay == LabelDisplay.PERCENT) {
-                this._displayPercentageItem.setShowDot(true);
-            }
-            else if (this._labelDisplay == LabelDisplay.TIME) {
-                this._displayTimeItem.setShowDot(true);
-            }
-            else {
-                this._displayNoneItem.setShowDot(true);
-            }
+        if (this._labelDisplay == LabelDisplay.PERCENT) {
+            this._displayPercentageItem.setShowDot(true);
+        }
+        else if (this._labelDisplay == LabelDisplay.TIME) {
+            this._displayTimeItem.setShowDot(true);
+        }
+        else {
+            this._displayNoneItem.setShowDot(true);
+        }
 
-            this._updateLabel();
+        this._updateLabel();
     },
-    
+
     _readPrimaryDevice: function() {
         this._proxy.GetPrimaryDeviceRemote(Lang.bind(this, function(device, error) {
             if (error) {
                 this._hasPrimary = false;
                 this._primaryDeviceId = null;
-                this._batteryItem.actor.hide();                
+                this._batteryItem.actor.hide();
                 return;
             }
             let [device_id, device_type, icon, percentage, state, seconds] = device;
@@ -309,7 +304,7 @@ MyApplet.prototype = {
     _devicesChanged: function() {
         this.set_applet_icon_symbolic_name('battery-missing');
         this._proxy.GetRemote('Icon', Lang.bind(this, function(icon, error) {
-            if (icon) {    
+            if (icon) {
                 let gicon = Gio.icon_new_for_string(icon);
                 this._applet_icon.gicon = gicon;
                 this.actor.show();
@@ -322,7 +317,7 @@ MyApplet.prototype = {
         this._readOtherDevices();
         this._updateLabel();
     },
-    
+
     _updateLabel: function() {
         this._proxy.GetDevicesRemote(Lang.bind(this, function(devices, error) {
             if (error) {
@@ -355,10 +350,9 @@ MyApplet.prototype = {
             this._mainLabel.set_text("");
         }));
     }
-    
 };
 
-function main(metadata, orientation, panel_height) {  
+function main(metadata, orientation, panel_height) {
     let myApplet = new MyApplet(orientation, panel_height);
-    return myApplet;      
+    return myApplet;
 }

--- a/files/usr/share/cinnamon/applets/recent@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/recent@cinnamon.org/applet.js
@@ -33,30 +33,25 @@ function MyApplet(orientation, panel_height) {
 MyApplet.prototype = {
     __proto__: Applet.IconApplet.prototype,
 
-    _init: function(orientation, panel_height) {        
+    _init: function(orientation, panel_height) {
         Applet.IconApplet.prototype._init.call(this, orientation, panel_height);
-        
-        try {        
-            this.set_applet_icon_symbolic_name("document-open-recent");
-            this.set_applet_tooltip(_("Recent documents"));
-            
-            this.menuManager = new PopupMenu.PopupMenuManager(this);
-            this.menu = new Applet.AppletPopupMenu(this, orientation);
-            this.menuManager.addMenu(this.menu);            
-                                                                
-            this.RecentManager = new DocInfo.DocManager();
-            this._display();
-            this.RecentManager.connect('changed', Lang.bind(this, this._redisplay));
-        }
-        catch (e) {
-            global.logError(e);
-        }
+
+        this.set_applet_icon_symbolic_name("document-open-recent");
+        this.set_applet_tooltip(_("Recent documents"));
+
+        this.menuManager = new PopupMenu.PopupMenuManager(this);
+        this.menu = new Applet.AppletPopupMenu(this, orientation);
+        this.menuManager.addMenu(this.menu);
+
+        this.RecentManager = new DocInfo.DocManager();
+        this._display();
+        this.RecentManager.connect('changed', Lang.bind(this, this._redisplay));
     },
-    
+
     on_applet_clicked: function(event) {
-        this.menu.toggle();        
+        this.menu.toggle();
     },
-    
+
     _display: function() {
         for (let id = 0; id < 15 && id < this.RecentManager._infosByTimestamp.length; id++) {
             let icon = this.RecentManager._infosByTimestamp[id].createIcon(22);
@@ -74,21 +69,21 @@ MyApplet.prototype = {
             this.menu.addMenuItem(new PopupMenu.PopupMenuItem(_("No recent documents")));
         }
     },
-    
+
     _redisplay: function() {
         this.menu.removeAll();
         this._display();
     },
 
-    _launchFile: function(a, b, c) {        
+    _launchFile: function(a, b, c) {
         Gio.app_info_launch_default_for_uri(c, global.create_app_launch_context());
     },
-    
+
     _clearAll: function() {
         let GtkRecent = new Gtk.RecentManager();
         GtkRecent.purge_items();
     },
-    
+
     destroy: function() {
         this.RecentManager.disconnectAll();
         this.actor._delegate = null;
@@ -98,7 +93,7 @@ MyApplet.prototype = {
     }
 };
 
-function main(metadata, orientation, panel_height) {  
+function main(metadata, orientation, panel_height) {
     let myApplet = new MyApplet(orientation, panel_height);
-    return myApplet;      
+    return myApplet;
 }

--- a/files/usr/share/cinnamon/applets/removable-drives@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/removable-drives@cinnamon.org/applet.js
@@ -21,8 +21,8 @@ DriveMenuItem.prototype = {
         this.addActor(this.label);
 
         let ejectIcon = new St.Icon({ icon_name: 'media-eject',
-				      icon_type: St.IconType.SYMBOLIC,
-				      style_class: 'popup-menu-icon ' });
+                                      icon_type: St.IconType.SYMBOLIC,
+                                      style_class: 'popup-menu-icon ' });
         let ejectButton = new St.Button({ child: ejectIcon });
         ejectButton.connect('clicked', Lang.bind(this, this._eject));
         this.addActor(ejectButton);
@@ -45,40 +45,35 @@ function MyApplet(orientation, panel_height) {
 MyApplet.prototype = {
     __proto__: Applet.IconApplet.prototype,
 
-    _init: function(orientation, panel_height) {        
+    _init: function(orientation, panel_height) {
         Applet.IconApplet.prototype._init.call(this, orientation, panel_height);
-        
-        try {        
-            this.set_applet_icon_symbolic_name("drive-harddisk");
-            this.set_applet_tooltip(_("Removable drives"));
-            
-            this.menuManager = new PopupMenu.PopupMenuManager(this);
-            this.menu = new Applet.AppletPopupMenu(this, orientation);
-            this.menuManager.addMenu(this.menu);            
-                                            
-            this._contentSection = new PopupMenu.PopupMenuSection();
-            this.menu.addMenuItem(this._contentSection);
 
-            this._update();
+        this.set_applet_icon_symbolic_name("drive-harddisk");
+        this.set_applet_tooltip(_("Removable drives"));
 
-            this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-            this.menu.addAction(_("Open file manager"), function(event) {
-                let appSystem = Cinnamon.AppSystem.get_default();
-                let app = appSystem.lookup_app('nemo.desktop');
-                app.activate_full(-1, event.get_time());
-            });     
-            
-            Main.placesManager.connect('mounts-updated', Lang.bind(this, this._update));
-        }
-        catch (e) {
-            global.logError(e);
-        }
+        this.menuManager = new PopupMenu.PopupMenuManager(this);
+        this.menu = new Applet.AppletPopupMenu(this, orientation);
+        this.menuManager.addMenu(this.menu);
+
+        this._contentSection = new PopupMenu.PopupMenuSection();
+        this.menu.addMenuItem(this._contentSection);
+
+        this._update();
+
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+        this.menu.addAction(_("Open file manager"), function(event) {
+                                let appSystem = Cinnamon.AppSystem.get_default();
+                                let app = appSystem.lookup_app('nemo.desktop');
+                                app.activate_full(-1, event.get_time());
+                            });
+
+        Main.placesManager.connect('mounts-updated', Lang.bind(this, this._update));
     },
-    
+
     on_applet_clicked: function(event) {
-        this.menu.toggle();        
+        this.menu.toggle();
     },
-    
+
     _update: function() {
         this._contentSection.removeAll();
 
@@ -93,10 +88,10 @@ MyApplet.prototype = {
 
         this.actor.visible = any;
     }
-    
+
 };
 
-function main(metadata, orientation, panel_height) {  
+function main(metadata, orientation, panel_height) {
     let myApplet = new MyApplet(orientation, panel_height);
-    return myApplet;      
+    return myApplet;
 }

--- a/files/usr/share/cinnamon/applets/scale@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/scale@cinnamon.org/applet.js
@@ -13,19 +13,14 @@ MyApplet.prototype = {
     _init: function(metadata, orientation, panel_height) {
         Applet.IconApplet.prototype._init.call(this, orientation, panel_height);
 
-        try {            
-            Gtk.IconTheme.get_default().append_search_path(metadata.path);
-            this.set_applet_icon_symbolic_name("cinnamon-scale");
-            this.set_applet_tooltip(_("Scale"));            
-            this._hover_activates = false;            
-            global.settings.connect('changed::panel-edit-mode', Lang.bind(this, this.on_panel_edit_mode_changed));
-            global.settings.connect('changed::scale-applet-hover', Lang.bind(this, this._reload_settings));
-            this.actor.connect('enter-event', Lang.bind(this, this._onEntered));
-            this._reload_settings();
-        }
-        catch (e) {
-            global.logError(e);
-        }
+        Gtk.IconTheme.get_default().append_search_path(metadata.path);
+        this.set_applet_icon_symbolic_name("cinnamon-scale");
+        this.set_applet_tooltip(_("Scale"));
+        this._hover_activates = false;
+        global.settings.connect('changed::panel-edit-mode', Lang.bind(this, this.on_panel_edit_mode_changed));
+        global.settings.connect('changed::scale-applet-hover', Lang.bind(this, this._reload_settings));
+        this.actor.connect('enter-event', Lang.bind(this, this._onEntered));
+        this._reload_settings();
     },
 
     on_panel_edit_mode_changed: function () {

--- a/files/usr/share/cinnamon/applets/settings@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/settings@cinnamon.org/applet.js
@@ -20,40 +20,34 @@ function MyApplet(orientation, panel_height) {
 MyApplet.prototype = {
     __proto__: Applet.IconApplet.prototype,
 
-    _init: function(orientation, panel_height) {        
+    _init: function(orientation, panel_height) {
         Applet.IconApplet.prototype._init.call(this, orientation, panel_height);
-        
-        try {        
-            this.set_applet_icon_symbolic_name("go-up");
-            this.set_applet_tooltip(_("Settings"));                            
-            this.menuManager = new PopupMenu.PopupMenuManager(this);
-            this._buildMenu(orientation);
-                        
-        }
-        catch (e) {
-            global.logError(e);
-        }
+
+        this.set_applet_icon_symbolic_name("go-up");
+        this.set_applet_tooltip(_("Settings"));
+        this.menuManager = new PopupMenu.PopupMenuManager(this);
+        this._buildMenu(orientation);
     },
-    
+
     on_applet_clicked: function(event) {
-        this.menu.toggle();        
+        this.menu.toggle();
     },
-    
+
     _buildMenu: function(orientation) {
         this.menu = new Applet.AppletPopupMenu(this, orientation);
-        this.menuManager.addMenu(this.menu);        
+        this.menuManager.addMenu(this.menu);
         Panel.populateSettingsMenu(this.menu);
     },
-    
+
     on_orientation_changed: function(orientation){
         this.menu.destroy();
         this._buildMenu(orientation);
     }
-        
-    
+
+
 };
 
-function main(metadata, orientation, panel_height) {  
+function main(metadata, orientation, panel_height) {
     let myApplet = new MyApplet(orientation, panel_height);
-    return myApplet;      
+    return myApplet;
 }

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -31,7 +31,7 @@ const MediaServer2IFace = {
                    access: 'read'},
                  { name: 'CanQuit',
                    signature: 'b',
-                   access: 'read'}],
+                   access: 'read'}]
 };
 
 const MediaServer2PlayerIFace = {
@@ -121,7 +121,7 @@ Prop.prototype = {
         DBus.session.proxifyObject(this, owner, '/org/mpris/MediaPlayer2', this);
     }
 }
-DBus.proxifyPrototype(Prop.prototype, PropIFace)
+DBus.proxifyPrototype(Prop.prototype, PropIFace);
 
 function MediaServer2() {
     this._init.apply(this, arguments);
@@ -146,7 +146,7 @@ MediaServer2.prototype = {
             }));
     }
 }
-DBus.proxifyPrototype(MediaServer2.prototype, MediaServer2IFace)
+DBus.proxifyPrototype(MediaServer2.prototype, MediaServer2IFace);
 
 function MediaServer2Player() {
     this._init.apply(this, arguments);
@@ -210,22 +210,22 @@ MediaServer2Player.prototype = {
             function(repeat, ex) {
                 if (!ex) {
                     if (repeat == "None")
-                        repeat = false
+                        repeat = false;
                     else
-                        repeat = true
+                        repeat = true;
                     callback(this, repeat);
                 }
             }));
     },
     setRepeat: function(value) {
         if (value)
-            value = "Playlist"
+            value = "Playlist";
         else
-            value = "None"
+            value = "None";
         this.SetRemote('LoopStatus', value);
     }
 }
-DBus.proxifyPrototype(MediaServer2Player.prototype, MediaServer2PlayerIFace)
+DBus.proxifyPrototype(MediaServer2Player.prototype, MediaServer2PlayerIFace);
 
 function TrackInfo() {
     this._init.apply(this, arguments);
@@ -253,7 +253,7 @@ TrackInfo.prototype = {
     },
     show: function() {
         this.actor.show();
-    },
+    }
 };
 
 function ControlButton() {
@@ -269,17 +269,17 @@ ControlButton.prototype = {
             icon_type: St.IconType.SYMBOLIC,
             icon_name: icon,
             icon_size: 16,
-            style_class: 'sound-button-icon',
+            style_class: 'sound-button-icon'
         });
         this.button.set_child(this.icon);
-        this.actor.add_actor(this.button);        
+        this.actor.add_actor(this.button);
     },
     getActor: function() {
         return this.actor;
     },
     setIcon: function(icon) {
         this.icon.icon_name = icon;
-    },
+    }
 }
 
 function TextImageMenuItem() {
@@ -331,8 +331,8 @@ TextImageMenuItem.prototype = {
          let icon_uri = file.get_uri();
 
          return St.TextureCache.get_default().load_uri_async(icon_uri, 16, 16);
-    },
-}
+    }
+};
 
 function Player() {
     this._init.apply(this, arguments);
@@ -362,7 +362,7 @@ Player.prototype = {
         this._trackControls = new St.Bin({style_class: 'sound-playback-control', x_align: St.Align.MIDDLE});
 
         let mainBox = new St.BoxLayout({style_class: 'sound-track-box', vertical: true});
-        mainBox.add_actor(this._trackInfosTop)
+        mainBox.add_actor(this._trackInfosTop);
         mainBox.add_actor(this._trackCover);
         mainBox.add_actor(this._trackInfosBottom);
 
@@ -447,7 +447,6 @@ Player.prototype = {
         return this._name.charAt(0).toUpperCase() + this._name.slice(1);
     },
 
-
     _setName: function(status) {
         this._playerInfo.setText(this._getName() + " - " + _(status));
     },
@@ -495,13 +494,6 @@ Player.prototype = {
             this._title.setLabel(metadata["xesam:title"].toString());
         else
             this._title.setLabel(_("Unknown Title"));
-        /*if (metadata["mpris:trackid"]) {
-            this._trackId = {
-                _init: function() {
-                    DBus.session.proxifyObject(this, this._owner, metadata["mpris:trackid"]);
-                }
-            }
-        }*/
 
         let change = false;
         if (metadata["mpris:artUrl"]) {
@@ -687,7 +679,7 @@ MediaPlayerLauncher.prototype = {
     },
 
     activate: function (event) {
-    	this._menu.actor.hide();
+            this._menu.actor.hide();
         this._app.activate_full(-1, event.get_time());
         return true;
     }
@@ -704,59 +696,54 @@ MyApplet.prototype = {
     _init: function(orientation, panel_height) {
         Applet.IconApplet.prototype._init.call(this, orientation, panel_height);
 
-        try {
-            this.menuManager = new PopupMenu.PopupMenuManager(this);
-            this.menu = new Applet.AppletPopupMenu(this, orientation);
-            this.menuManager.addMenu(this.menu);
+        this.menuManager = new PopupMenu.PopupMenuManager(this);
+        this.menu = new Applet.AppletPopupMenu(this, orientation);
+        this.menuManager.addMenu(this.menu);
 
-            this.set_applet_icon_symbolic_name('audio-x-generic');
+        this.set_applet_icon_symbolic_name('audio-x-generic');
 
-            // menu not showed by default
-            this._players = {};
-            // watch players
-            for (var p=0; p<compatible_players.length; p++) {
-                DBus.session.watch_name('org.mpris.MediaPlayer2.'+compatible_players[p], false,
-                    Lang.bind(this, this._addPlayer),
-                    Lang.bind(this, this._removePlayer)
-                );
-            }
-
-            this._control = new Gvc.MixerControl({ name: 'Cinnamon Volume Control' });
-            this._control.connect('state-changed', Lang.bind(this, this._onControlStateChanged));
-            this._control.connect('default-sink-changed', Lang.bind(this, this._readOutput));
-            this._control.connect('default-source-changed', Lang.bind(this, this._readInput));
-            this._control.connect('stream-added', Lang.bind(this, this._maybeShowInput));
-            this._control.connect('stream-removed', Lang.bind(this, this._maybeShowInput));
-            this._volumeMax = 1*this._control.get_vol_max_norm(); // previously was 1.5*this._control.get_vol_max_norm();, but we'd need a little mark on the slider to make it obvious to the user we're going over 100%..
-
-            this._output = null;
-            this._outputVolumeId = 0;
-            this._outputMutedId = 0;
-
-            this._input = null;
-            this._inputVolumeId = 0;
-            this._inputMutedId = 0;
-
-            this._icon_name = '';
-
-            this.actor.connect('scroll-event', Lang.bind(this, this._onScrollEvent));
-
-            this.mute_out_switch = new PopupMenu.PopupSwitchMenuItem(_("Mute output"), false);
-            this.mute_in_switch = new PopupMenu.PopupSwitchMenuItem(_("Mute input"), false);
-            this._applet_context_menu.addMenuItem(this.mute_out_switch);
-            this._applet_context_menu.addMenuItem(this.mute_in_switch);
-            this.mute_out_switch.connect('toggled', Lang.bind(this, this._toggle_out_mute));
-            this.mute_in_switch.connect('toggled', Lang.bind(this, this._toggle_in_mute));
-
-            this._control.open();
-
-            this._volumeControlShown = false;
-
-            this._showFixedElements();
+        // menu not showed by default
+        this._players = {};
+        // watch players
+        for (var p=0; p<compatible_players.length; p++) {
+            DBus.session.watch_name('org.mpris.MediaPlayer2.'+compatible_players[p], false,
+                                    Lang.bind(this, this._addPlayer),
+                                    Lang.bind(this, this._removePlayer)
+                                   );
         }
-        catch (e) {
-            global.logError(e);
-        }
+
+        this._control = new Gvc.MixerControl({ name: 'Cinnamon Volume Control' });
+        this._control.connect('state-changed', Lang.bind(this, this._onControlStateChanged));
+        this._control.connect('default-sink-changed', Lang.bind(this, this._readOutput));
+        this._control.connect('default-source-changed', Lang.bind(this, this._readInput));
+        this._control.connect('stream-added', Lang.bind(this, this._maybeShowInput));
+        this._control.connect('stream-removed', Lang.bind(this, this._maybeShowInput));
+        this._volumeMax = 1*this._control.get_vol_max_norm(); // previously was 1.5*this._control.get_vol_max_norm();, but we'd need a little mark on the slider to make it obvious to the user we're going over 100%..
+
+        this._output = null;
+        this._outputVolumeId = 0;
+        this._outputMutedId = 0;
+
+        this._input = null;
+        this._inputVolumeId = 0;
+        this._inputMutedId = 0;
+
+        this._icon_name = '';
+
+        this.actor.connect('scroll-event', Lang.bind(this, this._onScrollEvent));
+
+        this.mute_out_switch = new PopupMenu.PopupSwitchMenuItem(_("Mute output"), false);
+        this.mute_in_switch = new PopupMenu.PopupSwitchMenuItem(_("Mute input"), false);
+        this._applet_context_menu.addMenuItem(this.mute_out_switch);
+        this._applet_context_menu.addMenuItem(this.mute_in_switch);
+        this.mute_out_switch.connect('toggled', Lang.bind(this, this._toggle_out_mute));
+        this.mute_in_switch.connect('toggled', Lang.bind(this, this._toggle_in_mute));
+
+        this._control.open();
+
+        this._volumeControlShown = false;
+
+        this._showFixedElements();
     },
 
     on_applet_clicked: function(event) {
@@ -862,21 +849,21 @@ MyApplet.prototype = {
         this._volumeControlShown = true;
 
         if (this._nbPlayers()==0){
-        	this._availablePlayers = new Array();
+                this._availablePlayers = new Array();
             let appsys = Cinnamon.AppSystem.get_default();
             let allApps = appsys.get_all();
             let listedDesktopFiles = new Array();
             for (let y=0; y<allApps.length; y++) {
-            	let app = allApps[y];
-            	let entry = app.get_tree_entry();
-            	let path = entry.get_desktop_file_path();
-            	for (var p=0; p<compatible_players.length; p++) {
+                    let app = allApps[y];
+                    let entry = app.get_tree_entry();
+                    let path = entry.get_desktop_file_path();
+                    for (var p=0; p<compatible_players.length; p++) {
                     let desktopFile = compatible_players[p]+".desktop";
-            		if (path.indexOf(desktopFile) != -1 && listedDesktopFiles.indexOf(desktopFile) == -1) {
-                		this._availablePlayers.push(app);
+                            if (path.indexOf(desktopFile) != -1 && listedDesktopFiles.indexOf(desktopFile) == -1) {
+                                this._availablePlayers.push(app);
                         listedDesktopFiles.push(desktopFile);
-            		}
-           		}
+                            }
+                           }
             }
 
             if (this._availablePlayers.length > 0){
@@ -1025,19 +1012,19 @@ MyApplet.prototype = {
             this._mutedChanged (null, null, '_output');
             this._volumeChanged (null, null, '_output');
             let sinks = this._control.get_sinks();
-	        this._selectDeviceItem.menu.removeAll();
-	        for (let i = 0; i < sinks.length; i++) {
-	        	let sink = sinks[i];
-	        	let menuItem = new PopupMenu.PopupMenuItem(sink.get_description());
-	        	if (sinks[i].get_id() == this._output.get_id()) {
-	        		menuItem.setShowDot(true);
-	        	}
-	        	menuItem.connect('activate', Lang.bind(this, function() {
-	        		log('Changing default sink to ' + sink.get_description());
-	                this._control.set_default_sink(sink);
-	            }));
-	            this._selectDeviceItem.menu.addMenuItem(menuItem);
-	        }
+            this._selectDeviceItem.menu.removeAll();
+            for (let i = 0; i < sinks.length; i++) {
+                let sink = sinks[i];
+                let menuItem = new PopupMenu.PopupMenuItem(sink.get_description());
+                if (sinks[i].get_id() == this._output.get_id()) {
+                    menuItem.setShowDot(true);
+                }
+                menuItem.connect('activate', Lang.bind(this, function() {
+                                                           log('Changing default sink to ' + sink.get_description());
+                                                           this._control.set_default_sink(sink);
+                                                       }));
+                this._selectDeviceItem.menu.addMenuItem(menuItem);
+            }
         } else {
             this._outputSlider.setValue(0);
             this.setIconName('audio-volume-muted-symbolic');

--- a/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
@@ -55,17 +55,17 @@ MyApplet.prototype = {
         try {
             let hiddenIcons = ["network", "power", "keyboard", "gnome-settings-daemon", "volume", "bluetooth", "bluetooth-manager", "battery", "a11y", "spotify"];
             let buggyIcons = ["pidgin", "thunderbird"];
-            
+
             if (hiddenIcons.indexOf(role) != -1 ) {
                 // We've got an applet for that
                 return;
             }
 
-            global.log("Adding systray: " + role + " (" + icon.get_width() + "x" + icon.get_height() + "px)");            
+            global.log("Adding systray: " + role + " (" + icon.get_width() + "x" + icon.get_height() + "px)");
 
             let box = new St.Bin({ style_class: 'panel-status-button', reactive: true, track_hover: true});
-	    let iconParent = icon.get_parent();
-	    if (iconParent) iconParent.remove_actor(icon);
+            let iconParent = icon.get_parent();
+            if (iconParent) iconParent.remove_actor(icon);
             box.add_actor(icon);
 
             this._insertStatusItem(box, -1);
@@ -117,9 +117,7 @@ MyApplet.prototype = {
             this.actor.insert_actor(actor, 0);
         }
         actor._rolePosition = position;
-    },
-
-
+    }
 };
 
 function main(metadata, orientation, panel_height) {

--- a/files/usr/share/cinnamon/applets/trash@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/trash@cinnamon.org/applet.js
@@ -13,28 +13,23 @@ function MyApplet(orientation, panel_height) {
 MyApplet.prototype = {
     __proto__: Applet.IconApplet.prototype,
 
-    _init: function(orientation, panel_height) {        
+    _init: function(orientation, panel_height) {
         Applet.IconApplet.prototype._init.call(this, orientation, panel_height);
-        
-        try {        
-            this.set_applet_icon_symbolic_name("user-trash");
-            this.set_applet_tooltip(_("Trash"));
-                   
-            this.trash_path = 'trash:///';
-            this.trash_directory =  Gio.file_new_for_uri(this.trash_path);
-            
-            this._initContextMenu();
 
-            this._onTrashChange();
-            
-            this.monitor = this.trash_directory.monitor_directory(0, null, null);
-            this.monitor.connect('changed', Lang.bind(this, this._onTrashChange));
-        }
-        catch (e) {
-            global.logError(e);
-        }
+        this.set_applet_icon_symbolic_name("user-trash");
+        this.set_applet_tooltip(_("Trash"));
+
+        this.trash_path = 'trash:///';
+        this.trash_directory =  Gio.file_new_for_uri(this.trash_path);
+
+        this._initContextMenu();
+
+        this._onTrashChange();
+
+        this.monitor = this.trash_directory.monitor_directory(0, null, null);
+        this.monitor.connect('changed', Lang.bind(this, this._onTrashChange));
     },
-    
+
     _initContextMenu: function () {
         this.empty_item = new Applet.MenuItem(_("Empty Trash"), Gtk.STOCK_REMOVE, Lang.bind(this, this._emptyTrash));
         this._applet_context_menu.addMenuItem(this.empty_item);
@@ -42,7 +37,7 @@ MyApplet.prototype = {
         this.open_item = new Applet.MenuItem(_("Open Trash"), Gtk.STOCK_OPEN, Lang.bind(this, this._openTrash));
         this._applet_context_menu.addMenuItem(this.open_item);
     },
-    
+
     on_applet_clicked: function(event) {
         this._openTrash();
     },
@@ -50,15 +45,15 @@ MyApplet.prototype = {
     _openTrash: function() {
         Gio.app_info_launch_default_for_uri(this.trash_directory.get_uri(), null);
     },
-   
+
     _onTrashChange: function() {
       if (this.trash_directory.query_exists(null)) {
-          let children = this.trash_directory.enumerate_children('standard::*', Gio.FileQueryInfoFlags.NONE, null);          
+          let children = this.trash_directory.enumerate_children('standard::*', Gio.FileQueryInfoFlags.NONE, null);
           if (children.next_file(null, null) == null) {
-              this.set_applet_icon_symbolic_name("user-trash");        
+              this.set_applet_icon_symbolic_name("user-trash");
           } else {
               //this.set_applet_icon_name("user-trash-full");
-              this.set_applet_icon_symbolic_name("user-trash");        
+              this.set_applet_icon_symbolic_name("user-trash");
           }
       }
     },
@@ -75,9 +70,9 @@ MyApplet.prototype = {
                 let child = this.trash_directory.get_child(child_info.get_name());
                 child.delete(null);
               }
-        }      
+        }
     },
-    
+
     on_orientation_changed: function (orientation) {
         this._initContextMenu();
     }
@@ -90,49 +85,49 @@ function ConfirmEmptyTrashDialog(emptyMethod) {
 }
 
 ConfirmEmptyTrashDialog.prototype = {
-  __proto__: ModalDialog.ModalDialog.prototype,
+    __proto__: ModalDialog.ModalDialog.prototype,
 
-  _init: function(emptyMethod) {
-    ModalDialog.ModalDialog.prototype._init.call(this, { styleClass: null });
+    _init: function(emptyMethod) {
+        ModalDialog.ModalDialog.prototype._init.call(this, { styleClass: null });
 
-    let mainContentBox = new St.BoxLayout({ style_class: 'polkit-dialog-main-layout',
-                                            vertical: false });
-    this.contentLayout.add(mainContentBox, { x_fill: true, y_fill: true });
+        let mainContentBox = new St.BoxLayout({ style_class: 'polkit-dialog-main-layout',
+                                                vertical: false });
+        this.contentLayout.add(mainContentBox, { x_fill: true, y_fill: true });
 
-    let messageBox = new St.BoxLayout({ style_class: 'polkit-dialog-message-layout',
-                                        vertical: true });
-    mainContentBox.add(messageBox, { y_align: St.Align.START });
+        let messageBox = new St.BoxLayout({ style_class: 'polkit-dialog-message-layout',
+                                            vertical: true });
+        mainContentBox.add(messageBox, { y_align: St.Align.START });
 
-    this._subjectLabel = new St.Label({ style_class: 'polkit-dialog-headline',
-                                        text: _("Empty Trash?") });
+        this._subjectLabel = new St.Label({ style_class: 'polkit-dialog-headline',
+                                            text: _("Empty Trash?") });
 
-    messageBox.add(this._subjectLabel, { y_fill:  false, y_align: St.Align.START });
+        messageBox.add(this._subjectLabel, { y_fill:  false, y_align: St.Align.START });
 
-    this._descriptionLabel = new St.Label({ style_class: 'polkit-dialog-description',
-                                            text: MESSAGE });
+        this._descriptionLabel = new St.Label({ style_class: 'polkit-dialog-description',
+                                                text: MESSAGE });
 
-    messageBox.add(this._descriptionLabel, { y_fill:  true, y_align: St.Align.START });
+        messageBox.add(this._descriptionLabel, { y_fill:  true, y_align: St.Align.START });
 
-    this.setButtons([
-      {
-        label: _("Cancel"),
-        action: Lang.bind(this, function() {
-          this.close();
-        }),
-        key: Clutter.Escape
-      },
-      {
-        label: _("Empty"),
-        action: Lang.bind(this, function() {
-          this.close();
-          emptyMethod();
-        })
-      }
-    ]);
-  }
+        this.setButtons([
+                            {
+                                label: _("Cancel"),
+                                action: Lang.bind(this, function() {
+                                                      this.close();
+                                                  }),
+                                key: Clutter.Escape
+                            },
+                            {
+                                label: _("Empty"),
+                                action: Lang.bind(this, function() {
+                                                      this.close();
+                                                      emptyMethod();
+                                                  })
+                            }
+                        ]);
+    }
 };
 
-function main(metadata, orientation, panel_height) {      
+function main(metadata, orientation, panel_height) {
     let myApplet = new MyApplet(orientation, panel_height);
-    return myApplet;      
+    return myApplet;
 }

--- a/files/usr/share/cinnamon/applets/windows-quick-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/windows-quick-list@cinnamon.org/applet.js
@@ -9,112 +9,106 @@ const Main = imports.ui.main;
 const Gtk = imports.gi.Gtk;
 
 function MyApplet(metadata, orientation, panel_height) {
-	this._init(metadata, orientation, panel_height);
+        this._init(metadata, orientation, panel_height);
 };
 
 MyApplet.prototype = {
-	__proto__: Applet.IconApplet.prototype,
+        __proto__: Applet.IconApplet.prototype,
 
     _init: function(metadata, orientation, panel_height) {
         Applet.IconApplet.prototype._init.call(this, orientation, panel_height);
 
-		try {
-			Gtk.IconTheme.get_default().append_search_path(metadata.path);
-            this.set_applet_icon_symbolic_name("windows-quick-list");
-            this.set_applet_tooltip(_("All windows"));            
-			
-			
-			this.menu = new Applet.AppletPopupMenu(this, orientation);
-			this.menuManager = new PopupMenu.PopupMenuManager(this);
-			this.menuManager.addMenu(this.menu);  						           
-		}
-		catch (e) {
-			global.logError(e);
-		}
-	},
-	
-	updateMenu: function() {
-		this.menu.removeAll();
-		try {
-			let tracker = Cinnamon.WindowTracker.get_default();
+        Gtk.IconTheme.get_default().append_search_path(metadata.path);
+        this.set_applet_icon_symbolic_name("windows-quick-list");
+        this.set_applet_tooltip(_("All windows"));
 
-			for ( let wks=0; wks<global.screen.n_workspaces; ++wks ) {
-				// construct a list with all windows
-				let workspace_name = Main.getWorkspaceName(wks);
-				let metaWorkspace = global.screen.get_workspace_by_index(wks);
-				let windows = metaWorkspace.list_windows();				
-				let sticky_windows = windows.filter(
-						function(w) {
-							return !w.is_skip_taskbar() && w.is_on_all_workspaces();
-							}
-                                		);
-				windows = windows.filter(
-						function(w) {
-							return !w.is_skip_taskbar() && !w.is_on_all_workspaces();
-							}
-                                		);
+        this.menu = new Applet.AppletPopupMenu(this, orientation);
+        this.menuManager = new PopupMenu.PopupMenuManager(this);
+        this.menuManager.addMenu(this.menu);
+    },
 
-				if(sticky_windows.length && (wks==0)) {
-					for ( let i = 0; i < sticky_windows.length; ++i ) {
-						let metaWindow = sticky_windows[i];
-						let item = new PopupMenu.PopupMenuItem(metaWindow.get_title());
-							item.label.add_style_class_name('window-sticky');
-						item.connect('activate', Lang.bind(this, function() { this.activateWindow(metaWorkspace, metaWindow); } ));
-						item._window = sticky_windows[i];
-						let app = tracker.get_window_app(item._window);
-						item._icon = app.create_icon_texture(24);
-        				item.addActor(item._icon, { align: St.Align.END });
-						this.menu.addMenuItem(item);
-					}
-						this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-				}
+    updateMenu: function() {
+        this.menu.removeAll();
+        try {
+            let tracker = Cinnamon.WindowTracker.get_default();
 
-				if(windows.length) {
-					if(wks>0) {
-						this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-					}
-					if(global.screen.n_workspaces>1) {					
-						let item = new PopupMenu.PopupMenuItem(workspace_name);
-						item.actor.reactive = false;
-						item.actor.can_focus = false;
-						item.label.add_style_class_name('popup-subtitle-menu-item');
-						if(wks == global.screen.get_active_workspace().index()) {
-							item.setShowDot(true);
-						}
-						this.menu.addMenuItem(item);
-					}
+            for ( let wks=0; wks<global.screen.n_workspaces; ++wks ) {
+                // construct a list with all windows
+                let workspace_name = Main.getWorkspaceName(wks);
+                let metaWorkspace = global.screen.get_workspace_by_index(wks);
+                let windows = metaWorkspace.list_windows();
+                let sticky_windows = windows.filter(
+                    function(w) {
+                        return !w.is_skip_taskbar() && w.is_on_all_workspaces();
+                    }
+                );
+                windows = windows.filter(
+                    function(w) {
+                        return !w.is_skip_taskbar() && !w.is_on_all_workspaces();
+                    }
+                );
+
+                if(sticky_windows.length && (wks==0)) {
+                    for ( let i = 0; i < sticky_windows.length; ++i ) {
+                        let metaWindow = sticky_windows[i];
+                        let item = new PopupMenu.PopupMenuItem(metaWindow.get_title());
+                        item.label.add_style_class_name('window-sticky');
+                        item.connect('activate', Lang.bind(this, function() { this.activateWindow(metaWorkspace, metaWindow); } ));
+                        item._window = sticky_windows[i];
+                        let app = tracker.get_window_app(item._window);
+                        item._icon = app.create_icon_texture(24);
+                        item.addActor(item._icon, { align: St.Align.END });
+                        this.menu.addMenuItem(item);
+                    }
+                    this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+                }
+
+                if(windows.length) {
+                    if(wks>0) {
+                        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+                    }
+                    if(global.screen.n_workspaces>1) {
+                        let item = new PopupMenu.PopupMenuItem(workspace_name);
+                        item.actor.reactive = false;
+                        item.actor.can_focus = false;
+                        item.label.add_style_class_name('popup-subtitle-menu-item');
+                        if(wks == global.screen.get_active_workspace().index()) {
+                            item.setShowDot(true);
+                        }
+                        this.menu.addMenuItem(item);
+                    }
 
 
-					for ( let i = 0; i < windows.length; ++i ) {
-						let metaWindow = windows[i];
-						let item = new PopupMenu.PopupMenuItem(windows[i].get_title());
-						item.connect('activate', Lang.bind(this, function() { this.activateWindow(metaWorkspace, metaWindow); } ));
-						item._window = windows[i];
-						let app = tracker.get_window_app(item._window);
-						item._icon = app.create_icon_texture(24);
-        				item.addActor(item._icon, { align: St.Align.END });
-						this.menu.addMenuItem(item);
-					}
-				}
-			}
-		} catch(e) {
-			global.logError(e);			
-		}		
-	},
+                    for ( let i = 0; i < windows.length; ++i ) {
+                        let metaWindow = windows[i];
+                        let item = new PopupMenu.PopupMenuItem(windows[i].get_title());
+                        item.connect('activate', Lang.bind(this, function() { this.activateWindow(metaWorkspace, metaWindow); } ));
+                        item._window = windows[i];
+                        let app = tracker.get_window_app(item._window);
+                        item._icon = app.create_icon_texture(24);
+                        item.addActor(item._icon, { align: St.Align.END });
+                        this.menu.addMenuItem(item);
+                    }
+                }
+            }
+        } catch(e) {
+            global.logError(e);
+        }
+    },
 
-	activateWindow: function(metaWorkspace, metaWindow) {
-		if(!metaWindow.is_on_all_workspaces()) { metaWorkspace.activate(global.get_current_time()); }
-		metaWindow.unminimize(global.get_current_time());
-		metaWindow.activate(global.get_current_time());
-	},
-	
-	on_applet_clicked: function(event) {
-		this.updateMenu();
-		this.menu.toggle();    
-	}
+    activateWindow: function(metaWorkspace, metaWindow) {
+        if(!metaWindow.is_on_all_workspaces()) { metaWorkspace.activate(global.get_current_time()); }
+        metaWindow.unminimize(global.get_current_time());
+        metaWindow.activate(global.get_current_time());
+    },
+
+    on_applet_clicked: function(event) {
+        this.updateMenu();
+        this.menu.toggle();
+    }
 };
 
 function main(metadata, orientation, panel_height) {
-	let myApplet = new MyApplet(metadata, orientation, panel_height);
-	return myApplet;
+    let myApplet = new MyApplet(metadata, orientation, panel_height);
+    return myApplet;
 }

--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
@@ -9,42 +9,33 @@ function MyApplet(orientation, panel_height) {
 MyApplet.prototype = {
     __proto__: Applet.Applet.prototype,
 
-    _init: function(orientation, panel_height) {        
+    _init: function(orientation, panel_height) {
         Applet.Applet.prototype._init.call(this, orientation, panel_height);
-        
-        try {
-            this.actor.set_style_class_name("workspace-switcher-box");
-            this.actor.connect('scroll-event', this.hook.bind(this));
-            this.set_applet_tooltip(_("Switch workspace"));
-            this.button = [];
-            this._createButtons();
-            global.screen.connect('notify::n-workspaces', Lang.bind(this, this._createButtons));
-            global.window_manager.connect('switch-workspace', Lang.bind(this, this._updateButtons));   
-            this.on_panel_edit_mode_changed();
-            global.settings.connect('changed::panel-edit-mode', Lang.bind(this, this.on_panel_edit_mode_changed));                       
-        }
-        catch (e) {
-            global.logError(e);
-        }
+
+        this.actor.set_style_class_name("workspace-switcher-box");
+        this.actor.connect('scroll-event', this.hook.bind(this));
+        this.set_applet_tooltip(_("Switch workspace"));
+        this.button = [];
+        this._createButtons();
+        global.screen.connect('notify::n-workspaces', Lang.bind(this, this._createButtons));
+        global.window_manager.connect('switch-workspace', Lang.bind(this, this._updateButtons));
+        this.on_panel_edit_mode_changed();
+        global.settings.connect('changed::panel-edit-mode', Lang.bind(this, this.on_panel_edit_mode_changed));
     },
-    
-    on_applet_clicked: function(event) {
-        
-    },
-    
+
     on_panel_edit_mode_changed: function() {
         let reactive = !global.settings.get_boolean('panel-edit-mode');
         for ( let i=0; i<this.button.length; ++i ) {
-            this.button[i].reactive = reactive;            
+            this.button[i].reactive = reactive;
         }
-    }, 
-    
+    },
+
     hook: function(actor, event){
         var direction = event.get_scroll_direction();
         if(direction==0) this.switch_workspace(-1);
         if(direction==1) this.switch_workspace(1);
     },
-    
+
     switch_workspace: function(incremental){
         var index = global.screen.get_active_workspace_index();
         index += incremental;
@@ -52,7 +43,7 @@ MyApplet.prototype = {
             global.screen.get_workspace_by_index(index).activate(global.get_current_time());
         }
     },
-    
+
     _createButtons: function() {
         for ( let i=0; i<this.button.length; ++i ) {
             this.button[i].destroy();
@@ -61,8 +52,8 @@ MyApplet.prototype = {
         this.button = [];
         for ( let i=0; i<global.screen.n_workspaces; ++i ) {
             this.button[i] = new St.Button({ name: 'workspaceButton',
-                                     style_class: 'workspace-button',
-                                     reactive: true });
+                                             style_class: 'workspace-button',
+                                             reactive: true });
             let text = '';
             if ( i == global.screen.get_active_workspace_index() ) {
                 text = (i+1).toString();
@@ -79,9 +70,9 @@ MyApplet.prototype = {
             }
             let index = i;
             this.button[i].connect('button-release-event', Lang.bind(this, function() {
-                let metaWorkspace = global.screen.get_workspace_by_index(index);
-                metaWorkspace.activate(global.get_current_time());
-            }));
+                                                                         let metaWorkspace = global.screen.get_workspace_by_index(index);
+                                                                         metaWorkspace.activate(global.get_current_time());
+                                                                     }));
         }
     },
 
@@ -104,7 +95,7 @@ MyApplet.prototype = {
     }
 };
 
-function main(metadata, orientation, panel_height) {  
+function main(metadata, orientation, panel_height) {
     let myApplet = new MyApplet(orientation, panel_height);
-    return myApplet;      
+    return myApplet;
 }

--- a/files/usr/share/cinnamon/applets/xrandr@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/xrandr@cinnamon.org/applet.js
@@ -8,24 +8,24 @@ const Lang = imports.lang;
 const Applet = imports.ui.applet;
 const PopupMenu = imports.ui.popupMenu;
 
-const N_ = function(e) { return e };
+const N_ = function(e) { return e; };
 
 const possibleRotations = [ GnomeDesktop.RRRotation.ROTATION_0,
-			    GnomeDesktop.RRRotation.ROTATION_90,
-			    GnomeDesktop.RRRotation.ROTATION_180,
-			    GnomeDesktop.RRRotation.ROTATION_270
-			  ];
+                            GnomeDesktop.RRRotation.ROTATION_90,
+                            GnomeDesktop.RRRotation.ROTATION_180,
+                            GnomeDesktop.RRRotation.ROTATION_270
+                          ];
 
 let rotations = [ [ GnomeDesktop.RRRotation.ROTATION_0, N_("Normal") ],
-		  [ GnomeDesktop.RRRotation.ROTATION_90, N_("Left") ],
-		  [ GnomeDesktop.RRRotation.ROTATION_270, N_("Right") ],
-		  [ GnomeDesktop.RRRotation.ROTATION_180, N_("Upside-down") ]
-		];
+                  [ GnomeDesktop.RRRotation.ROTATION_90, N_("Left") ],
+                  [ GnomeDesktop.RRRotation.ROTATION_270, N_("Right") ],
+                  [ GnomeDesktop.RRRotation.ROTATION_180, N_("Upside-down") ]
+                ];
 
 const XRandr2Iface = {
     name: 'org.gnome.SettingsDaemon.XRANDR_2',
     methods: [
-	{ name: 'ApplyConfiguration', inSignature: 'xx', outSignature: '' },
+        { name: 'ApplyConfiguration', inSignature: 'xx', outSignature: '' }
     ]
 };
 let XRandr2 = DBus.makeProxyClass(XRandr2Iface);
@@ -37,46 +37,41 @@ function MyApplet(orientation, panel_height) {
 MyApplet.prototype = {
     __proto__: Applet.IconApplet.prototype,
 
-    _init: function(orientation, panel_height) {        
+    _init: function(orientation, panel_height) {
         Applet.IconApplet.prototype._init.call(this, orientation, panel_height);
-        
-        try {        
-            this.set_applet_icon_symbolic_name("preferences-desktop-display");
-            this.set_applet_tooltip(_("Display"));
-            
-            this.menuManager = new PopupMenu.PopupMenuManager(this);
-            this.menu = new Applet.AppletPopupMenu(this, orientation);
-            this.menuManager.addMenu(this.menu);            
-                                
-            this._proxy = new XRandr2(DBus.session, 'org.gnome.SettingsDaemon', '/org/gnome/SettingsDaemon/XRANDR');
 
-            try {
-                this._screen = new GnomeDesktop.RRScreen({ gdk_screen: Gdk.Screen.get_default() });
-                this._screen.init(null);
-            } catch(e) {
-                // an error means there is no XRandR extension
-                global.logError(e);
-                this.actor.hide();
-                return;
-            }
+        this.set_applet_icon_symbolic_name("preferences-desktop-display");
+        this.set_applet_tooltip(_("Display"));
 
-            this._createMenu();
-            this._screen.connect('changed', Lang.bind(this, this._randrEvent));
-        }
-        catch (e) {
+        this.menuManager = new PopupMenu.PopupMenuManager(this);
+        this.menu = new Applet.AppletPopupMenu(this, orientation);
+        this.menuManager.addMenu(this.menu);
+
+        this._proxy = new XRandr2(DBus.session, 'org.gnome.SettingsDaemon', '/org/gnome/SettingsDaemon/XRANDR');
+
+        try {
+            this._screen = new GnomeDesktop.RRScreen({ gdk_screen: Gdk.Screen.get_default() });
+            this._screen.init(null);
+        } catch(e) {
+            // an error means there is no XRandR extension
             global.logError(e);
+            this.actor.hide();
+            return;
         }
+
+        this._createMenu();
+        this._screen.connect('changed', Lang.bind(this, this._randrEvent));
     },
-    
+
     on_applet_clicked: function(event) {
-        this.menu.toggle();        
+        this.menu.toggle();
     },
-    
+
     _randrEvent: function() {
         this.menu.removeAll();
         this._createMenu();
     },
-    
+
     _createMenu: function() {
         let config = GnomeDesktop.RRConfig.new_current(this._screen);
         let outputs = config.get_outputs();
@@ -142,13 +137,13 @@ MyApplet.prototype = {
             retval = current;
         }
         return retval;
-    }    
-    
+    }
+
 };
 
-function main(metadata, orientation, panel_height) {  
+function main(metadata, orientation, panel_height) {
     let myApplet = new MyApplet(orientation, panel_height);
-    return myApplet;      
+    return myApplet;
 }
 
 


### PR DESCRIPTION
Cleanup includes:
- Remove trailing whitespaces
- Replace tabs with spaces
- Don't use try/catch in _init as applet manager already does that
- Proper use of ";' and ","

Certain applets have pull requests pending and are not included in cleanup.
These include:
- Window list
- Show Desktop
- Menu
- Notifications

Diff (ignore-all-space): http://pastebin.com/Bh3JeZMn
