### PR TITLE
[Scale] Automatically close Scale if opened on an empty workspace.

### DIFF
--- a/js/ui/overview.js
+++ b/js/ui/overview.js
@@ -11,6 +11,7 @@ const Gdk = imports.gi.Gdk;
 
 const Main = imports.ui.main;
 const MessageTray = imports.ui.messageTray;
+const ModalDialog = imports.ui.modalDialog;
 const Tweener = imports.ui.tweener;
 const WorkspacesView = imports.ui.workspacesView;
 
@@ -231,6 +232,16 @@ Overview.prototype = {
     show : function() {
         if (this._shown)
             return;
+        if (Main.getTabList().length == 0) {
+            let dialog = new ModalDialog.ModalDialog();
+            dialog.contentLayout.add(new St.Label({text: _("Workspace is empty, Scale will close.")}));
+            dialog.open();
+            let timestamp = global.get_current_time();
+            Mainloop.timeout_add(500, function() {
+                dialog.close(timestamp);
+            });
+            return;
+        }
         // Do this manually instead of using _syncInputMode, to handle failure
         if (!Main.pushModal(this._group))
             return;

--- a/js/ui/workspacesView.js
+++ b/js/ui/workspacesView.js
@@ -2,12 +2,14 @@
 
 const Clutter = imports.gi.Clutter;
 const Lang = imports.lang;
+const Mainloop = imports.mainloop;
 const Meta = imports.gi.Meta;
 const Cinnamon = imports.gi.Cinnamon;
 const St = imports.gi.St;
 const Signals = imports.signals;
 
 const Main = imports.ui.main;
+const ModalDialog = imports.ui.modalDialog;
 const Tweener = imports.ui.tweener;
 const Workspace = imports.ui.workspace;
 


### PR DESCRIPTION
It makes little sense to open Scale on an empty workspace, and it can
be bewildering even to experienced users to see nothing
but a dimmed background image, especially if they opened
Scale by mistake.

This patch makes Scale briefly display a message and return
to the current desktop, if opened on an empty workspace.

Update 3: The earlier reported problems with stability have now been diagnosed to be caused by an unrelated bug.
