### PR TITLE
Remove unused imports from cinnamon-settings

### DIFF
--- a/files/usr/lib/cinnamon-settings/cinnamon-settings.py
+++ b/files/usr/lib/cinnamon-settings/cinnamon-settings.py
@@ -8,7 +8,7 @@ try:
     import os
     import glob
     import gettext
-    from gi.repository import Gio, Gtk, GObject, GdkPixbuf, GtkClutter, Gst
+    from gi.repository import Gio, Gtk, GObject, GdkPixbuf
     import SettingsWidgets
     import capi
 # Standard setting pages... this can be expanded to include applet dirs maybe?


### PR DESCRIPTION
Imports of Gst and GtkClutter have been rendered useless by recent modification of cinnamon-settings.
