### PR TITLE
fixing #2110 keyboard tab nav in looking glass

### DIFF
--- a/js/ui/lookingGlass.js
+++ b/js/ui/lookingGlass.js
@@ -1181,6 +1181,8 @@ LookingGlass.prototype = {
     // Handle key events which are relevant for all tabs of the LookingGlass
     _globalKeyPressEvent : function(actor, event) {
         let symbol = event.get_key_symbol();
+        let newIndex;
+
         if (symbol == Clutter.Escape) {
             if (this._objInspector.actor.visible) {
                 this._objInspector.close();
@@ -1188,18 +1190,23 @@ LookingGlass.prototype = {
                 this.close();
             }
             return true;
-        } else if (symbol==Clutter.Right) {
-	    let newIndex = this._notebook._selectedIndex-1;
-	    if (newIndex == 5) {
-		newIndex = 0;
-	    }
-	    return true;
-	} else if (symbol==Clutter.Left) {
-	    let newIndex = this._notebook._selectedIndex-1;
-	    if (newIndex == -1){
-		newIndex = 4;
-	    }
-	}
+        } else if (symbol == Clutter.Page_Down) {
+            newIndex = this._notebook._selectedIndex + 1;
+            if (newIndex == this._notebook._tabs.length) {
+                newIndex = 0;
+            }
+        } else if (symbol == Clutter.Page_Up) {
+            newIndex = this._notebook._selectedIndex - 1;
+            if (newIndex == -1){
+                newIndex = this._notebook._tabs.length - 1;
+            }
+        }
+
+        if(newIndex) {
+            this._notebook.selectIndex(newIndex);
+            return true;
+        }
+
         return false;
     },
 


### PR DESCRIPTION
Hi,

I saw this code while developing an applet and found several issues with it:
1. it is looking for 'newIndex' when pressing left/right but it is not activating the index in the notebook. Means the whole "left/right" keynav is not even working (at least for me)
2. missing return value (cosmetic, emitted signals do need return values from callbacks?)
3. Left/Right keys are not working really, because starting lookingglass opens the "Evaluator" tab and this one is "stealing" the left/right listeners in the "js>>" input field
4. overflow of "Right" Key is wrong, we have 6 Tabs (Evaluator, Windows, Errors, Memory, Applets, Extenstions, "Desklets") but it sets the last one to 4 and we can never navigate to "Extensions" and "Desklets" by keys, so even if adding the notebook.selectIndex would not switch between all tabs
5. intendation issue

I fixed it on my local machine by
1. adding the notebook selecting after determining newIndex
2. added return value
3. removed binding to left/right keys and used Page_Up/Page_Down
4. do not set static values, rather than use selt._notebook._tabs.length
5. fixed intendation

Should fix Issue #2110

Bye
Andreas
