### PR TITLE
fix error in make maintainer-clean due to missing target in files/Makefile

### DIFF
--- a/files/Makefile.in
+++ b/files/Makefile.in
@@ -4,6 +4,8 @@ clean:
 
 distclean:
 
+maintainer-clean:
+
 install:
 	find -mindepth 1 -maxdepth 1 -type d -exec cp -R {} $(DESTDIR)/ \;
 


### PR DESCRIPTION
make maintainer-clean fails with error on the 'files' directory due to missing target.
