### PR TITLE
Add checkbox to menu settings to make icon configuration more intuitive

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -822,6 +822,7 @@ MyApplet.prototype = {
             this.menu.actor.add_style_class_name('menu-background');
             this.menu.connect('open-state-changed', Lang.bind(this, this._onOpenStateChanged));                                
 
+            this.settings.bindProperty(Settings.BindingDirection.IN, "menu-icon-custom", "menuIconCustom", this._updateIconAndLabel, null);
             this.settings.bindProperty(Settings.BindingDirection.IN, "menu-icon", "menuIcon", this._updateIconAndLabel, null);
             this.settings.bindProperty(Settings.BindingDirection.IN, "menu-label", "menuLabel", this._updateIconAndLabel, null);
             Main.themeManager.connect("theme-set", Lang.bind(this, this._updateIconAndLabel));
@@ -1005,15 +1006,18 @@ MyApplet.prototype = {
 
     _updateIconAndLabel: function(){
         try {
-            if (this.menuIcon == "" ||
-                (GLib.path_is_absolute(this.menuIcon) && GLib.file_test(this.menuIcon, GLib.FileTest.EXISTS)))
-                this.set_applet_icon_path(this.menuIcon);
-            else if (Gtk.IconTheme.get_default().has_icon(this.menuIcon)) {
+            if (this.menuIconCustom &&
+               (this.menuIcon == "" ||
+               (GLib.path_is_absolute(this.menuIcon) && GLib.file_test(this.menuIcon, GLib.FileTest.EXISTS))))
+                    this.set_applet_icon_path(this.menuIcon);
+            else if (this.menuIconCustom &&
+                     Gtk.IconTheme.get_default().has_icon(this.menuIcon)) {
                 if (this.menuIcon.search("-symbolic") != -1)
                     this.set_applet_icon_symbolic_name(this.menuIcon);
                 else
                     this.set_applet_icon_name(this.menuIcon);
             }
+            else if (Gtk.IconTheme.get_default().has_icon("menu")) this.set_applet_icon_name("menu");
             else this.set_applet_icon_path(global.datadir + '/theme/menu.svg');
         } catch(e) {
            global.logWarning("Could not load icon file \""+this.menuIcon+"\" for menu button");

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/settings-schema.json
@@ -1,9 +1,17 @@
 {
+ "menu-icon-custom" : {
+    "type" : "checkbox",
+    "default" : "false",
+    "description" : "Use a custom icon",
+    "tooltip" : "Unchecking this allows the theme to set the icon"
+ },
  "menu-icon" : {
     "type" : "iconfilechooser",
-    "default" : "menu",
-    "description": "Icon",
-    "tooltip": "Select an icon to show in the panel."
+    "default" : "/usr/share/cinnamon/theme/menu.svg",
+    "description" : "Icon",
+    "tooltip" : "Select an icon to show in the panel.",
+    "dependency" : "menu-icon-custom",
+    "indent" : "true"
  }, 
  "menu-label" : {
     "type" : "entry",


### PR DESCRIPTION
This updates the menu applet to add a checkbox as per @clefebvre's comments in https://github.com/linuxmint/Cinnamon/pull/2850.
