### PR TITLE
Edit cs_info.py so it displays the correct amount of CPU cores

### DIFF
--- a/files/usr/lib/cinnamon-settings/modules/cs_info.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_info.py
@@ -55,7 +55,7 @@ def getDiskSize():
 
 def getProcInfos():
     infos = [
-        ("/proc/cpuinfo", [("cpu_name", "model name"), ("cpu_siblings", "siblings"), ("cpu_cores", "cpu cores")]),
+        ("/proc/cpuinfo", [("cpu_name", "model name"), ("cpu_cores", "siblings")]),
         ("/proc/meminfo", [("mem_total", "MemTotal")])
     ]
 


### PR DESCRIPTION
Using cpu_cores from /proc/cpuinfo is wrong and should use siblings instead.

Fixes #1973
