### PR TITLE
Move refreshApps and refreshFavs to after instantations they depend on.

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -921,7 +921,7 @@ MyApplet.prototype = {
                     parent !== this._activeContainer && button !== this._previousTreeSelectedActor) {
                 this._previousTreeSelectedActor.style_class = "menu-category-button";
             }
-            if (parent != this._activeContainer) {
+            if (parent != this._activeContainer && parent._vis_iter) {
                 parent._vis_iter.reloadVisible();
             }
             let _maybePreviousActor = this._activeActor;


### PR DESCRIPTION
Potentially addresses:

https://bugs.launchpad.net/linuxmint/+bug/1081842

Also fixes some whitespace messiness.
