### PR TITLE
Remove graphics memory amount from System Information

### DIFF
--- a/files/usr/lib/cinnamon-settings/modules/cs_info.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_info.py
@@ -20,35 +20,18 @@ def getProcessOut(command):
 
 def getGraphicsInfos():
     cards = {}
-    cardUnits = {
-        "K": 1024,
-        "M": 1024*1024,
-        "G": 1024*1024*1024,
-        "T": 1024*1024*1024*1024,
-    }
     count = 0
     for card in getProcessOut(("lspci")):
         if not "VGA" in card:
             continue
         cardId = card.split()[0]
-        cardUnitSize = 0
-        cardUnitName = ""
         cardName = None
-        cardSize = 0
         for line in getProcessOut(("lspci", "-v", "-s", cardId)):
             if line.startswith(cardId):
                 cardName = (line.split(":")[2].split("(rev")[0].strip())
-            else:
-                for (size, unit) in re.findall("\[size=([\.0-9]*)([a-zA-Z])\]", line):
-                    size = int(size)
-                    unitSize = cardUnits[unit.upper()]
-                    if (size*unitSize) > (cardSize * cardUnitSize):
-                        cardSize = size
-                        cardUnitSize = unitSize
-                        cardUnitName = unit.upper()
-
+  
         if cardName:
-            cards[count] = ("%s ( %s %sB )" % (cardName, cardSize, cardUnitName))
+            cards[count] = (cardName)
             count += 1
     return cards
 


### PR DESCRIPTION
We were showing the largest memory area from lspci. Only on integrated graphics devices, this is the video RAM.
On dedicated graphics cards this is the aperture set by the BIOS (a fake memory area); the real video memory is often of different size; it is not shown in lspci.

Fixes #1973 partially.
