### PR TITLE
[2.0] sound applet: add deadbeef support (closes #1351)

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -104,7 +104,7 @@ let compatible_players = [
     'pragha', 'quodlibet', 'guayadeque', 'amarok', 'googlemusicframe', 'xbmc',
     'noise', 'xnoise', 'gmusicbrowser', 'spotify', 'audacious', 'vlc',
     'beatbox', 'songbird', 'pithos', 'gnome-mplayer', 'nuvolaplayer', 'qmmp',
-    'deadbeef'];
+    'deadbeef', 'smplayer'];
 let support_seek = [
     'clementine', 'banshee', 'rhythmbox', 'rhythmbox3', 'pragha', 'quodlibet',
     'amarok', 'noise', 'xnoise', 'gmusicbrowser', 'spotify', 'vlc', 'beatbox',


### PR DESCRIPTION
Trivial change which adds deadbeef to the list of supported media players for the sound applet.
