### PR TITLE
layout.js:  Ignore panel heights for metawindow position calculations

### DIFF
--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -796,7 +796,8 @@ Chrome.prototype = {
 
         for (i = 0; i < this._trackedActors.length; i++) {
             let actorData = this._trackedActors[i];
-            if (!actorData.affectsInputRegion && !actorData.affectsStruts)
+            if ((!actorData.affectsInputRegion && !actorData.affectsStruts) ||
+                 primary.inFullscreen)
                 continue;
 
             let [x, y] = actorData.actor.get_transformed_position();


### PR DESCRIPTION
when in fullscreen mode.

This caused undesirable behavior in some applications that use tooltips
to display information/controls (like VLC) when in fullscreen mode.

The panel height was still being taken into account initially when
figuring out the useable screen area.
