### PR TITLE
Fix for roles not being honored after applet manager revamp

### DIFF
--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -222,13 +222,17 @@ function removeAppletFromPanels(appletDefinition) {
 
 function addAppletToPanels(extension, appletDefinition) {
     // Try to lock the applets role
-    if(!extension.lockRole())
+    if(!extension.lockRole(null))
         return;
     
     try {
         // Create the applet
         let applet = createApplet(extension, appletDefinition);
         if(applet == null)
+            return;
+        
+        // Now actually lock the applets role and set the provider
+        if(!extension.lockRole(applet))
             return;
 
         applet._order = appletDefinition.order;
@@ -282,7 +286,7 @@ function addAppletToPanels(extension, appletDefinition) {
 
 function get_role_provider(role) {
     if (Extension.Type.APPLET.roles[role]) {
-        return Extension.Type.APPLET.roles[role];
+        return Extension.Type.APPLET.roles[role].roleProvider;
     }
     return null;
 }

--- a/js/ui/deskletManager.js
+++ b/js/ui/deskletManager.js
@@ -164,9 +164,17 @@ function _unloadDesklet(deskletDefinition) {
 }
 
 function _loadDesklet(extension, deskletDefinition) {
+    // Try to lock the desklets role
+    if(!extension.lockRole(null))
+        return;
+    
     try {
         let desklet = _createDesklets(extension, deskletDefinition);
         if (!desklet)
+            return;
+        
+        // Now actually lock the desklets role and set the provider
+        if(!extension.lockRole(desklet))
             return;
 
         desklet._extension = extension;

--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -304,11 +304,19 @@ Extension.prototype = {
         }
     },
 
-    lockRole: function() {
+    lockRole: function(roleProvider) {
         let role = this.meta['role'];
-        if(role && this.type.roles[role] != null) {
-            this.logError('Role ' + role + ' already taken by ' + this.lowerType + ': ' + this.type.roles[role].uuid);
-            return false;
+        if(role && this.type.roles[role] != this) {
+            if(this.type.roles[role] != null) {
+                this.logError('Role ' + role + ' already taken by ' + this.lowerType + ': ' + this.type.roles[role].uuid);
+                return false;
+            }
+        
+            if(roleProvider != null) {
+                this.type.roles[role] = this;
+                this.roleProvider = roleProvider;
+                global.log("Role locked: " + role);
+            }
         }
 
         return true;
@@ -318,6 +326,8 @@ Extension.prototype = {
         let role = this.meta['role'];
         if(role && this.type.roles[role] == this) {
             this.type.roles[role] = null;
+            this.roleProvider = null;
+            global.log("Role unlocked: " + role);
         }
     }
 }

--- a/js/ui/extensionSystem.js
+++ b/js/ui/extensionSystem.js
@@ -38,7 +38,7 @@ function prepareExtensionUnload(extension) {
 
 // Callback for extension.js
 function finishExtensionLoad(extension) {
-    if(!extension.lockRole()) {
+    if(!extension.lockRole(extension.module)) {
         return false;
     }
     


### PR DESCRIPTION
This takes care of propper role handling for applets, extensions and desklets ( not sure if the latter 2 would actually need this feature )
