### PR TITLE
Change xchat to hexchat in favorite apps again

### DIFF
--- a/debian/cinnamon.gsettings-override
+++ b/debian/cinnamon.gsettings-override
@@ -1,3 +1,3 @@
 [org.cinnamon]
-favorite-apps=[ 'firefox.desktop', 'mintInstall.desktop', 'cinnamon-settings.desktop', 'xchat.desktop', 'gnome-terminal.desktop', 'nemo.desktop' ]
+favorite-apps=[ 'firefox.desktop', 'mintInstall.desktop', 'cinnamon-settings.desktop', 'hexchat.desktop', 'gnome-terminal.desktop', 'nemo.desktop' ]
 


### PR DESCRIPTION
Preventing hexchat from existing in the RC favorites menu
