### PR TITLE
disable tweeners when desktop-effects are disabled

### DIFF
--- a/js/ui/tweener.js
+++ b/js/ui/tweener.js
@@ -60,6 +60,8 @@ function addTween(target, tweeningParameters) {
 }
 
 function _wrapTweening(target, tweeningParameters) {
+    if (!tweeningParameters.FORCE_ANIMATION && !global.settings.get_boolean('desktop-effects'))
+        tweeningParameters.time = 0.001;
     let state = _getTweenState(target);
 
     if (!state.destroyedId) {


### PR DESCRIPTION
- set tweener animation time to 0.001 seconds when desktop effects are disabled.  0 seemed to break callbacks.
- add support for FORCE_ANIMATION boolean parameter to enable the
  animation even when desktop effects are disabled.  I chose the capital letters so any use of it will be questioned.

Example usage of FORCE_ANIMATION:

``` javascript
Tweener.addTween(this, {
            opacity: 255,
            xOffset: 0,
            yOffset: 0,
            transition: 'linear',
            onComplete: onComplete,
            FORCE_ANIMATION: true,
            time: POPUP_ANIMATION_TIME });
```
