### PR TITLE
Add missing stylesheet rule for flashspot utility

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -1752,3 +1752,7 @@ StScrollBar StButton#vhandle:hover {
    font-size: 0.9em;
    box-shadow: none;
 }
+
+.flashspot {
+   background-color: white;
+}


### PR DESCRIPTION
I just noticed this was missing, and I must not have committed it with flashspot.js originally. Without an accompanying rule in the theme, flashspot will always be transparent.

(flashspot.js is a utility class from G-S for briefly highlighting an area on the screen)
