### PR TITLE
bugfix: cinnamon-settings doesn't start when user has defined python customization file

### DIFF
--- a/files/usr/lib/cinnamon-settings/cinnamon-settings.py
+++ b/files/usr/lib/cinnamon-settings/cinnamon-settings.py
@@ -2,6 +2,7 @@
 
 try:
     import os
+    import os.path
     import commands
     import sys
     import string    
@@ -14,7 +15,6 @@ try:
     import tz    
     import time
     from datetime import datetime
-    from user import home
     import thread
     import urllib
     import lxml.etree
@@ -28,6 +28,8 @@ except Exception, detail:
     print detail
     sys.exit(1)
 
+# get home directory
+home = os.path.expanduser("~")
 
 # i18n
 gettext.install("cinnamon", "/usr/share/cinnamon/locale")


### PR DESCRIPTION
If you have defined a ~/.pythonrc.py, the following statement doesn't work anymore: "from user import home". Besides,  this is a bad practice and user module has been removed in python3. This issue is always reproducible. 

You can either use pyxdg, for instance a drop-in alternative would be "from xdg.BaseDirectory import _home as home" (but that adds a pyxdg dependency to cinnamon-settings) or use standard library os.path.expanduser("~") which is garanteed to work on all platforms supported by Python.

Since i don't which is Cinnamon dependencies policy, i favored the latter solution.
