### PR TITLE
Use transparent background for main cinnamon-settings page instead of @bg_color

### DIFF
--- a/files/usr/lib/cinnamon-settings/cinnamon-settings.py
+++ b/files/usr/lib/cinnamon-settings/cinnamon-settings.py
@@ -295,7 +295,7 @@ class MainWindow:
         widget.set_hexpand(True)
         widget.set_vexpand(False)
         css_provider = Gtk.CssProvider()
-        css_provider.load_from_data("GtkIconView {background-color: @bg_color;}")
+        css_provider.load_from_data("GtkIconView {background-color: transparent;}")
         c = widget.get_style_context()
         c.add_provider(css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
         self.side_view[category["id"]] = widget


### PR DESCRIPTION
@bg_color - some themes don't look good with this.

Ref #1661
