### PR TITLE
[Dual-Monitor, Scale] Show all windows belonging to the current workspace together

### DIFF
--- a/js/ui/workspace.js
+++ b/js/ui/workspace.js
@@ -747,10 +747,6 @@ Workspace.prototype = {
             this._windowRemovedId = this.metaWorkspace.connect('window-removed',
                                                                Lang.bind(this, this._windowRemoved));
         }
-        this._windowEnteredMonitorId = global.screen.connect('window-entered-monitor',
-                                                           Lang.bind(this, this._windowEnteredMonitor));
-        this._windowLeftMonitorId = global.screen.connect('window-left-monitor',
-                                                           Lang.bind(this, this._windowLeftMonitor));
         this._repositionWindowsId = 0;
 
         this.leavingOverview = false;
@@ -1407,18 +1403,6 @@ Workspace.prototype = {
         this._doRemoveWindow(metaWin);
     },
 
-    _windowEnteredMonitor : function(metaScreen, monitorIndex, metaWin) {
-        if (monitorIndex == this.monitorIndex) {
-            this._doAddWindow(metaWin);
-        }
-    },
-
-    _windowLeftMonitor : function(metaScreen, monitorIndex, metaWin) {
-        if (monitorIndex == this.monitorIndex) {
-            this._doRemoveWindow(metaWin);
-        }
-    },
-
     // check for maximized windows on the workspace
     hasMaximizedWindows: function() {
         for (let i = 0; i < this._windows.length; i++) {
@@ -1503,8 +1487,6 @@ Workspace.prototype = {
             this.metaWorkspace.disconnect(this._windowAddedId);
             this.metaWorkspace.disconnect(this._windowRemovedId);
         }
-        global.screen.disconnect(this._windowEnteredMonitorId);
-        global.screen.disconnect(this._windowLeftMonitorId);
 
         if (this._repositionWindowsId > 0)
             Mainloop.source_remove(this._repositionWindowsId);
@@ -1523,10 +1505,9 @@ Workspace.prototype = {
         this.leavingOverview = false;
     },
 
-    // Tests if @win belongs to this workspaces and monitor
+    // Tests if @win belongs to this workspace
     _isMyWindow : function (win) {
-        return (this.metaWorkspace == null || Main.isWindowActorDisplayedOnWorkspace(win, this.metaWorkspace.index())) &&
-            (!win.get_meta_window() || win.get_meta_window().get_monitor() == this.monitorIndex);
+        return (this.metaWorkspace == null || Main.isWindowActorDisplayedOnWorkspace(win, this.metaWorkspace.index()));
     },
 
     // Tests if @win should be shown in the Overview
@@ -1650,12 +1631,6 @@ Workspace.prototype = {
             };
 
             let metaWindow = win.get_meta_window();
-
-            // We need to move the window before changing the workspace, because
-            // the move itself could cause a workspace change if the window enters
-            // the primary monitor
-            if (metaWindow.get_monitor() != this.monitorIndex)
-                metaWindow.move_to_monitor(this.monitorIndex);
 
             let index = this.metaWorkspace ? this.metaWorkspace.index() : global.screen.get_active_workspace_index();
             metaWindow.change_workspace_by_index(index,

--- a/js/ui/workspacesView.js
+++ b/js/ui/workspacesView.js
@@ -67,18 +67,6 @@ WorkspacesView.prototype = {
             this._workspaces[w].actor.reparent(this.actor);
         this._workspaces[activeWorkspaceIndex].actor.raise_top();
 
-        this._extraWorkspaces = [];
-        let monitors = Main.layoutManager.monitors;
-        let m = 0;
-        for (let i = 0; i < monitors.length; i++) {
-            if (i == Main.layoutManager.primaryIndex)
-                continue;
-            let ws = new Workspace.Workspace(null, i);
-            this._extraWorkspaces[m++] = ws;
-            ws.setGeometry(monitors[i].x, monitors[i].y, monitors[i].width, monitors[i].height);
-            global.overlay_group.add_actor(ws.actor);
-        }
-
         // Position/scale the desktop windows and their children after the
         // workspaces have been created. This cannot be done first because
         // window movement depends on the Workspaces object being accessible
@@ -88,8 +76,6 @@ WorkspacesView.prototype = {
                                  Lang.bind(this, function() {
                 for (let w = 0; w < this._workspaces.length; w++)
                     this._workspaces[w].zoomToOverview();
-                for (let w = 0; w < this._extraWorkspaces.length; w++)
-                    this._extraWorkspaces[w].zoomToOverview();
         }));
         this._overviewShownId =
             Main.overview.connect('shown',
@@ -208,8 +194,6 @@ WorkspacesView.prototype = {
 
         for (let w = 0; w < this._workspaces.length; w++)
             this._workspaces[w].zoomFromOverview();
-        for (let w = 0; w < this._extraWorkspaces.length; w++)
-            this._extraWorkspaces[w].zoomFromOverview();
     },
 
     destroy: function() {
@@ -219,8 +203,6 @@ WorkspacesView.prototype = {
     syncStacking: function(stackIndices) {
         for (let i = 0; i < this._workspaces.length; i++)
             this._workspaces[i].syncStacking(stackIndices);
-        for (let i = 0; i < this._extraWorkspaces.length; i++)
-            this._extraWorkspaces[i].syncStacking(stackIndices);
     },
 
     updateWindowPositions: function() {
@@ -345,8 +327,6 @@ WorkspacesView.prototype = {
     },
 
     _onDestroy: function() {
-        for (let i = 0; i < this._extraWorkspaces.length; i++)
-            this._extraWorkspaces[i].destroy();
         this._scrollAdjustment.run_dispose();
         Main.overview.disconnect(this._overviewShowingId);
         Main.overview.disconnect(this._overviewShownId);
@@ -409,8 +389,6 @@ WorkspacesView.prototype = {
             this._firstDragMotion = false;
             for (let i = 0; i < this._workspaces.length; i++)
                 this._workspaces[i].setReservedSlot(dragEvent.dragActor._delegate);
-            for (let i = 0; i < this._extraWorkspaces.length; i++)
-                this._extraWorkspaces[i].setReservedSlot(dragEvent.dragActor._delegate);
         }
 
         return DND.DragMotionResult.CONTINUE;
@@ -422,8 +400,6 @@ WorkspacesView.prototype = {
 
         for (let i = 0; i < this._workspaces.length; i++)
             this._workspaces[i].setReservedSlot(null);
-        for (let i = 0; i < this._extraWorkspaces.length; i++)
-            this._extraWorkspaces[i].setReservedSlot(null);
     },
 
     _swipeScrollBegin: function() {


### PR DESCRIPTION
This makes Scale behave more sensibly with multiple monitors.Currently, Scale shows the windows belonging to the primary monitor on the primary, while it displays all other windows, including those from other workspaces, on the secondary monitor. This patch makes Scale show all the windows belonging to the current workspace on the primary monitor and leaves the second monitor empty.

See also #1276.
