### PR TITLE
Revert "Use the stock cinnamon theme as a 'fallback' theme..."

### DIFF
--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -90,8 +90,6 @@ const LAYOUT_TRADITIONAL = "traditional";
 const LAYOUT_FLIPPED = "flipped";
 const LAYOUT_CLASSIC = "classic";
 
-const FALLBACK_THEME_PATH = "/usr/share/cinnamon/theme/cinnamon.css"
-
 const CIN_LOG_FOLDER = GLib.get_home_dir() + '/.cinnamon/';
 
 let automountManager = null;
@@ -777,7 +775,7 @@ function loadTheme() {
     if (_cssStylesheet != null)
         cssStylesheet = _cssStylesheet;
 
-    let theme = new St.Theme( {default_stylesheet: FALLBACK_THEME_PATH} );
+    let theme = new St.Theme ();
     theme.load_stylesheet(cssStylesheet);
     
     themeContext.set_theme (theme);


### PR DESCRIPTION
This reverts commit cab6a167ef98e20d39f4f220ea848b2ff77af326.

Was causing numerous issues and causing 'hybrid' appearances in theme elements.

Fixes #2327
