### PR TITLE
[window-list applet] Improve focus tracking by checking whether a dialog has focus

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -378,8 +378,23 @@ AppMenuButton.prototype = {
         this.rightClickMenu.destroy();
     },
     
+    _hasFocus: function(metaWindow) {
+        if (metaWindow.has_focus()) {
+            return true;
+        }
+        let transientHasFocus = false;
+        metaWindow.foreach_transient(function(transient) {
+            if (transient.has_focus()) {
+                transientHasFocus = true;
+                return false;
+            }
+            return true;
+        }); 
+        return transientHasFocus;
+    },
+    
     doFocus: function() {
-        if (this.metaWindow.has_focus() && !this.metaWindow.minimized) {                                     
+        if (this._hasFocus(this.metaWindow) && !this.metaWindow.minimized) {                                     
         	this.actor.add_style_pseudo_class('focus');    
             this.actor.remove_style_class_name("window-list-item-demands-attention");    	
             this.actor.remove_style_class_name("window-list-item-demands-attention-top");


### PR DESCRIPTION
The window list applet loses track of which which window has focus if the window opens a dialog. This patch fixes that issue by iterating through a window's "transient" windows to see whether one has focus.

How to test:
1) Open gedit and give it focus.
2) Make sure that gedit is highlighted in the window list.
3) In gedit, pull up the Open dialog (Ctrl-O).

Current behavior: window list does not show any window having focus.
Desired behavior: window list should keep gedit highlighted as long as the main window or any window belonging to the main window is active.

Current status: Ready for test. The patch conflicts with the unmerged alert-notifications patch.
