### PR TITLE
settings.js: fix apparent typo in SettingsManager.unregister

### DIFF
--- a/js/ui/settings.js
+++ b/js/ui/settings.js
@@ -814,6 +814,6 @@ SettingsManager.prototype = {
         },
 
         unregister: function (uuid, instance_id) {
-            this.instances[uuid][instance_id] = null;
+            this.uuids[uuid][instance_id] = null;
         }
 };


### PR DESCRIPTION
Removing my Alt-Tab-Enhanced applet from the panel produces the following error output:

```
   917  error t=2014-01-27T19:06:42.690Z this.instances is undefined
   918  trace t=2014-01-27T19:06:42.691Z 
   919  <----------------
   920  ("Alt_Tab_Enhanced@autarkper","Alt_Tab_Enhanced@autarkper")@/usr/share/cinnamon/js/ui/settings.js:817
   921  ()@/usr/share/cinnamon/js/ui/settings.js:521
   922  disable()@/home/pang/.local/share/cinnamon/applets/Alt_Tab_Enhanced@autarkper/applet.js:2958
   923  ()@/home/pang/.local/share/cinnamon/applets/Alt_Tab_Enhanced@autarkper/applet.js:3205
   924  ()@/usr/share/cinnamon/js/ui/applet.js:332
   925  removeAppletFromPanels([object Object])@/usr/share/cinnamon/js/ui/appletManager.js:211
   926  onEnabledAppletsChanged([object _private_Gio_Settings],"enabled-applets")@/usr/share/cinnamon/js/ui/appletManager.js:168
   927  ---------------->
   928  error t=2014-01-27T19:06:42.691Z Error during on_applet_removed_from_panel() call on applet: Alt_Tab_Enhanced@autarkper/454
```

As far as I can tell, this is caused by an apparent typo introduced in commit 26e9b3dd: "this.instances" is only used once, and should most likely be "this.uuids"; by changing to the latter I can make the error go away.
