### PR TITLE
[Bugfix] fix preventShow for tooltips

### DIFF
--- a/js/ui/tooltips.js
+++ b/js/ui/tooltips.js
@@ -44,7 +44,6 @@ Tooltip.prototype = {
     },
 
     _onEnterEvent: function(actor, event) {
-        this.preventShow = false;
         Tweener.addTween(this, {time: 0.3, onComplete: Lang.bind(this, this._onTimerComplete)});
         this._mousePosition = event.get_coords();
     },
@@ -60,7 +59,6 @@ Tooltip.prototype = {
     },
 
     _onReleaseEvent: function(actor, event) {
-        this.preventShow = true;
         this.hide();
     },
 


### PR DESCRIPTION
This repairs preventShow for tooltips. The bug was introduced by https://github.com/linuxmint/Cinnamon/commit/ba698d80cb3232b30bc7582ab369f37e2102d81a#js/ui/tooltips.js, which was part of the solution for #273. The actual solution is not affected by this.
