### PR TITLE
[window list] Overview of menus. Add move-to-monitor menu options.

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -180,7 +180,6 @@ AppMenuButtonRightClickMenu.prototype = {
             // out a bit later.
             Mainloop.timeout_add(0, function() {
                 metaWindow.change_workspace(workspace);
-                Main._checkWorkspaces();
             });
         }
     },


### PR DESCRIPTION
1. Refactor the window-list menus to be populated on demand. 
2. Add move-to-monitor menu options.

This also fixes the following bug:
Attempting to close a window that doesn't want to be closed causes the menu to be destroyed.
