### PR TITLE
hotCorner.js: remove activation of Scale on drag-over

### DIFF
--- a/js/ui/hotCorner.js
+++ b/js/ui/hotCorner.js
@@ -230,17 +230,6 @@ HotCorner.prototype = {
         this._animRipple(this._ripple3, 0.35,  1.0,   0.0,   0.3,     1);
     },
 
-    handleDragOver: function(source, actor, x, y, time) {
-        if (source != Main.xdndHandler)
-            return;
-
-        if (!Main.overview.visible && !Main.overview.animationInProgress && !Main.expo.visible) {
-            this.rippleAnimation();
-            Main.overview.showTemporarily();
-            Main.overview.beginItemDrag(actor);
-        }
-    },
-
     runAction: function(){
         this._activationTime = Date.now() / 1000;
 


### PR DESCRIPTION
This fixes a regression which would leave the user stuck in Scale after dragging an item over a hot corner. See #2230.
