### PR TITLE
[cinnamon startup] Move pointer to center of primary monitor.

### DIFF
--- a/js/misc/pointerTracker.js
+++ b/js/misc/pointerTracker.js
@@ -9,6 +9,7 @@ const PointerTracker = new Lang.Class({
         let deviceManager = display.get_device_manager();
         let pointer = deviceManager.get_client_pointer();
         let [lastScreen, lastPointerX, lastPointerY] = pointer.get_position();
+
         this.hasMoved = function() {
             let [screen, pointerX, pointerY] = pointer.get_position();
             try {
@@ -16,6 +17,15 @@ const PointerTracker = new Lang.Class({
             } finally {
                 [lastScreen, lastPointerX, lastPointerY] = [screen, pointerX, pointerY];
             }
-        }
+        };
+        this.getPosition = function() {
+            [lastScreen, lastPointerX, lastPointerY] = pointer.get_position();
+            return [lastPointerX, lastPointerY, lastScreen];
+        };
+        this.setPosition = function(x, y, screenOpt) {
+            let [screen, pointerX, pointerY] = pointer.get_position();
+            pointer.warp(screenOpt || screen, Math.round(x), Math.round(y));
+            [lastScreen, lastPointerX, lastPointerY] = pointer.get_position();
+        };
     }
 });

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -8,6 +8,7 @@ const Mainloop = imports.mainloop;
 const Meta = imports.gi.Meta;
 const Cinnamon = imports.gi.Cinnamon;
 const St = imports.gi.St;
+const PointerTracker = imports.misc.pointerTracker;
 
 const AutomountManager = imports.ui.automountManager;
 const AutorunManager = imports.ui.autorunManager;
@@ -239,6 +240,9 @@ function start() {
     global.top_window_group.reparent(global.stage);
 
     layoutManager = new Layout.LayoutManager();
+    let pointerTracker = new PointerTracker.PointerTracker();
+    pointerTracker.setPosition(layoutManager.primaryMonitor.width/2, layoutManager.primaryMonitor.height/2);
+
     xdndHandler = new XdndHandler.XdndHandler();
     // This overview object is just a stub for non-user sessions
     overview = new Overview.Overview();


### PR DESCRIPTION
This addresses my issue #1323 by centering the mouse pointer in the primary monitor fairly early in Cinnamon's startup sequence.
