### PR TITLE
[Expo] Fix problem with the exit animation.

### DIFF
--- a/js/ui/expoThumbnail.js
+++ b/js/ui/expoThumbnail.js
@@ -357,7 +357,7 @@ ExpoWorkspaceThumbnail.prototype = {
                 if ((evstate & Clutter.ModifierType.BUTTON1_MASK) ||
                         (evstate & Clutter.ModifierType.BUTTON3_MASK))
                 {
-                   this.activate();
+                   this.activate(null, event.get_time());
                     return true;
                 } else if (evstate & Clutter.ModifierType.BUTTON2_MASK) {
                     this.remove();
@@ -911,9 +911,9 @@ ExpoWorkspaceThumbnail.prototype = {
         if (clone && clone.metaWindow != null){
             Main.activateWindow(clone.metaWindow, time, this.metaWorkspace.index());
         }
-        Main.expo.hide();
         if (this.metaWorkspace != global.screen.get_active_workspace())
             this.metaWorkspace.activate(time);
+        Main.expo.hide();
     },
 
     shade : function (force){


### PR DESCRIPTION
This fixes a regression caused by my latest Expo rework: The exit animation zoomed into the wrong workspace on mouse activation of a different workspace. See issue #1409.

How to test:
0) Make sure you have at least two workspaces, one of which should be empty (it is then easier to spot the bad behavior).
1) Switch to the empty workspace and open Expo.
2) In Expo, switch to another, non-empty workspace, by clicking its background.

Expected behavior: The selected workspace should zoom into view.
Regressed behavior: The previously selected workspace zooms into view before you are taken to the selected workspace.
