### PR TITLE
[Design] Lock desklets

### DIFF
--- a/data/org.cinnamon.gschema.xml.in
+++ b/data/org.cinnamon.gschema.xml.in
@@ -63,6 +63,14 @@
       <_description>If desklet-snap is enabled, the possible positions of desklets will be all integer multiples of the value of "desklet-snap-size"</_description>
     </key>
 
+    <key name="locked-desklets" type="as">
+      <default>[]</default>
+      <_summary>Uuids of locked desklets</_summary>
+      <_description>
+        If a desklet's uuid is listed in this array, it is considered locked and therefore cannot be repositioned through drag-and-drop operations.
+      </_description>
+    </key>
+
     <key name="panel-autohide" type="b">
       <default>false</default>
       <_summary>Auto-hide panel</_summary>
@@ -886,8 +894,8 @@
       <default>[]</default>
       <_summary>Desktop files of the applications to be shown on desktop</_summary>
       <_description>
-	The "launchers" desklet provides a method to show a launcher on the desktop
-	This list maps the desklet id to the desktop file of application.
+        The "launchers" desklet provides a method to show a launcher on the desktop
+        This list maps the desklet id to the desktop file of application.
       </_description>
     </key>
   </schema>

--- a/js/ui/deskletManager.js
+++ b/js/ui/deskletManager.js
@@ -29,6 +29,8 @@ let mouseTrackTimoutId = null;
 const ENABLED_DESKLETS_KEY = 'enabled-desklets';
 const DESKLET_SNAP_KEY = 'desklet-snap';
 const DESKLET_SNAP_INTERVAL_KEY = 'desklet-snap-interval';
+const LOCKED_DESKLETS_KEY = 'locked-desklets';
+
 /**
  * init:
  *
@@ -45,9 +47,14 @@ function init(){
             hasDesklets = true;
     }
 
-    global.settings.connect('changed::' + ENABLED_DESKLETS_KEY, _onEnabledDeskletsChanged);
-    global.settings.connect('changed::' + DESKLET_SNAP_KEY, _onDeskletSnapChanged);
-    global.settings.connect('changed::' + DESKLET_SNAP_INTERVAL_KEY, _onDeskletSnapChanged);
+    global.settings.connect('changed::' + ENABLED_DESKLETS_KEY,
+                            _onEnabledDeskletsChanged);
+    global.settings.connect('changed::' + DESKLET_SNAP_KEY,
+                            _onDeskletSnapChanged);
+    global.settings.connect('changed::' + DESKLET_SNAP_INTERVAL_KEY,
+                            _onDeskletSnapChanged);
+    global.settings.connect('changed::' + LOCKED_DESKLETS_KEY,
+                            _onLockedDeskletsChanged);
     
     enableMouseTracking(true);
 }
@@ -93,6 +100,8 @@ function checkMouseTracking() {
  * Disable and remove the desklet @uuid:@desklet_id
  */
 function removeDesklet(uuid, desklet_id){
+    _unlockDesklet(uuid);
+
     let list = global.settings.get_strv(ENABLED_DESKLETS_KEY);
     for (let i = 0; i < list.length; i++){
         let definition = list[i];
@@ -339,6 +348,41 @@ function _onDeskletSnapChanged(){
 
     global.settings.set_strv(ENABLED_DESKLETS_KEY, enabledDesklets);
     return;
+}
+
+function _lockDesklet(uuid) {
+    if (getDeskletLockedState(uuid))
+        return;
+    let lockedDesklets = global.settings.get_strv(LOCKED_DESKLETS_KEY);
+    lockedDesklets.push(uuid);
+    global.settings.set_strv(LOCKED_DESKLETS_KEY, lockedDesklets);
+}
+
+function _unlockDesklet(uuid) {
+    if (!getDeskletLockedState(uuid))
+        return;
+    let lockedDesklets = global.settings.get_strv(LOCKED_DESKLETS_KEY);
+    lockedDesklets.splice(lockedDesklets.indexOf(uuid), 1);
+    global.settings.set_strv(LOCKED_DESKLETS_KEY, lockedDesklets);
+}
+
+function getDeskletLockedState(uuid) {
+    let lockedDesklets = global.settings.get_strv(LOCKED_DESKLETS_KEY);
+    return lockedDesklets.indexOf(uuid) !== -1;
+}
+
+function toggleDeskletLockedState(uuid) {
+    if (getDeskletLockedState(uuid))
+        _unlockDesklet(uuid);
+    else
+        _lockDesklet(uuid);
+}
+
+function _onLockedDeskletsChanged() {
+    // Inform the desklets about the new locked state.
+    let lockedDesklets = global.settings.get_strv(LOCKED_DESKLETS_KEY);
+    for (let uuid in enabledDeskletDefinitions.uuidMap) 
+        deskletObj[uuid].setLockedState(lockedDesklets.indexOf(uuid) !== -1);
 }
 
 /**


### PR DESCRIPTION
This adds the ability to lock desklets on the desktop such that their position can't be changed through DND. Right now the "locked" state is identical for all active desklets and stored in gsettings under the key `desklets-locked' in /org/cinnamon which defaults to false. Personally, I think it's sensible to have this affect all desklets. It may be argued, however, that a per-desklet setting would be more useful. In that case the locked state would need to be stored alongside the desklets uuid in the enabled-desklets field. Alternatively, the value could be stored in the desklet's metadata.json file, but then we'd have to rely on desklet authors not to tamper with the key themselves.