### PR TITLE
use non-legacy icon name for gnome-fs-network

### DIFF
--- a/js/ui/placesManager.js
+++ b/js/ui/placesManager.js
@@ -333,7 +333,7 @@ PlacesManager.prototype = {
             } else {
                 // Asume the bookmark is an unmounted network location
                 // try to mount and open by the default file manager 
-                let icon = Gio.ThemedIcon.new('gnome-fs-network');          
+                let icon = Gio.ThemedIcon.new('network-workgroup');          
                 item = new PlaceInfo('bookmark:' + bookmark, label,
                         function(size) {
                             return St.TextureCache.get_default().load_gicon(null, icon, size);


### PR DESCRIPTION
rename gnome-fs-network to network-workgroup (already exists in mint x icons)

https://github.com/linuxmint/Cinnamon/issues/3403
