### PR TITLE
Fix app switcher behavior when alt-tabbing out of a modal window

### DIFF
--- a/js/ui/appSwitcher/appSwitcher.js
+++ b/js/ui/appSwitcher/appSwitcher.js
@@ -95,6 +95,9 @@ AppSwitcher.prototype = {
         this._motionTimeoutId = 0;
         this._checkDestroyedTimeoutId = 0;
         this._currentIndex = this._windows.indexOf(global.display.focus_window);
+        if (this._currentIndex < 0) {
+            this._currentIndex = 0;
+        }
         this._modifierMask = primaryModifier(binding.get_mask());
 
         this._tracker = Cinnamon.WindowTracker.get_default();


### PR DESCRIPTION
Old behavior: when alt-tabbing out of a modal window, its parent window became the first target window, which resulted in the modal window to be the "new" focused window
Wanted behavior: The next "main" window is targeted
