### PR TITLE
add alternative muffin Meta API

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -275,7 +275,7 @@ libcinnamon_la_LIBADD =		\
 libcinnamon_la_CPPFLAGS = $(cinnamon_cflags)
 
 Cinnamon-0.1.gir: libcinnamon.la St-1.0.gir
-Cinnamon_0_1_gir_INCLUDES = Clutter-1.0 ClutterX11-1.0 Meta-3.0 Soup-2.4 GMenu-3.0 NetworkManager-1.0 NMClient-1.0
+Cinnamon_0_1_gir_INCLUDES = Clutter-1.0 ClutterX11-1.0 Meta-Muffin.0 Soup-2.4 GMenu-3.0 NetworkManager-1.0 NMClient-1.0
 Cinnamon_0_1_gir_CFLAGS = $(libcinnamon_la_CPPFLAGS) -I $(srcdir)
 Cinnamon_0_1_gir_LIBS = libcinnamon.la
 Cinnamon_0_1_gir_FILES = $(libcinnamon_la_gir_sources)


### PR DESCRIPTION
This patch changes the API of the Meta introspection to make it muffin specific in order to avoid a clash with gnome-shell API.  Although muffin's introspection is private, some distro packaging will automatically pick up typelib causing hard to debug packaging errors.

Although both opensuse and Mageia have worked around this issue by disabling auto-typelib dependencies in the spec file, this patch does things correctly by identifying the Meta API used by muffin as unique to Muffin.

This patch needs to be applied with the corresponding patches in Muffin.
