### PR TITLE
Creates a -common package to hold arch-indep files

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+cinnamon (1.6.7+nmu1) UNRELEASED; urgency=low
+
+  * Temporary version to make sure the split into cinnamon and
+    cinnamon-common does not break developers test environment. For
+    cleanliness purpose, remove this version from this changelog file just
+    before the next release.
+
+ -- Nicolas Bourdaud <nicolas.bourdaud@gmail.com>  Mon, 19 Nov 2012 21:36:11 +0100
+
 cinnamon (1.6.7) nadia; urgency=low
 
   * 1.6.7

--- a/debian/cinnamon-common.install
+++ b/debian/cinnamon-common.install
@@ -1,0 +1,6 @@
+/etc
+/usr/share/cinnamon
+/usr/share/desktop-directories
+/usr/share/glib-2.0
+/usr/share/gnome-session
+/usr/share/xsessions

--- a/debian/cinnamon.install
+++ b/debian/cinnamon.install
@@ -1,0 +1,5 @@
+/usr/bin
+/usr/lib
+/usr/share/applications
+/usr/share/dbus-1
+/usr/share/man

--- a/debian/control.in
+++ b/debian/control.in
@@ -50,6 +50,7 @@ Depends: ${gir:Depends},
          gjs (>= 1.29.18),
          ${shlibs:Depends},
          ${misc:Depends},
+         cinnamon-common (= ${source:Version}),
          caribou,
          cups-pk-helper,
          gnome-settings-daemon (>= 2.91.5.1),
@@ -87,3 +88,22 @@ Description: Cinnamon desktop
  by the GNOME Panel and by the window manager in previous versions of
  GNOME. Cinnamon has rich visual effects enabled by new
  graphical technologies.
+
+Package: cinnamon-common
+Replaces: cinnamon (<< 1.6.7+nmu1)
+Breaks: cinnamon (<< 1.6.7+nmu1)
+Architecture: all
+Depends: ${misc:Depends}, python
+Description: Cinnamon desktop (Common data files)
+ Cinnamon redefines user interactions with the GNOME desktop.
+ In particular, it offers new paradigms for launching applications,
+ accessing documents, and organizing open windows in GNOME. Later, it
+ will introduce a new applets eco-system and offer new solutions for
+ other desktop features, such as notifications and contacts
+ management. Cinnamon is intended to replace functions handled
+ by the GNOME Panel and by the window manager in previous versions of
+ GNOME. Cinnamon has rich visual effects enabled by new
+ graphical technologies.
+ .
+ This package contains the architecture independent files needed by Cinnamon
+


### PR DESCRIPTION
Split the cinnamon binary deb package into cinnamon and cinnamon-common. The later contains only architecture independent files.

This split is the same as the one used by the cinnamon package in Debian
