### PR TITLE
Check for the cc-panel path, not for the unneeded binary

### DIFF
--- a/files/usr/bin/cinnamon-settings
+++ b/files/usr/bin/cinnamon-settings
@@ -7,7 +7,7 @@ if len(sys.argv) > 1:
 	if os.path.exists("/usr/lib/cinnamon-settings/modules/cs_%s.py" % module):
 		print "Python module"
 		os.execvp("/usr/lib/cinnamon-settings/cinnamon-settings.py", ("",) + tuple(sys.argv[1:]))
-	elif os.path.exists("/usr/bin/cinnamon-control-center"):
+	elif os.path.exists("/usr/lib/cinnamon-control-center-1/panels"):
 		print "Unknown module %s, using cinnamon-control-center" % module
 		os.execvp("/usr/lib/cinnamon-settings/cinnamon-settings.py", ("",) + tuple(sys.argv[1:]))
 	elif os.path.exists("/usr/bin/gnome-control-center"):


### PR DESCRIPTION
/usr/bin/cinnamon-control-center binary is not used at all by Cinnamon, so we don't package it on Arch Linux. Instead of that, cinnamon settings should check the panels patch (/usr/lib/cinnamon-control-center-1/panels) to decide if cinnamon-control-center is installed or not.
