### PR TITLE
Fix #2080: sound applet now shows correct time

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -679,6 +679,9 @@ Player.prototype = {
 
     _runTimer: function() {
         if (this._playerStatus == 'Playing') {
+            if (this._timeoutId != 0) {
+                Mainloop.source_remove(this._timeoutId);
+            }
             this._timeoutId = Mainloop.timeout_add_seconds(1, Lang.bind(this, this._runTimer));
             this._currentTime += 1;
             this._updateTimer();


### PR DESCRIPTION
Every time a new song was loaded in any player, the Cinnamon sound
applet would register a new timeout function to run every second and add
one to the current playtime displayed, but the timeout was never being
deregistered. So after the second song was started, there were two
timeouts operating, and two seconds were being added each time.

This patch removes the previous timeout before setting a new one, so
that only one "add one second" function will be called every second.
