### PR TITLE
[RFT] Generally disable window effects in system-modal state

### DIFF
--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -159,9 +159,13 @@ WindowManager.prototype = {
     },
 
     _shouldAnimate : function(actor) {
+        if (Main.modalCount) {
+            // system is in modal state
+            return false;
+        }
         if (Main.software_rendering)
             return false;
-        if (Main.overview.visible || this._animationsBlocked > 0)
+        if (this._animationsBlocked > 0)
             return false;
         if (!actor)
             return global.settings.get_boolean("desktop-effects");


### PR DESCRIPTION
If the system is in a modal state (such as when Expo, Scale or Alt-Tab is showing) it makes little sense to do window effects. This makes activation of a minimized window from Alt-Tab bypass the "map" animation so that the activated window is instantly available.

Current status: Ready For Test.
