### PR TITLE
Fix regression in sound applet.

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -458,7 +458,7 @@ Player.prototype = {
         if (support_seek.indexOf(this._name) == -1) {
             this._time.hide();
             this.showPosition = false;
-            this._positionSlider.hide();
+            this._positionSlider.actor.hide();
         }
         this._getStatus();
         this._trackId = {};


### PR DESCRIPTION
The regression is caused https://github.com/linuxmint/Cinnamon/commit/b9f8a6d5e422cc43a067d1f9daf009757cdc7221, which tries to hide the position slider. PopupSliderMenuItem does not have a function "hide()".
