### PR TITLE
Upstream Bluetooth commits

### DIFF
--- a/files/usr/share/cinnamon/applets/bluetooth@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/bluetooth@cinnamon.org/applet.js
@@ -265,8 +265,8 @@ MyApplet.prototype = {
             this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
             this._fullMenuItems = [new PopupMenu.PopupSeparatorMenuItem(),
-                                   new PopupMenu.PopupMenuItem(_("Send Files to Device…")),
-                                   new PopupMenu.PopupMenuItem(_("Set Up a New Device…")),
+                                   new PopupMenu.PopupMenuItem(_("Send Files to Device...")),
+                                   new PopupMenu.PopupMenuItem(_("Set up a New Device...")),
                                    new PopupMenu.PopupSeparatorMenuItem()];
             this._hasDevices = false;
 
@@ -466,7 +466,7 @@ MyApplet.prototype = {
         }
 
         if (device.capabilities & GnomeBluetoothApplet.Capabilities.OBEX_PUSH) {
-            item.menu.addAction(_("Send Files…"), Lang.bind(this, function() {
+            item.menu.addAction(_("Send Files..."), Lang.bind(this, function() {
                 this._applet.send_to_address(device.bdaddr, device.alias);
             }));
         }


### PR DESCRIPTION
bluetooth: zero-pad PIN

https://git.gnome.org/browse/gnome-shell/commit/js/ui/status/bluetooth.js?id=76616dc98c3b1d7dd73f3976af2f8d01a30a78d5

bluetooth: Enforce a PIN length of 6 digits

https://git.gnome.org/browse/gnome-shell/commit/js/ui/status/bluetooth.js?id=48d6eb168fa489ac34b16ae315c32210bdcc6f5a

Bluetooth: don't restrict the length of non numeric PINs

https://git.gnome.org/browse/gnome-shell/commit/js/ui/status/bluetooth.js?id=3710b88ab9c9e59bb94ed71b0ef853fc07deab30

Bluetooth: Remove ObexFTP functionality

https://git.gnome.org/browse/gnome-shell/commit/js/ui/status/bluetooth.js?id=1f2d7fa28fdae6d8c839aa92bcbcb1a9a2ebe403

js: Use proper Unicode ellipsis (…) instead of three dots

https://git.gnome.org/browse/gnome-shell/commit/js/ui/status/bluetooth.js?id=2a5f8e84bb0906eddf4e4e4fe29df8b838357273

Bluetooth: Use "Passkey" instead of "PIN"

https://git.gnome.org/browse/gnome-shell/commit/js/ui/status/bluetooth.js?id=9ba78ce04a446b4d1d1a59de0987619811d90af4
