### PR TITLE
Add standalone wallpaper changer..

### DIFF
--- a/files/usr/bin/cinnamon-apply-wallpaper
+++ b/files/usr/bin/cinnamon-apply-wallpaper
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+import gi
+from gi.repository import CinnamonDesktop, Gio, Gdk
+
+settings = Gio.Settings("org.cinnamon.desktop.background")
+
+bg = CinnamonDesktop.BG()
+
+bg.load_from_preferences(settings)
+bg.set_accountsservice_background(bg.get_filename());
+
+display = Gdk.Display.get_default();
+n_screens = display.get_n_screens();
+
+for i in range(0, n_screens):
+    screen = display.get_screen(i);
+    root_window = screen.get_root_window();
+    bg.create_and_set_surface_as_root(root_window, screen)
+    print root_window
+    print "done"

--- a/js/ui/backgroundManager.js
+++ b/js/ui/backgroundManager.js
@@ -5,6 +5,7 @@ const Gdk = imports.gi.Gdk;
 const Lang = imports.lang;
 const Desktop = imports.gi.CinnamonDesktop;
 const Mainloop = imports.mainloop;
+const Util = imports.misc.util;
 
 function BackgroundManager() {
     this._init();
@@ -25,34 +26,19 @@ BackgroundManager.prototype = {
 
         this._cinnamonSettings = new Gio.Settings({ schema: 'org.cinnamon.desktop.background' }); 
 
-        this.bg = new Desktop.BG();
-        this.bg.connect("changed", Lang.bind(this, this.draw_background));
-        this.bg.connect("transitioned", Lang.bind(this, this.draw_background));
-
         this.connect_screen_signals();
 
         this._cinnamonSettings.connect("changed", Lang.bind(this, this.on_settings_changed_event_cb));
 
-        this.bg.load_from_preferences(this._cinnamonSettings);
         this.draw_background();
     },
 
     draw_background: function() {
-        let display;
-        let n_screens;
-        display = Gdk.Display.get_default();
-        n_screens = display.get_n_screens();
-
-        for (let i = 0; i < n_screens; ++i) {
-            let screen = display.get_screen(i);
-            let root_window = screen.get_root_window();
-            this.bg.create_and_set_surface_as_root(root_window, screen);
-        }
+        Util.trySpawnCommandLine("cinnamon-apply-wallpaper");
     },
 
     on_settings_changed_event_cb: function() {
-        this.bg.load_from_preferences(this._cinnamonSettings);
-        this.bg.set_accountsservice_background(this.bg.get_filename());
+        this.draw_background();
     },
 
     screen_signal_timeout_cb: function() {


### PR DESCRIPTION
It seems to work fine for me here except for the fact that I get 'failed to create drawable'
messages, which doesn't sound good.  I wonder if the bg object is expiring before
the X server gets around to actually changing the pixmap, but I get the warning
even if I add time.sleep(5) or something.

Anyhow, I fixed up backgroundManager.js to only call the script on changes.
