### PR TITLE
cinnamon settings: fallback to GNOME backgrounds

### DIFF
--- a/files/usr/lib/cinnamon-settings/modules/cs_backgrounds.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_backgrounds.py
@@ -338,6 +338,11 @@ class BackgroundWallpaperPane (Gtk.VBox):
             for i in os.listdir("/usr/share/cinnamon-background-properties"):
                 if i.endswith(".xml"):
                     pictures_list += self.parse_xml_backgrounds_list(os.path.join("/usr/share/cinnamon-background-properties", i))
+        else:
+            if os.path.exists("/usr/share/gnome-background-properties"):
+                for i in os.listdir("/usr/share/gnome-background-properties"):
+                    if i.endswith(".xml"):
+                        pictures_list += self.parse_xml_backgrounds_list(os.path.join("/usr/share/gnome-background-properties", i))
         
         path = os.path.join(os.getenv("HOME"), ".cinnamon", "backgrounds")
         if os.path.exists(path):


### PR DESCRIPTION
Read backgrounds from GNOME directory if no Cinnamon backgrounds are installed.

In contrast to my previous pull request (https://github.com/linuxmint/Cinnamon/pull/2570), read GNOME backgrounds only if cinnamon-background-properties directory is not available. Therefore Linux Mint users are not affected by this change (they will see Cinnamon backgrounds only), but Arch Linux and Fedora users will be able to choose GNOME backgrounds instead of having an empty background selection panel in cinnamon settings.
