### PR TITLE
[Alt-Tab, 1.6.2?] Fix thumbnail size calculation for some dual-head setups

### DIFF
--- a/js/ui/altTab.js
+++ b/js/ui/altTab.js
@@ -153,7 +153,7 @@ AltTabPopup.prototype = {
             if (childBox.x2 > primary.x + primary.width - rightPadding)
                 childBox.x2 = primary.x + primary.width - rightPadding;
             childBox.y1 = this._appSwitcher.actor.allocation.y2 + spacing;
-            this._thumbnails.addClones(primary.height - bottomPadding - childBox.y1);
+            this._thumbnails.addClones(primary.y + primary.height - bottomPadding - childBox.y1);
             let [childMinHeight, childNaturalHeight] = this._thumbnails.actor.get_preferred_height(-1);
             childBox.y2 = childBox.y1 + childNaturalHeight;
             this._thumbnails.actor.allocate(childBox, flags);


### PR DESCRIPTION
This is cherry-picked from GNOME Shell. I think it makes sense, but I don't have the hardware to test it.

```
altTab: Fix thumbnail size calculation for some dual-head setups

The old formula worked only when the primary monitor was positioned at the
top of the virtual desktop.  When that was not the case, the available
space was miscalculated sometimes resulting in negative numbers, which in
the end produced strangely vertically stretched window thumbnails.

https://bugzilla.gnome.org/show_bug.cgi?id=651130
```
