### PR TITLE
Fix expo applet warnings

### DIFF
--- a/files/usr/share/cinnamon/applets/expo@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/expo@cinnamon.org/applet.js
@@ -3,15 +3,15 @@ const Lang = imports.lang;
 const Main = imports.ui.main;
 const Gtk = imports.gi.Gtk;
 
-function MyApplet(metadata, orientation, panel_height) {
-    this._init(metadata, orientation, panel_height);
+function MyApplet(metadata, orientation, panel_height, instance_id) {
+    this._init(metadata, orientation, panel_height, instance_id);
 }
 
 MyApplet.prototype = {
     __proto__: Applet.IconApplet.prototype,
 
-    _init: function(metadata, orientation, panel_height) {
-        Applet.IconApplet.prototype._init.call(this, orientation, panel_height);
+    _init: function(metadata, orientation, panel_height, instance_id) {
+        Applet.TextIconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
 
         try {
             Gtk.IconTheme.get_default().append_search_path(metadata.path);
@@ -21,7 +21,6 @@ MyApplet.prototype = {
             global.settings.connect('changed::panel-edit-mode', Lang.bind(this, this.on_panel_edit_mode_changed));
             global.settings.connect('changed::expo-applet-hover', Lang.bind(this, this._reload_settings));
             this.actor.connect('enter-event', Lang.bind(this, this._onEntered));
-            this._reload_settings();
         }
         catch (e) {
             global.logError(e);
@@ -56,7 +55,7 @@ MyApplet.prototype = {
     }
 };
 
-function main(metadata, orientation, panel_height) {
-    let myApplet = new MyApplet(metadata, orientation, panel_height);
+function main(metadata, orientation, panel_height, instance_id) {
+    let myApplet = new MyApplet(metadata, orientation, panel_height, instance_id);
     return myApplet;
 }


### PR DESCRIPTION
After switching to settings API, the expo applet was still missing the instance_id when creating the settings object.
There was also another warning about

```
this._reload_settings();
```

I have removed it (is it even used?).
