### PR TITLE
fix an issue with the panel size of some symbolic icons

### DIFF
--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -592,9 +592,9 @@ IconApplet.prototype = {
             if (this._scaleMode) {
                 let height = (this._panelHeight / DEFAULT_PANEL_HEIGHT) * PANEL_SYMBOLIC_ICON_DEFAULT_HEIGHT / global.ui_scale;
                 this._applet_icon = new St.Icon({gicon: gicon, icon_size: height,
-                                                icon_type: St.IconType.SYMBOLIC, reactive: true, track_hover: true, style_class: 'applet-icon' });
+                                                icon_type: St.IconType.SYMBOLIC, reactive: true, track_hover: true, style_class: 'system-status-icon' });
             } else {
-                this._applet_icon = new St.Icon({gicon: gicon, icon_size: FALLBACK_ICON_HEIGHT, icon_type: St.IconType.FULLCOLOR, reactive: true, track_hover: true, style_class: 'applet-icon' });
+                this._applet_icon = new St.Icon({gicon: gicon, icon_type: St.IconType.SYMBOLIC, reactive: true, track_hover: true, style_class: 'system-status-icon' });
             }
             this._applet_icon_box.child = this._applet_icon;
         }


### PR DESCRIPTION
Fixes an issue when using set_applet_icon_symbolic_path() and getting an oversized icon on the panel. Tested in both normal and hidpi with various size settings in Cinnamon Settings->Panel and it seems work properly although sometimes changes to size settings required a cinnamon restart for them to properly take effect.
