### PR TITLE
Don't hard code text colors in the treeview of Xlets

### DIFF
--- a/files/usr/lib/cinnamon-settings/bin/ExtensionCore.py
+++ b/files/usr/lib/cinnamon-settings/bin/ExtensionCore.py
@@ -813,7 +813,7 @@ class ExtensionSidePage (SidePage):
             iter = self.gm_model.insert_before(None, None)
             self.gm_model.set_value(iter, 0, uuid)
             if not self.themes:
-                self.gm_model.set_value(iter, 1, '<b>%s</b>\n<b><span foreground="#333333" size="x-small">%s</span></b>' % (extensionName, uuid))
+                self.gm_model.set_value(iter, 1, '<b>%s</b>\n<b><span size="x-small">%s</span></b>' % (extensionName, uuid))
             else:
                 self.gm_model.set_value(iter, 1, '<b>%s</b>' % (extensionName))
             self.gm_model.set_value(iter, 2, 0)
@@ -1136,7 +1136,7 @@ class ExtensionSidePage (SidePage):
                                         found += 1
 
                                 self.model.set_value(iter, 0, extension_uuid)                
-                                self.model.set_value(iter, 1, '<b>%s</b>\n<b><span foreground="#333333" size="xx-small">%s</span></b>\n<i><span foreground="#555555" size="x-small">%s</span></i>' % (extension_name, extension_uuid, extension_description))                                  
+                                self.model.set_value(iter, 1, '<b>%s</b>\n<span font_weight="heavy" size="xx-small">%s</span>\n<i><span font_weight="light" size="x-small">%s</span></i>' % (extension_name, extension_uuid, extension_description))                                  
                                 self.model.set_value(iter, 2, found)
                                 self.model.set_value(iter, 3, extension_max_instances)
 


### PR DESCRIPTION
This causes the text to be unreadable in many themes. A perfect example is Mint-X-Blue. Select an item in the treeview to see the issue.
