### PR TITLE
soundplugin: Remove workaround for quodlibet

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -559,9 +559,6 @@ Player.prototype = {
         if (metadata["mpris:length"]) {
             // song length in secs
             this._songLength = metadata["mpris:length"] / 1000000;
-            // FIXME upstream
-            if (this._name == "quodlibet")
-                this._songLength = metadata["mpris:length"] / 1000;
             // reset timer
             this._stopTimer();
             if (this._playerStatus == "Playing")


### PR DESCRIPTION
QuodLibet's MPRIS plugin reports the correct mpris:length value at least since
version 2.4 (released 2012-03-18).
