### PR TITLE
Fixes issue #1316 (Ghost windows)

### DIFF
--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -724,7 +724,8 @@ WindowManager.prototype = {
 
     _destroyWindow : function(cinnamonwm, actor) {
 
-        Tweener.removeTweens(actor); //Fixes [Bug] Very short-lived windows cause stuck "dead window" (issue #1316)
+        //Fixes [Bug] Very short-lived windows cause stuck "dead window" (issue #1316)
+        Tweener.removeTweens(actor);
         
         if (actor.meta_window.get_window_type() == Meta.WindowType.NORMAL) {
             Main.soundManager.play('close');


### PR DESCRIPTION
I put #ebbes fix as mentioned on #1316 and all seems to work well.
I was using last version of Cinnamon (2.0.3) and some windows that closed too fast remained as ghost on top of everything and the only way to get rid of them was by cinnamon --replace command (very annoying)
