### PR TITLE
Fix menu and tooltip when dragging applets to the opposite panel

### DIFF
--- a/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
@@ -25,23 +25,21 @@ const PANEL_LAUNCHERS_DRAGGABLE_KEY = 'panel-launchers-draggable';
 const PANEL_RESIZABLE_KEY = 'panel-resizable';
 const PANEL_SCALE_TEXT_ICONS_KEY = 'panel-scale-text-icons';
 
+const CUSTOM_LAUNCHERS_PATH = GLib.get_home_dir() + '/.cinnamon/panel-launchers';
+
 let pressLauncher = null;
 
 function PanelAppLauncherMenu(launcher, orientation) {
     this._init(launcher, orientation);
 }
 
-const CUSTOM_LAUNCHERS_PATH = GLib.get_home_dir() + '/.cinnamon/panel-launchers';
-
 PanelAppLauncherMenu.prototype = {
-    __proto__: PopupMenu.PopupMenu.prototype,
+    __proto__: Applet.AppletPopupMenu.prototype,
 
     _init: function(launcher, orientation) {
         this._launcher = launcher;
 
-        PopupMenu.PopupMenu.prototype._init.call(this, launcher.actor, 0.0, orientation, 0);
-        Main.uiGroup.add_actor(this.actor);
-        this.actor.hide();
+        Applet.AppletPopupMenu.prototype._init.call(this, launcher, orientation);
 
         this.launchItem = new PopupMenu.PopupMenuItem(_("Launch"));
         this.addMenuItem(this.launchItem);
@@ -90,6 +88,7 @@ PanelAppLauncher.prototype = {
         this.app = app;
         this.appinfo = appinfo;
         this.launchersBox = launchersBox;
+        this._applet = launchersBox;
         this.actor = new St.Bin({ style_class: 'panel-launcher',
                                   reactive: true,
                                   can_focus: true,

--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -56,27 +56,25 @@ dragHelper.prototype = {
 
 let drag_helper = new dragHelper();
 
-function AppMenuButtonRightClickMenu(actor, metaWindow, orientation) {
-    this._init(actor, metaWindow, orientation);
+function AppMenuButtonRightClickMenu(launcher, metaWindow, orientation) {
+    this._init(launcher, metaWindow, orientation);
 }
 
 AppMenuButtonRightClickMenu.prototype = {
-    __proto__: PopupMenu.PopupMenu.prototype,
+    __proto__: Applet.AppletPopupMenu.prototype,
 
-    _init: function(actor, metaWindow, orientation) {
-        //take care of menu initialization        
-        PopupMenu.PopupMenu.prototype._init.call(this, actor, 0.0, orientation, 0);        
-        Main.uiGroup.add_actor(this.actor);
-        this.actor.hide();
-        this.window_list = actor._delegate._applet._windows;
-        actor.connect('key-press-event', Lang.bind(this, this._onSourceKeyPress));        
-        this.connect('open-state-changed', Lang.bind(this, this._onToggled));        
+    _init: function(launcher, metaWindow, orientation) {
+        Applet.AppletPopupMenu.prototype._init.call(this, launcher, orientation);
+        
+        this.window_list = launcher.actor._delegate._applet._windows;
+        launcher.actor.connect('key-press-event', Lang.bind(this, this._onSourceKeyPress));
+        this.connect('open-state-changed', Lang.bind(this, this._onToggled));
 
-        this.metaWindow = metaWindow;
         this.orientation = orientation;
-     },
+        this.metaWindow = metaWindow;
+    },
 
-     _populateMenu: function(){
+    _populateMenu: function(){
         let mw = this.metaWindow;
         let itemCloseWindow = new PopupMenu.PopupMenuItem(_("Close"));
         itemCloseWindow.connect('activate', Lang.bind(this, this._onCloseWindowActivate));
@@ -157,13 +155,13 @@ AppMenuButtonRightClickMenu.prototype = {
         (this.orientation == St.Side.BOTTOM ? items : items.reverse()).forEach(function(item) {
             this.addMenuItem(item);
         }, this);
-     },
+    },
 
-     _onRestoreOpacity: function(actor, event) {
+    _onRestoreOpacity: function(actor, event) {
         this.metaWindow.get_compositor_private().set_opacity(255);
-     },
+    },
 
-     _onToggled: function(actor, isOpening){
+    _onToggled: function(actor, isOpening){
         if (!isOpening) {
             return;
         }
@@ -351,7 +349,7 @@ AppMenuButton.prototype = {
         if (draggable) {
             //set up the right click menu
             this._menuManager = new PopupMenu.PopupMenuManager(this);
-            this.rightClickMenu = new AppMenuButtonRightClickMenu(this.actor, this.metaWindow, orientation);
+            this.rightClickMenu = new AppMenuButtonRightClickMenu(this, this.metaWindow, orientation);
             this._menuManager.addMenu(this.rightClickMenu);
 
             this._draggable = DND.makeDraggable(this.actor);

--- a/js/ui/tooltips.js
+++ b/js/ui/tooltips.js
@@ -1,5 +1,6 @@
 const Mainloop = imports.mainloop;
 const St = imports.gi.St;
+const Applet = imports.ui.applet;
 const Main = imports.ui.main;
 const Lang = imports.lang;
 const Tweener = imports.ui.tweener;
@@ -117,6 +118,12 @@ PanelItemTooltip.prototype = {
         Tooltip.prototype._init.call(this, panelItem.actor, initTitle);
         this._panelItem = panelItem;
         this.orientation = orientation;
+        if (panelItem instanceof Applet.Applet) {
+            panelItem.connect("orientation-changed", Lang.bind(this, this._onOrientationChanged));
+        }
+        else if (panelItem._applet) {
+            panelItem._applet.connect("orientation-changed", Lang.bind(this, this._onOrientationChanged));
+        }
     },
 
     show: function() {
@@ -145,6 +152,10 @@ PanelItemTooltip.prototype = {
 
         this._tooltip.show();
         this._visible = true;
+    },
+
+    _onOrientationChanged: function(a, orientation) {
+        this.orientation = orientation;
     }
 };
 


### PR DESCRIPTION
This fixes a bug which occurs whenever an applet is dragged from one panel to the other, in which the menu and tooltip are placed incorrectly due to the orientation not being updated until Cinnamon is restarted.

This pull request causes applets to emit a signal whenever the orientation is changed, and has applet popup menus and applet tooltips connect to the signal on creation. This shouldn't break any existing applets, but it will allow applets which have menus and/or tooltips attached to something other than an applet (eg. window list and panel launcher applets which are also updated in this pull request) - to take advantage of the fix by using the applet version of the menu or tooltip and then setting `this._applet` on the object to which the menu or tooltip is attached.

Note: this fix does not effect non-applet versions of menus and tooltips.
