### PR TITLE
[2.0] st-scroll-view.c: avoid double disconnect

### DIFF
--- a/src/st/st-scroll-view.c
+++ b/src/st/st-scroll-view.c
@@ -408,6 +408,7 @@ st_scroll_view_dispose (GObject *object)
 
   if (priv->setting_connect_id > 0) {
     g_signal_handler_disconnect (priv->settings, priv->setting_connect_id);
+    priv->setting_connect_id = 0;
   }
 
   g_signal_handlers_disconnect_by_func (ST_SCROLL_VIEW (object), motion_event_cb, ST_SCROLL_VIEW (object));


### PR DESCRIPTION
The console has recently started displaying the following message just after Cinnamon has started:

```
Window manager warning: Log level 16: /build/buildd/glib2.0-2.32.3/./gobject/gsignal.c:2572: instance `0x7829000' has no handler with id `20365'
```

The enclosed patch seems to silence the warning, with the disclaimer that I am not at all familiar with the GObject object model.
