### PR TITLE
only display icon dirs with index.theme files

### DIFF
--- a/files/usr/lib/cinnamon-settings/modules/cs_themes.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_themes.py
@@ -78,7 +78,7 @@ class ThemesViewSidePage (ExtensionSidePage):
     
     def _load_icon_themes(self):
         dirs = ("/usr/share/icons", os.path.join(os.path.expanduser("~"), ".icons"))
-        valid = walk_directories(dirs, lambda d: os.path.isdir(d) and not os.path.exists(os.path.join(d, "cursors")))
+        valid = walk_directories(dirs, lambda d: os.path.isdir(d) and not os.path.exists(os.path.join(d, "cursors")) and os.path.exists(os.path.join(d, "index.theme")))
         valid.sort(lambda a,b: cmp(a.lower(), b.lower()))
         res = []
         for i in valid:


### PR DESCRIPTION
This limits the icon directories to those with index.theme files,
and prevents directories without icons from getting displayed in
the icon dropbox.

This commit fixes #2589
