### PR TITLE
Don't define a fallback theme if the selected theme IS the fallback

### DIFF
--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -777,7 +777,7 @@ function loadTheme() {
 
     let theme;
 
-    if (_cssStylesheet == _defaultCssStylesheet)
+    if (cssStylesheet == _defaultCssStylesheet)
         theme = new St.Theme();
     else
         theme = new St.Theme( {default_stylesheet: _defaultCssStylesheet} );


### PR DESCRIPTION
Should fix #2291
