### PR TITLE
Fixed #2170: sound applet player status icons

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -114,7 +114,7 @@ function TextImageMenuItem() {
 TextImageMenuItem.prototype = {
     __proto__: PopupMenu.PopupBaseMenuItem.prototype,
 
-    _init: function(text, icon, image, align, style) {
+    _init: function(text, icon, align, style) {
         PopupMenu.PopupBaseMenuItem.prototype._init.call(this);
 
         this.actor = new St.BoxLayout({style_class: style});


### PR DESCRIPTION
There are two variants of solving #2170:
- f0c53fb: the cinnamon theme designer edits the icons `player-playing`, `player-paused` and `player-stopped` and these are used; in older version this was hardcoded
- 7ca1101: The easier idea by @JosephMcc uses the default icons `media-playback-start`, `media-playback-pause` and `media-playback-stop`
