### PR TITLE
[Mint 16] Moved "Account Details" to "Prefrences" in Cinnamon Settings

### DIFF
--- a/files/usr/lib/cinnamon-settings/modules/cs_user.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_user.py
@@ -79,7 +79,7 @@ class Module:
         sidePage = SidePage(_("Account details"), "user.svg", keywords, advanced, content_box, module=self)
         self.sidePage = sidePage
         self.name = "user"
-        self.category = "appear"        
+        self.category = "prefs"        
                 
         self.face_button = Gtk.Button()
         self.face_image = Gtk.Image()  


### PR DESCRIPTION
Gabriel was expecting Account Details to be in preferences which does make sense I suppose

http://blog.linuxmint.com/?p=2477#comment-101152 
