### PR TITLE
Issue #2060 - cinnamon-settings can hang

### DIFF
--- a/files/usr/lib/cinnamon-settings/modules/cs_info.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_info.py
@@ -6,16 +6,26 @@ import platform
 import subprocess
 import os
 import re
+import threading
+
+
+def killProcess(process):
+    process.kill()
 
 def getProcessOut(command):
+    timeout = 2.0  # Timeout for any subprocess before aborting it
+
     lines = []
     p = subprocess.Popen(command, stdout=subprocess.PIPE)
+    timer = threading.Timer(timeout, killProcess, [p])
+    timer.start()
     while True:
         line = p.stdout.readline()
         if not line:
             break
         if line != '':
             lines.append(line)
+    timer.cancel()
     return lines
 
 def getGraphicsInfos():


### PR DESCRIPTION
If any subprocesses executed by cs_info.py hang (such as a hung
NFS mount preventing "df" from returning), then cinnamon-settings
will never start.

This adds a 2 second timeout for any subprocess which will cancel
the operation and kill the process if all output isn't received
during the timeout period.
