### PR TITLE
Fix for background settings not working correctly with timed backgrounds

### DIFF
--- a/files/usr/lib/cinnamon-settings/modules/cs_backgrounds.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_backgrounds.py
@@ -188,7 +188,7 @@ class ThreadedIconView(Gtk.IconView):
             print "Could not find filename in %s" % filename
             return None
         except Exception, detail:
-                print "Failed to read filename from %s: %s" % (filename, detail)
+            print "Failed to read filename from %s: %s" % (filename, detail)
             return None
     
 


### PR DESCRIPTION
Cinnamon settings breaks when selecting backgrounds, as it fails to open an xml as an image.
That xml file is a timed xml configuration.
This fix reads the first file name from that xml file and uses it for the thumbnail generation.

Still getting used to git, hopefully this branch revert works.. it still shows all my old commits, but the files changed look correct.
