### PR TITLE
Panel applet launcher editor: handle spaces correctly in app and icon paths

### DIFF
--- a/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/cinnamon-add-panel-launcher.py
+++ b/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/cinnamon-add-panel-launcher.py
@@ -92,6 +92,7 @@ class Handler:
     def onIconPicked(self, *args):
         global iconPath, iface
         iconPath = iface.icon_picker.get_uri()[7:]
+        iconPath = iconPath.strip().replace("%20", " ")
         iface.icon_path.set_text(iconPath)
         updatePreviewIcon(iconPath)
         


### PR DESCRIPTION
#1998
