### PR TITLE
Panel rework

### DIFF
--- a/data/org.cinnamon.gschema.xml.in
+++ b/data/org.cinnamon.gschema.xml.in
@@ -269,11 +269,21 @@
        Duration of the effect (in milliseconds)    
       </_description>
     </key>
+
+     <key name="desktop-panel-layout" type="s">
+      <default>"traditional"</default>
+      <_summary>Panel-layout style</_summary>
+      <_description>
+       Layout styles: "traditional" (a single panel at the bottom), "flipped" (a single panel at the top),
+       "classic" (main panel at the top, secondary panel at the bottom), "classic-gold" (main panel at the bottom, secondary panel at the top)
+      </_description>
+    </key>
     
     <key name="desktop-layout" type="s">
       <default>"traditional"</default>
       <_summary>Layout style</_summary>
       <_description>
+      Deprecated, retained for backward compatibility. New versions of Cinnamon use "desktop-panel-layout".
        Layout styles: traditional (1 panel at the bottom), flipped (1 panel on top), classic (1 panel on top, 1 panel at the bottom)
       </_description>
     </key>

--- a/files/usr/lib/cinnamon-settings/modules/cs_panel.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_panel.py
@@ -11,38 +11,31 @@ class Module:
         self.name = "panel"
         self.category = "prefs"
 
-        desktop_layouts = [["traditional", _("Traditional (panel at the bottom)")], ["flipped", _("Flipped (panel at the top)")], ["classic", _("Classic (panels at the top and at the bottom)")]]        
-        desktop_layouts_combo = GSettingsComboBox(_("Panel layout"), "org.cinnamon", "desktop-layout", None, desktop_layouts)
+        desktop_layouts = [["traditional", _("Bottom")], ["flipped", _("Top")], ["classic", _("Top + bottom")], ["classic-gold", _("Bottom + top")]]
+        desktop_layouts_combo = GSettingsComboBox(_("Panel layout"), "org.cinnamon", "desktop-panel-layout", None, desktop_layouts)
         sidePage.add_widget(desktop_layouts_combo) 
         label = Gtk.Label()
-        label.set_markup("<i><small>%s</small></i>" % _("Note: If you change the layout you will need to restart Cinnamon and Cinnamon Settings."))
-        sidePage.add_widget(label)
+        label.set_markup("<i><small>%s</small></i>" % _("Note: If you change the layout you will need to restart Cinnamon for the change to take effect."))
+        sidePage.add_widget(label, True)
 
-        settings = Gio.Settings.new("org.cinnamon")
-        layout_type = settings.get_string("desktop-layout")
-        if layout_type != "classic":
-            sidePage.add_widget(GSettingsCheckButton(_("Auto-hide panel"), "org.cinnamon", "panel-autohide", None))
-            box = IndentedHBox()
-            box.add(GSettingsSpinButton(_("Show delay"), "org.cinnamon", "panel-show-delay", "org.cinnamon/panel-autohide", 0, 2000, 50, 200, _("milliseconds")))
-            sidePage.add_widget(box, True)
-            box = IndentedHBox()
-            box.add(GSettingsSpinButton(_("Hide delay"), "org.cinnamon", "panel-hide-delay", "org.cinnamon/panel-autohide", 0, 2000, 50, 200, _("milliseconds")))
-            sidePage.add_widget(box, True)
-        else:
-            sidePage.add_widget(GSettingsCheckButton(_("Auto-hide top panel"), "org.cinnamon", "panel-autohide", None))
-            box = IndentedHBox()
-            box.add(GSettingsSpinButton(_("Show delay"), "org.cinnamon", "panel-show-delay", "org.cinnamon/panel-autohide", 0, 2000, 50, 200, _("milliseconds")))
-            sidePage.add_widget(box, True)
-            box = IndentedHBox()
-            box.add(GSettingsSpinButton(_("Hide delay"), "org.cinnamon", "panel-hide-delay", "org.cinnamon/panel-autohide", 0, 2000, 50, 200, _("milliseconds")))
-            sidePage.add_widget(box, True)
-            sidePage.add_widget(GSettingsCheckButton(_("Auto-hide bottom panel"), "org.cinnamon", "panel2-autohide", None))
-            box = IndentedHBox()
-            box.add(GSettingsSpinButton(_("Show delay"), "org.cinnamon", "panel2-show-delay", "org.cinnamon/panel2-autohide", 0, 2000, 50, 200, _("milliseconds")))
-            sidePage.add_widget(box, True)
-            box = IndentedHBox()
-            box.add(GSettingsSpinButton(_("Hide delay"), "org.cinnamon", "panel2-hide-delay", "org.cinnamon/panel2-autohide", 0, 2000, 50, 200, _("milliseconds")))
-            sidePage.add_widget(box, True)
+        sidePage.add_widget(GSettingsCheckButton(_("Auto-hide main panel"), "org.cinnamon", "panel-autohide", None))
+        box = IndentedHBox()
+        box.add(GSettingsSpinButton(_("Show delay"), "org.cinnamon", "panel-show-delay", "org.cinnamon/panel-autohide", 0, 2000, 50, 200, _("milliseconds")))
+        sidePage.add_widget(box, True)
+        box = IndentedHBox()
+        box.add(GSettingsSpinButton(_("Hide delay"), "org.cinnamon", "panel-hide-delay", "org.cinnamon/panel-autohide", 0, 2000, 50, 200, _("milliseconds")))
+        sidePage.add_widget(box, True)
+
+        sidePage.add_widget(GSettingsCheckButton(_("Auto-hide secondary panel"), "org.cinnamon", "panel2-autohide", None))
+        secondaryLabel = Gtk.Label()
+        secondaryLabel.set_markup("<i><small>%s</small></i>" % _("Note: The secondary panel is not available in single-panel layouts."))
+        sidePage.add_widget(secondaryLabel)
+        box = IndentedHBox()
+        box.add(GSettingsSpinButton(_("Show delay"), "org.cinnamon", "panel2-show-delay", "org.cinnamon/panel2-autohide", 0, 2000, 50, 200, _("milliseconds")))
+        sidePage.add_widget(box, True)
+        box = IndentedHBox()
+        box.add(GSettingsSpinButton(_("Hide delay"), "org.cinnamon", "panel2-hide-delay", "org.cinnamon/panel2-autohide", 0, 2000, 50, 200, _("milliseconds")))
+        sidePage.add_widget(box, True)
 
         sidePage.add_widget(GSettingsCheckButton(_("Use customized panel size (otherwise it's defined by the theme)"), "org.cinnamon", "panel-resizable", None), True)
 

--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -56,7 +56,7 @@ AppletContextMenu.prototype = {
         PopupMenu.PopupMenu.prototype._init.call(this, launcher.actor, 0.0, orientation, 0);
         Main.uiGroup.add_actor(this.actor);
         this.actor.hide();                    
-    }    
+    }
 }
 
 function AppletPopupMenu(launcher, orientation) {
@@ -66,16 +66,17 @@ function AppletPopupMenu(launcher, orientation) {
 AppletPopupMenu.prototype = {
     __proto__: PopupMenu.PopupMenu.prototype,
 
-    _init: function(launcher, orientation) {    
+    _init: function(launcher, orientation) {
+        this.launcher = launcher;
         PopupMenu.PopupMenu.prototype._init.call(this, launcher.actor, 0.0, orientation, 0);
         Main.uiGroup.add_actor(this.actor);
-        this.actor.hide();                    
+        this.actor.hide();
     },
 
     setMaxHeight: function() {
-        let monitor = Main.layoutManager.primaryMonitor;
+        let monitor = Main.layoutManager.findMonitorForActor(this.launcher.actor);
         this.actor.style = ('max-height: ' +
-                            Math.round(monitor.height - Main.panel.actor.height) +
+                            Math.round(monitor.height - this.launcher.actor.get_parent().height) +
                             'px;');
     }
 }

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -9,6 +9,7 @@ const St = imports.gi.St;
 const Main = imports.ui.main;
 const Params = imports.misc.params;
 const ScreenSaver = imports.misc.screenSaver;
+const Panel = imports.ui.panel;
 const Tweener = imports.ui.tweener;
 const EdgeFlip = imports.ui.edgeFlip;
 const HotCorner = imports.ui.hotCorner;
@@ -25,31 +26,16 @@ LayoutManager.prototype = {
     _init: function () {
         this._rtl = (St.Widget.get_default_direction() == St.TextDirection.RTL);
         this.monitors = [];
+        this._panels = [];
+        this._panelBoxes = [];
         this.primaryMonitor = null;
         this.primaryIndex = -1;
         this.hotCornerManager = null;
-        this._leftPanelBarrier = 0;
-        this._rightPanelBarrier = 0;
-        this._leftPanelBarrier2 = 0;
-        this._rightPanelBarrier2 = 0;
         this.edgeRight = null;
         this.edgeLeft = null;
         this._chrome = new Chrome(this);
         this.enabledEdgeFlip = global.settings.get_boolean("enable-edge-flip");
         this.edgeFlipDelay = global.settings.get_int("edge-flip-delay");
-
-        this.panelBox = new St.BoxLayout({ name: 'panelBox',
-                                           vertical: true });
-
-        this.panelBox2 = new St.BoxLayout({ name: 'panelBox',
-                                            vertical: true });        
-
-        this.addChrome(this.panelBox, { addToWindowgroup: false });
-        this.addChrome(this.panelBox2, { addToWindowgroup: false });
-        this.panelBox.connect('allocation-changed',
-                              Lang.bind(this, this._updatePanelBarriers));
-        this.panelBox2.connect('allocation-changed',
-                               Lang.bind(this, this._updatePanelBarriers));
 
         this.keyboardBox = new St.BoxLayout({ name: 'keyboardBox',
                                               reactive: true,
@@ -57,11 +43,13 @@ LayoutManager.prototype = {
         this.addChrome(this.keyboardBox, { visibleInFullscreen: true });
         this._keyboardHeightNotifyId = 0;
 
-        this._processPanelSettings();
+        this.setupDesktopLayout();
         this._monitorsChanged();
+        this._processPanelSettings();
 
         global.settings.connect("changed::enable-edge-flip", Lang.bind(this, this._onEdgeFlipChanged));
         global.settings.connect("changed::edge-flip-delay", Lang.bind(this, this._onEdgeFlipChanged));
+        global.settings.connect("changed::panel-scale-text-icons", Lang.bind(this, this._processPanelSettings))
         global.settings.connect("changed::panel-autohide", Lang.bind(this, this._processPanelSettings));
         global.settings.connect("changed::panel2-autohide", Lang.bind(this, this._processPanelSettings));
         global.settings.connect("changed::panel-resizable", Lang.bind(this, this._processPanelSettings));
@@ -72,6 +60,121 @@ LayoutManager.prototype = {
                               Lang.bind(this, this._monitorsChanged));
         global.window_manager.connect('switch-workspace',
                                       Lang.bind(this, this._windowsRestacked));
+    },
+
+    setupDesktopLayout: function() {
+        this.setupDesktopLayout = null; // don't call again
+
+        this._applet_side = St.Side.BOTTOM;
+        this._desktop_layout = global.settings.get_string("desktop-panel-layout");
+        let newLayoutString = "";
+        
+        if (this._desktop_layout == "flipped") {
+            newLayoutString = "top,top";
+        }
+        else if (this._desktop_layout == "traditional") {
+            newLayoutString = "bottom,bottom";
+        }
+        else if (this._desktop_layout == "classic") {
+            newLayoutString = "top,top+bottom,bottom";
+        }
+        else if (this._desktop_layout == "classic-gold") {
+            newLayoutString = "bottom,bottom+top,top";
+        }
+        else {
+            newLayoutString = this._desktop_layout; // could be a data string
+        }
+        
+        let panelData = [];
+        let parse = Lang.bind(this, function(layoutString) {
+            layoutString.trim().split('+').forEach(function(panelString, index) {
+                let panelOpts = panelString.trim().split(',');
+                let isBottom = !panelOpts[0] || panelOpts[0] != 'top';
+                // we use strings to designate monitors, since the actual index may
+                // change if monitors are rearranged during a session
+                let monitorIndex = isBottom ? "bottomIndex" : "topIndex"
+                let monitor = panelOpts.length > 1 ? panelOpts[1] : null;
+                if (monitor) {
+                    switch (monitor) {
+                        case "top": monitorIndex = "topIndex";
+                            break;
+                        case "bottom": monitorIndex = "bottomIndex";
+                            break;
+                        case "left": monitorIndex = "leftIndex";
+                            break;
+                        case "right": monitorIndex = "rightIndex";
+                            break;
+                        default:
+                            global.logError("Unknown monitor identifier: '" + monitor + "'");
+                    }
+                }
+                panelData.push({
+                    isBottom: isBottom,
+                    monitorIndex: monitorIndex
+                });
+            }, this);
+            return panelData.length > 0;
+        });
+
+        if (!parse(newLayoutString)) {
+            parse("bottom,bottom"); // this should work if all else fails
+        }
+
+        panelData.forEach(function(data, index) {
+            let isPrimary = index == 0;
+            if (isPrimary) {
+                this._applet_side = data.isBottom ? St.Side.BOTTOM : St.Side.TOP;
+            }
+            let box = new St.BoxLayout({ name: 'panelBox', vertical: true });
+            this.addChrome(box, { addToWindowgroup: false });
+            this._panelBoxes.push(box);
+
+            let panel = new Panel.Panel(this, data.isBottom, isPrimary);
+            box.add(panel.actor);
+            box._panelData = data;
+            panel.connect('height-changed', Lang.bind(this, this._processPanelSettings));
+            this._panels.push(panel);
+        }, this);
+    },
+
+    get desktop_layout() {
+        return this._desktop_layout;
+    },
+
+    get applet_side() {
+        return this._applet_side;
+    },
+
+    get panel() {
+        return this._panels[0];
+    },
+
+    get panels() {
+        return this._panels;
+    },
+
+    get panel2() {
+        return this._panels[1];
+    },
+
+    getPanel : function(index, safe) {
+        return this._panels[safe ? Math.min(index, this._panels.length - 1) : index];
+    },
+
+    get panelBox() {
+        return this._panelBoxes[0];
+    },
+
+    enablePanels: function() {
+        this._panels.forEach(function(panel) {
+            panel.enable();
+        }, this);
+    },
+
+    disablePanels: function() {
+        this._panels.forEach(function(panel) {
+            panel.disable();
+        }, this);
     },
 
     _onEdgeFlipChanged: function(){
@@ -118,16 +221,29 @@ LayoutManager.prototype = {
     },
     
     _processPanelSettings: function() {
-        if (this._processPanelSettingsTimeout) {
-            Mainloop.source_remove(this._processPanelSettingsTimeout);
-        }
-        // delay this action somewhat, to let others do their thing before us
-        this._processPanelSettingsTimeout = Mainloop.timeout_add(0, Lang.bind(this, function() {
-            this._processPanelSettingsTimeout = 0;
-            this._updateBoxes();
-            this._chrome.modifyActorParams(this.panelBox, { affectsStruts: Main.panel && !Main.panel.isHideable() });
-            this._chrome.modifyActorParams(this.panelBox2, { affectsStruts: Main.panel2 && !Main.panel2.isHideable() });
-        }));
+        let panelResizable = global.settings.get_boolean("panel-resizable");
+        let panelScalable = panelResizable && global.settings.get_boolean("panel-scale-text-icons");
+        this._panels.forEach(function(panel, index) {
+            let panelHeight = null;
+            if (panelResizable) {
+                if (panel.bottomPosition) {
+                    panelHeight = global.settings.get_int("panel-bottom-height");
+                }
+                else {
+                    panelHeight = global.settings.get_int("panel-top-height");
+                }
+            }
+            panel._setPanelHeight(panelHeight, panelScalable);
+            let wasHideable = panel.isHideable();
+            panel.setHideable(global.settings.get_boolean(index == 0 ? "panel-autohide" : "panel2-autohide"));
+            if (panel.isHideable()) {
+                panel._hidePanel();
+            }
+            else if (wasHideable) {
+                panel._showPanel();
+            }
+        }, this);
+        this._updateBoxes();
     },
     
     _updateMonitors: function() {
@@ -138,141 +254,53 @@ LayoutManager.prototype = {
         for (let i = 0; i < nMonitors; i++)
             this.monitors.push(screen.get_monitor_geometry(i));
 
-        if (nMonitors == 1) {
-            this.primaryIndex = this.bottomIndex = 0;
-        } else {
-            // If there are monitors below the primary, then we need
-            // to split primary from bottom.
-            this.primaryIndex = this.bottomIndex = screen.get_primary_monitor();
-            for (let i = 0; i < this.monitors.length; i++) {
-                let monitor = this.monitors[i];
-                if (this._isAboveOrBelowPrimary(monitor)) {
-                    if (monitor.y > this.monitors[this.bottomIndex].y)
-                        this.bottomIndex = i;
-                }
+        this.primaryIndex = this.bottomIndex = this.topIndex = this.leftIndex = this.rightIndex = screen.get_primary_monitor();
+        // If there are monitors below the primary, then we need
+        // to split primary from bottom.
+        for (let i = 0; i < this.monitors.length; i++) {
+            let monitor = this.monitors[i];
+            if (this._isAboveOrBelowPrimary(monitor)) {
+                if (monitor.y > this.monitors[this.bottomIndex].y)
+                    this.bottomIndex = i;
+                if (monitor.y < this.monitors[this.topIndex].y)
+                    this.topIndex = i;
+            }
+            else {
+                if (monitor.x > this.monitors[this.rightIndex].x)
+                    this.rightIndex = i;
+                if (monitor.x < this.monitors[this.leftIndex].x)
+                    this.leftIndex = i;
             }
         }
         this.primaryMonitor = this.monitors[this.primaryIndex];
         this.bottomMonitor = this.monitors[this.bottomIndex];
+        this.topMonitor = this.monitors[this.topIndex];
     },
 
     _updateHotCorners: function() {
         if (this.hotCornerManager)
-            this.hotCornerManager.updatePosition(this.primaryMonitor, this.bottomMonitor);
+            this.hotCornerManager.updatePosition(this.topMonitor, this.bottomMonitor);
+    },
+
+    _getMonitor: function(index) {
+        return this.monitors[this[index]];
     },
 
     _updateBoxes: function() {
         this._updateHotCorners();
 
-        let getPanelHeight = function(panel) {
-            let panelHeight = 0;
-            if (panel) {
-                panelHeight = panel.actor.get_height();
-            }
-            return panelHeight;
-        };
-
-        let p1height = getPanelHeight(Main.panel);
-
-        if (Main.desktop_layout == Main.LAYOUT_TRADITIONAL) {
-            this.panelBox.set_size(this.bottomMonitor.width, p1height);
-            this.panelBox.set_position(this.bottomMonitor.x, this.bottomMonitor.y + this.bottomMonitor.height - p1height);
-        }
-        else if (Main.desktop_layout == Main.LAYOUT_FLIPPED) {
-            this.panelBox.set_size(this.primaryMonitor.width, p1height);
-            this.panelBox.set_position(this.primaryMonitor.x, this.primaryMonitor.y);
-        }
-        else if (Main.desktop_layout == Main.LAYOUT_CLASSIC) { 
-            let p2height = getPanelHeight(Main.panel2);
-
-            this.panelBox.set_size(this.primaryMonitor.width, p1height);
-            this.panelBox.set_position(this.primaryMonitor.x, this.primaryMonitor.y);
-
-            this.panelBox2.set_size(this.bottomMonitor.width, p2height);
-            this.panelBox2.set_position(this.bottomMonitor.x, this.bottomMonitor.y + this.bottomMonitor.height - p2height);
-        }
+        this._panelBoxes.forEach(function(box, index) {
+            let panel = this._panels[index];
+            let monitor = this._getMonitor(box._panelData.monitorIndex);
+            panel.setCurrentMonitor(monitor);
+            panel._updateBoxPosition(box);
+            this._chrome.modifyActorParams(box, { affectsStruts: !panel.isHideable() });
+        }, this);
 
         this.keyboardBox.set_position(this.bottomMonitor.x,
                                       this.bottomMonitor.y + this.bottomMonitor.height);
         this.keyboardBox.set_size(this.bottomMonitor.width, -1);
         this._chrome._queueUpdateRegions();
-    },
-
-    getPorthole: function() {
-        let porthole = {};
-        let screen = {x: 0, y: 0, width: global.screen_width, height: global.screen_height};
-        
-        let getPanelHeight = function(panel) {
-            let panelHeight = 0;
-            let hideable = true;
-            if (panel) {
-                panelHeight = panel.actor.get_height();
-                hideable = panel.isHideable();
-            }
-            return hideable ? 0 : panelHeight;
-        };
-        let p1height = getPanelHeight(Main.panel);
-        if (Main.desktop_layout == Main.LAYOUT_TRADITIONAL) {       
-            porthole.x = screen.x; porthole.y = screen.y;
-            porthole.width = screen.width; porthole.height = screen.height - p1height;
-        }
-        else if (Main.desktop_layout == Main.LAYOUT_FLIPPED) {         
-            porthole.x = screen.x; porthole.y = screen.y + p1height;
-            porthole.width = screen.width; porthole.height = screen.height - p1height;
-        }
-        else if (Main.desktop_layout == Main.LAYOUT_CLASSIC) {
-            let p2height = getPanelHeight(Main.panel2);
-            porthole.x = screen.x; porthole.y = screen.y + p1height;
-            porthole.width = screen.width; porthole.height = screen.height - p1height - p2height;
-        }
-        return porthole;
-    },
-
-    _updatePanelBarriers: function(panelBox) {
-        let leftPanelBarrier;
-        let rightPanelBarrier;
-        if (panelBox==this.panelBox){
-            leftPanelBarrier = this._leftPanelBarrier;
-            rightPanelBarrier = this._rightPanelBarrier;
-        }else{
-            leftPanelBarrier = this._leftPanelBarrier2;
-            rightPanelBarrier = this._rightPanelBarrier2;
-        }
-        if (leftPanelBarrier)
-            global.destroy_pointer_barrier(leftPanelBarrier);
-        if (rightPanelBarrier)
-            global.destroy_pointer_barrier(rightPanelBarrier);
-
-        if (panelBox.height) {                        
-            if ((Main.desktop_layout == Main.LAYOUT_TRADITIONAL && panelBox==this.panelBox) || (Main.desktop_layout == Main.LAYOUT_CLASSIC && panelBox==this.panelBox2)) {
-                let monitor = this.bottomMonitor;
-                leftPanelBarrier = global.create_pointer_barrier(monitor.x, monitor.y + monitor.height - panelBox.height,
-                                                                 monitor.x, monitor.y + monitor.height,
-                                                                 1 /* BarrierPositiveX */);
-                rightPanelBarrier = global.create_pointer_barrier(monitor.x + monitor.width, monitor.y + monitor.height - panelBox.height,
-                                                                  monitor.x + monitor.width, monitor.y + monitor.height,
-                                                                  4 /* BarrierNegativeX */);
-            }
-            else {
-                let primary = this.primaryMonitor;
-                leftPanelBarrier = global.create_pointer_barrier(primary.x, primary.y,
-                                                                 primary.x, primary.y + panelBox.height,
-                                                                 1 /* BarrierPositiveX */);
-                rightPanelBarrier = global.create_pointer_barrier(primary.x + primary.width, primary.y,
-                                                                  primary.x + primary.width, primary.y + panelBox.height,
-                                                                  4 /* BarrierNegativeX */);
-            }
-        } else {
-            leftPanelBarrier = 0;
-            rightPanelBarrier = 0;
-        }
-        if (panelBox==this.panelBox){
-            this._leftPanelBarrier = leftPanelBarrier;
-            this._rightPanelBarrier = rightPanelBarrier;
-        }else{
-            this._leftPanelBarrier2 = leftPanelBarrier;
-            this._rightPanelBarrier2 = rightPanelBarrier;
-        }
     },
 
     _monitorsChanged: function() {
@@ -328,19 +356,11 @@ LayoutManager.prototype = {
                        onComplete: this._startupAnimationComplete,
                        onCompleteScope: this
                      };
-        
-        if (Main.desktop_layout == Main.LAYOUT_TRADITIONAL) {
-          this.panelBox.anchor_y  = -(this.panelBox.height);
-        }
-        else if (Main.desktop_layout == Main.LAYOUT_FLIPPED) {
-          this.panelBox.anchor_y  =   this.panelBox.height;
-        }
-        else if (Main.desktop_layout == Main.LAYOUT_CLASSIC) {
-          this.panelBox.anchor_y  =   this.panelBox.height;
-          this.panelBox2.anchor_y = -(this.panelBox2.height);
-        }
-        Tweener.addTween(this.panelBox, params);
-        Tweener.addTween(this.panelBox2, params);
+
+        this._panelBoxes.forEach(function(box) {
+            box.anchor_y = box._panelData.isBottom ? -box.height : box.height;
+            Tweener.addTween(box, params);
+        }, this);
     },
 
     _startupAnimationComplete: function() {

--- a/js/ui/lookingGlass.js
+++ b/js/ui/lookingGlass.js
@@ -15,6 +15,7 @@ const Lang = imports.lang;
 const History = imports.misc.history;
 const Extension = imports.ui.extension;
 const Link = imports.ui.link;
+const Layout = imports.ui.layout;
 const CinnamonEntry = imports.ui.cinnamonEntry;
 const Tweener = imports.ui.tweener;
 const Main = imports.ui.main;
@@ -1112,7 +1113,7 @@ LookingGlass.prototype = {
     },
 
     _resize: function() {
-        if (Main.desktop_layout == Main.LAYOUT_TRADITIONAL) {
+        if (Main.layoutManager.applet_side == St.Side.BOTTOM) {
             let primary = Main.layoutManager.primaryMonitor;
             let myWidth = primary.width * 0.7;
             let availableHeight = primary.height - Main.layoutManager.keyboardBox.height;

--- a/js/ui/panelMenu.js
+++ b/js/ui/panelMenu.js
@@ -121,10 +121,10 @@ Button.prototype = {
             // Setting the max-height won't do any good if the minimum height of the
             // menu is higher then the screen; it's useful if part of the menu is
             // scrollable so the minimum height is smaller than the natural height
-            let monitor = Main.layoutManager.primaryMonitor;
+            let monitor = Main.layoutManager.findMonitorForActor(this.launcher.actor);
             this.menu.actor.style = ('max-height: ' +
-                                     Math.round(monitor.height - Main.panel.actor.height) +
-                                     'px;');
+                                Math.round(monitor.height - this.actor.get_parent().height) +
+                                'px;');
         }
         this.menu.toggle();
     },

--- a/js/ui/tooltips.js
+++ b/js/ui/tooltips.js
@@ -126,14 +126,12 @@ PanelItemTooltip.prototype = {
         let tooltipHeight = this._tooltip.get_allocation_box().y2-this._tooltip.get_allocation_box().y1;
         let tooltipWidth = this._tooltip.get_allocation_box().x2-this._tooltip.get_allocation_box().x1;
 
-        let monitor;
+        let monitor = Main.layoutManager.findMonitorForActor(this._panelItem.actor);
         let tooltipTop;
         if (this.orientation == St.Side.BOTTOM) {
-            monitor = Main.layoutManager.bottomMonitor;
             tooltipTop = monitor.y+monitor.height-tooltipHeight-this._panelItem.actor.get_allocation_box().y2+this._panelItem.actor.get_allocation_box().y1;
         }
         else {
-            monitor = Main.layoutManager.primaryMonitor;
             tooltipTop = monitor.y+this._panelItem.actor.get_allocation_box().y2;
         }
         var tooltipLeft = this._mousePosition[0]- Math.round(tooltipWidth/2);

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -248,29 +248,14 @@ WindowManager.prototype = {
         }
 
         if (effect == "traditional") {
-            actor.set_scale(1.0, 1.0);
-            this._minimizing.push(actor);
-            let monitor;
-            let yDest;            
-            if (Main.desktop_layout == Main.LAYOUT_TRADITIONAL || Main.desktop_layout == Main.LAYOUT_CLASSIC) {
-                monitor = Main.layoutManager.bottomMonitor;
-                yDest = monitor.height;
-            }
-            else {
-                monitor = Main.layoutManager.primaryMonitor;
-                yDest = 0;
-            }
-
-            let xDest = monitor.x + monitor.width/4;
-            if (St.Widget.get_default_direction() == St.TextDirection.RTL)
-                xDest = monitor.width - monitor.width/4;
-
             if (AppletManager.get_role_provider_exists(AppletManager.Roles.WINDOWLIST)) {
                 let windowApplet = AppletManager.get_role_provider(AppletManager.Roles.WINDOWLIST);
                 let actorOrigin = windowApplet.getOriginFromWindow(actor.get_meta_window());
                 
                 if (actorOrigin !== false) {
-                    [xDest, yDest] = actorOrigin.get_transformed_position();
+                    actor.set_scale(1.0, 1.0);
+                    this._minimizing.push(actor);
+                    let [xDest, yDest] = actorOrigin.get_transformed_position();
                     // Adjust horizontal destination or it'll appear to zoom
                     // down to our button's left (or right in RTL) edge.
                     // To center it, we'll add half its width.
@@ -280,33 +265,33 @@ WindowManager.prototype = {
                     actor.get_meta_window()._cinnamonwm_has_origin = true;
                     actor.get_meta_window()._cinnamonwm_minimize_transition = transition;
                     actor.get_meta_window()._cinnamonwm_minimize_time = time;
+                    Tweener.addTween(actor,
+                                     { scale_x: 0.0,
+                                       scale_y: 0.0,
+                                       x: xDest,
+                                       y: yDest,
+                                       time: time,
+                                       transition: transition,
+                                       onComplete: this._minimizeWindowDone,
+                                       onCompleteScope: this,
+                                       onCompleteParams: [cinnamonwm, actor],
+                                       onOverwrite: this._minimizeWindowOverwritten,
+                                       onOverwriteScope: this,
+                                       onOverwriteParams: [cinnamonwm, actor]
+                                     });
+                    return; // done
                 }
             }
-            
-            Tweener.addTween(actor,
-                             { scale_x: 0.0,
-                               scale_y: 0.0,
-                               x: xDest,
-                               y: yDest,
-                               time: time,
-                               transition: transition,
-                               onComplete: this._minimizeWindowDone,
-                               onCompleteScope: this,
-                               onCompleteParams: [cinnamonwm, actor],
-                               onOverwrite: this._minimizeWindowOverwritten,
-                               onOverwriteScope: this,
-                               onOverwriteParams: [cinnamonwm, actor]
-                             });
+            effect = "scale"; // fall-back effect
         }
-        else if (effect == "fade") {
+
+        if (effect == "fade") {
             this._minimizing.push(actor);
             this._fadeWindow(cinnamonwm, actor, 0, time, transition, this._minimizeWindowDone, this._minimizeWindowOverwritten);            
-        }
-        else if (effect == "scale") {                                
+        } else if (effect == "scale") {                                
             this._minimizing.push(actor);
             this._scaleWindow(cinnamonwm, actor, 0.0, 0.0, time, transition, this._minimizeWindowDone, this._minimizeWindowOverwritten); 
-        }
-        else {
+        } else {
             cinnamonwm.completed_minimize(actor);
         }
     },


### PR DESCRIPTION
This is my project to gradually make Cinnamon's panels more flexible. Instead of limiting the set of possible panel layouts to a few confusingly-named options, it opens up for user-defined layouts, with panels on different monitors.

The implementation is mainly backward-compatible with the current settings keys, except for the key controlling the panel layout, which had to be changed to enable switching back and forth between old and new versions.

This is a new version of pull #1504, the discussion of which got side-lined by people picking on petty details.

Current status: Ready to be merged.
