### PR TITLE
Demote cinnamon-settings-center from depend to recommend

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -55,7 +55,6 @@ Depends: ${gir:Depends},
          gjs (>= 1.29.18),
          ${shlibs:Depends},
          ${misc:Depends},
-	 cinnamon-control-center,
          caribou,
          cups-pk-helper,
          gnome-settings-daemon (>= 2.91.5.1),
@@ -79,7 +78,8 @@ Depends: ${gir:Depends},
          mesa-utils,
          gkbd-capplet,
          python-pyinotify
-Recommends: gnome-themes-standard, gnome-terminal, nemo, cinnamon-screensaver
+Recommends: gnome-themes-standard, gnome-terminal, nemo, cinnamon-screensaver,
+ cinnamon-control-center
 Conflicts: cinnamon-session, cinnamon-settings
 Provides: cinnamon-session, cinnamon-settings
 Replaces: cinnamon-session, cinnamon-settings

--- a/debian/control.in
+++ b/debian/control.in
@@ -51,7 +51,6 @@ Depends: ${gir:Depends},
          ${shlibs:Depends},
          ${misc:Depends},
          cinnamon-common (= ${source:Version}),
-	 cinnamon-control-center,
          caribou,
          cups-pk-helper,
          gnome-settings-daemon (>= 2.91.5.1),
@@ -76,7 +75,8 @@ Depends: ${gir:Depends},
          python-lxml,
          gkbd-capplet,
          python-pyinotify
-Recommends: gnome-themes-standard, gnome-terminal, nemo, cinnamon-screensaver
+Recommends: gnome-themes-standard, gnome-terminal, nemo, cinnamon-screensaver,
+ cinnamon-control-center
 Conflicts: cinnamon-session, cinnamon-settings
 Provides: cinnamon-session, cinnamon-settings, notification-daemon
 Replaces: cinnamon-session, cinnamon-settings


### PR DESCRIPTION
From what I have understood, cinnamon-settings-center is not absolutely necessary for cinnamon. So put only as recommends.
