### PR TITLE
Expo: Remove close-button from window thumbnail, close window on thumbnail middle-click

### DIFF
--- a/js/ui/expoThumbnail.js
+++ b/js/ui/expoThumbnail.js
@@ -259,6 +259,10 @@ ExpoWindowClone.prototype = {
         {
             this.emit('selected', event.get_time());
         }
+        if ((Cinnamon.get_event_state(event) & Clutter.ModifierType.BUTTON2_MASK))
+        {
+            this.emit('middle-button-release', event.get_time());
+        }
         return true;
     },
 
@@ -718,6 +722,9 @@ ExpoWorkspaceThumbnail.prototype = {
                 // Muffin appears not to broadcast when a window turns sticky
                 this.box.emit('sticky-detected', clone.metaWindow);
             }
+        }));
+        clone.connect('middle-button-release', Lang.bind(this, function(sender, time) {
+            clone.metaWindow.delete(time);
         }));
         clone.connect('hovering', Lang.bind(this, this.onCloneHover));
         clone.connect('demanding-attention', Lang.bind(this, function() {this.overviewModeOn();}));


### PR DESCRIPTION
This patch removes the window-close-button that would appear on a window thumbnail when hovered. Instead, it lets you middle-click a window thumbnail to close a window.

Personally, I don't much care about this. I did the basic implementation of the window-close button with the intention that it would be refined in subsequent iterations, but that did not happen. So I'm ready to scrap the idea and move in another direction.
