### PR TITLE
Fix for background settings not working correctly with timed backgrounds

### DIFF
--- a/files/usr/lib/cinnamon-settings/modules/cs_backgrounds.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_backgrounds.py
@@ -178,7 +178,10 @@ class ThreadedIconView(Gtk.IconView):
                 self._loading_queue = self._loading_queue[1:]
             self._loading_queue_lock.release()
             if not finished:
-                pix = PIX_CACHE.get_pix(to_load["filename"], BACKGROUND_ICONS_SIZE)
+                filename = to_load["filename"]
+                if filename.endswith(".xml"):
+                    filename = self.getFirstFileFromBackgroundXml(filename)
+                pix = PIX_CACHE.get_pix(filename, BACKGROUND_ICONS_SIZE)
                 if pix != None:
                     if "name" in to_load:
                         label = to_load["name"]
@@ -196,6 +199,24 @@ class ThreadedIconView(Gtk.IconView):
         self._loading_lock.acquire()
         self._loading = False
         self._loading_lock.release()                 
+        
+    def getFirstFileFromBackgroundXml(self, filename):
+        try:
+            f = open(filename)
+            rootNode = lxml.etree.fromstring(f.read())
+            f.close()
+            if rootNode.tag == "background":
+                for backgroundNode in rootNode:
+                    if backgroundNode.tag == "static":
+                        for staticNode in backgroundNode:
+                            if staticNode.tag == "file":
+                                return staticNode.text
+            print "Could not find filename in %s" % filename
+            return None
+        except Exception, detail:
+            print "Failed to read filename from %s: %s" % (filename, detail)
+            return None
+    
 
 class BackgroundWallpaperPane (Gtk.VBox):
     def __init__(self, sidepage, gnome_background_schema):


### PR DESCRIPTION
Had to recreate this request, since git and or hate me.

Cinnamon settings breaks when selecting backgrounds, as it fails to open an xml as an image.
That xml file is a timed xml configuration.
This fix reads the first file name from that xml file and uses it for the thumbnail generation.

Still getting used to git, hopefully this branch revert works.. it still shows all my old commits, but the files changed look correct.
