### PR TITLE
add a check as to whether icon_info is None

### DIFF
--- a/files/usr/lib/cinnamon-desktop-editor/cinnamon-desktop-editor.py
+++ b/files/usr/lib/cinnamon-desktop-editor/cinnamon-desktop-editor.py
@@ -107,7 +107,7 @@ class IconPicker(object):
         else:
             theme = Gtk.IconTheme.get_default()
             icon_info = theme.lookup_icon(fn, 64, 0)
-            icon_info_fn = icon_info.get_filename()
+            icon_info_fn = icon_info.get_filename() if icon_info != None else None
             if icon_info_fn:
                 chooser.set_filename(icon_info_fn)
         filter = Gtk.FileFilter();


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1036273

```
Traceback (most recent call last):
  File "/usr/lib/cinnamon-desktop-editor/cinnamon-desktop-editor.py", line 104, in pick_icon
    icon_info_fn = icon_info.get_filename()
AttributeError: 'NoneType' object has no attribute 'get_filename'
```
