### PR TITLE
st-theme-node-drawing.c: test for COGL_INVALID_HANDLE 

### DIFF
--- a/src/st/st-theme-node-drawing.c
+++ b/src/st/st-theme-node-drawing.c
@@ -1965,7 +1965,7 @@ st_theme_node_paint (StThemeNode           *node,
    *    such that it's aligned to the outside edges)
    */
 
-  if (node->box_shadow_material)
+  if (node->box_shadow_material != COGL_INVALID_HANDLE)
     _st_paint_shadow_with_opacity (node->box_shadow,
                                    node->box_shadow_material,
                                    &allocation,


### PR DESCRIPTION
Having a look at the possible causes of issue #2125, I noticed this in the log:

```
_st_create_shadow_material: assertion `src_texture != COGL_INVALID_HANDLE' failed
```

Following that trail, I noticed one instance where the code conspicuously does not check for COGL_INVALID_HANDLE before using a value returned from _st_create_shadow_material.
