### PR TITLE
[deskletManager.js] get_mouse_window can now take a null parameter

### DIFF
--- a/js/ui/deskletManager.js
+++ b/js/ui/deskletManager.js
@@ -23,7 +23,6 @@ var enabledDeskletDefinitions;
 
 let userDeskletsDir;
 
-let dummyMetaWindow = new Meta.Window();
 let mouseTrackEnabled = false;
 let mouseTrackTimoutId = null;
 
@@ -65,7 +64,7 @@ function enableMouseTracking(enable) {
 }
 
 function hasMouseWindow(){
-    let window = global.screen.get_mouse_window(dummyMetaWindow);
+    let window = global.screen.get_mouse_window(null);
     return window && window.window_type != Meta.WindowType.DESKTOP;
 }
 


### PR DESCRIPTION
There is no longer any need to create a dummy MetaWindow, which causes problems down the line. This fixes #1945. Depends on linuxmint/muffin#78.
