### PR TITLE
Fix menu height for alternate layouts and themes

### DIFF
--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -137,9 +137,9 @@ AppletPopupMenu.prototype = {
      */
     setMaxHeight: function() {
         let monitor = Main.layoutManager.primaryMonitor;
-        this.actor.style = ('max-height: ' +
-                            Math.round(monitor.height - Main.panel.actor.height) +
-                            'px;');
+        let maxHeight = Math.round(monitor.height - Main.panel.actor.height - this.actor.get_theme_node().get_length('-boxpointer-gap'));
+        if (Main.panel2!==null) maxHeight -= Main.panel2.actor.height;
+        this.actor.style = ('max-height: ' + maxHeight + 'px;');
     }
 }
 


### PR DESCRIPTION
The applet popup menu was still overflowing the window on some themes. This fixes the max height by taking into account the theme-set gap between the menu and the panel, as well as a second panel if there is one.
