### PR TITLE
[Main] Use Date.toISOString in formatTime function

### DIFF
--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -805,13 +805,7 @@ function _logInfo(msg) {
 }
 
 function formatTime(d) {
-    function pad(n) { return n < 10 ? '0' + n : n; }
-    return d.getUTCFullYear()+'-'
-        + pad(d.getUTCMonth()+1)+'-'
-        + pad(d.getUTCDate())+'T'
-        + pad(d.getUTCHours())+':'
-        + pad(d.getUTCMinutes())+':'
-        + pad(d.getUTCSeconds())+'Z';
+    return d.toISOString();
 }
 
 function renderLogLine(line) {


### PR DESCRIPTION
I don't know why we are formatting the string in <a href="https://xkcd.com/1179/">ISO-8601</a> format, but if we are doing so, there is a much easier way of doing it.
