### PR TITLE
Window-workspace-shift rework

### DIFF
--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -5,6 +5,7 @@ const Lang = imports.lang;
 const Meta = imports.gi.Meta;
 const St = imports.gi.St;
 const Cinnamon = imports.gi.Cinnamon;
+const Mainloop = imports.mainloop;
 
 const AltTab = imports.ui.altTab;
 const Main = imports.ui.main;
@@ -790,30 +791,28 @@ WindowManager.prototype = {
         
     },
 
-    _moveWindowToWorkspaceLeft : function(display, screen, window, binding) {
+    _shiftWindowToWorkspace : function(window, direction) {
         if (window.get_window_type() === Meta.WindowType.DESKTOP) {
             return;
         }
-        let workspace = global.screen.get_active_workspace().get_neighbor(Meta.MotionDirection.LEFT)
+        let workspace = global.screen.get_active_workspace().get_neighbor(direction);
         if (workspace != global.screen.get_active_workspace()) {
-            window.change_workspace(workspace);
             workspace.activate(global.get_current_time());
-            window.raise();
             this.showWorkspaceOSD();
+            Mainloop.idle_add(Lang.bind(this, function() {
+                // Unless this is done a bit later, window is sometimes not activated
+                window.change_workspace(workspace);
+                window.activate(global.get_current_time());
+            }));
         }
     },
 
+    _moveWindowToWorkspaceLeft : function(display, screen, window, binding) {
+        this._shiftWindowToWorkspace(window, Meta.MotionDirection.LEFT);
+    },
+
     _moveWindowToWorkspaceRight : function(display, screen, window, binding) {
-        if (window.get_window_type() === Meta.WindowType.DESKTOP) {
-            return;
-        }
-        let workspace = global.screen.get_active_workspace().get_neighbor(Meta.MotionDirection.RIGHT)
-        if (workspace != global.screen.get_active_workspace()) {
-            window.change_workspace(workspace);
-            workspace.activate(global.get_current_time());
-            window.raise();
-            this.showWorkspaceOSD();
-        }
+        this._shiftWindowToWorkspace(window, Meta.MotionDirection.RIGHT);
     },
 
     _showWorkspaceSwitcher : function(display, screen, window, binding) {


### PR DESCRIPTION
This fixes two problems with window-workspace shifting (Ctrl+Shift+Alt+Left/Right):
1. The desktop window could itself be subject to workspace shifting linuxmint/nemo#106.
2. Shifting a window through a workspace that already had a window could lead to the wrong window being shifted. (#1368)

The solution to point 2 is actually a by-product of an attempt of mine to make the visual experience less confusing, by doing the workspace switch first and shifting the window later. I think there is still room for improvement in that respect.
