### PR TITLE
Fix compile error

### DIFF
--- a/src/cinnamon-global.c
+++ b/src/cinnamon-global.c
@@ -477,12 +477,12 @@ cinnamon_global_class_init (CinnamonGlobalClass *klass)
                                                         G_PARAM_READABLE));
 }
 
-/**•
- * _cinnamon_global_init: (skip)•
+/**
+ * _cinnamon_global_init: (skip)
  * @first_property_name: the name of the first property
  * @...: the value of the first property, followed optionally by more
  *  name/value pairs, followed by %NULL
- *•
+ *
  * Initializes Cinnamon global singleton with the construction-time
  * properties.
  *


### PR DESCRIPTION
```
cinnamon-global.c:476: Warning: Cinnamon: GTK-Doc comment block start token "/**" should not be followed by comment text:
/**â€¢
   ^
cinnamon-global.c:477: Error: Cinnamon: identifier not found on the first line:
â€¢
^
g-ir-scanner: compile: gcc -Wall -Wno-deprecated-declarations -pthread -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -m32 -march=i686 -mtune=atom -fasynchronous-unwind-tables -I/usr/include/gnome-menus-3.0 -I/usr/include/libnm-glib -I/usr/include/clutter-1.0 -I/usr/include/cogl -I/usr/include/json-glib-1.0 -I/usr/include/gudev-1.0 -I/usr/include/libevdev-1.0 -I/usr/include/libnm-glib -I/usr/include/libsoup-2.4 -I/usr/include/libxml2 -I/usr/include/gtk-3.0 -I/usr/include/at-spi2-atk/2.0 -I/usr/include/gtk-3.0 -I/usr/include/gio-unix-2.0 -I/usr/include/cairo -I/usr/include/pango-1.0 -I/usr/include/atk-1.0 -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/libpng16 -I/usr/include/pango-1.0 -I/usr/include/harfbuzz -I/usr/include/pango-1.0 -I/usr/include/NetworkManager -I/usr/include/dbus-1.0 -I/usr/lib/dbus-1.0/include -I/usr/include/cairo -I/usr/include/pixman-1 -I/usr/include/freetype2 -I/usr/include/libdrm -I/usr/include/libpng16 -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -c -o /builddir/build/BUILD/Cinnamon-2.0.14/src/tmp-introspectQ12UBy/Cinnamon-0.1.o /builddir/build/BUILD/Cinnamon-2.0.14/src/tmp-introspectQ12UBy/Cinnamon-0.1.c
g-ir-scanner: link: /bin/sh ../libtool --mode=link --tag=CC gcc -o /builddir/build/BUILD/Cinnamon-2.0.14/src/tmp-introspectQ12UBy/Cinnamon-0.1 -export-dynamic -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -m32 -march=i686 -mtune=atom -fasynchronous-unwind-tables -Wl,-z,relro /builddir/build/BUILD/Cinnamon-2.0.14/src/tmp-introspectQ12UBy/Cinnamon-0.1.o -L. libcinnamon.la -L/usr/lib/gnome-bluetooth -rpath /usr/lib/gnome-bluetooth -lgio-2.0 -lgobject-2.0 -Wl,--export-dynamic -lgmodule-2.0 -pthread -lglib-2.0
libtool: link: gcc -o /builddir/build/BUILD/Cinnamon-2.0.14/src/tmp-introspectQ12UBy/.libs/Cinnamon-0.1 -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -m32 -march=i686 -mtune=atom -fasynchronous-unwind-tables -Wl,-z -Wl,relro /builddir/build/BUILD/Cinnamon-2.0.14/src/tmp-introspectQ12UBy/Cinnamon-0.1.o -Wl,--export-dynamic -pthread -Wl,--export-dynamic  -L. ./.libs/libcinnamon.so -L/usr/lib/gnome-bluetooth -lmuffin -lcjs -lmozjs185 -lplds4 -lplc4 -lnspr4 -lpthread -ldl -lgnome-menu-3 -lgstbase-0.10 -lgstreamer-0.10 -lgthread-2.0 -lgconf-2 -lsoup-2.4 -lGL -lstartup-notification-1 -lgirepository-1.0 -lcanberra -lpolkit-agent-1 -lpolkit-gobject-1 -lnm-glib -lnm-util -ldbus-glib-1 -ldbus-1 -lgnome-keyring -lgnome-bluetooth-applet -lm -lclutter-1.0 -lcogl-pango -lcogl -lwayland-egl -lgbm -ldrm -lEGL -lXrandr -ljson-glib-1.0 -lwayland-cursor -lwayland-client -lwayland-server -lgudev-1.0 -levdev -lxkbcommon -lXext -lXdamage -lXfixes -lXcomposite -lXi -lcroco-0.6 -lxml2 -lcinnamon-desktop -lX11 -lgtk-3 -lgdk-3 -lpangocairo-1.0 -lpango-1.0 -latk-1.0 -lcairo-gobject -lcairo -lgdk_pixbuf-2.0 -lpulse-mainloop-glib -lpulse -lgio-2.0 -lgobject-2.0 -lgmodule-2.0 -lglib-2.0 -pthread -Wl,-rpath -Wl,/usr/lib/cinnamon -Wl,-rpath -Wl,/usr/lib/gnome-bluetooth
<unknown>:: Fatal: Cinnamon: warnings configured as fatal
<unknown>:: Fatal: Cinnamon: warnings configured as fatal
make[3]: Leaving directory `/builddir/build/BUILD/Cinnamon-2.0.14/src'
make[3]: *** [Cinnamon-0.1.gir] Error 1
make[2]: *** [all] Error 2
make[2]: Leaving directory `/builddir/build/BUILD/Cinnamon-2.0.14/src'
make[1]: Leaving directory `/builddir/build/BUILD/Cinnamon-2.0.14'
make[1]: *** [all-recursive] Error 1
make: *** [all] Error 2
RPM build errors:
```
