### PR TITLE
popupMenu.js: avoid unintended side effect of unexpected recursive call of PopupMenu.close

### DIFF
--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -1248,6 +1248,7 @@ PopupMenu.prototype = {
         if (!this.isOpen)
             return;
             
+        this.isOpen = false;
         global.menuStackLength -= 1;
 
         Main.panel._hidePanel();
@@ -1258,8 +1259,6 @@ PopupMenu.prototype = {
             this._activeMenuItem.setActive(false);
 
         this._boxPointer.hide(animate);
-
-        this.isOpen = false;
         this.emit('open-state-changed', false);
     }
 };


### PR DESCRIPTION
Calling this._boxPointer.hide in PopupMenu.close triggers
PopupMenuManager._onKeyFocusChanged,
which ends up calling PopupMenu.close recursively, causing
global.menuStackLength to be decremented twice, unless
the isOpen flag is set to false before the call.
