### PR TITLE
[1.8] Fixes animation path of traditional minimize

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -877,7 +877,17 @@ MyApplet.prototype = {
         //this._refreshItems();
         this._onWindowStateChange('map', actor);
     },
-  
+   
+    getOriginFromWindow: function(metaWindow) {
+        for ( let i=0; i<this._windows.length; ++i ) {
+            if ( this._windows[i].metaWindow == metaWindow ) {
+                return this._windows[i].actor;
+            }
+        }
+
+        return false;
+    },
+
     _windowAdded: function(metaWorkspace, metaWindow) {
         if (!this.isInteresting(metaWindow))
             return;        

--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/metadata.json
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/metadata.json
@@ -2,5 +2,6 @@
  "uuid": "window-list@cinnamon.org",
  "name": "Cinnamon Window list",
  "description": "Main Cinnamon window list",
- "icon": "gnome-panel-window-list"
+ "icon": "gnome-panel-window-list",
+ "role": "windowlist"
 }

--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -22,11 +22,13 @@ const applets = {};
 // question - should multiple applets be able to fill
 // the same role?
 const Roles = {
-    NOTIFICATIONS: 'notifications'
+    NOTIFICATIONS: 'notifications',
+    WINDOWLIST: 'windowlist'
 }
 
 let AppletHooks = {
-    notifications: false
+    notifications: false,
+    windowlist: false
 }
 
 var enabledApplets;
@@ -265,6 +267,15 @@ function get_applet_enabled(uuid) {
 function get_role_provider_exists(role) {
     if (role in AppletHooks && AppletHooks[role] == true) {
         return true;
+    }
+    return false;
+}
+
+function get_role_provider(role) {
+    for (var i in appletMeta) {
+        if (appletMeta[i]['role'] == role) {
+            return appletObj[i];
+        }
     }
     return false;
 }

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -6,6 +6,7 @@ const Meta = imports.gi.Meta;
 const St = imports.gi.St;
 const Cinnamon = imports.gi.Cinnamon;
 
+const AppletManager = imports.ui.appletManager;
 const AltTab = imports.ui.altTab;
 const Main = imports.ui.main;
 const Tweener = imports.ui.tweener;
@@ -233,10 +234,16 @@ WindowManager.prototype = {
         catch(e) {
             log(e);
         }
-                
-        if (effect == "traditional") {  
+
+        if (actor.get_meta_window()._cinnamonwm_has_origin) {
+            // reset all cached values in case "traditional" is no longer in effect
+            actor.get_meta_window()._cinnamonwm_has_origin = false;
+            actor.get_meta_window()._cinnamonwm_minimize_transition = undefined;
+            actor.get_meta_window()._cinnamonwm_minimize_time = undefined;
+        }
+
+        if (effect == "traditional") {
             actor.set_scale(1.0, 1.0);
-            actor.move_anchor_point_from_gravity(Clutter.Gravity.CENTER);        
             this._minimizing.push(actor);
             let monitor;
             let yDest;            
@@ -247,10 +254,30 @@ WindowManager.prototype = {
             else {
                 monitor = Main.layoutManager.primaryMonitor;
                 yDest = 0;
-            }            
+            }
+
             let xDest = monitor.x + monitor.width/4;
             if (St.Widget.get_default_direction() == St.TextDirection.RTL)
-                xDest = monitor.width - monitor.width/4;        
+                xDest = monitor.width - monitor.width/4;
+
+            if (AppletManager.get_role_provider_exists(AppletManager.Roles.WINDOWLIST)) {
+                let windowApplet = AppletManager.get_role_provider(AppletManager.Roles.WINDOWLIST);
+                let actorOrigin = windowApplet.getOriginFromWindow(actor.get_meta_window());
+                
+                if (actorOrigin !== false) {
+                    [xDest, yDest] = actorOrigin.get_transformed_position();
+                    // Adjust horizontal destination or it'll appear to zoom
+                    // down to our button's left (or right in RTL) edge.
+                    // To center it, we'll add half its width.
+                    // We use the allocation box because otherwise our
+                    // pseudo-class ":focus" may be larger when not minimized.
+                    xDest += actorOrigin.get_allocation_box().get_size()[0] / 2;
+                    actor.get_meta_window()._cinnamonwm_has_origin = true;
+                    actor.get_meta_window()._cinnamonwm_minimize_transition = transition;
+                    actor.get_meta_window()._cinnamonwm_minimize_time = time;
+                }
+            }
+            
             Tweener.addTween(actor,
                              { scale_x: 0.0,
                                scale_y: 0.0,
@@ -531,7 +558,50 @@ WindowManager.prototype = {
         catch(e) {
             log(e);
         }
+        
+        if (actor.get_meta_window()._cinnamonwm_has_origin === true) {
+            /* "traditional" minimize mapping has been applied, do the converse un-minimize */
+            let xSrc, ySrc, xDest, yDest;
+            [xDest, yDest] = actor.get_transformed_position();
+
+            if (AppletManager.get_role_provider_exists(AppletManager.Roles.WINDOWLIST))
+            {
+                let windowApplet = AppletManager.get_role_provider(AppletManager.Roles.WINDOWLIST);
+                let actorOrigin = windowApplet.getOriginFromWindow(actor.get_meta_window());
                 
+                if (actorOrigin !== false) {
+                    actor.set_scale(0.0, 0.0);
+                    this._mapping.push(actor);
+                    [xSrc, ySrc] = actorOrigin.get_transformed_position();
+                    // Adjust horizontal destination or it'll appear to zoom
+                    // down to our button's left (or right in RTL) edge.
+                    // To center it, we'll add half its width.
+                    xSrc += actorOrigin.get_allocation_box().get_size()[0] / 2;
+                    actor.set_position(xSrc, ySrc);
+                    actor.show();
+
+                    let myTransition = actor.get_meta_window()._cinnamonwm_minimize_transition||transition;
+                    let lastTime = actor.get_meta_window()._cinnamonwm_minimize_time;
+                    let myTime = typeof(lastTime) !== "undefined" ? lastTime : time;
+                    Tweener.addTween(actor,
+                                     { scale_x: 1.0,
+                                       scale_y: 1.0,
+                                       x: xDest,
+                                       y: yDest,
+                                       time: myTime,
+                                       transition: myTransition,
+                                       onComplete: this._mapWindowDone,
+                                       onCompleteScope: this,
+                                       onCompleteParams: [cinnamonwm, actor],
+                                       onOverwrite: this._mapWindowOverwrite,
+                                       onOverwriteScope: this,
+                                       onOverwriteParams: [cinnamonwm, actor]
+                                     });
+                    return;
+                }
+            } // if window list doesn't support finding an origin
+        }
+        
         if (effect == "fade") {            
             this._mapping.push(actor);
             actor.opacity = 0;


### PR DESCRIPTION
Changes animation path to window button's location instead of hard set position. Addresses linuxmint/Cinnamon#1212

Adds a new applet role "windowlist" which must implement a `getOriginFromWindow` function that, given a meta window, must return the actor that launched it.

Adds a new appletManager function `get_role_provider` that, given an applet role, returns the currently-loaded applet responsible for that role.

Thanks @mtwebster for the guidance on applet roles and other fun stuff :)
