### PR TITLE
Cinnamon-menu-editor: Use GLib.Error for catching errors

### DIFF
--- a/files/usr/lib/cinnamon-menu-editor/cme/util.py
+++ b/files/usr/lib/cinnamon-menu-editor/cme/util.py
@@ -22,9 +22,6 @@ import uuid
 from collections import Sequence
 from gi.repository import Gtk, GdkPixbuf, GMenu, GLib
 
-# XXX: look into pygobject error marshalling
-from gi._glib import GError
-
 DESKTOP_GROUP = GLib.KEY_FILE_DESKTOP_GROUP
 KEY_FILE_FLAGS = GLib.KeyFileFlags.KEEP_COMMENTS | GLib.KeyFileFlags.KEEP_TRANSLATIONS
 
@@ -143,7 +140,7 @@ def getIcon(item):
         return None
     try:
         pixbuf = info.load_icon()
-    except GError:
+    except GLib.GError:
         return None
     if pixbuf is None:
         return None


### PR DESCRIPTION
Should fix #1702, #1740
