### PR TITLE
Add environment variable for compatibility with clutter 1.14 (gnome 3.8)

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -257,10 +257,12 @@ main (int argc, char **argv)
 
   g_option_context_free (ctx);
 
+  /* Disable XInput extension - required for 3.8 compatibility */
+  g_setenv ("CLUTTER_DISABLE_XINPUT", "1", TRUE);
+
   meta_plugin_type_register (gnome_cinnamon_plugin_get_type ());
 
   /* Prevent meta_init() from causing gtk to load gail and at-bridge */
-  g_setenv ("CLUTTER_DISABLE_XINPUT", "1", TRUE);
   g_setenv ("NO_GAIL", "1", TRUE);
   g_setenv ("NO_AT_BRIDGE", "1", TRUE);
   meta_init ();


### PR DESCRIPTION
This should have no effect on lesser clutter versions, and thus should be compatible with 3.4 and 3.6 environments
