### PR TITLE
Removed Menu from panel.js popup settings

### DIFF
--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -433,9 +433,11 @@ function populateSettingsMenu(menu) {
 
     menuItem = new SettingsLauncher(_("Panel"), "panel", "panel", menu.settingsItem.menu);
     menu.settingsItem.menu.addMenuItem(menuItem);
-
-    menuItem = new SettingsLauncher(_("Menu"), "menu", "menu", menu.settingsItem.menu);
-    menu.settingsItem.menu.addMenuItem(menuItem);
+	
+	/**
+		menuItem = new SettingsLauncher(_("Menu"), "menu", "menu", menu.settingsItem.menu);
+		menu.settingsItem.menu.addMenuItem(menuItem);
+    */
 
     menuItem = new SettingsLauncher(_("All settings"), "", "preferences-system", menu.settingsItem.menu);
     menu.settingsItem.menu.addMenuItem(menuItem);


### PR DESCRIPTION
This was broken because of the recent changes to the menu settings being moved to settings API
