### PR TITLE
[Design] Enable multiple workspace rows (Real 2D workspace grid), add workspace-thumbnail zoom, and more

### DIFF
--- a/data/org.cinnamon.gschema.xml.in
+++ b/data/org.cinnamon.gschema.xml.in
@@ -331,8 +331,26 @@
     <key type="i" name="number-workspaces">
         <default>2</default>
         <_summary>Number of workspaces in Cinnamon session</_summary>
-        <_description>
-                Number of Workspaces</_description>
+        <_description>Number of Workspaces</_description>
+    </key>
+
+    <key type="b" name="multiple-workspace-rows-enabled">
+        <default>false</default>
+        <_summary>Enable multiple workspace rows</_summary>
+        <_description>Enable or disable having more than one row of workspaces</_description>
+    </key>
+
+    <key type="i" name="number-workspace-rows">
+        <default>2</default>
+        <range min="2" max="8" />
+        <_summary>Number of workspace rows</_summary>
+        <_description>Number of workspace rows, if multiple workspace rows enabled</_description>
+    </key>
+
+    <key type="b" name="workspace-rows-top-down">
+        <default>true</default>
+        <_summary>Enable top-down workspace rows</_summary>
+        <_description>Control whether the first workspace row is at the bottom or at the top, if multiple workspace rows enabled</_description>
     </key>
 
     <key name="overview-corner" type="as">
@@ -425,6 +443,14 @@
       <summary>Display the Expo view as a grid</summary>
       <description>
         When enabled the Expo view will be displayed as a grid.
+      </description>
+    </key>
+
+    <key name="expo-always-scale-mode" type="b">
+      <default>false</default>
+      <summary>Always show all Expo workspace thumbnails in Scale mode</summary>
+      <description>
+        When enabled both the selected and the non-selected workspaces will be shown in Scale mode.
       </description>
     </key>
 

--- a/files/usr/lib/cinnamon-settings/modules/cs_workspaces.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_workspaces.py
@@ -5,13 +5,20 @@ from SettingsWidgets import *
 class Module:
     def __init__(self, content_box):
         keywords = _("workspace, osd, expo, monitor")
-        advanced = True
+        advanced = False
         sidePage = SidePage(_("Workspaces"), "workspaces.svg", keywords, advanced, content_box)
         self.sidePage = sidePage
         self.name = "workspaces"
         self.category = "prefs"
         self.comment = _("Manage workspace preferences")
-        sidePage.add_widget(GSettingsCheckButton(_("Enable workspace OSD"), "org.cinnamon", "workspace-osd-visible", None))
+
+        sidePage.add_widget(GSettingsCheckButton(_("Enable multiple workspace rows"), "org.cinnamon", "multiple-workspace-rows-enabled", None), True)
+        box = IndentedHBox()
+        box.add(GSettingsSpinButton(_("Number of workspace rows"), "org.cinnamon", "number-workspace-rows", "org.cinnamon/multiple-workspace-rows-enabled", 0, 200, 1, 1, None))
+        sidePage.add_widget(box, True)
+        box.add(GSettingsCheckButton(_("Top-down"), "org.cinnamon", "workspace-rows-top-down", "org.cinnamon/multiple-workspace-rows-enabled"))
+
+        sidePage.add_widget(GSettingsCheckButton(_("Enable workspace OSD"), "org.cinnamon", "workspace-osd-visible", None), True)
 
         box = IndentedHBox()
         box.add(GSettingsSpinButton(_("Workspace OSD duration"), "org.cinnamon", "workspace-osd-duration", "org.cinnamon/workspace-osd-visible", 0, 2000, 50, 400, _("milliseconds")))
@@ -25,9 +32,10 @@ class Module:
         box.add(GSettingsSpinButton(_("Workspace OSD vertical position"), "org.cinnamon", "workspace-osd-y", "org.cinnamon/workspace-osd-visible", 0, 100, 5, 50, _("percent of the monitor's height")))
         sidePage.add_widget(box, True)
 
-        sidePage.add_widget(GSettingsCheckButton(_("Allow cycling through workspaces"), "org.cinnamon.muffin", "workspace-cycle", None), True)
+        sidePage.add_widget(GSettingsCheckButton(_("Allow cycling through workspaces"), "org.cinnamon.muffin", "workspace-cycle", None))
         sidePage.add_widget(GSettingsCheckButton(_("Only use workspaces on primary monitor (requires Cinnamon restart)"), "org.cinnamon.muffin", "workspaces-only-on-primary", None), True)
         sidePage.add_widget(GSettingsCheckButton(_("Display Expo view as a grid"), "org.cinnamon", "workspace-expo-view-as-grid", None))
+        sidePage.add_widget(GSettingsCheckButton(_("Always show all Expo workspace thumbnails in Scale mode"), "org.cinnamon", "expo-always-scale-mode", None))
 
     def shouldLoad(self):
         return True

--- a/js/Makefile.am
+++ b/js/Makefile.am
@@ -3,6 +3,7 @@ jsdir = $(pkgdatadir)/js
 
 nobase_dist_js_DATA = \
 	misc/config.js		\
+	misc/connector.js	\
 	misc/docInfo.js		\
 	misc/fileUtils.js	\
 	misc/format.js		\

--- a/js/misc/connector.js
+++ b/js/misc/connector.js
@@ -1,0 +1,81 @@
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+
+const Lang = imports.lang;
+
+/* usage:
+ * "let connection = connect(someObject, 'some-signal', someFunction [, ...])
+ *  ///...
+ *  connection.disconnect();
+ *  "
+ * 
+ * @arg-0: target, the object you want to connect to
+ * @arg-1 .. @arg-n: arguments to the target's connect function
+ *
+ * return value: an object that you call disconnect on
+ */
+var connect = function() {
+    let args = [].slice.apply(arguments);
+    let target = args.shift();
+    let id = target.connect.apply(target, args);
+    return {
+        disconnect: function() {
+            if (target) {
+                target.disconnect(id); target = null;
+                }
+        },
+        forget: function() {
+            target = null;
+        },
+        getTarget: function() {
+            return target;
+        },
+        /* Ties the connection to an object, so it is automatically destroyed with the object.
+         */
+        tie: function(object) {
+            object.connect('destroy', Lang.bind(this, this.disconnect));
+        }
+    };
+};
+
+function Connector() {
+    this._init.apply(this, arguments);
+}
+
+/* A class that takes care of your connections - just remember to
+ * call destroy when it is time to disconnect.
+ */
+Connector.prototype = {
+    _init: function() {
+        this.connections = [];
+    },
+
+    /* usage: "addConnection(someObject, 'some-signal', someFunction [, ...])"
+     * 
+     * @arg-0: target, the object you want to connect to
+     * @arg-1 .. @arg-n: arguments to the target's connect function
+     *
+     * @return aConnection, the created connection, which you can optionally disconnect or "forget" later on.
+     */
+    addConnection: function() {
+        let connection = connect.apply(0, arguments);
+        this.connections.push(connection);
+        return connection;
+    },
+
+    /* Disconnects all connections.
+     */
+    destroy: function() {
+        if (this.connections) {
+            this.connections.forEach(function(connection) {
+                connection.disconnect();
+            }, this);
+            this.connections = null;
+        }
+    },
+
+    /* Ties the connector to an object, so the connector is automatically destroyed with the object.
+     */
+    tie: function(object) {
+        object.connect('destroy', Lang.bind(this, this.destroy));
+    }
+};

--- a/js/misc/gridNavigator.js
+++ b/js/misc/gridNavigator.js
@@ -2,13 +2,17 @@
 const Lang = imports.lang;
 const Clutter = imports.gi.Clutter;
 
-function nextIndex(itemCount, numCols, currentIndex, symbol) {
+function nextIndex(itemCount, numCols, currentIndex, symbolIn, invertUpDown) {
     let result = -1;
+    let symbol = symbolIn;
+    let numRows = Math.ceil(itemCount/numCols);
+    if (invertUpDown && numRows > 1) {
+        if (symbolIn === Clutter.Down) symbol = Clutter.Up;
+        if (symbolIn === Clutter.Up) symbol = Clutter.Down;
+    }
     if (itemCount > 3 // grid navigation is not suited for a low item count
         && (symbol === Clutter.Down || symbol === Clutter.Up))
     {
-        let numRows = Math.ceil(itemCount/numCols);
-
         let curRow = Math.floor(currentIndex/numCols);
         let curCol = currentIndex % numCols;
 

--- a/js/ui/expo.js
+++ b/js/ui/expo.js
@@ -111,58 +111,6 @@ Expo.prototype = {
         this._coverPane.hide();
         this._addWorkspaceButton.hide();
         this._windowCloseArea.hide();
-
-        let ctrlAltMask = Clutter.ModifierType.CONTROL_MASK | Clutter.ModifierType.MOD1_MASK;
-        this._group.connect('key-press-event',
-            Lang.bind(this, function(actor, event) {
-                if (this._shown) {
-                    if (this._expo.handleKeyPressEvent(actor, event)) {
-                        return true;
-                    }
-                    let symbol = event.get_key_symbol();
-                    if (symbol === Clutter.plus || symbol === Clutter.Insert) {
-                        this._workspaceOperationPending = true;
-                    }
-                    let modifiers = Cinnamon.get_event_state(event);
-                    if ((symbol === Clutter.Delete && (modifiers & ctrlAltMask) !== ctrlAltMask)
-                        || symbol === Clutter.w && modifiers & Clutter.ModifierType.CONTROL_MASK)
-                    {
-                        this._workspaceOperationPending = true;
-                    }
-                    if (symbol === Clutter.Escape) {
-                        if (!this._workspaceOperationPending) {
-                            this.hide();
-                        }
-                        this._workspaceOperationPending = false;
-                        return true;
-                    }
-                }
-                return false;
-            }));
-        this._group.connect('key-release-event',
-            Lang.bind(this, function(actor, event) {
-                if (this._shown) {
-                    let symbol = event.get_key_symbol();
-                    if (symbol === Clutter.plus || symbol === Clutter.Insert) {
-                        if (this._workspaceOperationPending) {
-                            this._workspaceOperationPending = false;
-                            Main._addWorkspace();
-                        }
-                        return true;
-                    }
-                    let modifiers = Cinnamon.get_event_state(event);
-                    if ((symbol === Clutter.Delete && (modifiers & ctrlAltMask) !== ctrlAltMask)
-                        || symbol === Clutter.w && modifiers & Clutter.ModifierType.CONTROL_MASK)
-                    {
-                        if (this._workspaceOperationPending) {
-                            this._workspaceOperationPending = false;
-                            this._expo.removeSelectedWorkspace();
-                        }
-                        return true;
-                    }
-                }
-                return false;
-            }));
         this._expo = new ExpoThumbnail.ExpoThumbnailsBox();
         this._group.add_actor(this._expo.actor);
         this._relayout();

--- a/js/ui/workspace.js
+++ b/js/ui/workspace.js
@@ -1058,7 +1058,7 @@ WorkspaceMonitor.prototype = {
     },
 
     _showWindowOverlay: function(clone, fade) {
-        if (this._slotWidth) {
+        if (this._slotWidth && !Main.overview.animationInProgress) {
             // This is a little messy and complicated because when we
             // start the fade-in we may not have done the final positioning
             // of the workspaces. (Tweener doesn't necessarily finish


### PR DESCRIPTION
This patch enables multiple workspace rows, i.e., a real 2-dimensional workspace grid, fully supported by Expo and Scale. To navigate up and down using the keyboard, keep Ctrl+Alt+Up or Down pressed about 250 milliseconds; a shorter key-press will bring up Expo or Scale as usual.

To enable multiple workspace rows, open Cinnamon Settings, Workspaces.

**For optimum experience, you need a version of Muffin that includes linuxmint/Muffin#76.**

This patch includes my Expo-workspace-thumbnail-zoom patch, #1700.

Update 2013-11-09: This pull request has become quite old and it's getting increasingly difficult to keep synchronized with upstream development, so I will eventually be forced to either let it bit-rot or pull it.
