### PR TITLE
Remove dead code and trailing whitespaces from the show desktop applet

### DIFF
--- a/files/usr/share/cinnamon/applets/show-desktop@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/show-desktop@cinnamon.org/applet.js
@@ -8,7 +8,7 @@ function MyApplet(orientation, panel_height) {
 MyApplet.prototype = {
     __proto__: Applet.IconApplet.prototype,
 
-    _init: function(orientation, panel_height) {        
+    _init: function(orientation, panel_height) {
         Applet.IconApplet.prototype._init.call(this, orientation, panel_height);
         
         this.set_applet_icon_name("desktop");
@@ -20,7 +20,7 @@ MyApplet.prototype = {
     }
 };
 
-function main(metadata, orientation, panel_height) {  
+function main(metadata, orientation, panel_height) {
     let myApplet = new MyApplet(orientation, panel_height);
-    return myApplet;      
+    return myApplet;
 }


### PR DESCRIPTION
The on_window_mapped function is no longer called since commit 3dbacb53d536995b9fa02e8fed6667a81c301b0e, so it can be removed.
