### PR TITLE
Sound applet: do a full rescan when a sound card is added or removed

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -809,6 +809,8 @@ MyApplet.prototype = {
 
             this._control = new Gvc.MixerControl({ name: 'Cinnamon Volume Control' });
             this._control.connect('state-changed', Lang.bind(this, this._onControlStateChanged));
+            this._control.connect('card-added', Lang.bind(this, this._onControlStateChanged));
+            this._control.connect('card-removed', Lang.bind(this, this._onControlStateChanged));
             this._control.connect('default-sink-changed', Lang.bind(this, this._readOutput));
             this._control.connect('default-source-changed', Lang.bind(this, this._readInput));
             this._control.connect('stream-added', Lang.bind(this, this._maybeShowInput));


### PR DESCRIPTION
When adding a sound card, associated sinks weren't appearing in the "Output device..." menu because nothing was connected to the card-added signal.

This commit plugs card-added and card-removed to the same function as state-changed.
