### PR TITLE
[Clock Desklet] CinnamonDesktop & More

### DIFF
--- a/files/usr/share/cinnamon/desklets/clock@cinnamon.org/desklet.js
+++ b/files/usr/share/cinnamon/desklets/clock@cinnamon.org/desklet.js
@@ -2,6 +2,7 @@
 const Lang = imports.lang;
 const Mainloop = imports.mainloop;
 const St = imports.gi.St;
+const CinnamonDesktop = imports.gi.CinnamonDesktop;
 
 const Desklet = imports.ui.desklet;
 const Settings = imports.ui.settings;
@@ -18,37 +19,50 @@ MyDesklet.prototype = {
         this._date = new St.Label({style_class: "clock-desklet-label"});
         this.setContent(this._date);
         this.setHeader(_("Clock"));
+        
+        this.clock = new CinnamonDesktop.WallClock();
 
         this.settings = new Settings.DeskletSettings(this, this.metadata["uuid"], desklet_id);
 
-        this.settings.bindProperty(Settings.BindingDirection.IN,
-                                   "date-format",
-                                   "format",
-                                   function() {},
-                                   null);
+        this.settings.bindProperty(Settings.BindingDirection.IN, "date-format", "format", function() {}, null);
 
-	this.settings.bindProperty(Settings.BindingDirection.IN,
-				   "font-size",
-				   "size",
-				   this._onSettingsChanged,
-				   null);
+        this.settings.bindProperty(Settings.BindingDirection.IN, "font-size", "size", this._onSettingsChanged, null);
+        
+        this.settings.bindProperty(Settings.BindingDirection.IN, "use-custom-format", "use_custom_format", this._onSettingsChanged, null);
+        
+        this._menu.addSettingsAction(_("Date and Time Settings"), "calendar")
 
         this._onSettingsChanged();
         this._updateDate();
     },
 
-
     _onSettingsChanged: function(){
         this._date.style="font-size: " + this.size + "pt";
+        this._updateDate();
     },
 
     on_desklet_removed: function() {
-	Mainloop.source_remove(this.timeout);
+        Mainloop.source_remove(this.timeout);
     },
 
     _updateDate: function(){
         let displayDate = new Date();
-        this._date.set_text(displayDate.toLocaleFormat(this.format));
+        
+        if (this.use_custom_format) {
+            let display_text = displayDate.toLocaleFormat(this.format);
+            
+            if (!display_text) {
+                global.logError("Clock desklet: bad time format string - check your string.");
+                display_text = "~CLOCK FORMAT ERROR~ " + now.toLocaleFormat("%l:%M %p");
+            }
+            this._date.set_text(display_text);
+        }
+        else {
+            //RavetcoFX: The replace() is replacing all text from ", " and before with a hacky regular expression wildcard command
+            //this makes it so the date from CinnamonDesktop.WallClock() does not display in the desklet's content box.
+            this._date.set_text(this.clock.get_clock().replace(/^.+, /, "").capitalize());
+        }
+            
         this.timeout = Mainloop.timeout_add_seconds(1, Lang.bind(this, this._updateDate));
     }
 }

--- a/files/usr/share/cinnamon/desklets/clock@cinnamon.org/metadata.json
+++ b/files/usr/share/cinnamon/desklets/clock@cinnamon.org/metadata.json
@@ -3,5 +3,6 @@
  "name": "Clock desklet",
  "description": "A desklet that displays the time",
  "icon": "stock_calendar",
- "prevent-decorations": false
+ "prevent-decorations": false,
+ "max-instances": "100"
 }

--- a/files/usr/share/cinnamon/desklets/clock@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/desklets/clock@cinnamon.org/settings-schema.json
@@ -4,13 +4,19 @@
         "default": 50,
         "min": 10,
         "max": 200,
-	"units": " ",
+    	"units": " ",
         "description" : "Font size:",
         "step": 1
     },
     "date-format": {
         "type": "entry",
-        "default": "%I:%M %p",
+        "default": "%l:%M %p",
         "description": "Date format:"
+    },
+    "use-custom-format" : {
+        "type" : "checkbox",
+        "default" : false,
+        "description": "Use a custom date format",
+        "tooltip": "Check this to define a custom format for the time in the clock desklet."
     }
 }


### PR DESCRIPTION
-Update to use CinnamonDesktop Wallclock (but not show the date)
-Add a menu item to open Date & Time settings
-Allow multiple instances
-Cleaned up code a bit (Evil Whitespaces and weird organization)
