### PR TITLE
remove gthread init call which no longer exists

### DIFF
--- a/src/run-js-test.c
+++ b/src/run-js-test.c
@@ -73,7 +73,6 @@ main(int argc, char **argv)
   gsize len;
   int code;
 
-  g_thread_init (NULL);
 
   gtk_init (&argc, &argv);
 


### PR DESCRIPTION
This removes a depreciated gthread init call as this call no longer exists in gtk and causes a compiler error.
