### PR TITLE
[Bugfix] fix a typo that leads to a ReferenceError

### DIFF
--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -874,7 +874,7 @@ Panel.prototype = {
                 leftWidth = Math.max(leftWidth - space_missing, leftMinWidth);
             }
             else if (centerWidth >= rightWidth) {
-                centerWidth = Math.max(centerWidth - space_mising, centerMinWidth);
+                centerWidth = Math.max(centerWidth - space_missing, centerMinWidth);
             }
             else {
                 rightWidth = Math.max(rightWidth - space_missing, rightMinWidth);


### PR DESCRIPTION
This fixes a typo is Panel._allocate(). space_mising -> space_missing

This bug is also present in the two proposals for panel rework (#1506, #1591)
