### PR TITLE
Extend Skype focus fix to SkypeTab-ng (issue #233)

### DIFF
--- a/js/ui/windowAttentionHandler.js
+++ b/js/ui/windowAttentionHandler.js
@@ -25,7 +25,7 @@ WindowAttentionHandler.prototype = {
         // We are just ignoring the hint on skip_taskbar windows for now.
         // (Which is the same behaviour as with metacity + panel)                  
 
-        if (!window || window.has_focus() || window.is_skip_taskbar() || window.get_wm_class() == "Skype")
+        if (!window || window.has_focus() || window.is_skip_taskbar() || window.get_wm_class().indexOf("Skype") > -1)
             return;
 
         try {


### PR DESCRIPTION
Issue #233 fixes focus stealing for Skype with commit c5bbcad, but SkypeTab-ng has `WM_CLASS(STRING) = "SkypeTab"` This solves for both.
