### PR TITLE
Cinnamon Settings: Remove now-unnecessary "Always show location entry in Nemo option

### DIFF
--- a/files/usr/lib/cinnamon-settings/modules/cs_themes.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_themes.py
@@ -75,9 +75,6 @@ class ThemeViewSidePage (SidePage):
         other_settings_box.pack_start(menusHaveIconsCB, False, False, 2)
         buttonsHaveIconsCB = GSettingsCheckButton(_("Buttons Have Icons"), "org.gnome.desktop.interface", "buttons-have-icons", None)
         other_settings_box.pack_start(buttonsHaveIconsCB, False, False, 2)
-        if 'org.nemo' in Gio.Settings.list_schemas():
-            alwaysUseLocationEntryCB = GSettingsCheckButton(_("Always Use Location Entry In Nemo"), "org.nemo.preferences", "show-location-entry", None)
-            other_settings_box.pack_start(alwaysUseLocationEntryCB, False, False, 2)
         cursorThemeSwitcher = GSettingsComboBox(_("Cursor theme"), "org.gnome.desktop.interface", "cursor-theme", None, self._load_cursor_themes())
         other_settings_box.pack_start(cursorThemeSwitcher, False, False, 2)
         keybindingThemeSwitcher = GSettingsComboBox(_("Keybinding theme"), "org.gnome.desktop.interface", "gtk-key-theme", None, self._load_keybinding_themes())


### PR DESCRIPTION
Rendered obsolete by:  https://github.com/linuxmint/nemo/pull/184
