### PR TITLE
Fix tooltip placement for dual-monitor setup

### DIFF
--- a/js/ui/tooltips.js
+++ b/js/ui/tooltips.js
@@ -83,7 +83,7 @@ Tooltip.prototype = {
         var tooltipLeft = this._mousePosition[0];
 
         if (tooltipLeft<0) tooltipLeft = 0;
-        if (tooltipLeft+tooltipWidth>monitor.width) tooltipLeft = monitor.width-tooltipWidth;
+        if (tooltipLeft+tooltipWidth>monitor.x+monitor.width) tooltipLeft = (monitor.x+monitor.width)-tooltipWidth;
 
         this._tooltip.set_position(tooltipLeft, tooltipTop);
 


### PR DESCRIPTION
When a non-panel tooltip (eg. sound applet navigation buttons) is shown on the right-hand monitor in a dual-monitor setup, the tooltip instead shows on the left monitor. This changes the code for Tooltip to be more like PanelItemTooltip.
