### PR TITLE
Fix Background Module for python2-pillow 2.5.0-1 in ArchLinux

### DIFF
--- a/files/usr/lib/cinnamon-settings/bin/imtools.py
+++ b/files/usr/lib/cinnamon-settings/bin/imtools.py
@@ -859,7 +859,7 @@ def paste(destination, source, box=(0, 0), mask=None, force=False):
     :type force: bool
     """
     # Paste on top
-    if source == mask:
+    if mask and source == mask:
         if has_alpha(source):
             # invert_alpha = the transparant pixels of the destination
             if has_alpha(destination) and (destination.size == source.size


### PR DESCRIPTION
To fix https://github.com/linuxmint/Cinnamon/issues/3333 and https://bbs.archlinux.org/viewtopic.php?id=183840
