### PR TITLE
Allow symbolic applet icons by path

### DIFF
--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -515,6 +515,8 @@ IconApplet.prototype = {
      * @icon_path (string): path of the icon
      * 
      * Sets the icon of the applet to the image file at @icon_path
+     * 
+     * The icon will be full color
      */
     set_applet_icon_path: function (icon_path) {
         if (this._applet_icon_box.child) this._applet_icon_box.child.destroy();
@@ -525,6 +527,33 @@ IconApplet.prototype = {
             if (this._scaleMode) {
                 this._applet_icon = new St.Icon({gicon: gicon, icon_size: this._panelHeight * COLOR_ICON_HEIGHT_FACTOR,
                                                 icon_type: St.IconType.FULLCOLOR, reactive: true, track_hover: true, style_class: 'applet-icon' });
+            } else {
+                this._applet_icon = new St.Icon({gicon: gicon, icon_size: 22, icon_type: St.IconType.FULLCOLOR, reactive: true, track_hover: true, style_class: 'applet-icon' });
+            }
+            this._applet_icon_box.child = this._applet_icon;
+        }
+        this.__icon_type = -1;
+        this.__icon_name = icon_path;
+    },
+
+    /**
+     * set_applet_icon_symbolic_path:
+     * @icon_path (string): path of the icon
+     * 
+     * Sets the icon of the applet to the image file at @icon_path
+     * 
+     * The icon will be symbolic
+     */
+    set_applet_icon_symbolic_path: function(icon_path) {
+        if (this._applet_icon_box.child) this._applet_icon_box.child.destroy();
+        this._applet_icon_box.child = null;
+        if (icon_path){
+            let file = Gio.file_new_for_path(icon_path);
+            let gicon = new Gio.FileIcon({ file: file });
+            if (this._scaleMode) {
+                let height = (this._panelHeight / DEFAULT_PANEL_HEIGHT) * PANEL_SYMBOLIC_ICON_DEFAULT_HEIGHT;
+                this._applet_icon = new St.Icon({gicon: gicon, icon_size: height,
+                                                icon_type: St.IconType.SYMBOLIC, reactive: true, track_hover: true, style_class: 'applet-icon' });
             } else {
                 this._applet_icon = new St.Icon({gicon: gicon, icon_size: 22, icon_type: St.IconType.FULLCOLOR, reactive: true, track_hover: true, style_class: 'applet-icon' });
             }


### PR DESCRIPTION
This will allow applet developers to specify symbolic applet icons by path and not just by icon name.
