### PR TITLE
session: remove nm-applet from required components (it's not)

### DIFF
--- a/files/usr/share/cinnamon-session/sessions/cinnamon.session
+++ b/files/usr/share/cinnamon-session/sessions/cinnamon.session
@@ -1,5 +1,5 @@
 [Cinnamon Session]
 Name=Cinnamon
-RequiredComponents=cinnamon;cinnamon-settings-daemon;cinnamon-screensaver;cinnamon-fallback-mount-helper;nemo-autostart;nm-applet;
+RequiredComponents=cinnamon;cinnamon-settings-daemon;cinnamon-screensaver;cinnamon-fallback-mount-helper;nemo-autostart;
 DesktopName=GNOME
 

--- a/files/usr/share/cinnamon-session/sessions/cinnamon2d.session
+++ b/files/usr/share/cinnamon-session/sessions/cinnamon2d.session
@@ -1,5 +1,5 @@
 [Cinnamon Session]
 Name=Cinnamon (Software Rendering)
-RequiredComponents=cinnamon;cinnamon-settings-daemon;cinnamon-screensaver;cinnamon-fallback-mount-helper;nemo-autostart;nm-applet;
+RequiredComponents=cinnamon;cinnamon-settings-daemon;cinnamon-screensaver;cinnamon-fallback-mount-helper;nemo-autostart;
 DesktopName=GNOME
 


### PR DESCRIPTION
nm-applet is not used by Cinnamon since it has it's own network applet on this path:
/usr/share/cinnamon/applets/network@cinnamon.org

The nm-applet systray icon is hidden anyway by the systray applet. It's D-Bus API is not used either. There is no reason to have it in required components.
