### PR TITLE
Make createWindowClone aware of width and height

### DIFF
--- a/js/misc/windowUtils.js
+++ b/js/misc/windowUtils.js
@@ -2,69 +2,72 @@ const Clutter = imports.gi.Clutter;
 
 // Creates scaled clones of metaWindow and its transients,
 // keeping their relative size to each other.
-// When scaled, the clone with the biggest width and the one with 
-// the biggest height are made to fit into size
-// if size is not given, windows are not scaled
-function createWindowClone(metaWindow, size, withTransients, withPositions) {
-    let clones = [];
-    let textures = [];
-    
-    if (!metaWindow) {
-      return clones;
-    }
-    
-    let metaWindowActor = metaWindow.get_compositor_private();
-    if (!metaWindowActor) {
-      return clones;
-    }
-    let texture = metaWindowActor.get_texture();
-    let [width, height] = metaWindowActor.get_size();
-    let [maxWidth, maxHeight] = [width, height];
-    let [x, y] = metaWindowActor.get_position();
-    let [minX, minY] = [x, y];
-    let [maxX, maxY] = [minX + width, minY + height];
-    textures.push({t: texture, x: x, y: y, w: width, h: height});
-    if (withTransients) {
-      metaWindow.foreach_transient(function(win) {
-        let metaWindowActor = win.get_compositor_private();
-        texture = metaWindowActor.get_texture();
-        [width, height] = metaWindowActor.get_size();
-        [x, y] = metaWindowActor.get_position();
-        maxWidth = Math.max(maxWidth, width);
-        maxHeight = Math.max(maxHeight, height);
-        minX = Math.min(minX, x);
-        maxX = Math.max(maxX, x + width);
-        minY = Math.min(minY, y);
-        maxY = Math.max(maxY, y + height);
-        textures.push({t: texture, x: x, y: y, w: width, h: height});
-      });
-    }
-    let scale = 1;
-    if (size) {
-      if (withPositions) {
-        scale = Math.min(size/Math.max(maxX - minX, maxY - minY), 1);
-      }
-      else {
-        scale = Math.min(size/Math.max(maxWidth, maxHeight), 1);
-      }
-    }
-    for (i in textures) {
-      let data = textures[i];
-      let [texture, width, height, x, y] = [data.t, data.w, data.h, data.x, data.y];
-      if (withPositions) {
-        x -= minX;
-        y -= minY;
-      }
-      let params = {};
-      params.source = texture;
-      if (scale != 1) {
-        params.width = Math.round(width * scale);
-        params.height = Math.round(height * scale);
-        x = Math.round(x * scale);
-        y = Math.round(y * scale);
-      }
-      let clone = {actor: new Clutter.Clone(params), x: x, y: y};
-      clones.push(clone);
-    }
+// When scaled, all clones are made to fit in width and height
+// if neither width nor height is given, windows are not scaled
+function createWindowClone(metaWindow, width, height, withTransients, withPositions) {
+  let clones = [];
+  let textures = [];
+  
+  if (!metaWindow) {
     return clones;
+  }
+  
+  let metaWindowActor = metaWindow.get_compositor_private();
+  if (!metaWindowActor) {
+    return clones;
+  }
+  let texture = metaWindowActor.get_texture();
+  let [windowWidth, windowHeight] = metaWindowActor.get_size();
+  let [maxWidth, maxHeight] = [windowWidth, windowHeight];
+  let [x, y] = metaWindowActor.get_position();
+  let [minX, minY] = [x, y];
+  let [maxX, maxY] = [minX + windowWidth, minY + windowHeight];
+  textures.push({t: texture, x: x, y: y, w: windowWidth, h: windowHeight});
+  if (withTransients) {
+    metaWindow.foreach_transient(function(win) {
+      let metaWindowActor = win.get_compositor_private();
+      texture = metaWindowActor.get_texture();
+      [windowWidth, windowHeight] = metaWindowActor.get_size();
+      [x, y] = metaWindowActor.get_position();
+      maxWidth = Math.max(maxWidth, windowWidth);
+      maxHeight = Math.max(maxHeight, windowHeight);
+      minX = Math.min(minX, x);
+      maxX = Math.max(maxX, x + windowWidth);
+      minY = Math.min(minY, y);
+      maxY = Math.max(maxY, y + windowHeight);
+      textures.push({t: texture, x: x, y: y, w: windowWidth, h: windowHeight});
+    });
+  }
+  let scale = 1;
+  let scaleWidth = 1;
+  let scaleHeight = 1;
+  if (width) {
+    scaleWidth = Math.min(width/(maxX - minX), 1);
+  }
+  if (height) {
+    scaleHeight = Math.min(height/(maxY - minY), 1);
+  }
+  if (width || height) {
+    scale = Math.min(scaleWidth, scaleHeight);
+  }
+  
+  for (i in textures) {
+    let data = textures[i];
+    let [texture, texWidth, texHeight, x, y] = [data.t, data.w, data.h, data.x, data.y];
+    if (withPositions) {
+      x -= minX;
+      y -= minY;
+    }
+    let params = {};
+    params.source = texture;
+    if (scale != 1) {
+      params.width = Math.round(texWidth * scale);
+      params.height = Math.round(texHeight * scale);
+      x = Math.round(x * scale);
+      y = Math.round(y * scale);
+    }
+    let clone = {actor: new Clutter.Clone(params), x: x, y: y};
+    clones.push(clone);
+  }
+  return clones;
 }

--- a/js/ui/altTab.js
+++ b/js/ui/altTab.js
@@ -551,7 +551,7 @@ AltTabPopup.prototype = {
             let lastClone = null;
             let previewClones = [];
             let window = this._appIcons[this._currentApp].cachedWindows[0];
-            let clones = WindowUtils.createWindowClone(window, null, true, false);
+            let clones = WindowUtils.createWindowClone(window, null, null, true, false);
             for (let i = 0; i < clones.length; i++) {
                 let clone = clones[i];
                 previewClones.push(clone.actor);
@@ -1056,7 +1056,7 @@ AppIcon.prototype = {
     set_size: function(size) {
         if (this.showThumbnail){
             this.icon = new St.Group();
-            let clones = WindowUtils.createWindowClone(this.window, size, true, true);
+            let clones = WindowUtils.createWindowClone(this.window, size, size, true, true);
             for (i in clones) {
                 let clone = clones[i];
                 this.icon.add_actor(clone.actor);
@@ -1303,7 +1303,7 @@ ThumbnailList.prototype = {
         for (let i = 0; i < this._thumbnailBins.length; i++) {
             let metaWindow = this._windows[i];
             let container = new St.Group();
-            let clones = WindowUtils.createWindowClone(metaWindow, availHeight, true, true);
+            let clones = WindowUtils.createWindowClone(metaWindow, availHeight, 0, true, true);
             for (let j = 0; j < clones.length; j++) {
               let clone = clones[j];
               container.add_actor(clone.actor);

--- a/js/ui/expoThumbnail.js
+++ b/js/ui/expoThumbnail.js
@@ -147,7 +147,7 @@ ExpoWindowClone.prototype = {
         this.clone = new St.Group({reactive: false});
         this.actor.add_actor(this.clone);
         let [pwidth, pheight] = [this.realWindow.width, this.realWindow.height];
-        let clones = WindowUtils.createWindowClone(this.metaWindow, 0, withTransients);
+        let clones = WindowUtils.createWindowClone(this.metaWindow, 0, 0, withTransients);
         for (i in clones) {
             let clone = clones[i].actor;
             this.clone.add_actor(clone);

--- a/js/ui/workspace.js
+++ b/js/ui/workspace.js
@@ -178,7 +178,7 @@ WindowClone.prototype = {
         this.clone = new St.Group({reactive: false});
         this.actor.add_actor(this.clone);
         let [pwidth, pheight] = [this.realWindow.width, this.realWindow.height];
-        let clones = WindowUtils.createWindowClone(this.metaWindow, 0, withTransients);
+        let clones = WindowUtils.createWindowClone(this.metaWindow, 0, 0, withTransients);
         for (i in clones) {
             let clone = clones[i].actor;
             this.clone.add_actor(clone);


### PR DESCRIPTION
This replaces the "size"-parameter of createWindowClone() by "width" and "height", so that these are now used for the clone to fit into. If one of them is not given, the respective dimension is not regarded.
