### PR TITLE
Fix cinnamon-settings crashing in Mint 13

### DIFF
--- a/files/usr/lib/cinnamon-settings/modules/cs_keyboard.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_keyboard.py
@@ -7,6 +7,8 @@ import gettext
 
 gettext.install("cinnamon", "/usr/share/cinnamon/locale")
 
+HAS_DEDICATED_TERMINAL_SHORTCUT = False
+
 schema = Gio.Settings("org.gnome.settings-daemon.plugins.media-keys")
 key_list = schema.list_keys()
 for key in key_list:


### PR DESCRIPTION
Fixes #2051
