### PR TITLE
Add option to modify the alt-tab switcher delay

### DIFF
--- a/data/org.cinnamon.gschema.xml.in
+++ b/data/org.cinnamon.gschema.xml.in
@@ -479,6 +479,12 @@
       <_summary>Enforce displaying the alt-tab switcher on the primary monitor instead of the active one</_summary>
     </key>
 
+    <key type="i" name="alttab-switcher-delay">
+      <default>150</default>
+      <_summary>Duration of the effect (in milliseconds)</_summary>
+      <_description>Duration of the effect (in milliseconds)</_description>
+    </key>
+
     <key name="window-list-applet-scroll" type="b">
       <default>false</default>
       <summary>Enable mouse-scroll in window-list applet</summary>

--- a/files/usr/lib/cinnamon-settings/modules/cs_windows.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_windows.py
@@ -23,10 +23,24 @@ class Module:
             bg.add(vbox)
 
             section = Section(_("Alt-Tab"))  
-            alttab_styles = [["icons", _("Icons only")], ["thumbnails", _("Thumbnails only")],["icons+thumbnails", _("Icons and thumbnails")],["icons+preview", _("Icons and window preview")],["preview", _("Window preview (no icons)")],["coverflow", _("Coverflow (3D)")],["timeline", _("Timeline (3D)")]]
+            alttab_styles = [
+                ["icons", _("Icons only")],
+                ["thumbnails", _("Thumbnails only")],
+                ["icons+thumbnails", _("Icons and thumbnails")],
+                ["icons+preview", _("Icons and window preview")],
+                ["preview", _("Window preview (no icons)")],
+                ["coverflow", _("Coverflow (3D)")],
+                ["timeline", _("Timeline (3D)")]
+            ]
             alttab_styles_combo = self._make_combo_group(_("Alt-Tab switcher style"), "org.cinnamon", "alttab-switcher-style", alttab_styles)
             section.add(alttab_styles_combo)
             section.add(GSettingsCheckButton(_("Display the alt-tab switcher on the primary monitor instead of the active one"), "org.cinnamon", "alttab-switcher-enforce-primary-monitor", None))
+            section.add(
+                GSettingsSpinButton(
+                    "Delay before displaying the alt-tab switcher",
+                    "org.cinnamon", "alttab-switcher-delay", dep_key=None,
+                    min=0, max=1000, step=50, page=150, 
+                    units=_("milliseconds")))
             vbox.add(section)
 
             vbox.add(Gtk.Separator.new(Gtk.Orientation.HORIZONTAL))        

--- a/js/ui/appSwitcher/appSwitcher.js
+++ b/js/ui/appSwitcher/appSwitcher.js
@@ -9,7 +9,6 @@ const Mainloop = imports.mainloop;
 const Main = imports.ui.main;
 const Cinnamon = imports.gi.Cinnamon;
 
-const INITIAL_DELAY_TIMEOUT = 150;
 const CHECK_DESTROYED_TIMEOUT = 100;
 const DISABLE_HOVER_TIMEOUT = 500; // milliseconds
 
@@ -137,7 +136,8 @@ AppSwitcher.prototype = {
         
             // We delay showing the popup so that fast Alt+Tab users aren't
             // disturbed by the popup briefly flashing.
-            this._initialDelayTimeoutId = Mainloop.timeout_add(INITIAL_DELAY_TIMEOUT, Lang.bind(this, this._show));
+            let delay = global.settings.get_int("alttab-switcher-delay");
+            this._initialDelayTimeoutId = Mainloop.timeout_add(delay, Lang.bind(this, this._show));
         }
         return this._haveModal;
     },


### PR DESCRIPTION
The alt-tab switcher uses a default delay of 150 ms before actually
showing the dialog to avoid repeated flashing. The downside of this
approach is that it makes it appear to be laggy. This commit adds the
ability to modify the delay of the dialog in the Window settings with
150 ms remaining the default choice to maintain the previous behavior
for people who prefer it.

Signed-off-by: Niklas Koep niklas.koep@gmail.com
