### PR TITLE
Re-enable notification actions

### DIFF
--- a/js/ui/messageTray.js
+++ b/js/ui/messageTray.js
@@ -685,7 +685,6 @@ Notification.prototype = {
     // Puts @actor into the action area of the notification, replacing
     // the previous contents
     setActionArea: function(actor, props) {
-    	return;
         if (this._actionArea) {
             this._actionArea.destroy();
             this._actionArea = null;


### PR DESCRIPTION
At some point in the past (a8cba889d9c564ad7830498210c5ce90f497c92d), notification actions were purposely disabled. As @nbourdau commented in #1479, this renders certain programs such as Ekiga unable to work properly. In the case of Ekiga, it prevents answering the phone calls coming in, unless you manually connect the call by dialing nothing.
