### PR TITLE
cinnamon-settings-users: use pkexec instead of gksu

### DIFF
--- a/files/usr/bin/cinnamon-settings-users
+++ b/files/usr/bin/cinnamon-settings-users
@@ -2,5 +2,5 @@
 
 import os
 
-os.system("gksu /usr/lib/cinnamon-settings-users/cinnamon-settings-users.py")
+os.system("pkexec /usr/lib/cinnamon-settings-users/cinnamon-settings-users.py")
 

--- a/files/usr/share/polkit-1/actions/org.cinnamon.settings-users.policy
+++ b/files/usr/share/polkit-1/actions/org.cinnamon.settings-users.policy
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
+<policyconfig>
+
+  <action id="org.cinnamon.settings-users">
+    <message>Authentication is required to run the Users and Groups</message>
+    <icon_name>system-users</icon_name>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/lib/cinnamon-settings-users/cinnamon-settings-users.py</annotate>
+    <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
+  </action>
+
+</policyconfig>
+


### PR DESCRIPTION
gksu is a deprecated stuff, and Cinnamon already has a nice polkit authentication agent. So use polkit to authenticate the user when launch cinnamon-settings-users.
