### PR TITLE
Use cinnamon instead of /usr/bin/cinnamon in session files

### DIFF
--- a/data/cinnamon.desktop.in.in
+++ b/data/cinnamon.desktop.in.in
@@ -2,7 +2,7 @@
 Type=Application
 _Name=Cinnamon
 _Comment=Window management and application launching
-Exec=@bindir@/cinnamon
+Exec=cinnamon
 X-GNOME-Bugzilla-Bugzilla=GNOME
 X-GNOME-Bugzilla-Product=cinnamon
 X-GNOME-Bugzilla-Component=general

--- a/files/usr/share/xsessions/cinnamon.desktop
+++ b/files/usr/share/xsessions/cinnamon.desktop
@@ -2,7 +2,7 @@
 Name=Cinnamon
 Comment=This session logs you into Cinnamon
 Exec=gnome-session-cinnamon
-TryExec=/usr/bin/cinnamon
+TryExec=cinnamon
 Icon=
 Type=Application
 


### PR DESCRIPTION
This allows running cinnamon in a different prefix like /usr/local,
provided the bin folder in that prefix is included in $PATH.

cinnamon2d is not changed, since the cinnamon2d executable is always in the same location: it's from the files/usr/bin directory, so always /usr/bin/cinnamon2d and not /usr/local/bin/cinnamon2d.
