### PR TITLE
Correction to day abbreviation in some languages

### DIFF
--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/calendar.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/calendar.js
@@ -119,14 +119,14 @@ function _getCalendarDayAbbreviation(dayNumber) {
     // We use 2014/03/02 (months are zero-based in JS) because it was a Sunday
 
     let abbreviations = [
-        new Date(2014, 2, 2).toLocaleFormat('%A').first_cap(),        
-        new Date(2014, 2, 3).toLocaleFormat('%A').first_cap(),
-        new Date(2014, 2, 4).toLocaleFormat('%A').first_cap(),
-        new Date(2014, 2, 5).toLocaleFormat('%A').first_cap(),
-        new Date(2014, 2, 6).toLocaleFormat('%A').first_cap(),
-        new Date(2014, 2, 7).toLocaleFormat('%A').first_cap(),
-        new Date(2014, 2, 8).toLocaleFormat('%A').first_cap()
-    ];  
+        new Date(2014, 2, 2).toLocaleFormat('%a'),
+        new Date(2014, 2, 3).toLocaleFormat('%a'),
+        new Date(2014, 2, 4).toLocaleFormat('%a'),
+        new Date(2014, 2, 5).toLocaleFormat('%a'),
+        new Date(2014, 2, 6).toLocaleFormat('%a'),
+        new Date(2014, 2, 7).toLocaleFormat('%a'),
+        new Date(2014, 2, 8).toLocaleFormat('%a')
+    ];
 
     return abbreviations[dayNumber];
 }


### PR DESCRIPTION
In some languages all the days begins with the same letter, to get the abbreviation is recommended use locale system directly and not another rare method.

We have the %a time format for this.
