### PR TITLE
cinnamon-settings: append /usr/sbin to PATH before calling lspci

### DIFF
--- a/files/usr/lib/cinnamon-settings/modules/cs_info.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_info.py
@@ -31,6 +31,8 @@ def getProcessOut(command):
 def getGraphicsInfos():
     cards = {}
     count = 0
+    envpath = os.environ["PATH"]
+    os.environ["PATH"] = envpath + ":/usr/local/sbin:/usr/sbin:/sbin"
     for card in getProcessOut(("lspci")):
         if not "VGA" in card:
             continue
@@ -43,6 +45,7 @@ def getGraphicsInfos():
         if cardName:
             cards[count] = (cardName)
             count += 1
+    os.environ["PATH"] = envpath
     return cards
 
 def getDiskSize():


### PR DESCRIPTION
Some distros, e.g. Gentoo, install lspci in /usr/sbin

Fixes issue #3548
