### PR TITLE
Fix a regression caused by #1159, adresses #1502

### DIFF
--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -733,7 +733,7 @@ Chrome.prototype = {
             if (!window.showing_on_its_workspace())
                 continue;
 
-            if (metaWindow.is_fullscreen()) {
+            if (metaWindow.get_layer() == Meta.StackLayer.FULLSCREEN || metaWindow.is_fullscreen()) {
                 let monitor = this._findMonitorForWindow(window);
                 if (monitor)
                     monitor.inFullscreen = true;


### PR DESCRIPTION
This fixes the GIMP not covering the panel, when the GIMP is fullscreened in multi-window-mode
