### PR TITLE
[resubmission of 1346] Replaced the linear numbering of getUnique<identifier> functions

### DIFF
--- a/files/usr/lib/cinnamon-menu-editor/Alacarte/util.py
+++ b/files/usr/lib/cinnamon-menu-editor/Alacarte/util.py
@@ -18,6 +18,7 @@
 
 import os
 import xml.dom.minidom
+import uuid
 from collections import Sequence
 from gi.repository import Gtk, GdkPixbuf, GMenu, GLib
 
@@ -40,12 +41,8 @@ def fillKeyFile(keyfile, items):
             keyfile.set_string(DESKTOP_GROUP, key, item)
 
 def getUniqueFileId(name, extension):
-    append = 0
     while 1:
-        if append == 0:
-            filename = name + extension
-        else:
-            filename = name + '-' + str(append) + extension
+        filename = name + '-' + str(uuid.uuid1()) + extension
         if extension == '.desktop':
             path = getUserItemPath()
             if not os.path.isfile(os.path.join(path, filename)) and not getItemPath(filename):
@@ -54,22 +51,17 @@ def getUniqueFileId(name, extension):
             path = getUserDirectoryPath()
             if not os.path.isfile(os.path.join(path, filename)) and not getDirectoryPath(filename):
                 break
-        append += 1
     return filename
 
 def getUniqueRedoFile(filepath):
-    append = 0
     while 1:
-        new_filepath = filepath + '.redo-' + str(append)
+        new_filepath = filepath + '.redo-' + str(uuid.uuid1())
         if not os.path.isfile(new_filepath):
             break
-        else:
-            append += 1
     return new_filepath
 
 def getUniqueUndoFile(filepath):
     filename, extension = os.path.split(filepath)[1].rsplit('.', 1)
-    append = 0
     while 1:
         if extension == 'desktop':
             path = getUserItemPath()
@@ -77,11 +69,9 @@ def getUniqueUndoFile(filepath):
             path = getUserDirectoryPath()
         elif extension == 'menu':
             path = getUserMenuPath()
-        new_filepath = os.path.join(path, filename + '.' + extension + '.undo-' + str(append))
+        new_filepath = os.path.join(path, filename + '.' + extension + '.undo-' + str(uuid.uuid1()))
         if not os.path.isfile(new_filepath):
             break
-        else:
-            append += 1
     return new_filepath
 
 def getItemPath(file_id):


### PR DESCRIPTION
This patch replaces the the linear numbering of getUnique<blah> functions (which counts up from 1 to find a free file name) with a call to uuid.uuidv1.

This provides unique GUID tagged entries which allows synchronizing ~/.local/share/applications files more easily between two computers.

Instead of:
alacarte-made-1.desktop

we get:
alacarte-made-aa49738a-2ac8-11e2-869b-1c6f65c8b78b.desktop

Both are functionally the same to the end user, but easier for synchronization purposes (i.e. with rsync or Unison) since name collisions are avoided.

This is a resubmission of my original patch since it was linked against my master branch and got tagged with a bunch of useless commits.
## Why UUIDs:

The problem with using a hash function is that currently when you edit a shortcut that is already in the local user directory, it's not resaved, so the hash function would wind up not representing the contents anyway.

So if the user created a launcher to SpecialProgramA, the later changes it to point to SpecialProgramB, the filename would still hold the MD5 of SpecialProgramA. If they then later recreate a launcher to SpecialProgramA, you'd have a filename clash you'd have to deal with.

The UUID ensures the filename is unique, and after an initial sync, that editing a launcher on one computer means you're editing that specific launcher.
