### PR TITLE
[sound applet] Let mute icon have precedence over other icons.

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -759,6 +759,12 @@ MyApplet.prototype = {
         }
     },
 
+    on_applet_removed_from_panel : function() {
+        if (this._iconTimeoutId) {
+            Mainloop.source_remove(this._iconTimeoutId);
+        }
+    },
+
     on_applet_clicked: function(event) {
         this.menu.toggle();
     },
@@ -807,11 +813,17 @@ MyApplet.prototype = {
     },
 
     setIconName: function(icon) {
-       this._icon_name = icon;
-       if (this._nbPlayers()==0)
-         this.set_applet_icon_symbolic_name(icon);
-       else
-         this.set_applet_icon_symbolic_name('audio-x-generic');
+        this._icon_name = icon;
+        this.set_applet_icon_symbolic_name(icon);
+        if (this._nbPlayers()>0) {
+            if (this._iconTimeoutId) {
+                Mainloop.source_remove(this._iconTimeoutId);
+            }
+            this._iconTimeoutId = Mainloop.timeout_add(3000, Lang.bind(this, function() {
+                this._iconTimeoutId = null;
+                this.set_applet_icon_symbolic_name(this['_output'].is_muted ? 'audio-volume-muted' : 'audio-x-generic');
+            }));
+        }
     },
 
     _nbPlayers: function() {


### PR DESCRIPTION
This is a partial fix for #1407, addressing that the icon stays unchanged if the output volume is muted while a sound application is running.

How to test:
0) With no sound application running, mute the output volume. The sound applet should display the 'muted' icon.
1) Start a sound application from the sound applet's context menu.
2) Mute the output volume.

Expected result: The sound applet should display the 'muted' icon as long as the output volume is muted. If you unmute or change the volume, the applet icon should briefly reflect the action until it goes back to showing the usual icon.
