### PR TITLE
My implementation of applet settings

### DIFF
--- a/data/org.cinnamon.gschema.xml.in
+++ b/data/org.cinnamon.gschema.xml.in
@@ -514,6 +514,11 @@
       <_summary>Whether edge flip is enabled</_summary>
     </key>
 
+    <key type="a{sv}" name="applet-settings">
+      <default>[]</default>
+      <_summary>The settings stored by applets using set_applet_setting</_summary>
+    </key>
+
     <child name="calendar" schema="org.cinnamon.calendar"/>
     <child name="theme" schema="org.cinnamon.theme"/>   
     <child name="recorder" schema="org.cinnamon.recorder"/>

--- a/src/cinnamon-global.h
+++ b/src/cinnamon-global.h
@@ -144,6 +144,9 @@ void     cinnamon_global_init_xdnd                 (CinnamonGlobal  *global);
 
 void     cinnamon_global_reexec_self               (CinnamonGlobal  *global);
 
+const gchar *cinnamon_global_get_applet_setting (gchar *key);
+void cinnamon_global_set_applet_setting (gchar *key, gchar *value);
+
 G_END_DECLS
 
 #endif /* __CINNAMON_GLOBAL_H__ */


### PR DESCRIPTION
I still need to find something to avoid two applets using the same name for a key, maybe adding the applet's name to the key's name.

In JS code, you can use global.get_applet_setting("name of key") to read settings,
global.set_applet_setting("name of key", value) to set something,
where value is a string.

If a key does not exist, NULL is returned when trying to read it.
