### PR TITLE
Added 'stick' option to title bar buttons

### DIFF
--- a/files/usr/lib/cinnamon-settings/modules/cs_windows.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_windows.py
@@ -87,7 +87,8 @@ class TitleBarButtonsOrderSelector(Gtk.Table):
             ("menu", _("Menu")),
             ("close", _("Close")),
             ("minimize", _("Minimize")),
-            ("maximize", _("Maximize"))
+            ("maximize", _("Maximize")),
+            ("stick", _("Sticky"))
         ]
         
         for i in self.left_side_widgets + self.right_side_widgets:


### PR DESCRIPTION
I wanted to add a button to title bars so I can toggle 'always on visible workspace'.  I found that this was possible with dconf-editor, but not an option in the Cinnamon Settings gui.  Now it shows up in the gui.
