### PR TITLE
Cinnamon settings display "Login Screen" module even when mdm isn't present (closes #2014) 

### DIFF
--- a/files/usr/lib/cinnamon-settings/bin/SettingsWidgets.py
+++ b/files/usr/lib/cinnamon-settings/bin/SettingsWidgets.py
@@ -109,7 +109,10 @@ class SAModule:
         self.category = category
 
     def process (self):
-        return fileexists(self.name.split()[0])
+        for f in self.name.split():
+            if not fileexists(f):
+                return False
+        return True
 
 def fileexists(program):
 


### PR DESCRIPTION
With cinnamon 1.8.2 on Ubuntu 13.04 "Login Screen" module is displayed even though mdm isn't present. Fixed as described in #2014.
