### PR TITLE
HIG cleanup

### DIFF
--- a/files/usr/lib/cinnamon-settings/bin/SettingsWidgets.py
+++ b/files/usr/lib/cinnamon-settings/bin/SettingsWidgets.py
@@ -155,7 +155,7 @@ class IndentedHBox(Gtk.HBox):
         self.pack_start(indent, False, False, 0)
 
     def add(self, item):
-        self.pack_start(item, False, False, 0)
+        self.pack_start(item, False, True, 0)
 
     def add_expand(self, item):
         self.pack_start(item, True, True, 0)
@@ -628,7 +628,7 @@ class GSettingsComboBox(Gtk.HBox):
         
         if (label != ""):
             self.pack_start(self.label, False, False, 2)                
-        self.pack_start(self.content_widget, False, False, 2)                     
+        self.pack_start(self.content_widget, True, True, 2)                     
         self.content_widget.connect('changed', self.on_my_value_changed)
         self.content_widget.show_all()
         self.dependency_invert = False
@@ -682,7 +682,7 @@ class GSettingsIntComboBox(Gtk.HBox):
 
         if (label != ""):
             self.pack_start(self.label, False, False, 2)
-        self.pack_start(self.content_widget, False, False, 2)
+        self.pack_start(self.content_widget, False, True, 2)
         self.content_widget.connect('changed', self.on_my_value_changed)
         self.content_widget.show_all()
 

--- a/files/usr/lib/cinnamon-settings/modules/cs_effects.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_effects.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from SettingsWidgets import *
+from gi.repository.Gtk import SizeGroup, SizeGroupMode
 
 class Module:
     def __init__(self, content_box):
@@ -50,17 +51,29 @@ class Module:
                                "easeInOutBounce"]]
 
         def _make_effect_group(group_label, key, effects):
-            tmin, tmax, tstep, tpage = (0, 2000, 50, 200)
+            tmin, tmax, tstep, tdefault = (0, 2000, 50, 200)
+            self.size_groups = getattr(self, "size_groups", [SizeGroup(SizeGroupMode.HORIZONTAL) for x in range(4)])
             root = "org.cinnamon"
             path = "org.cinnamon/desktop-effects"
             template = "desktop-effects-%s-%s"
+
             box = IndentedHBox()
             label = Gtk.Label()
             label.set_markup(group_label)
+            label.props.xalign = 0.0
+            self.size_groups[0].add_widget(label)
             box.add(label)
-            box.add(GSettingsComboBox("", root, template % (key, "effect"), path, effects))
-            box.add(GSettingsComboBox("", root, template % (key, "transition"), path, transition_effects))
-            box.add(GSettingsSpinButton("", root, template % (key, "time"), path, tmin, tmax, tstep, tpage, _("milliseconds")))
+
+            w = GSettingsComboBox("", root, template % (key, "effect"), path, effects)
+            self.size_groups[1].add_widget(w)
+            box.add(w)
+            w = GSettingsComboBox("", root, template % (key, "transition"), path, transition_effects)
+            self.size_groups[2].add_widget(w)
+            box.add(w)
+            w = GSettingsSpinButton("", root, template % (key, "time"), path, tmin, tmax, tstep, tdefault, _("milliseconds"))
+            self.size_groups[3].add_widget(w)
+            box.add(w)
+
             return box
         
         #CLOSING WINDOWS


### PR DESCRIPTION
Clean up cinnamon-settings UI to be less messy and misaligned. Additionally it removes lots of copy&paste code, so the total LOC go down.

So far `cs_effects.py` has got the treatment. Additionally, I had to touch `SettingsWidget.py` packing options, since it forces `fill=False`, which is a very bad default for almost everything. Even if we don't expand, we almost certainly want to fill.

![before](https://f.cloud.github.com/assets/179487/845569/d943e206-f3ea-11e2-90fd-3aacf0ead8fb.png)
![after](https://f.cloud.github.com/assets/179487/845596/fbc69250-f3eb-11e2-90f0-c3fa9c7e90f3.png)
