### PR TITLE
Fix sound settings to make more sense

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/settings-schema.json
@@ -11,7 +11,9 @@
         "max": 512,
         "units": "characters",
         "step": 1,
-        "description": "Limit song information to"
+        "description": "Limit song information to",
+        "dependency": "showtrack",
+        "indent": true
     },
     "showalbum": {
         "type": "checkbox",


### PR DESCRIPTION
This adds indentation and dependency to one of the settings for the sound applet to improve readability and make more sense.
