### PR TITLE
Use better styleclass names for menu applet

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -1061,7 +1061,13 @@ StScrollBar StButton#vhandle:hover {
 	padding-right: 30px;
 	padding-bottom: 10px;
 }
-.menu-applications-box {
+.menu-applications-inner-box {
+	padding-top: 10px;
+	padding-left: 10px;
+	padding-right: 10px;
+	padding-bottom: 0px;
+}
+.menu-applications-outer-box {
 	padding-top: 10px;
 	padding-left: 10px;
 	padding-right: 10px;

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1841,8 +1841,8 @@ MyApplet.prototype = {
                                       this.menu.passEvents = false;
                                   }));
         
-        this.applicationsBox = new St.BoxLayout({ style_class: 'menu-applications-box', vertical:true });
-        this.applicationsBox.add_style_class_name('inner-box');
+        this.applicationsBox = new St.BoxLayout({ style_class: 'menu-applications-inner-box', vertical:true });
+        this.applicationsBox.add_style_class_name('menu-applications-box'); //this is to support old themes
         this.applicationsScrollBox.add_actor(this.applicationsBox);
         this.applicationsScrollBox.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC);
         this.categoriesApplicationsBox.actor.add_actor(this.categoriesBox);
@@ -1850,8 +1850,8 @@ MyApplet.prototype = {
                      
         this._refreshFavs();
                                                           
-        this.mainBox = new St.BoxLayout({ style_class: 'menu-applications-box', vertical:false });       
-        this.mainBox.add_style_class_name('outer-box');
+        this.mainBox = new St.BoxLayout({ style_class: 'menu-applications-outer-box', vertical:false });       
+        this.mainBox.add_style_class_name('menu-applications-box'); //this is to support old themes
                 
         this.mainBox.add_actor(leftPane, { span: 1 });
         this.mainBox.add_actor(rightPane, { span: 1 });


### PR DESCRIPTION
This sets better styleclass names for the menu applet as implemented in https://github.com/linuxmint/Cinnamon/pull/2854. In addition, it adds comments to explain the additional changes. It also changes the default theme to use the new names.
