### PR TITLE
Calendar settings: Make "Show week number in calendar" not "advanced"

### DIFF
--- a/files/usr/lib/cinnamon-settings/modules/cs_calendar.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_calendar.py
@@ -34,7 +34,7 @@ class Module:
         except Exception, detail:
             print detail
             
-        sidePage.add_widget(GSettingsCheckButton(_("Show week numbers in calendar"), "org.cinnamon.calendar", "show-weekdate", None), True)
+        sidePage.add_widget(GSettingsCheckButton(_("Show week numbers in calendar"), "org.cinnamon.calendar", "show-weekdate", None), False)
         sidePage.add_widget(GSettingsEntry(_("Date format for the panel"), "org.cinnamon.calendar", "date-format", None), True)
         sidePage.add_widget(GSettingsEntry(_("Date format inside the date applet"), "org.cinnamon.calendar", "date-format-full", None), True)
         sidePage.add_widget(Gtk.LinkButton.new_with_label("http://www.foragoodstrftime.com/", _("Generate your own date formats")), True)


### PR DESCRIPTION
The advanced/normal dichotomy in Cinnamon Settings seems a bit random. For some reason, "Show week number in calendar" had been classified as "advanced", which surely must be an oversight. This patch remedies this.
