### PR TITLE
Let Cinnamon fallback to Cinnamon 2D

### DIFF
--- a/files/usr/share/gnome-session/sessions/cinnamon.session
+++ b/files/usr/share/gnome-session/sessions/cinnamon.session
@@ -2,6 +2,6 @@
 Name=Cinnamon
 RequiredComponents=cinnamon;gnome-settings-daemon;
 IsRunnableHelper=/usr/lib/gnome-session/gnome-session-check-accelerated
-FallbackSession=gnome-fallback
+FallbackSession=cinnamon2d
 DesktopName=GNOME
 


### PR DESCRIPTION
Looks like no one ever changed the fallback of Cinnamon since it got forked from Gnome which means Cinnamon falls back to gnome-fallback if no 3D acceleration is available. At least I wasn't able to find any previous discussion or reasoning why this would be desired... ;-)

This pull request includes 1 commit that changes the fallback from gnome-fallback to cinnamon2d.
