### PR TITLE
cinnamon-settings windows: Add minimum opacity setting for windows.

### DIFF
--- a/files/usr/lib/cinnamon-settings/modules/cs_windows.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_windows.py
@@ -50,7 +50,7 @@ class Module:
             combo = self._make_titlebar_action_group(_("Action on title bar with mouse scroll"),
                                                       "org.cinnamon.desktop.wm.preferences", "action-scroll-titlebar",
                                                       scroll_options)
-            opacity_spinner = GSettingsSpinButton(_("Minimum (0-255):"), "org.cinnamon.desktop.wm.preferences", "min-window-opacity", None, 0, 255, 1, 1, None)
+            opacity_spinner = GSettingsSpinButton(_("Minimum opacity:"), "org.cinnamon.desktop.wm.preferences", "min-window-opacity", None, 0, 100, 1, 1, _("%"))
 
             combo.pack_start(opacity_spinner, False, False, 2)
 


### PR DESCRIPTION
Depends on:
muffin           61096831db59763f6c121a3b86ccc2e8f8b0d29c (linuxmint/muffin#148)
cinnamon-desktop 8dacf5efad64038aefb2162e7bacbb1a080d7d7b (linuxmint/cinnamon-desktop#10)
