### PR TITLE
[Expo] Re-enable panels earlier on exit, like Scale does.

### DIFF
--- a/js/ui/expo.js
+++ b/js/ui/expo.js
@@ -388,7 +388,9 @@ Expo.prototype = {
         this._hideInProgress = true;
 
         let activeWorkspace = this._expo.lastActiveWorkspace;
+
         if (!options || !options.toScale ) {
+            Main.enablePanels();
             activeWorkspace.overviewModeOff(true, true);
         }
 
@@ -418,9 +420,6 @@ Expo.prototype = {
                     cover.destroy();
                     if (index == Main.layoutManager.monitors.length < 1) {
                         this._group.hide();
-                        if (!options || !options.toScale ) {
-                            Main.enablePanels();
-                        }
                         this._hideDone();
                     }
                 }


### PR DESCRIPTION
Comparing how Expo and Scale exit to the normal desktop, I find that Scale does it a bit more smoothly, because it enables the panels before the animation. This patch makes Expo do the same.
