### PR TITLE
Added notification-daemon as a provided-package by Cinnamon.

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -75,7 +75,7 @@ Depends: ${gir:Depends},
 Recommends: gnome-control-center, gnome-user-guide, gnome-themes-standard, gnome-session-fallback, gnome-terminal, nemo
 Breaks: gnome-control-center (<< 1:3.0)
 Conflicts: cinnamon-session, cinnamon-settings
-Provides: cinnamon-session, cinnamon-settings
+Provides: cinnamon-session, cinnamon-settings, notification-daemon
 Replaces: cinnamon-session, cinnamon-settings
 Description: Cinnamon desktop
  Cinnamon redefines user interactions with the GNOME desktop.


### PR DESCRIPTION
Fixes #1432.

Tiny change which causes apt to correctly recognize that Cinnamon provides notification-daemon (since it registers the dbus interface). This allows any other notification packages to be uninstalled without breaking dependencies for applications which need one (since Cinnamon already provides it).
