### PR TITLE
[Expo] Fix small issue with workspace-close button not made visible after dragging

### DIFF
--- a/js/ui/expoThumbnail.js
+++ b/js/ui/expoThumbnail.js
@@ -969,6 +969,7 @@ ExpoWorkspaceThumbnail.prototype = {
     },
 
     handleDragOverOrDrop : function(dropping, source, actor, x, y, time) {
+        this.hovering = false; // normal hover logic is off during dnd
         if (dropping) {
             let draggable = source._draggable;
             actor.opacity = draggable._dragOrigOpacity;


### PR DESCRIPTION
This fixes a small regression caused by my recently merged Expo rework.

How to test:
1) Drag a window from one workspace to another.

Expected result: After dropping, the target workspace should have its close button visible.
Regression: The target workspace does not have its close button visible.
