### PR TITLE
Call XInitThreads() at the beginning of main()

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -220,6 +220,7 @@ center_pointer_on_screen ()
 int
 main (int argc, char **argv)
 {
+  XInitThreads();
   GOptionContext *ctx;
   GError *error = NULL;
   int ecode;


### PR DESCRIPTION
This is related to issue #2803 and related to pull request linuxmint/cinnamon-desktop#6 which depends on this. See those issues for more information.
