### PR TITLE
Sound Applet: Added support for quick muting via middle click

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -806,6 +806,22 @@ MyApplet.prototype = {
         this._notifyVolumeChange();
     },
 
+    _onButtonReleaseEvent: function (actor, event) {
+        Applet.IconApplet.prototype._onButtonReleaseEvent.call(this, actor, event);
+
+        if (event.get_button() == 2) {
+            if (this._output.is_muted)
+                this._output.change_is_muted(false);
+            else {
+                this._output.change_is_muted(true);
+            }
+
+            this._output.push_volume();
+        }
+
+        return true;
+    },
+
     setIconName: function(icon) {
        this._icon_name = icon;
        if (this._nbPlayers()==0)


### PR DESCRIPTION
Hello,
One thing I miss in Cinnamon is the support for quickly muting the default sound output. I've added support to this feature via middle-button clicking on the applet to toggle the sound on/off.

Another user was also asking for this at https://github.com/linuxmint/Cinnamon/issues/149.

Although this problem was solved by `mtwebster`, I didn't like his solution much, it's not fast enough for me (having to right click the applet to open a menu is annoying). I think since the middle mouse scroll is already used for scrolling the sound, it would be more intuitive to use the middle button click to quickly mute the sound.

What I did was extend the original "button released" event and add a middle button condition that mutes the default sound output.
