### PR TITLE
[DND] Cannot drop anywhere in area that lies on top of hidden panel (Expo window-close area)

### DIFF
--- a/js/ui/dnd.js
+++ b/js/ui/dnd.js
@@ -404,7 +404,7 @@ _Draggable.prototype = {
             this._dragActor.set_position(stageX + this._dragOffsetX,
                                          stageY + this._dragOffsetY);
 
-            let target = this._dragActor.get_stage().get_actor_at_pos(Clutter.PickMode.ALL,
+            let target = this._dragActor.get_stage().get_actor_at_pos(Clutter.PickMode.REACTIVE,
                                                                       stageX, stageY);
 
             // We call observers only once per motion with the innermost


### PR DESCRIPTION
This fixes an issue that makes drag and drop sometimes not work.

Steps to reproduce:
1. Arrange to have a fairly tall panel at the bottom.
2. Open expo and drag a window to the window-close area that should become visible in the lower part of the screen.
3. Drag the window down to base of the screen, all the time within the window-close area.

Desired behavior: As long as the cursor is within the window-close area the cursor should indicate that dropping is allowed.
Actual behavior: As soon as the cursor enters the area where the panel usually is visible the cursor changes to indicate that dropping is not allowed.

Disclaimer: this is a small fix that may have wide-reaching implications. The fix should be thoroughly tested in different drag-and-drop scenarios.
