### PR TITLE
[applets] Applet roles not honored after applet-manager revamp.

### DIFF
--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -313,6 +313,9 @@ function createApplet(extension, appletDefinition) {
         return null;
     }
 
+    if (extension.meta['role']) {
+        Extension.Type.APPLET.roles[extension.meta['role']] = applet;
+    }
     appletObj[applet_id] = applet;
     applet._uuid = extension.uuid;
     applet._applet_id = applet_id;


### PR DESCRIPTION
I have noticed that minimize-to-window-list-button does not work after the recent applet-manager revamp, and I've traced the issue to the applet-role system, which does not update the registry with an applet's role, so the role lookup doesn't work.
