### PR TITLE
Make menu applet open on button-press instead of release, and

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -916,6 +916,7 @@ MyApplet.prototype = {
             if (!this.prevent_open)
                 this.menu.toggle_with_options(false);
         }
+        return true;
     },
 
     _onSourceKeyPress: function(actor, event) {


### PR DESCRIPTION
prevent menu from opening during panel edit mode.
