### PR TITLE
[utils.js] Set stdout and stderr of spawned processes to /dev/null

### DIFF
--- a/js/misc/util.js
+++ b/js/misc/util.js
@@ -82,7 +82,7 @@ function trySpawn(argv)
 {
     try {
         GLib.spawn_async(null, argv, null,
-                         GLib.SpawnFlags.SEARCH_PATH,
+                         GLib.SpawnFlags.SEARCH_PATH | GLib.SpawnFlags.STDOUT_TO_DEV_NULL  | GLib.SpawnFlags.STDERR_TO_DEV_NULL,
                          null, null);
     } catch (err) {
         if (err.code == GLib.SpawnError.G_SPAWN_ERROR_NOENT) {


### PR DESCRIPTION
I've noticed that if I run 'cinnamon --replace' and start a program (with Ctrl+r) in the new session, the Cinnamon instance will not exit until the program exits, and if I kill the old session after starting a newer one, the program I started will be killed as well.

This patch disconnects the started program from the Cinnamon instance by setting the spawned child process's standard output and standard error to /dev/null.
