### PR TITLE
Don't let the hotcorner ripple actors interfere with the upper left panel box

### DIFF
--- a/js/ui/hotCorner.js
+++ b/js/ui/hotCorner.js
@@ -146,6 +146,10 @@ HotCorner.prototype = {
         Main.uiGroup.add_actor(this._ripple2);
         Main.uiGroup.add_actor(this._ripple3);
 
+        this._ripple1.hide();
+        this._ripple2.hide();
+        this._ripple3.hide();
+
         // Construct the overview corner icon
         this.iconActor = new St.Button({name: 'overview-corner', reactive: true, track_hover: true});
         this.iconActor.connect('button-release-event', Lang.bind(this, this.runAction));
@@ -202,6 +206,10 @@ HotCorner.prototype = {
         // Show three concentric ripples expanding outwards; the exact
         // parameters were found by trial and error, so don't look
         // for them to make perfect sense mathematically
+
+        this._ripple1.show();
+        this._ripple2.show();
+        this._ripple3.show();
 
         //                              delay  time  scale opacity => scale
         this._animRipple(this._ripple1, 0.0,   0.83,  0.25,  1.0,     1.5);


### PR DESCRIPTION
Fixes #2025

Back before we had multiple hotcorners, layout.js would initialize the one hotcorner, along with its ripples, then add the panels themselves.  This would make the panels always on top of the transparent (but technically visible) ripples.  

Like this:
![screenshot_area_2013-05-22_20 40 09](https://f.cloud.github.com/assets/262776/552133/2ef89388-c342-11e2-9425-c339c54d0ec0.png)

Then we added the capability of multiple hotcorners.  In the process though, for various reasons, we ended up initializing those ripple actors and adding them to the stage AFTER we set up the panels, which resulted in 4 groups of ripple circles all in the upper left corner, on top of the panel:

Like this:
![screenshot_area_2013-05-22_20 40 51](https://f.cloud.github.com/assets/262776/552139/6cba3eec-c342-11e2-8b5b-5aaddeb4e749.png)

This is why the upper left corner has been unresponsive to drag and drop.

If for whatever reason you had all 4 hotcorners active, and then activate them all, that fixes the problem temporarily, because those ripples get moved to their respective corners, and once they're done rippling, they get hidden completely (not just transparent).  Until the next Cinnamon restart, when it starts all over.

This patch simple hides the ripples immediately after creation, and show()s them right before they are to be used, so they're not interfering with anything.
