### PR TITLE
Adding high resolution cover art for Spotify

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -590,6 +590,10 @@ Player.prototype = {
         if (metadata["mpris:artUrl"]) {
             if (this._trackCoverFile != metadata["mpris:artUrl"].toString()) {
                 this._trackCoverFile = metadata["mpris:artUrl"].toString();
+                
+                if ( this._name === "spotify" )
+                    this._trackCoverFile = this._trackCoverFile.replace("/thumb/", "/300/");
+
                 change = true;
             }
         }


### PR DESCRIPTION
All we need to do is change the original url (http://open.spotify.com/thumb/[hash]) to one that has one of the following sizes: 60, 85, 120, 300, or 640 so it becomes http://open.spotify.com/[size]/[hash]

300 seemed most appropriate for the Sound applet.

In addition it also removes the Spotify watermark.
