### PR TITLE
[notificationDaemon] Fix apparent typo.

### DIFF
--- a/js/ui/notificationDaemon.js
+++ b/js/ui/notificationDaemon.js
@@ -152,7 +152,7 @@ NotificationDaemon.prototype = {
         for (let i = 0; i < this._sources.length; i++) {
             let source = this._sources[i];
             if (source.pid == pid &&
-                (source.initialTitle == title || source.trayIcon || trayIcon))
+                (source.initialTitle == title || source.trayIcon == trayIcon))
                 return source;
         }
         return null;


### PR DESCRIPTION
I have found something that looks like a typo in notificationDaemon.js; the second "||" should surely be a "==".
