### PR TITLE
bluetooth: zero-pad PIN

### DIFF
--- a/files/usr/share/cinnamon/applets/bluetooth@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/bluetooth@cinnamon.org/applet.js
@@ -111,7 +111,7 @@ ConfirmNotification.prototype = {
         this._applet = applet;
         this._devicePath = device_path;
         this.addBody(_("Device %s wants to pair with this computer").format(long_name));
-        this.addBody(_("Please confirm whether the PIN '%s' matches the one on the device.").format(pin));
+        this.addBody(_("Please confirm whether the PIN '%06d' matches the one on the device.").format(pin));
 
         this.addButton('matches', _("Matches"));
         this.addButton('does-not-match', _("Does not match"));


### PR DESCRIPTION
Bluetooth PINs always consist of 6 digits, so make sure to add leading zeros as necessary. 

https://bugzilla.gnome.org/show_bug.cgi?id=651251

https://git.gnome.org/browse/gnome-shell/commit/?h=wip/wayland&id=76616dc98c3b1d7dd73f3976af2f8d01a30a78d5
