### PR TITLE
st: Be more forgiving when calling get_theme_node() on unstaged widgets

### DIFF
--- a/src/st/st-widget.c
+++ b/src/st/st-widget.c
@@ -611,7 +611,7 @@ st_widget_get_theme_node (StWidget *widget)
         {
           g_critical ("st_widget_get_theme_node called on the widget %s which is not in the stage.",
                     st_describe_actor (CLUTTER_ACTOR (widget)));
-          return NULL;
+          return g_object_new (ST_TYPE_THEME_NODE, NULL);
         }
 
       if (parent_node == NULL)


### PR DESCRIPTION
Most of this commit was already in there

https://bugzilla.gnome.org/show_bug.cgi?id=610279
