### PR TITLE
Xlet settings dependencies with operators

### DIFF
--- a/files/usr/lib/cinnamon-settings/bin/XletSettingsWidgets.py
+++ b/files/usr/lib/cinnamon-settings/bin/XletSettingsWidgets.py
@@ -507,10 +507,10 @@ class CheckButton(Gtk.CheckButton, BaseWidget):
 
     def update_dependents(self):
         for dep in self.dependents:
-			if(dep[1] and dep[1][0] == "!"): #not operator
-				self.settings_obj.factory.widgets[dep[0]].update_dep_state(not self.get_active())
-			else:
-				self.settings_obj.factory.widgets[dep[0]].update_dep_state(self.get_active())
+            if(dep[1] and dep[1][0] == "!"): #not operator
+                self.settings_obj.factory.widgets[dep[0]].update_dep_state(not self.get_active())
+            else:
+                self.settings_obj.factory.widgets[dep[0]].update_dep_state(self.get_active())
 
     def on_settings_file_changed(self):
         self.handler_block(self.handler)
@@ -731,31 +731,31 @@ class ComboBox(Gtk.HBox, BaseWidget):
         val = self.get_val()
         try:
             val = int(val)
+        except:
+            try:
+                val = float(val)
             except:
-                try:
-                    val = float(val)
-                except:
-                    pass
+                pass
 
         for dep in self.dependents:
-	    if(dep[1]):
-		if(not dep[1][0]):
-		    self.settings_obj.factory.widgets[dep[0]].update_dep_state(bool(val))
-		elif(dep[1][0] == "!"):		# not operator
-		    self.settings_obj.factory.widgets[dep[0]].update_dep_state(not bool(val))
-		elif(dep[1][1] is not None):
-		    if(dep[1][0] == "=="):      # == operator
-			self.settings_obj.factory.widgets[dep[0]].update_dep_state(val == dep[1][1])
-		    elif(dep[1][0] == "!="):    # != operator
-			self.settings_obj.factory.widgets[dep[0]].update_dep_state(val != dep[1][1])
-		    elif(dep[1][0] == "<"):     # < operator
-			self.settings_obj.factory.widgets[dep[0]].update_dep_state(val < dep[1][1])
-		    elif(dep[1][0] == "<="):    # <= operator
-			self.settings_obj.factory.widgets[dep[0]].update_dep_state(val <= dep[1][1])
-		    elif(dep[1][0] == ">"):     # > operator
-			self.settings_obj.factory.widgets[dep[0]].update_dep_state(val > dep[1][1])
-		    elif(dep[1][0] == ">="):    # >= operator
-			self.settings_obj.factory.widgets[dep[0]].update_dep_state(val >= dep[1][1])
+            if(dep[1]):
+                if(not dep[1][0]):
+                    self.settings_obj.factory.widgets[dep[0]].update_dep_state(bool(val))
+                elif(dep[1][0] == "!"):        # not operator
+                    self.settings_obj.factory.widgets[dep[0]].update_dep_state(not bool(val))
+                elif(dep[1][1] is not None):
+                    if(dep[1][0] == "=="):      # == operator
+                        self.settings_obj.factory.widgets[dep[0]].update_dep_state(val == dep[1][1])
+                    elif(dep[1][0] == "!="):    # != operator
+                        self.settings_obj.factory.widgets[dep[0]].update_dep_state(val != dep[1][1])
+                    elif(dep[1][0] == "<"):     # < operator
+                        self.settings_obj.factory.widgets[dep[0]].update_dep_state(val < dep[1][1])
+                    elif(dep[1][0] == "<="):    # <= operator
+                        self.settings_obj.factory.widgets[dep[0]].update_dep_state(val <= dep[1][1])
+                    elif(dep[1][0] == ">"):     # > operator
+                        self.settings_obj.factory.widgets[dep[0]].update_dep_state(val > dep[1][1])
+                    elif(dep[1][0] == ">="):    # >= operator
+                        self.settings_obj.factory.widgets[dep[0]].update_dep_state(val >= dep[1][1])
 
 
     def on_settings_file_changed(self):
@@ -812,7 +812,6 @@ class RadioGroup(Gtk.VBox, BaseWidget):
                 button.orig_key = key
 
             self.pack_start(hbox, False, False, 2)
-        self.handler = self.scale.connect('value-changed', self.update_dependents)
 
         if self.entry is not None:
             self.entry.set_text(self.get_custom_val())
@@ -833,30 +832,30 @@ class RadioGroup(Gtk.VBox, BaseWidget):
         val = self.get_val()
         try:
             val = int(val)
+        except:
+            try:
+                val = float(val)
             except:
-                try:
-                    val = float(val)
-                except:
-                    pass
+                pass
         for dep in self.dependents:
-	    if(dep[1]):
-		if(not dep[1][0]):
-		    self.settings_obj.factory.widgets[dep[0]].update_dep_state(bool(val))
-		elif(dep[1][0] == "!"):		# not operator
-		    self.settings_obj.factory.widgets[dep[0]].update_dep_state(not bool(val))
-		elif(dep[1][1] is not None):
-		    if(dep[1][0] == "=="):      # == operator
-			self.settings_obj.factory.widgets[dep[0]].update_dep_state(val == dep[1][1])
-		    elif(dep[1][0] == "!="):    # != operator
-			self.settings_obj.factory.widgets[dep[0]].update_dep_state(val != dep[1][1])
-		    elif(dep[1][0] == "<"):     # < operator
-			self.settings_obj.factory.widgets[dep[0]].update_dep_state(val < dep[1][1])
-		    elif(dep[1][0] == "<="):    # <= operator
-			self.settings_obj.factory.widgets[dep[0]].update_dep_state(val <= dep[1][1])
-		    elif(dep[1][0] == ">"):     # > operator
-			self.settings_obj.factory.widgets[dep[0]].update_dep_state(val > dep[1][1])
-		    elif(dep[1][0] == ">="):    # >= operator
-			self.settings_obj.factory.widgets[dep[0]].update_dep_state(val >= dep[1][1])
+            if(dep[1]):
+                if(not dep[1][0]):
+                    self.settings_obj.factory.widgets[dep[0]].update_dep_state(bool(val))
+                elif(dep[1][0] == "!"):		# not operator
+                    self.settings_obj.factory.widgets[dep[0]].update_dep_state(not bool(val))
+                elif(dep[1][1] is not None):
+                    if(dep[1][0] == "=="):      # == operator
+                        self.settings_obj.factory.widgets[dep[0]].update_dep_state(val == dep[1][1])
+                    elif(dep[1][0] == "!="):    # != operator
+                        self.settings_obj.factory.widgets[dep[0]].update_dep_state(val != dep[1][1])
+                    elif(dep[1][0] == "<"):     # < operator
+                        self.settings_obj.factory.widgets[dep[0]].update_dep_state(val < dep[1][1])
+                    elif(dep[1][0] == "<="):    # <= operator
+                        self.settings_obj.factory.widgets[dep[0]].update_dep_state(val <= dep[1][1])
+                    elif(dep[1][0] == ">"):     # > operator
+                        self.settings_obj.factory.widgets[dep[0]].update_dep_state(val > dep[1][1])
+                    elif(dep[1][0] == ">="):    # >= operator
+                        self.settings_obj.factory.widgets[dep[0]].update_dep_state(val >= dep[1][1])
 
     def on_custom_focus(self, event, widget):
         self.custom_button.set_active(True)
@@ -872,6 +871,7 @@ class RadioGroup(Gtk.VBox, BaseWidget):
                 self.update_custom_settings_value()
             else:
                 self.update_settings_value(widget.orig_key)
+            self.update_dependents()
 
     def update_custom_settings_value(self):
         self.set_val(self.entry.get_text())

--- a/files/usr/lib/cinnamon-settings/bin/XletSettingsWidgets.py
+++ b/files/usr/lib/cinnamon-settings/bin/XletSettingsWidgets.py
@@ -305,7 +305,7 @@ class BaseWidget(object):
 
             return (key, match.group(3), value)
         else:                                   #no operator
-            return (key)
+            return (key,)
 
     def update_dependents(self):
         pass
@@ -496,7 +496,7 @@ class CheckButton(Gtk.CheckButton, BaseWidget):
         set_tt(self.get_tooltip(), self)
 
     def add_dependent(self, widget, arg):
-        if arg[0] and arg[0] != "!":
+        if arg and arg[0] != "!":
             print ("The operator '" + arg[0] + "' is not supported by a CheckBox widget as dependence. The UUID is: " + self.uuid)
             arg = ()
         self.dependents.append((widget, arg))
@@ -718,9 +718,6 @@ class ComboBox(Gtk.HBox, BaseWidget):
         self.combo.show_all()
 
     def add_dependent(self, widget, arg):
-        if arg[0] == "!":
-            print ("The operator '" + arg[0] + "' is not supported by a ComboBox widget as dependence. The UUID is: " + self.uuid)
-            arg = ()
         self.dependents.append((widget, arg))
 
     def on_my_value_changed(self, widget):
@@ -733,19 +730,25 @@ class ComboBox(Gtk.HBox, BaseWidget):
     def update_dependents(self):
         val = self.get_val()
         for dep in self.dependents:
-            if(dep[1] and dep[1][1]):
-                if(dep[1][0] == "=="):      # == operator
-                    self.settings_obj.factory.widgets[dep[0]].update_dep_state(val == dep[1][1])
-                elif(dep[1][0] == "!="):    # != operator
-                    self.settings_obj.factory.widgets[dep[0]].update_dep_state(val != dep[1][1])
-                elif(dep[1][0] == "<"):     # < operator
-                    self.settings_obj.factory.widgets[dep[0]].update_dep_state(val < dep[1][1])
-                elif(dep[1][0] == "<="):    # <= operator
-                    self.settings_obj.factory.widgets[dep[0]].update_dep_state(val <= dep[1][1])
-                elif(dep[1][0] == ">"):     # > operator
-                    self.settings_obj.factory.widgets[dep[0]].update_dep_state(val > dep[1][1])
-                elif(dep[1][0] == ">="):    # >= operator
-                    self.settings_obj.factory.widgets[dep[0]].update_dep_state(val >= dep[1][1])
+	    if(dep[1]):
+		if(not dep[1][0]):
+		    self.settings_obj.factory.widgets[dep[0]].update_dep_state(bool(val))
+		elif(dep[1][0] == "!"):		# not operator
+		    self.settings_obj.factory.widgets[dep[0]].update_dep_state(not bool(val))
+		elif(dep[1][1] is not None):
+		    if(dep[1][0] == "=="):      # == operator
+			self.settings_obj.factory.widgets[dep[0]].update_dep_state(val == dep[1][1])
+		    elif(dep[1][0] == "!="):    # != operator
+			self.settings_obj.factory.widgets[dep[0]].update_dep_state(val != dep[1][1])
+		    elif(dep[1][0] == "<"):     # < operator
+			self.settings_obj.factory.widgets[dep[0]].update_dep_state(val < dep[1][1])
+		    elif(dep[1][0] == "<="):    # <= operator
+			self.settings_obj.factory.widgets[dep[0]].update_dep_state(val <= dep[1][1])
+		    elif(dep[1][0] == ">"):     # > operator
+			self.settings_obj.factory.widgets[dep[0]].update_dep_state(val > dep[1][1])
+		    elif(dep[1][0] == ">="):    # >= operator
+			self.settings_obj.factory.widgets[dep[0]].update_dep_state(val >= dep[1][1])
+
 
     def on_settings_file_changed(self):
         self.combo.handler_block(self.handler)
@@ -816,28 +819,29 @@ class RadioGroup(Gtk.VBox, BaseWidget):
         self._value_changed_timer = None
 
     def add_dependent(self, widget, arg):
-        if arg[0] == "!":
-            print ("The operator '" + arg[0] + "' is not supported by a RadioGroup widget as dependence. The UUID is: " + self.uuid)
-            arg = ()
         self.dependents.append((widget, arg))
 
     def update_dependents(self):
         val = self.get_val()
-        print val
         for dep in self.dependents:
-            if(dep[1] and dep[1][1]):
-                if(dep[1][0] == "=="):      # == operator
-                    self.settings_obj.factory.widgets[dep[0]].update_dep_state(val == dep[1][1])
-                elif(dep[1][0] == "!="):    # != operator
-                    self.settings_obj.factory.widgets[dep[0]].update_dep_state(val != dep[1][1])
-                elif(dep[1][0] == "<"):     # < operator
-                    self.settings_obj.factory.widgets[dep[0]].update_dep_state(val < dep[1][1])
-                elif(dep[1][0] == "<="):    # <= operator
-                    self.settings_obj.factory.widgets[dep[0]].update_dep_state(val <= dep[1][1])
-                elif(dep[1][0] == ">"):     # > operator
-                    self.settings_obj.factory.widgets[dep[0]].update_dep_state(val > dep[1][1])
-                elif(dep[1][0] == ">="):    # >= operator
-                    self.settings_obj.factory.widgets[dep[0]].update_dep_state(val >= dep[1][1])
+	    if(dep[1]):
+		if(not dep[1][0]):
+		    self.settings_obj.factory.widgets[dep[0]].update_dep_state(bool(val))
+		elif(dep[1][0] == "!"):		# not operator
+		    self.settings_obj.factory.widgets[dep[0]].update_dep_state(not bool(val))
+		elif(dep[1][1] is not None):
+		    if(dep[1][0] == "=="):      # == operator
+			self.settings_obj.factory.widgets[dep[0]].update_dep_state(val == dep[1][1])
+		    elif(dep[1][0] == "!="):    # != operator
+			self.settings_obj.factory.widgets[dep[0]].update_dep_state(val != dep[1][1])
+		    elif(dep[1][0] == "<"):     # < operator
+			self.settings_obj.factory.widgets[dep[0]].update_dep_state(val < dep[1][1])
+		    elif(dep[1][0] == "<="):    # <= operator
+			self.settings_obj.factory.widgets[dep[0]].update_dep_state(val <= dep[1][1])
+		    elif(dep[1][0] == ">"):     # > operator
+			self.settings_obj.factory.widgets[dep[0]].update_dep_state(val > dep[1][1])
+		    elif(dep[1][0] == ">="):    # >= operator
+			self.settings_obj.factory.widgets[dep[0]].update_dep_state(val >= dep[1][1])
 
     def on_custom_focus(self, event, widget):
         self.custom_button.set_active(True)

--- a/files/usr/lib/cinnamon-settings/bin/XletSettingsWidgets.py
+++ b/files/usr/lib/cinnamon-settings/bin/XletSettingsWidgets.py
@@ -552,6 +552,8 @@ class CheckButton(Gtk.CheckButton, BaseWidget):
         self.set_active(self.get_val())
         self.handler_unblock(self.handler)
 
+        self.update_dependents()
+
     def update_dep_state(self, active):
         self.set_sensitive(active)
 
@@ -767,6 +769,8 @@ class ComboBox(Gtk.HBox, DependencyWidgetMiscType, BaseWidget):
                 self.combo.set_active_id(option_name)
         self.combo.handler_unblock(self.handler)
 
+        self.update_dependents()
+
     def update_dep_state(self, active):
         self.combo.set_sensitive(active)
 
@@ -877,6 +881,8 @@ class RadioGroup(Gtk.VBox, DependencyWidgetMiscType, BaseWidget):
                 self.custom_button.handler_block(self.custom_button.handler)
                 self.custom_button.set_active(True)
                 self.custom_button.handler_unblock(self.custom_button.handler)
+
+        self.update_dependents()
 
     def update_dep_state(self, active):
         for button in self.group:

--- a/files/usr/lib/cinnamon-settings/bin/XletSettingsWidgets.py
+++ b/files/usr/lib/cinnamon-settings/bin/XletSettingsWidgets.py
@@ -456,6 +456,41 @@ class BaseWidget(object):
         except:
             return 200            
 
+class DependencyWidgetMiscType(object):
+    def add_dependent(self, widget, arg):
+        self.dependents.append((widget, arg))
+
+    def update_dependents(self):
+        val = self.get_val()
+        try:
+            val = int(val)
+        except:
+            try:
+                val = float(val)
+            except:
+                pass
+
+        for dep in self.dependents:
+            if(dep[1]):
+                if(not dep[1][0]):
+                    self.settings_obj.factory.widgets[dep[0]].update_dep_state(bool(val))
+                elif(dep[1][0] == "!"):        # not operator
+                    self.settings_obj.factory.widgets[dep[0]].update_dep_state(not bool(val))
+                elif(dep[1][1] is not None):
+                    if(dep[1][0] == "=="):      # == operator
+                        self.settings_obj.factory.widgets[dep[0]].update_dep_state(val == dep[1][1])
+                    elif(dep[1][0] == "!="):    # != operator
+                        self.settings_obj.factory.widgets[dep[0]].update_dep_state(val != dep[1][1])
+                    elif(dep[1][0] == "<"):     # < operator
+                        self.settings_obj.factory.widgets[dep[0]].update_dep_state(val < dep[1][1])
+                    elif(dep[1][0] == "<="):    # <= operator
+                        self.settings_obj.factory.widgets[dep[0]].update_dep_state(val <= dep[1][1])
+                    elif(dep[1][0] == ">"):     # > operator
+                        self.settings_obj.factory.widgets[dep[0]].update_dep_state(val > dep[1][1])
+                    elif(dep[1][0] == ">="):    # >= operator
+                        self.settings_obj.factory.widgets[dep[0]].update_dep_state(val >= dep[1][1])
+
+
 def set_tt(tt, *widgets):
     for widget in widgets:
         widget.set_tooltip_text(tt)
@@ -678,7 +713,7 @@ class ColorChooser(Gtk.HBox, BaseWidget):
     def update_dep_state(self, active):
         self.chooser.set_sensitive(active)
 
-class ComboBox(Gtk.HBox, BaseWidget):
+class ComboBox(Gtk.HBox, DependencyWidgetMiscType, BaseWidget):
     def __init__(self, key, settings_obj, uuid):
         BaseWidget.__init__(self, key, settings_obj, uuid)
         super(ComboBox, self).__init__()
@@ -717,46 +752,12 @@ class ComboBox(Gtk.HBox, BaseWidget):
         self.handler = self.combo.connect("changed", self.on_my_value_changed)
         self.combo.show_all()
 
-    def add_dependent(self, widget, arg):
-        self.dependents.append((widget, arg))
-
     def on_my_value_changed(self, widget):
         tree_iter = widget.get_active_iter()
         if tree_iter != None:
             self.set_val(self.model[tree_iter][1])
 
         self.update_dependents()
-
-    def update_dependents(self):
-        val = self.get_val()
-        try:
-            val = int(val)
-        except:
-            try:
-                val = float(val)
-            except:
-                pass
-
-        for dep in self.dependents:
-            if(dep[1]):
-                if(not dep[1][0]):
-                    self.settings_obj.factory.widgets[dep[0]].update_dep_state(bool(val))
-                elif(dep[1][0] == "!"):        # not operator
-                    self.settings_obj.factory.widgets[dep[0]].update_dep_state(not bool(val))
-                elif(dep[1][1] is not None):
-                    if(dep[1][0] == "=="):      # == operator
-                        self.settings_obj.factory.widgets[dep[0]].update_dep_state(val == dep[1][1])
-                    elif(dep[1][0] == "!="):    # != operator
-                        self.settings_obj.factory.widgets[dep[0]].update_dep_state(val != dep[1][1])
-                    elif(dep[1][0] == "<"):     # < operator
-                        self.settings_obj.factory.widgets[dep[0]].update_dep_state(val < dep[1][1])
-                    elif(dep[1][0] == "<="):    # <= operator
-                        self.settings_obj.factory.widgets[dep[0]].update_dep_state(val <= dep[1][1])
-                    elif(dep[1][0] == ">"):     # > operator
-                        self.settings_obj.factory.widgets[dep[0]].update_dep_state(val > dep[1][1])
-                    elif(dep[1][0] == ">="):    # >= operator
-                        self.settings_obj.factory.widgets[dep[0]].update_dep_state(val >= dep[1][1])
-
 
     def on_settings_file_changed(self):
         self.combo.handler_block(self.handler)
@@ -769,7 +770,7 @@ class ComboBox(Gtk.HBox, BaseWidget):
     def update_dep_state(self, active):
         self.combo.set_sensitive(active)
 
-class RadioGroup(Gtk.VBox, BaseWidget):
+class RadioGroup(Gtk.VBox, DependencyWidgetMiscType, BaseWidget):
     def __init__(self, key, settings_obj, uuid):
         BaseWidget.__init__(self, key, settings_obj, uuid)
         super(RadioGroup, self).__init__()
@@ -824,38 +825,6 @@ class RadioGroup(Gtk.VBox, BaseWidget):
             button.handler = button.connect("toggled", self.on_button_activated)
             set_tt(self.get_tooltip(), button)
         self._value_changed_timer = None
-
-    def add_dependent(self, widget, arg):
-        self.dependents.append((widget, arg))
-
-    def update_dependents(self):
-        val = self.get_val()
-        try:
-            val = int(val)
-        except:
-            try:
-                val = float(val)
-            except:
-                pass
-        for dep in self.dependents:
-            if(dep[1]):
-                if(not dep[1][0]):
-                    self.settings_obj.factory.widgets[dep[0]].update_dep_state(bool(val))
-                elif(dep[1][0] == "!"):		# not operator
-                    self.settings_obj.factory.widgets[dep[0]].update_dep_state(not bool(val))
-                elif(dep[1][1] is not None):
-                    if(dep[1][0] == "=="):      # == operator
-                        self.settings_obj.factory.widgets[dep[0]].update_dep_state(val == dep[1][1])
-                    elif(dep[1][0] == "!="):    # != operator
-                        self.settings_obj.factory.widgets[dep[0]].update_dep_state(val != dep[1][1])
-                    elif(dep[1][0] == "<"):     # < operator
-                        self.settings_obj.factory.widgets[dep[0]].update_dep_state(val < dep[1][1])
-                    elif(dep[1][0] == "<="):    # <= operator
-                        self.settings_obj.factory.widgets[dep[0]].update_dep_state(val <= dep[1][1])
-                    elif(dep[1][0] == ">"):     # > operator
-                        self.settings_obj.factory.widgets[dep[0]].update_dep_state(val > dep[1][1])
-                    elif(dep[1][0] == ">="):    # >= operator
-                        self.settings_obj.factory.widgets[dep[0]].update_dep_state(val >= dep[1][1])
 
     def on_custom_focus(self, event, widget):
         self.custom_button.set_active(True)

--- a/files/usr/lib/cinnamon-settings/bin/XletSettingsWidgets.py
+++ b/files/usr/lib/cinnamon-settings/bin/XletSettingsWidgets.py
@@ -729,6 +729,14 @@ class ComboBox(Gtk.HBox, BaseWidget):
 
     def update_dependents(self):
         val = self.get_val()
+        try:
+            val = int(val)
+            except:
+                try:
+                    val = float(val)
+                except:
+                    pass
+
         for dep in self.dependents:
 	    if(dep[1]):
 		if(not dep[1][0]):
@@ -823,6 +831,13 @@ class RadioGroup(Gtk.VBox, BaseWidget):
 
     def update_dependents(self):
         val = self.get_val()
+        try:
+            val = int(val)
+            except:
+                try:
+                    val = float(val)
+                except:
+                    pass
         for dep in self.dependents:
 	    if(dep[1]):
 		if(not dep[1][0]):

--- a/files/usr/share/cinnamon/applets/settings-example@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/settings-example@cinnamon.org/settings-schema.json
@@ -27,16 +27,28 @@
  },
  "combo-selection" : {
     "type": "combobox",
-    "default" : "option 1",
+    "default" : 1,
     "description" : "Please pick an option:",
     "options" : {
-        "First Choice" : "option 1",
-        "Second Choice" : "option 2",
-        "Third Choice" : "option 3",
-        "Fourth Choice" : "option 4"
+        "First Choice" : 1,
+        "Second Choice" : 2,
+        "Third Choice" : 3,
+        "Fourth Choice" : 4
     },
     "tooltip" : "A combo selection can select between int, boolean, float, and string values"
  },
+ "options": {
+	"type": "radiogroup",
+	"default": 0.2,
+	"description": "Please pick another option:",
+	"options": {
+		"I": 0.2,
+		"II": 0.4,
+		"III": 0.6
+	},
+	"tooltip": "A radio group can select between int, boolean, float, and string values. You can't change the value? Well, set the Combobox to the fourth choice, and here you go!",
+	"dependency": "combo-selection == 4"
+},
  "scale-demo" : {
     "type" : "scale",
     "default" : 0.5,

--- a/files/usr/share/cinnamon/applets/settings-example@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/settings-example@cinnamon.org/settings-schema.json
@@ -38,17 +38,17 @@
     "tooltip" : "A combo selection can select between int, boolean, float, and string values"
  },
  "options": {
-	"type": "radiogroup",
-	"default": 0.2,
-	"description": "Please pick another option:",
-	"options": {
-		"I": 0.2,
-		"II": 0.4,
-		"III": 0.6
-	},
-	"tooltip": "A radio group can select between int, boolean, float, and string values. You can't change the value? Well, set the Combobox to the fourth choice, and here you go!",
-	"dependency": "combo-selection == 4"
-},
+    "type": "radiogroup",
+    "default": 0.2,
+    "description": "Please pick another option:",
+    "options": {
+        "I": 0.2,
+        "II": 0.4,
+        "III": 0.6
+    },
+    "tooltip": "A radio group can select between int, boolean, float, and string values. You can't change the value? Well, set the Combobox to the fourth choice, and here you go!",
+    "dependency": "combo-selection == 4"
+ },
  "scale-demo" : {
     "type" : "scale",
     "default" : 0.5,


### PR DESCRIPTION
This is something I wanted very early for my applet settings: dependencies with some operators.
Those dependence values are now possible:

- `!` and checkbox key: enabled if checkbox is not checked
- only combobox or radiogroup key: enabled if value can be cast to true
- `!` and combobox or radiogroup key: enabled if value can be cast to false
- combobox or radiogroup key, `==`, `!=`, `<`, `>`, `<=` or `>=` and a value: enabled if statement is true

##### Examples
`!use-foo`
`dropdown`
`bar-mode < 5`
`divisor != 0`