### PR TITLE
Reload extension-defined-stylesheets on theme change

### DIFF
--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -11,6 +11,7 @@ const AppletManager = imports.ui.appletManager;
 const Config = imports.misc.config;
 const DeskletManager = imports.ui.deskletManager;
 const ExtensionSystem = imports.ui.extensionSystem;
+const Main = imports.ui.main;
 
 const State = {
     INITIALIZING: 0,
@@ -132,6 +133,13 @@ Extension.prototype = {
 
         this.ensureFileExists(dir.get_child(this.lowerType + '.js'));
         this.loadStylesheet(dir.get_child('stylesheet.css'));
+        
+        if (this.stylesheet) {
+            Main.themeManager.connect('theme-set', Lang.bind(this, function() {
+                this.unloadStylesheet();
+                this.loadStylesheet(this.dir.get_child('stylesheet.css'));
+            }));
+        }
 
         try {
             global.add_extension_importer('imports.ui.extension.importObjects', this.uuid, this.meta.path);


### PR DESCRIPTION
adresses #2079

Extension-defined stylesheets are now reloaded whenever the user changes the Cinnamon theme, so that those stylesheets are not lost and the extension still looks as expected
