### PR TITLE
[2.0] Use org.gnome for mono fonts

### DIFF
--- a/files/usr/lib/cinnamon-settings/modules/cs_fonts.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_fonts.py
@@ -12,7 +12,7 @@ class Module:
         self.category = "appear"        
         sidePage.add_widget(GSettingsFontButton(_("Default font"), "org.cinnamon.desktop.interface", "font-name", None))
         sidePage.add_widget(GSettingsFontButton(_("Document font"), "org.cinnamon.desktop.interface", "document-font-name", None))
-        sidePage.add_widget(GSettingsFontButton(_("Monospace font"), "org.cinnamon.desktop.interface", "monospace-font-name", None))
+        sidePage.add_widget(GSettingsFontButton(_("Monospace font"), "org.gnome.desktop.interface", "monospace-font-name", None))
         sidePage.add_widget(GSettingsFontButton(_("Window title font"), "org.cinnamon.desktop.wm.preferences", "titlebar-font", None))
         sidePage.add_widget(GSettingsRangeSpin(_("Text scaling factor"), "org.cinnamon.desktop.interface", "text-scaling-factor", None, adjustment_step = 0.1), True)
         sidePage.add_widget(GSettingsComboBox(_("Antialiasing"), "org.cinnamon.settings-daemon.plugins.xsettings", "antialiasing", None, [(i, i.title()) for i in ("none", "grayscale", "rgba")]), True)


### PR DESCRIPTION
Apps like gedit and gnome-terminal ignore org.cinnamon for mono font settings.
