### PR TITLE
cinnamon settings: read backgrounds from GNOME directory as well

### DIFF
--- a/files/usr/lib/cinnamon-settings/modules/cs_backgrounds.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_backgrounds.py
@@ -338,6 +338,10 @@ class BackgroundWallpaperPane (Gtk.VBox):
             for i in os.listdir("/usr/share/cinnamon-background-properties"):
                 if i.endswith(".xml"):
                     pictures_list += self.parse_xml_backgrounds_list(os.path.join("/usr/share/cinnamon-background-properties", i))
+        if os.path.exists("/usr/share/gnome-background-properties"):
+            for i in os.listdir("/usr/share/gnome-background-properties"):
+                if i.endswith(".xml"):
+                    pictures_list += self.parse_xml_backgrounds_list(os.path.join("/usr/share/gnome-background-properties", i))
         
         path = os.path.join(os.getenv("HOME"), ".cinnamon", "backgrounds")
         if os.path.exists(path):


### PR DESCRIPTION
GNOME installs the following XML files, which can be used in cinnamon settings:
/usr/share/gnome-background-properties/adwaita.xml
/usr/share/gnome-background-properties/gnome-backgrounds.xml

Read these files in addition to cinnamon backgrounds.
