### PR TITLE
Implemented multi-line textbox setting

### DIFF
--- a/js/ui/settings.js
+++ b/js/ui/settings.js
@@ -39,6 +39,13 @@ var STRING_TYPES = {
             "description"
         ]
     },
+    "textview" : {
+        "required-fields": [
+            "type",
+            "default",
+            "description"
+        ]
+    },
     "colorchooser" : {
         "required-fields": [
             "type",


### PR DESCRIPTION
Implemented multi-line text box for the setting-schema.json.

Usage example: https://github.com/bettiolo/cinnamon-remote-connections/blob/master/src/settings-schema.json#L13
