### PR TITLE
Destroy tooltip on item destroyed

### DIFF
--- a/js/ui/tooltips.js
+++ b/js/ui/tooltips.js
@@ -21,6 +21,7 @@ Tooltip.prototype = {
         item.connect('motion-event', Lang.bind(this, this._onMotionEvent));
         item.connect('button-press-event', Lang.bind(this, this.hide));
         item.connect('button-release-event', Lang.bind(this, this._onReleaseEvent));
+        item.connect('destroy', Lang.bind(this, this.destroy));
         item.connect('allocation-changed', Lang.bind(this, function() {
             // An allocation change could mean that the actor has moved,
             // so hide, but wait until after the allocation cycle.


### PR DESCRIPTION
Fixes #2249 , which was caused by the tooltip not listening for a destroy event on the item it is attached to, if the tooltip was visible when the item was destroyed, it would persist as there was nothing to send a signal to hide it.
