### PR TITLE
Prevent Cinnamon from segfaulting after changing the theme

### DIFF
--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -136,7 +136,6 @@ Extension.prototype = {
         
         if (this.stylesheet) {
             Main.themeManager.connect('theme-set', Lang.bind(this, function() {
-                this.unloadStylesheet();
                 this.loadStylesheet(this.dir.get_child('stylesheet.css'));
             }));
         }


### PR DESCRIPTION
This prevents a segfault that can happen when opening mockturtl's weather applet's popup (and maybe other applet's popups as well) after changing the theme.
