### PR TITLE
[2.2] Remove redundant check for Meta.StackLayer.FULLSCREEN

### DIFF
--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -750,7 +750,7 @@ Chrome.prototype = {
             if (!window.showing_on_its_workspace())
                 continue;
 
-            if (metaWindow.get_layer() == Meta.StackLayer.FULLSCREEN || metaWindow.is_fullscreen()) {
+            if (metaWindow.is_fullscreen()) {
                 let monitor = this._findMonitorForWindow(window);
                 if (monitor)
                     monitor.inFullscreen = true;


### PR DESCRIPTION
Meta.StackLayer.FULLSCREEN is only set when metaWindow.is_fullscreen() is true, and even then not for all fullscreen windows.  See muffin's src/core/stack.c get_standalone_layer() for the conditions under which META_LAYER_FULLSCREEN is set.

This change is intended for after release of LM16.
