### PR TITLE
Ensure modal windows made by cinnamon get focus correctly when using a full screen program

### DIFF
--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -1154,6 +1154,7 @@ function pushModal(actor, timestamp) {
             log('pushModal: invocation of begin_modal failed');
             return false;
         }
+        Meta.disable_unredirect_for_screen(global.screen);
     }
 
     global.set_stage_input_mode(Cinnamon.StageInputMode.FULLSCREEN);
@@ -1234,6 +1235,7 @@ function popModal(actor, timestamp) {
 
     global.end_modal(timestamp);
     global.set_stage_input_mode(Cinnamon.StageInputMode.NORMAL);
+    Meta.enable_unredirect_for_screen(global.screen);
 }
 
 /**


### PR DESCRIPTION
For example, watching a video fullscreen, then alt-tabbing,
without this patch, most times, the alt-tab popup won't appear, even though it
will function.  With this patch, alt-tab properly shows above everything
