### PR TITLE
Give users the option to disable the screen lock password

### DIFF
--- a/files/usr/lib/cinnamon-settings/modules/cs_screensaver.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_screensaver.py
@@ -14,6 +14,7 @@ class Module:
         if os.path.exists("/usr/bin/cinnamon-screensaver-command"):
             sidePage.add_widget(GSettingsCheckButton(_("Ask for an away message when locking the screen from the menu"), "org.cinnamon.screensaver", "ask-for-away-message", None))
             sidePage.add_widget(GSettingsEntry(_("Default away message"), "org.cinnamon.screensaver", "default-message", None))
+            sidePage.add_widget(GSettingsCheckButton(_("Ask for password when unlocking"), "org.gnome.desktop.screensaver", "lock-enabled", None))
 
         widget = content_box.c_manager.get_c_widget("screen")
         if widget is not None:


### PR DESCRIPTION
The org.gnome.desktop.screensaver bit in my request is correct as gsettings-desktop-schemas provides it.

$ rpm -qf /usr/share/glib-2.0/schemas/org.gnome.desktop.screensaver.gschema.xml
gsettings-desktop-schemas-3.8.2-1.fc19.x86_64
