### PR TITLE
Dont allow uninstall from menu on critical apps

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -40,6 +40,7 @@ var UNSAFE_APPS = [
 "nemo",
 "mdm",
 "gdebi",
+"gnome-terminal",
 "system-config-printer",
 ];
 


### PR DESCRIPTION
Next cycle, we should remove this code and put in a warning into mint-remove-application for any app that reverse depends on mint-meta-cinnamon/mint-meta-common
Can't do that now as there is the translation freeze

~from @glebihan's mind
