### PR TITLE
[Expo] Use a more logical style class for the Expo window-close button.

### DIFF
--- a/js/ui/expoThumbnail.js
+++ b/js/ui/expoThumbnail.js
@@ -368,7 +368,7 @@ ExpoWorkspaceThumbnail.prototype = {
 
         this.actor.connect('scroll-event', Lang.bind(this, this.onScrollEvent));
         
-        this.closeWindowButton = new St.Button({ style_class: 'workspace-close-button' });
+        this.closeWindowButton = new St.Button({ style_class: 'window-close' });
         this.actor.add_actor(this.closeWindowButton);
         this.closeWindowButton.connect('clicked', Lang.bind(this, function(actor, event) {
             if (this.lastHoveredClone) {


### PR DESCRIPTION
As suggested by @bimsebasse in issue #1404, the Expo window-close button should not use the same style class as the workspace-close button. Until it is decided whether to create a separate class for this button, let it use the style class used by Scale's window-close buttons.
