### PR TITLE
Revert "Rebase and merge #1138"

### DIFF
--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -324,8 +324,6 @@ function start() {
     global.screen.connect('window-entered-monitor', _windowEnteredMonitor);
     global.screen.connect('window-left-monitor', _windowLeftMonitor);
     global.screen.connect('restacked', _windowsRestacked);
-    
-    global.settings.connect('changed::number-workspaces', _staticWorkspaces);
 
     global.window_manager.connect('map', _onWindowMapped);
 
@@ -441,7 +439,6 @@ function moveWindowToNewWorkspace(metaWindow, switchToNewWorkspace) {
 }
 
 function _staticWorkspaces() {
-    nWorks = global.settings.get_int('number-workspaces');
     let i;
     let dif = nWorks - global.screen.n_workspaces;
     if (dif > 0) {


### PR DESCRIPTION
This reverts commit 9356ed655813ee1c70772ec4aa7e37f1d2cb3ec6. The commit had the unfortunate side effect of deleting the last workspace in addition to the one to be deleted.

Steps to reproduce:
1) Open Expo.
2) Press Insert twice to create two new workspaces.
3) Delete the second-to-last workspace.

Expected behavior: Only the second-to-last workspace should disappear.
Actual behavior: The two last created workspaces are both deleted.
