### PR TITLE
menu applet: add a bit of extra padding during the app title width calculation

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1458,7 +1458,7 @@ MyApplet.prototype = {
     _onApplicationButtonRealized: function(actor) {
         if (actor.get_width() > this._applicationsBoxWidth){
             this._applicationsBoxWidth = actor.get_width();
-            this.applicationsBox.set_width(this._applicationsBoxWidth + 15);
+            this.applicationsBox.set_width(this._applicationsBoxWidth + 20);
         }
     },
     


### PR DESCRIPTION
menu applet: add a bit of extra padding during the app title width calculation, to keep the scroll bar from cutting off longer titles, and the selection box.

Addresses #1247
