### PR TITLE
Account for minimized status in app switcher order

### DIFF
--- a/js/ui/appSwitcher/appSwitcher.js
+++ b/js/ui/appSwitcher/appSwitcher.js
@@ -16,7 +16,9 @@ const DISABLE_HOVER_TIMEOUT = 500; // milliseconds
 function sortWindowsByUserTime(win1, win2) {
     let t1 = win1.get_user_time();
     let t2 = win2.get_user_time();
-    return (t2 > t1) ? 1 : -1 ;
+    let m1 = win1.minimized;
+    let m2 = win2.minimized;
+    return (m1 ^ m2 ? (m1 ? : 1 : -1) : ((t2 > t1) ? 1 : -1);
 }
 
 function matchSkipTaskbar(win) {


### PR DESCRIPTION
Minimized windows count last. If two windows are minimized, the same
algorithm as before takes over. This should resolve [**issue #2242**](https://github.com/linuxmint/Cinnamon/issues/2242).
