### PR TITLE
Add about dialog to applets and desklets

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -1490,6 +1490,48 @@ StScrollBar StButton#vhandle:hover {
     background-color: rgba(109,170, 0, 0.3);
 }
 /* ===================================================================
+ * About Dialog (applet.js and desklet.js)
+ * ===================================================================*/
+.about-content {
+    width: 550px;
+    height: 250px;
+    spacing: 8px;
+    padding-bottom: 16px;
+}
+
+.about-title {
+    font-size: 2em;
+    font-weight: bold;
+}
+
+.about-uuid {
+    font-size: .8em;
+}
+
+.about-icon {
+    padding-right: 20px;
+}
+
+.about-scrollBox {
+    border: solid 1px grey;
+    border-radius: 4px;
+}
+
+.about-scrollBox-innerBox {
+    padding: 1.2em;
+    spacing: 1.2em;
+}
+
+.about-description {
+    padding-top: 4px;
+}
+
+.about-version {
+    padding-left: 7px;
+}
+
+
+/* ===================================================================
  * Clock Desklet (desklet.js) 
  * ===================================================================*/
 .clock-desklet-label {

--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -13,7 +13,8 @@ const Util = imports.misc.util;
 const Pango = imports.gi.Pango;
 const Mainloop = imports.mainloop;
 const Flashspot = imports.ui.flashspot;
-	
+const ModalDialog = imports.ui.modalDialog;
+
 const COLOR_ICON_HEIGHT_FACTOR = .875;  // Panel height factor for normal color icons
 const PANEL_FONT_DEFAULT_HEIGHT = 11.5; // px
 const PANEL_SYMBOLIC_ICON_DEFAULT_HEIGHT = 1.14 * PANEL_FONT_DEFAULT_HEIGHT; // ems conversion
@@ -419,14 +420,22 @@ Applet.prototype = {
             this.context_menu_item_remove = new MenuItem(_("Remove this applet"), "edit-delete", Lang.bind(null, AppletManager._removeAppletFromPanel, this._uuid, this.instance_id));
         }
 
+        if (this.context_menu_item_about == null) {
+            this.context_menu_item_about = new MenuItem(_("About..."), "dialog-question", Lang.bind(this, this.openAbout));
+        }
+
         if (this.context_menu_separator == null) {
-                this.context_menu_separator = new PopupMenu.PopupSeparatorMenuItem();
+            this.context_menu_separator = new PopupMenu.PopupSeparatorMenuItem();
         }
 
         if (this._applet_context_menu._getMenuItems().length > 0) {
             this._applet_context_menu.addMenuItem(this.context_menu_separator);
-         }
-        
+        }
+
+        if (items.indexOf(this.context_menu_item_about) == -1) {
+            this._applet_context_menu.addMenuItem(this.context_menu_item_about);
+        }
+
         if (!this._meta["hide-configuration"] && GLib.file_test(this._meta["path"] + "/settings-schema.json", GLib.FileTest.EXISTS)) {     
             if (this.context_menu_item_configure == null) {            
                 this.context_menu_item_configure = new MenuItem(_("Configure..."), "system-run", Lang.bind(this, function() {
@@ -441,6 +450,10 @@ Applet.prototype = {
         if (items.indexOf(this.context_menu_item_remove) == -1) {
             this._applet_context_menu.addMenuItem(this.context_menu_item_remove);
         }
+    },
+
+    openAbout: function() {
+        new ModalDialog.SpicesAboutDialog(this._meta, "applets");
     }
 };
 

--- a/js/ui/desklet.js
+++ b/js/ui/desklet.js
@@ -12,6 +12,7 @@ const Util = imports.misc.util;
 const DeskletManager = imports.ui.deskletManager;
 const DND = imports.ui.dnd;
 const Main = imports.ui.main;
+const ModalDialog = imports.ui.modalDialog;
 const PopupMenu = imports.ui.popupMenu;
 const Tooltips = imports.ui.tooltips;
 const Tweener = imports.ui.tweener;
@@ -222,6 +223,10 @@ Desklet.prototype = {
             this._menu.addMenuItem(this.context_menu_separator);
         }
         
+        this.context_menu_item_about = new PopupMenu.PopupMenuItem(_("About..."))
+        this.context_menu_item_about.connect("activate", Lang.bind(this, this.openAbout));
+        this._menu.addMenuItem(this.context_menu_item_about);
+        
         if (!this._meta["hide-configuration"] && GLib.file_test(this._meta["path"] + "/settings-schema.json", GLib.FileTest.EXISTS)) {            
             this.context_menu_item_configure = new PopupMenu.PopupMenuItem(_("Configure..."));
             this.context_menu_item_configure.connect("activate", Lang.bind(this, function() {
@@ -233,6 +238,10 @@ Desklet.prototype = {
         this.context_menu_item_remove = new PopupMenu.PopupMenuItem(_("Remove this desklet"));
         this.context_menu_item_remove.connect("activate", Lang.bind(this, this._onRemoveDesklet));
         this._menu.addMenuItem(this.context_menu_item_remove);            
+    },
+
+    openAbout: function() {
+        new ModalDialog.SpicesAboutDialog(this._meta, "desklets");
     }
 };
 Signals.addSignalMethods(Desklet.prototype);

--- a/js/ui/modalDialog.js
+++ b/js/ui/modalDialog.js
@@ -5,6 +5,8 @@ const Lang = imports.lang;
 const St = imports.gi.St;
 const Cinnamon = imports.gi.Cinnamon;
 const Signals = imports.signals;
+const Gio = imports.gi.Gio;
+const Pango = imports.gi.Pango;
 
 const Params = imports.misc.params;
 
@@ -316,3 +318,124 @@ ModalDialog.prototype = {
     }
 };
 Signals.addSignalMethods(ModalDialog.prototype);
+
+function SpicesAboutDialog(metadata, type) {
+    this._init(metadata, type);
+}
+
+SpicesAboutDialog.prototype = {
+    __proto__: ModalDialog.prototype,
+    
+    _init: function(metadata, type) {
+        try {
+            ModalDialog.prototype._init.call(this, {});
+            
+            let contentBox = new St.BoxLayout({vertical: true, style_class: "about-content" });
+            this.contentLayout.add_actor(contentBox);
+            
+            let topBox = new St.BoxLayout();
+            contentBox.add_actor(topBox);
+            
+            //icon
+            let icon;
+            if (metadata.icon) icon = new St.Icon({icon_name: metadata.icon, icon_size: 48, icon_type: St.IconType.FULLCOLOR, style_class: "about-icon"});
+            else {
+                let file = Gio.file_new_for_path(metadata.path + "/icon.png");
+                if (file.query_exists(null)) {
+                    let gicon = new Gio.FileIcon({file: file});
+                    icon = new St.Icon({gicon: gicon, icon_size: 48, icon_type: St.IconType.FULLCOLOR, style_class: "about-icon"});
+                }
+                else {
+                    icon = new St.Icon({icon_name: "cs-"+type, icon_size: 48, icon_type: St.IconType.FULLCOLOR, style_class: "about-icon"});
+                }
+            }
+            topBox.add_actor(icon);
+            
+            let topTextBox = new St.BoxLayout({vertical: true});
+            topBox.add_actor(topTextBox);
+            
+            /*title*/
+            let titleBox = new St.BoxLayout();
+            topTextBox.add_actor(titleBox);
+            
+            let title = new St.Label({text: metadata.name, style_class: "about-title"});
+            titleBox.add_actor(title);
+            
+            if (metadata.version) {
+                let versionBin = new St.Bin({x_align: St.Align.START, y_align: St.Align.END});
+                titleBox.add_actor(versionBin);
+                let version = new St.Label({text: "v " + metadata.version, style_class: "about-version"});
+                versionBin.add_actor(version);
+            }
+            
+            //uuid
+            let uuid = new St.Label({text: metadata.uuid, style_class: "about-uuid"});
+            topTextBox.add_actor(uuid);
+            
+            //description
+            let desc = new St.Label({text: metadata.description, style_class: "about-description"});
+            let dText = desc.clutter_text;
+            topTextBox.add_actor(desc);
+            
+            /*optional content*/
+            let scrollBox = new St.ScrollView({style_class: "about-scrollBox"});
+            contentBox.add(scrollBox, {expand: true});
+            let infoBox = new St.BoxLayout({vertical: true, style_class: "about-scrollBox-innerBox"});
+            scrollBox.add_actor(infoBox);
+            
+            //comments
+            if (metadata.comments) {
+                let comments = new St.Label({text: "Comments:\n\t" + metadata.comments});
+                let cText = comments.clutter_text;
+                cText.ellipsize = Pango.EllipsizeMode.NONE;
+                cText.line_wrap = true;
+                cText.set_line_wrap_mode(Pango.WrapMode.WORD_CHAR);
+                infoBox.add_actor(comments);
+            }
+            
+            //website
+            if (metadata.website) {
+                let wsBox = new St.BoxLayout({vertical: true});
+                infoBox.add_actor(wsBox);
+                
+                let wLabel = new St.Label({text: "Website:"});
+                wsBox.add_actor(wLabel);
+                
+                let wsButton = new St.Button({x_align: St.Align.START, style_class: "cinnamon-link", name: "about-website"});
+                wsBox.add_actor(wsButton);
+                let website = new St.Label({text: metadata.website});
+                let wtext = website.clutter_text;
+                wtext.ellipsize = Pango.EllipsizeMode.NONE;
+                wtext.line_wrap = true;
+                wtext.set_line_wrap_mode(Pango.WrapMode.WORD_CHAR);
+                wsButton.add_actor(website);
+                wsButton.connect("clicked", Lang.bind(this, this.launchSite, metadata.website));
+            }
+            
+            //contributors
+            if (metadata.contributors) {
+                let list = metadata.contributors.split(",").join("\n\t");
+                let contributors = new St.Label({text: "Contributors:\n\t" + list});
+                infoBox.add_actor(contributors);
+            }
+            
+            //dialog close button
+            this.setButtons([
+                {label: "Close", key: "", focus: true, action: Lang.bind(this, this._onOk)}
+            ]);
+            
+            this.open(global.get_current_time());
+        } catch(e) {
+            global.log(e);
+        }
+    },
+    
+    _onOk: function() {
+        this.close(global.get_current_time());
+    },
+    
+    launchSite: function(a, b, site) {
+        Util.spawnCommandLine("xdg-open " + site);
+        this.close(global.get_current_time());
+    }
+}


### PR DESCRIPTION
This adds an about dialog to the context menu of applets and desklets. The information is pulled from `metadata.json`. This dialog will make it easier for users to check version numbers, access websites, and get additional information about the applet or desklet.

Available fields are:
- uuid
- name
- description
- comments
- website
- version
- contributors
