### PR TITLE
[WIP] Increase the speed of xletsettings

### DIFF
--- a/files/usr/lib/cinnamon-settings/bin/XletSettings.py
+++ b/files/usr/lib/cinnamon-settings/bin/XletSettings.py
@@ -79,11 +79,11 @@ class XletSetting:
     def on_settings_change(self, uuid, instance_id, key, payload):
         if(self.uuid == uuid and self.current_id == instance_id):
             #print ("Received signal with message: %s" % payload)
-            widget = self.setting_factories[self.current_id].widgets[key]
-            if(widget != None):
+            widgets = self.setting_factories[self.current_id].widgets
+            if(key in widgets and widgets[key] != None):
                 node = json.loads(payload.decode('utf-8'));
-                widget.settings_obj.data[key] = node
-                widget.on_settings_file_changed()
+                widgets[key].settings_obj.data[key] = node
+                widgets[key].on_settings_file_changed()
 
     def show (self):
         self.content.show_all()

--- a/files/usr/lib/cinnamon-settings/bin/XletSettingsWidgets.py
+++ b/files/usr/lib/cinnamon-settings/bin/XletSettingsWidgets.py
@@ -44,6 +44,12 @@ class Factory():
         self.handler = self.file_monitor.connect("changed", self.on_file_changed)
         self.file_changed_timeout = None
         self.resume_timeout = None
+        self.activeDBus = False
+
+    def setDBusActive(self, active):
+        self.activeDBus = active
+        if active:
+           self.pause_monitor();
 
     def create(self, key, setting_type, uuid):
         try:
@@ -74,9 +80,10 @@ class Factory():
         self.resume_timeout = GObject.timeout_add(2000, self.do_resume)
 
     def do_resume(self):
-        self.file_monitor = self.file_obj.monitor_file(Gio.FileMonitorFlags.SEND_MOVED, None)
-        self.handler = self.file_monitor.connect("changed", self.on_file_changed)
-        self.resume_timeout = None
+        if (not self.activeDBus):
+            self.file_monitor = self.file_obj.monitor_file(Gio.FileMonitorFlags.SEND_MOVED, None)
+            self.handler = self.file_monitor.connect("changed", self.on_file_changed)
+            self.resume_timeout = None
         return False
 
     def reset_to_defaults(self):

--- a/files/usr/lib/cinnamon-settings/bin/XletSettingsWidgets.py
+++ b/files/usr/lib/cinnamon-settings/bin/XletSettingsWidgets.py
@@ -83,7 +83,9 @@ class Factory():
         if (not self.activeDBus):
             self.file_monitor = self.file_obj.monitor_file(Gio.FileMonitorFlags.SEND_MOVED, None)
             self.handler = self.file_monitor.connect("changed", self.on_file_changed)
-            self.resume_timeout = None
+        if self.resume_timeout:
+            GObject.source_remove(self.resume_timeout)
+        self.resume_timeout = None
         return False
 
     def reset_to_defaults(self):

--- a/js/ui/cinnamonDBus.js
+++ b/js/ui/cinnamonDBus.js
@@ -68,7 +68,10 @@ const CinnamonIface = {
                 outSignature: ''
               }
              ],
-    signals: [],
+    signals: [{ name: "SettingsChanged",
+                inSignature:'ssss'
+              }
+             ],
     properties: [{ name: 'OverviewActive',
                    signature: 'b',
                    access: 'readwrite' },
@@ -257,8 +260,15 @@ Cinnamon.prototype = {
         Main.expo.toggle();
     },
 
+    emitSettingsChanged: function(uuid, instance_id, key, payload) {
+        DBus.session.emit_signal('/org/Cinnamon',
+                                 'org.Cinnamon',
+                                 'SettingsChanged',
+                                 'ssss',[uuid, instance_id, key, payload]
+        );
+    },
+
     CinnamonVersion: Config.PACKAGE_VERSION
 };
 
 DBus.conformExport(Cinnamon.prototype, CinnamonIface);
-

--- a/js/ui/cinnamonDBus.js
+++ b/js/ui/cinnamonDBus.js
@@ -241,7 +241,12 @@ Cinnamon.prototype = {
     },
 
     updateSetting: function(uuid, instance_id, key, payload) {
-        Main.settingsManager.uuids[uuid][instance_id].remote_set(key, payload);
+        let components = Main.settingsManager.uuids[uuid];
+        if(components != null) {
+            let instance = components[instance_id];
+            if(instance)
+                instance.remote_set(key, payload);
+        }
     },
 
     switchWorkspaceLeft: function() {

--- a/js/ui/settings.js
+++ b/js/ui/settings.js
@@ -605,6 +605,7 @@ SettingObj.prototype = {
 
     set_value: function(key, val) {
         this.json[key]["value"] = val;
+        Main.cinnamonDBusService.emitSettingsChanged(this.uuid, this.instanceId, key, JSON.stringify(this.json[key], null, 4));
         this.save();
     },
 


### PR DESCRIPTION
This change update the settings(xlet) using DBus signals. Will stopped the file monitor(for the .json file), if settings can connect to DBus to realize the update. I know that will be better the use of GDBus instead of DBus on cinnamonDBus.js, but this could changed afterwards. I don't know if will be good also send a signal to update all settings or if will be better using the file monitor for update all settings, when occurs a change in .json, but just now Cinnamon has a duplicate mechanism for update the settings. only partially from the value of the attributes, do not a complete update and this could be good for devs. So the file monitor continues active if DBus it's not active. This is the current way.