### PR TITLE
Switch to proper for-loop in createWindowClone

### DIFF
--- a/js/misc/windowUtils.js
+++ b/js/misc/windowUtils.js
@@ -51,7 +51,7 @@ function createWindowClone(metaWindow, width, height, withTransients, withPositi
     scale = Math.min(scaleWidth, scaleHeight);
   }
   
-  for (i in textures) {
+  for (let i = 0; i < textures.length; i++) {
     let data = textures[i];
     let [texture, texWidth, texHeight, x, y] = [data.t, data.w, data.h, data.x, data.y];
     if (withPositions) {


### PR DESCRIPTION
This may address #1934 at least partially. Since #1934 does not happen to me, I cannot test it. Still, this patch uses a better way to iterate an array.
