### PR TITLE
Add "pithos" as a player compatible with the sound applet.

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -99,7 +99,7 @@ const MediaServer2PlayerIFace = {
 
 /* global values */
 let icon_path = "/usr/share/cinnamon/theme/";
-let compatible_players = [ "clementine", "mpd", "exaile", "banshee", "rhythmbox", "rhythmbox3", "pragha", "quodlibet", "guayadeque", "amarok", "googlemusicframe", "xbmc", "xnoise", "gmusicbrowser", "spotify", "audacious", "vlc", "beatbox", "songbird" ];
+let compatible_players = [ "clementine", "mpd", "exaile", "banshee", "rhythmbox", "rhythmbox3", "pragha", "quodlibet", "guayadeque", "amarok", "googlemusicframe", "xbmc", "xnoise", "gmusicbrowser", "spotify", "audacious", "vlc", "beatbox", "songbird", "pithos" ];
 let support_seek = [ "clementine", "banshee", "rhythmbox", "rhythmbox3", "pragha", "quodlibet", "amarok", "xnoise", "gmusicbrowser", "spotify", "vlc", "beatbox" ];
 /* dummy vars for translation */
 let x = _("Playing");


### PR DESCRIPTION
I added "pithos" to "let compatible_players = [" in the sound applet's "applet.js" out of curiosity, and (to my surprise) the album art, skip forward button, and play/pause button all worked great with no other changes.

For the unfamiliar, pithos is a GTK+ client for Pandora Internet Radio available in the default repos.

I have _never_ made a pull request before, so I apologize in advance if I'm not following correct procedure.  Thanks! :)

![Pithos in Sound Applet Screenshot - Cinnamon 1 6 7 nadia](https://f.cloud.github.com/assets/1298191/14336/7eb5dfe8-4638-11e2-84ab-866dcd217a73.png)

Edit: I forgot to mention that the "stop" and "skip back" buttons are shown but have no function with pithos if somebody with more familiarity would like to correct that.
