### PR TITLE
Run dialog: don't keep duplicate commands in history

### DIFF
--- a/js/misc/history.js
+++ b/js/misc/history.js
@@ -15,7 +15,8 @@ HistoryManager.prototype = {
     _init: function(params) {
         params = Params.parse(params, { gsettingsKey: null,
                                         limit: DEFAULT_LIMIT,
-                                        entry: null });
+                                        entry: null,
+                                        deduplicate: false });
 
         this._key = params.gsettingsKey;
         this._limit = params.limit;
@@ -36,6 +37,8 @@ HistoryManager.prototype = {
             this._entry.connect('key-press-event', 
                                 Lang.bind(this, this._onEntryKeyPress));
         }
+
+        this._deduplicate = params.deduplicate;
     },
 
     _historyChanged: function() {
@@ -75,6 +78,12 @@ HistoryManager.prototype = {
     addItem: function(input) {
         if (this._history.length == 0 ||
             this._history[this._history.length - 1] != input) {
+
+            if (this._deduplicate) {
+                this._history = this._history.filter(function(x) {
+                    return x != input;
+                });
+            }
 
             this._history.push(input);
             this._save();

--- a/js/ui/runDialog.js
+++ b/js/ui/runDialog.js
@@ -241,7 +241,8 @@ __proto__: ModalDialog.ModalDialog.prototype,
         this._group.connect('notify::visible', Lang.bind(this._commandCompleter, this._commandCompleter.update));
 
         this._history = new History.HistoryManager({ gsettingsKey: HISTORY_KEY,
-                                                     entry: this._entryText });
+                                                     entry: this._entryText,
+                                                     deduplicate: true });
         this._entryText.connect('key-press-event', Lang.bind(this, function(o, e) {
             let symbol = e.get_key_symbol();
             if (symbol == Clutter.Return || symbol == Clutter.KP_Enter) {


### PR DESCRIPTION
The run dialog should only show unique commands. This makes the run
dialog significantly more useful as a quick launcher for regularly used
commands. History deduplication matches the behaviour of e.g. gmrun or
the the venerable Metacity/MATE run dialog.

Technically, if recalling a previously used command from history, the
command will be appended as most recent item to the history and all
earlier occurrences will be removed.

This patch also provides a smooth upgrade path for existing histories.
The history is initially left untouched, but once a previous command is
recalled, all duplicates are removed.
