### PR TITLE
Remove licensing information for folders that are removed from Cinnamon

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -24,19 +24,10 @@ Copyright: © 2000 Helix Code, Inc.
            © 2008 Intel Corp.
 License: GPL-2+ (/usr/share/common-licenses/GPL-2)
 
-Files: src/gdmuser/*
-Copyright: © 2007-2008 William Jon McCann <mccann@jhu.edu>
-           © 2004-2005 James M. Cape <jcape@ignore-your.tv>
-License: LGPL-2+ (/usr/share/common-licenses/LGPL-2)
-
 Files: src/tray/*
 Copyright: © 2002 Anders Carlsson <andersca@gnu.org>
            © 2003-2006 Vincent Untz
            © 2008 Red Hat, Inc.
-
-Files: src/big/*
-Copyright: © 2005-2008 Red Hat, Inc.
-           © 2008-2009 litl, LLC
 
 Files: src/st/*
 Copyright: © 2008 OpenedHand


### PR DESCRIPTION
Cinnamon does not include src/big/\* and src/gdmuser/\* anymore.
