### PR TITLE
Minimal menu speedup patch

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -933,6 +933,14 @@ MyApplet.prototype = {
             let scrollBoxHeight = (this.leftBox.get_allocation_box().y2-this.leftBox.get_allocation_box().y1) -
                                     (this.searchBox.get_allocation_box().y2-this.searchBox.get_allocation_box().y1);
             this.applicationsScrollBox.style = "height: "+scrollBoxHeight+"px;";
+	    this.initButtonLoad = 30;
+	    let n = Math.min(this._applicationsButtons.length,
+			     this.initButtonLoad)
+	    for (let i = 0; i < n; i++) {
+		if (!this._applicationsButtons[i].actor.visible) {
+		    this._applicationsButtons[i].actor.show();
+		}
+	    }
             Mainloop.idle_add(Lang.bind(this, this._initial_cat_selection));
 	} else {
             this.actor.remove_style_pseudo_class('active');            
@@ -950,7 +958,12 @@ MyApplet.prototype = {
     },
 
     _initial_cat_selection: function () {
-        this._select_category(null, this._allAppsCategoryButton);
+	let n = this._applicationsButtons.length;
+	for (let i = this.initButtonLoad; i < n; i++) {
+	    if (!this._applicationsButtons[i].actor.visible) {
+		this._applicationsButtons[i].actor.show();
+	    }
+	}
     },
 
     destroy: function() {


### PR DESCRIPTION
This is a simple patch that vastly improves menu performance.  The patch causes 30 application buttons to be added immediately and then the rest of the buttons to be added in the background.  This allows the menu to display immediately.
