### PR TITLE
Changed the default calendar applet date format to 12 hour

### DIFF
--- a/data/org.cinnamon.gschema.xml.in
+++ b/data/org.cinnamon.gschema.xml.in
@@ -665,7 +665,7 @@
     </key>
     
      <key name="date-format" type="s">
-      <default>'%a %b %e, %H:%M'</default>
+      <default>'%a %b %e, %I:%M %p'</default>
       <_summary>Format for the date in the panel</_summary>
       <_description>
        Format used to show the date in the panel.


### PR DESCRIPTION
This is to match my recent change to the clock desklet.

Because a large percentage of the users are Canadian or American, they would find it more friendly to have a clock in 12 hour format
