### PR TITLE
[Window Manager] Automatically show Workspace OSD when the active workspace changes

### DIFF
--- a/js/ui/altTab.js
+++ b/js/ui/altTab.js
@@ -293,7 +293,6 @@ AltTabPopup.prototype = {
             if (current == global.screen.get_active_workspace_index()) {
                 return false;
             }
-            Main.wm.showWorkspaceOSD();
             that.refresh('no-switch-windows');
             return true;
         };

--- a/js/ui/expoThumbnail.js
+++ b/js/ui/expoThumbnail.js
@@ -1239,7 +1239,6 @@ ExpoThumbnailsBox.prototype = {
             }
             this.kbThumbnailIndex = index;
             this.activateSelectedWorkspace();
-            Main.wm.showWorkspaceOSD();
             return true; // handled
         }
 

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -725,6 +725,7 @@ WindowManager.prototype = {
     },
 
     _switchWorkspace : function(cinnamonwm, from, to, direction) {
+        this.showWorkspaceOSD();
         if (!this._shouldAnimate()) {
             cinnamonwm.completed_switch_workspace();                                
             return;
@@ -872,7 +873,6 @@ WindowManager.prototype = {
         let workspace = global.screen.get_active_workspace().get_neighbor(direction);
         if (workspace != global.screen.get_active_workspace()) {
             workspace.activate(global.get_current_time());
-            this.showWorkspaceOSD();
             Mainloop.idle_add(Lang.bind(this, function() {
                 // Unless this is done a bit later, window is sometimes not activated
                 window.change_workspace(workspace);
@@ -905,15 +905,9 @@ WindowManager.prototype = {
         let current_workspace_index = global.screen.get_active_workspace_index();
         if (binding.get_name() == 'switch-to-workspace-left') {
            this.actionMoveWorkspaceLeft();
-           if (current_workspace_index !== global.screen.get_active_workspace_index()) {
-                this.showWorkspaceOSD();
-           }
         }
         else if (binding.get_name() == 'switch-to-workspace-right') {
            this.actionMoveWorkspaceRight();
-           if (current_workspace_index !== global.screen.get_active_workspace_index()) {
-                this.showWorkspaceOSD();
-           }
         }
     },
 

--- a/js/ui/workspacesView.js
+++ b/js/ui/workspacesView.js
@@ -167,7 +167,6 @@ WorkspacesView.prototype = {
         let active = global.screen.get_active_workspace_index();
 
         this._updateWorkspaceActors(showAnimation);
-        Main.wm.showWorkspaceOSD();
         this._updateScrollAdjustment(active, showAnimation);
     },
 


### PR DESCRIPTION
This removes the need to call windowManager.showWorkspaceOSD explicitly when the active workspace is changed. It has the added benefit of showing workspace OSD even when the workspace is implicitly changed, such as when the active workspace is deleted. It also works with direct workspace shifting using user-configured hotkeys.
