### PR TITLE
Fixes closing busy window from window-list applet

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -123,7 +123,6 @@ AppMenuButtonRightClickMenu.prototype = {
 
     _onCloseWindowActivate: function(actor, event){
         this.metaWindow.delete(global.get_current_time());
-        this.destroy();
     },
 
     _onCloseAllActivate: function(actor, event) {


### PR DESCRIPTION
Rely on app menu button's onDestroy() to delete the right-click menu. Addresses linuxmint/Cinnamon#1147
