### PR TITLE
[Design] Easier connection management (recommit)

### DIFF
--- a/js/Makefile.am
+++ b/js/Makefile.am
@@ -3,6 +3,7 @@ jsdir = $(pkgdatadir)/js
 
 nobase_dist_js_DATA = \
 	misc/config.js		\
+	misc/config.js          \
 	misc/docInfo.js		\
 	misc/fileUtils.js	\
 	misc/format.js		\

--- a/js/misc/connector.js
+++ b/js/misc/connector.js
@@ -1,0 +1,149 @@
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+
+const Lang = imports.lang;
+
+function _createConnection() {
+    if (!('_connectionManager' in this))
+        this._connectionManager = new Connector();
+    return this._connectionManager.createConnection.apply(this._connectionManager, arguments);
+}
+
+function _destroyConnections() {
+    if ('_connectionManager' in this)
+        this._connectionManager.destroyConnections();
+}
+
+function _addConnectionMaster(master, signal) {
+    if (!('_connectionManager' in this))
+        this._connectionManager = new Connector();
+    return this._connectionManager.addMaster(master, signal);
+}
+
+function _removeConnectionMasters() {
+    if ('_connectionManager' in this)
+        this._connectionManager.removeMasters();
+}
+
+function addConnectorMethods(proto) {
+    proto.createConnection = _createConnection;
+    proto.destroyConnections = _destroyConnections;
+    proto.addConnectionMaster = _addConnectionMaster;
+    proto.removeConnectionMasters = _removeConnectionMasters;
+}
+
+/* A class that takes care of a connection.
+ * Just remember to call disconnect on it when you don't need it anymore.
+ */
+function Connection() {
+    this._init.apply(this, arguments);
+}
+
+Connection.prototype = {
+    _init: function(target, args) {
+        this._target = target;
+        this._id = target.connect.apply(target, args);
+    },
+    
+    disconnect: function() {
+        if (this._target) {
+            this._target.disconnect(this._id);
+            this._target = null;
+        }
+    },
+    
+    forget: function() {
+        this._target = null;
+    },
+    
+    getTarget: function() {
+        return this._target;
+    }
+}
+
+/* usage:
+ * "let connection = createConnection(target, 'signal', callback [, ...])
+ *  ///...
+ *  connection.disconnect();
+ *  "
+ * 
+ * @arg-0: target, the object you want to connect to
+ * @arg-1: the signal name
+ * @arg-2: the callback
+ * @arg-3 .. @arg-n: optional arguments (i.e. user data)
+ *
+ * return a Connection object that you can later disconnect from
+ */
+function createConnection() {
+    let args = [].slice.apply(arguments);
+    let target = args.shift();
+    return new Connection(target, args);
+}
+
+/* A class that takes care of your connections.
+ * Just remember to call destroyConnections when it is time to disconnect.
+ * Alternatively you can watch an object for a destruction signal (addMaster)
+ */
+function Connector() {
+    this._init.apply(this, arguments);
+}
+
+Connector.prototype = {
+    _init: function() {
+        this.connections = [];
+        this.masters = [];
+    },
+
+    /* usage: "createConnection(target, 'signal', callback [, ...])"
+     * 
+     * @arg-0: target, the object you want to connect to
+     * @arg-1: the signal name
+     * @arg-2: the callback
+     * @arg-3 .. @arg-n: optional arguments (i.e. user data)
+     *
+     * @return a Connection, which you can optionally disconnect or "forget" later on.
+     */
+    createConnection: function() {
+        let connection = createConnection.apply(0, arguments);
+        this.connections.push(connection);
+        return connection;
+    },
+
+    /* Disconnects and remove all connections.
+     */
+    destroyConnections: function() {
+        this.connections.forEach(function(connection) {
+            connection.disconnect();
+        }, this);
+        this.connections = [];
+    },
+    
+    /* Watch an object for a destruction signal and when it happens, destroy all connections.
+     * 
+     * @master the object to watch for a destruction signal
+     * @signal the destruction signal to watch for (default value is 'destroy')
+     * 
+     * @return a Connection, which you can optionally disconnect later on.
+     */
+    addMaster: function(master, signal) {
+        if(!signal)
+            signal = 'destroy';
+        
+        let connection = createConnection(master, signal, Lang.bind(this, this._onMasterDestroyed));
+        this.masters.push(connection);
+        return connection;
+    },
+    
+    /* remove all masters
+     */
+    removeMasters: function() {
+        this.masters.forEach(function(connection) {
+            connection.disconnect();
+        }, this);
+        this.masters = [];
+    },
+    
+    _onMasterDestroyed: function() {
+        this.destroyConnections();
+        this.removeMasters();
+    }
+};

--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -8,6 +8,7 @@ const DND = imports.ui.dnd;
 const Clutter = imports.gi.Clutter;
 const AppletManager = imports.ui.appletManager;
 const Gtk = imports.gi.Gtk;
+const Connector = imports.misc.connector;
 const Util = imports.misc.util;
 const Pango = imports.gi.Pango;
 const Mainloop = imports.mainloop;
@@ -174,7 +175,7 @@ Applet.prototype = {
     _init: function(orientation, panel_height, instance_id) {
         this.actor = new St.BoxLayout({ style_class: 'applet-box', reactive: true, track_hover: true });        
         this._applet_tooltip = new Tooltips.PanelItemTooltip(this, "", orientation);                                        
-        this.actor.connect('button-release-event', Lang.bind(this, this._onButtonReleaseEvent));  
+        this.createConnection(this.actor, 'button-release-event', Lang.bind(this, this._onButtonReleaseEvent));  
 
         this._menuManager = new PopupMenu.PopupMenuManager(this);
         this._applet_context_menu = new AppletContextMenu(this, orientation);
@@ -193,9 +194,9 @@ Applet.prototype = {
         this._hook = null; // Defined in metadata.json, set by appletManager
         this._dragging = false;                
         this._draggable = DND.makeDraggable(this.actor);
-        this._draggable.connect('drag-begin', Lang.bind(this, this._onDragBegin));
-    	this._draggable.connect('drag-cancelled', Lang.bind(this, this._onDragCancelled));
-        this._draggable.connect('drag-end', Lang.bind(this, this._onDragEnd));        
+        this.createConnection(this._draggable, 'drag-begin', Lang.bind(this, this._onDragBegin));
+    	this.createConnection(this._draggable, 'drag-cancelled', Lang.bind(this, this._onDragCancelled));
+        this.createConnection(this._draggable, 'drag-end', Lang.bind(this, this._onDragEnd));        
 
         this._scaleMode = false;
         this._applet_tooltip_text = "";
@@ -204,7 +205,7 @@ Applet.prototype = {
         this.context_menu_separator = null;
 
         this._setAppletReactivity();
-        this._panelEditModeChangedId = global.settings.connect('changed::panel-edit-mode', Lang.bind(this, function() {
+        this.createConnection(global.settings, 'changed::panel-edit-mode', Lang.bind(this, function() {
             this._setAppletReactivity();
             this.finalizeContextMenu();
         }));
@@ -315,7 +316,7 @@ Applet.prototype = {
 
     // should only be called by appletManager
     _onAppletRemovedFromPanel: function() {
-        global.settings.disconnect(this._panelEditModeChangedId);
+        this.destroyConnections();
         this.on_applet_removed_from_panel();
     },
 
@@ -414,6 +415,8 @@ Applet.prototype = {
         }
     }
 };
+
+Connector.addConnectorMethods(Applet.prototype);
 
 /**
  * #IconApplet:

--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -215,6 +215,7 @@ function removeAppletFromPanels(appletDefinition) {
 
         if (applet._panelLocation != null) {
             applet._panelLocation.remove_actor(applet.actor);
+            applet.actor.destroy();
             applet._panelLocation = null;
         }
 


### PR DESCRIPTION
@autarkper recently closed #1737, which added connector.js, a concept to ease the connection management.

I had a similar idea for a while now, especially for applets, since currently most don't even bother to disconnect from their signals.
So, my approach has 3 different ways you can choose to use:

##### Connector.createConnection(object, 'signal', callback, ....);
- You can essentially replace any object.connect('signal', callback, ...) with this one.
- Returns a new Connection object, which has methods disconnect, forget and getTarget
- This can be used if you only have a single connection to manage.

##### let connector = new Connector.Connector();
- This is a connection manager which keeps a list of connections and supplies these methods:
- createConnection(..): same parameters as the manual function above
 - Also returns the connection object, so you can choose to forget or disconnect a single connection separate from all others.
 - The connection will be stored internally
- destroyConnections()
 - Calls disconnect on all connections and then clears the connections array.
- addMaster(master, signal): default value for signal is 'destroy'
 - When a master has been added, the manager will watch that object for the specified destruction signal.
 - When master emits signal, destroyConnections() will be called as well as removeMasters()
- removeMasters()
 - Calls disconnect on all master connections and then clears the masters array.

##### Connector.addConnectorMethods(MyClass.prototype);
- This adds createConnection, destroyConnections, addConnectionMaster and removeConnectionMasters to the class prototype.
- This uses a Connector instance internally, so you don't have to create a connector manually and can skip the connector variable.


### More work required
This should be used widely across cinnamon, especially on the applets. But I'm not gonna start working on that until I know this gets accepted.