### PR TITLE
Publish "Thumbnails only" in cinnamon settings as a style for alttab

### DIFF
--- a/files/usr/lib/cinnamon-settings/modules/cs_windows.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_windows.py
@@ -23,7 +23,7 @@ class Module:
             bg.add(vbox)
 
             section = Section(_("Alt-Tab"))  
-            alttab_styles = [["icons", _("Icons only")],["icons+thumbnails", _("Icons and thumbnails")],["icons+preview", _("Icons and window preview")],["preview", _("Window preview (no icons)")],["coverflow", _("Coverflow (3D)")],["timeline", _("Timeline (3D)")]]
+            alttab_styles = [["icons", _("Icons only")], ["thumbnails", _("Thumbnails only")],["icons+thumbnails", _("Icons and thumbnails")],["icons+preview", _("Icons and window preview")],["preview", _("Window preview (no icons)")],["coverflow", _("Coverflow (3D)")],["timeline", _("Timeline (3D)")]]
             alttab_styles_combo = self._make_combo_group(_("Alt-Tab switcher style"), "org.cinnamon", "alttab-switcher-style", alttab_styles)
             section.add(alttab_styles_combo)
             section.add(GSettingsCheckButton(_("Display the alt-tab switcher on the primary monitor instead of the active one"), "org.cinnamon", "alttab-switcher-enforce-primary-monitor", None))


### PR DESCRIPTION
This publishes a working but unpublished Alt-tab switcher style in cinnamon settings.
"Thumbnails only" looks like "Icons only", just with thumbnails.
