### PR TITLE
[sound applet] Avoid double destroy.

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -878,10 +878,18 @@ MyApplet.prototype = {
     },
 
     _cleanup: function() {
-        if (this._outputTitle) this._outputTitle.destroy();
-        if (this._outputSlider) this._outputSlider.destroy();
-        if (this._inputTitle) this._inputTitle.destroy();
-        if (this._inputSlider) this._inputSlider.destroy();
+        if (this._outputTitle) {
+            this._outputTitle.destroy(); this._outputTitle = 0;
+        }
+        if (this._outputSlider) {
+            this._outputSlider.destroy(); this._outputSlider = 0;
+        }
+        if (this._inputTitle) {
+            this._inputTitle.destroy(); this._inputTitle = 0;
+        }
+        if (this._inputSlider) {
+            this._inputSlider.destroy(); this._inputSlider = 0;
+        }
         this.menu.removeAll();
      },
 


### PR DESCRIPTION
This fixes a bug that shows when running multiple sound-applet compatible media players;
when you stop the second player the following is printed to the console:

```
    JS ERROR: !!!   Exception in callback for signal: destroy
    JS ERROR: !!!     message = '"No signal connection 3 found"'
    JS ERROR: !!!     lineNumber = '74'
    JS ERROR: !!!     fileName = '"/usr/share/gjs-1.0/signals.js"'
    JS ERROR: !!!     stack = '"_disconnect(3)@/usr/share/gjs-1.0/signals.js:74
([object Object])@/usr/share/cinnamon/js/ui/popupMenu.js:961
_emit("destroy")@/usr/share/gjs-1.0/signals.js:124
()@/usr/share/cinnamon/js/ui/popupMenu.js:147
()@/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js:894
("org.mpris.MediaPlayer2.audacious")@/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js:864
("org.mpris.MediaPlayer2.audacious",":1.197")@/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js:882
```
