### PR TITLE
Added mouse button modifier to Cinnamon window settings (makes it easier to properly use Blender). Added option to add the menu icon to the title bar.

### DIFF
--- a/files/usr/lib/cinnamon-settings/cinnamon-settings.py
+++ b/files/usr/lib/cinnamon-settings/cinnamon-settings.py
@@ -2542,12 +2542,13 @@ class TitleBarButtonsOrderSelector(Gtk.Table):
         
         self.left_side_widgets = []
         self.right_side_widgets = []
-        for i in range(3):
+        for i in range(4):
             self.left_side_widgets.append(Gtk.ComboBox())
             self.right_side_widgets.append(Gtk.ComboBox())
         
         buttons = [
             ("", ""),
+            ("menu", _("Menu")),
             ("close", _("Close")),
             ("minimize", _("Minimize")),
             ("maximize", _("Maximize"))


### PR DESCRIPTION
Added the mouse button modifier entry, so Blender users can easily change that setting since it's vital to properly use Blender without having to reconfigure it (workflow). "Alt+Right Click" interferes with the Blender shortcut for "Edge Loop Select". On top "Alt+Right Click" opens the same menu as "Alt+Space" so in my opinion it's quite superfluos. Should you prefer to keep it, I'd suggest to map the mouse button modifier to <Super> instead by default.

Added option to add the menu icon to the title bar. See the commit comment for more info on that.
