### PR TITLE
Added searching for files in Cinnamon Menu

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -30,7 +30,7 @@ const APPLICATION_ICON_SIZE = 22;
 const MAX_RECENT_FILES = 20;
 
 const INITIAL_BUTTON_LOAD = 30;
-const MAX_BUTTON_WIDTH = "max-width: 20em;";
+const MAX_BUTTON_WIDTH = "max-width: 75em;";   //original: 20em, but it has to be greater to fit results from MetaTracker
 
 const USER_DESKTOP_PATH = FileUtils.getUserDesktopDir();
 
@@ -920,6 +920,13 @@ MyApplet.prototype = {
             St.TextureCache.get_default().connect("icon-theme-changed", Lang.bind(this, this.onIconThemeChanged));
 
             this._recalc_height();
+
+            //DBus interface to MetaTracker
+            const TrackerInterface = <interface name='org.freedesktop.Tracker1.Resources'>
+                <method name='SparqlQuery'><arg type='s' direction='in'/><arg type='aas' direction='out'/></method>
+            </interface>;
+            const TrackerProxy = Gio.DBusProxy.makeProxyWrapper(TrackerInterface);
+            this._tracker_proxy = new TrackerProxy(Gio.DBus.session, 'org.freedesktop.Tracker1', '/org/freedesktop/Tracker1/Resources');  //bus name, object path
         }
         catch (e) {
             global.logError(e);
@@ -2177,8 +2184,28 @@ MyApplet.prototype = {
         var acResults = new Array(); // search box autocompletion results
         if (this.searchFilesystem) {
             // Don't use the pattern here, as filesystem is case sensitive
-            acResults = this._getCompletions(this.searchEntryText.get_text());
+            //acResults = this._getCompletions(this.searchEntryText.get_text());
+
+            //search for files using MetaTracker
+            var homeDir = GLib.get_home_dir();                            // "/home/<username>"
+            var trackerSearchText = this.searchEntryText.get_text();
+            if (trackerSearchText.length >= 3) {
+                //Blocking (synchronous) request for result, there is also an option to call it in not blocking manner.
+                //If MetaTracker is not installed: no error, simply results from file search are not displayed.
+                //If MetaTracker is not working: MetaTracker process will be automatically started and correct results will be displayed.
+                var result = this._tracker_proxy.SparqlQuerySync("SELECT nie:url(?f) WHERE { ?f fts:match '" + trackerSearchText + "' }");
+                for (let i = 0; i < result[0].length ; i++) {
+                    let filename = decodeURI(result[0][i]).substr(7);     //get path from URI: remove "file://" and decode percent encoding
+                    if (filename.indexOf(homeDir) == 0) {                 //Tracker returns also applications: we are not interested in them
+                        filename = "~" + filename.substr(homeDir.length); //make the path shorter: replace "/home/<username>" with "~"
+                        acResults.push(filename);
+                    }
+                    if (acResults.length == 500)                          //show not more than 500 results (like in tracker-needle GUI search tool)
+                        break;
+                }
+            }
         }
+        this._clearAllSelections(true);     //applet displays files wrongly for "enable filesystem path entry in search box"; so we fix this
 
         this._displayButtons(null, placesResults, recentResults, appResults, acResults);
        


### PR DESCRIPTION
Add possibility to search for files content in Cinnamon Menu using Tracker

Prerequisites:
![screenshot](https://cloud.githubusercontent.com/assets/8080496/3489405/91997ab2-052b-11e4-9a6e-2c4c5540eb39.jpg)
- install Tracker:
  sudo apt-get --install-recommends install tracker tracker-gui
- in Menu applet settings check "Enable filesystem path entry in search box" (a new option should be added or text of this option should be edited)

---

Currently the code is very simple, but the implementation is working and it is very helpful. If the code is accepted we should think
about elements that can be improved.

Problems:
- memory leak when there are many files in the result
  If there are more than 500 items returned in Tracker result only the first 500 files are displayed (like in tracker-needle).
  I made a test search for situation where Tracker returned 60 thousand items. Displaying result (500 items) takes 8 seconds what is ok.
  But unfortunately after every such query Cinnamon (64-bit) is using about 40MB more RAM! So we have a memory leak which has to be fixed.
  Maybe old TransientButton objects are not deleted?
- menu applet width is not decreased after displaying a file with a long path in a search result
  When a file with a long path is displayed in a search result then Menu applet width is increased to display more information.
  After closing menu and opening it again the width of menu should be narrow like at the beginning and increase only if needed.
  Second solution: If a found file has a long path maybe it is better to display only a file name and display a full path as a tip?
  Another problem: const MAX_BUTTON_WIDTH = "max-width: 75em;" is ok for 1366x768 screen resolution, but not for smaller resolutions.
- After closing menu and opening it again the previous Tracker results are still displayed. It has to be fixed.
  All this problems show that probably we have a problem because old unused objects are not deleted.
