### PR TITLE
[main.js] Use primary monitor's x,y coordinates when positioning cursor in the primary monitor.

### DIFF
--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -239,7 +239,8 @@ function start() {
 
     layoutManager = new Layout.LayoutManager();
     let pointerTracker = new PointerTracker.PointerTracker();
-    pointerTracker.setPosition(layoutManager.primaryMonitor.width/2, layoutManager.primaryMonitor.height/2);
+    pointerTracker.setPosition(layoutManager.primaryMonitor.x + layoutManager.primaryMonitor.width/2,
+        layoutManager.primaryMonitor.y + layoutManager.primaryMonitor.height/2);
 
     xdndHandler = new XdndHandler.XdndHandler();
     // This overview object is just a stub for non-user sessions


### PR DESCRIPTION
The original code does not use the primary monitor's x and y coordinates, so the code does not have the intended effect unless the primary monitor is placed top-aligned with the rest of the monitors.
