### PR TITLE
Bug Fix: Set proper switcher height on resize

### DIFF
--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
@@ -75,7 +75,7 @@ MyApplet.prototype = {
             this.button[i].set_child(label);
             this.actor.add(this.button[i]);
             if (this._scaleMode) {
-                this.button[i].set_width(this._panelHeight);
+                this.button[i].set_height(this._panelHeight);
             }
             let index = i;
             this.button[i].connect('button-release-event', Lang.bind(this, function() {


### PR DESCRIPTION
Allow Workspace switcher to properly resize when the height of the panel is changed.  Without this fix, the workspace switcher does not properly resize.
