### PR TITLE
Revert removal of panelMenu.js

### DIFF
--- a/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
@@ -8,7 +8,6 @@ const Signals = imports.signals;
 const St = imports.gi.St;
 const Mainloop = imports.mainloop;
 const Main = imports.ui.main;
-const PanelMenu = imports.ui.panelMenu;
 const PopupMenu = imports.ui.popupMenu;
 const MessageTray = imports.ui.messageTray;
 const ModemManager = imports.misc.modemManager;

--- a/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
@@ -3,7 +3,6 @@ const St = imports.gi.St;
 
 const Applet = imports.ui.applet;
 const Main = imports.ui.main;
-const PanelMenu = imports.ui.panelMenu;
 
 const ICON_SCALE_FACTOR = .88; // for custom panel heights, 22 (default icon size) / 25 (default panel height)
 


### PR DESCRIPTION
It turns out a lot of third party applets use this still, and it really does no harm leaving it in for legacy purposes.
