### PR TITLE
Stop build spam

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,7 @@ AC_CONFIG_AUX_DIR([config])
 AC_SUBST([PACKAGE_NAME], ["$PACKAGE_NAME"])
 AC_SUBST([PACKAGE_VERSION], ["$PACKAGE_VERSION"])
 
-AM_INIT_AUTOMAKE([1.11 no-dist-gzip dist-xz tar-ustar foreign])
+AM_INIT_AUTOMAKE([1.11 no-dist-gzip dist-xz tar-ustar foreign subdir-objects])
 AM_MAINTAINER_MODE([enable])
 
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])


### PR DESCRIPTION
```
src/Makefile-gvc.am:15: warning: source file 'gvc/gvc-channel-map.c' is in a subdirectory,
src/Makefile-gvc.am:15: but option 'subdir-objects' is disabled
src/Makefile.am:77:   'src/Makefile-gvc.am' included from here
src/Makefile-gvc.am:15: warning: source file 'gvc/gvc-mixer-card.c' is in a subdirectory,
src/Makefile-gvc.am:15: but option 'subdir-objects' is disabled
src/Makefile.am:77:   'src/Makefile-gvc.am' included from here
src/Makefile-gvc.am:15: warning: source file 'gvc/gvc-mixer-sink.c' is in a subdirectory,
src/Makefile-gvc.am:15: but option 'subdir-objects' is disabled
src/Makefile.am:77:   'src/Makefile-gvc.am' included from here
src/Makefile-gvc.am:15: warning: source file 'gvc/gvc-mixer-source.c' is in a subdirectory,
src/Makefile-gvc.am:15: but option 'subdir-objects' is disabled
src/Makefile.am:77:   'src/Makefile-gvc.am' included from here
src/Makefile-gvc.am:15: warning: source file 'gvc/gvc-mixer-sink-input.c' is in a subdirectory,
src/Makefile-gvc.am:15: but option 'subdir-objects' is disabled
src/Makefile.am:77:   'src/Makefile-gvc.am' included from here
src/Makefile-gvc.am:15: warning: source file 'gvc/gvc-mixer-source-output.c' is in a subdirectory,
src/Makefile-gvc.am:15: but option 'subdir-objects' is disabled
src/Makefile.am:77:   'src/Makefile-gvc.am' included from here
src/Makefile-gvc.am:15: warning: source file 'gvc/gvc-mixer-event-role.c' is in a subdirectory,
src/Makefile-gvc.am:15: but option 'subdir-objects' is disabled
src/Makefile.am:77:   'src/Makefile-gvc.am' included from here
src/Makefile-gvc.am:15: warning: source file 'gvc/gvc-mixer-control.c' is in a subdirectory,
src/Makefile-gvc.am:15: but option 'subdir-objects' is disabled
src/Makefile.am:77:   'src/Makefile-gvc.am' included from here
src/Makefile-st.am:127: warning: source file 'st/st-adjustment.c' is in a subdirectory,
src/Makefile-st.am:127: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-st.am:127: warning: source file 'st/st-background-effect.c' is in a subdirectory,
src/Makefile-st.am:127: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-st.am:127: warning: source file 'st/st-bin.c' is in a subdirectory,
src/Makefile-st.am:127: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-st.am:127: warning: source file 'st/st-border-image.c' is in a subdirectory,
src/Makefile-st.am:127: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-st.am:127: warning: source file 'st/st-box-layout.c' is in a subdirectory,
src/Makefile-st.am:127: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-st.am:127: warning: source file 'st/st-box-layout-child.c' is in a subdirectory,
src/Makefile-st.am:127: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-st.am:127: warning: source file 'st/st-button.c' is in a subdirectory,
src/Makefile-st.am:127: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-st.am:127: warning: source file 'st/st-clipboard.c' is in a subdirectory,
src/Makefile-st.am:127: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-st.am:127: warning: source file 'st/st-container.c' is in a subdirectory,
src/Makefile-st.am:127: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-st.am:127: warning: source file 'st/st-drawing-area.c' is in a subdirectory,
src/Makefile-st.am:127: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-st.am:127: warning: source file 'st/st-entry.c' is in a subdirectory,
src/Makefile-st.am:127: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-st.am:127: warning: source file 'st/st-focus-manager.c' is in a subdirectory,
src/Makefile-st.am:127: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-st.am:127: warning: source file 'st/st-group.c' is in a subdirectory,
src/Makefile-st.am:127: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-st.am:127: warning: source file 'st/st-icon.c' is in a subdirectory,
src/Makefile-st.am:127: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-st.am:127: warning: source file 'st/st-icon-colors.c' is in a subdirectory,
src/Makefile-st.am:127: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-st.am:127: warning: source file 'st/st-im-text.c' is in a subdirectory,
src/Makefile-st.am:127: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-st.am:127: warning: source file 'st/st-label.c' is in a subdirectory,
src/Makefile-st.am:127: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-st.am:127: warning: source file 'st/st-overflow-box.c' is in a subdirectory,
src/Makefile-st.am:127: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-st.am:127: warning: source file 'st/st-polygon.c' is in a subdirectory,
src/Makefile-st.am:127: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-st.am:127: warning: source file 'st/st-private.c' is in a subdirectory,
src/Makefile-st.am:127: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-st.am:127: warning: source file 'st/st-scrollable.c' is in a subdirectory,
src/Makefile-st.am:127: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-st.am:127: warning: source file 'st/st-scroll-bar.c' is in a subdirectory,
src/Makefile-st.am:127: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-st.am:127: warning: source file 'st/st-scroll-view.c' is in a subdirectory,
src/Makefile-st.am:127: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-st.am:127: warning: source file 'st/st-shadow.c' is in a subdirectory,
src/Makefile-st.am:127: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-st.am:127: warning: source file 'st/st-table.c' is in a subdirectory,
src/Makefile-st.am:127: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-st.am:127: warning: source file 'st/st-table-child.c' is in a subdirectory,
src/Makefile-st.am:127: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-st.am:127: warning: source file 'st/st-texture-cache.c' is in a subdirectory,
src/Makefile-st.am:127: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-st.am:127: warning: source file 'st/st-theme.c' is in a subdirectory,
src/Makefile-st.am:127: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-st.am:127: warning: source file 'st/st-theme-context.c' is in a subdirectory,
src/Makefile-st.am:127: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-st.am:127: warning: source file 'st/st-theme-node.c' is in a subdirectory,
src/Makefile-st.am:127: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-st.am:127: warning: source file 'st/st-theme-node-drawing.c' is in a subdirectory,
src/Makefile-st.am:127: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-st.am:127: warning: source file 'st/st-theme-node-transition.c' is in a subdirectory,
src/Makefile-st.am:127: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-st.am:127: warning: source file 'st/st-tooltip.c' is in a subdirectory,
src/Makefile-st.am:127: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-st.am:127: warning: source file 'st/st-widget.c' is in a subdirectory,
src/Makefile-st.am:127: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-st.am:164: warning: source file 'st/st-scroll-view-fade.c' is in a subdirectory,
src/Makefile-st.am:164: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
src/Makefile-tray.am:17: warning: source file 'tray/na-tray-child.c' is in a subdirectory,
src/Makefile-tray.am:17: but option 'subdir-objects' is disabled
src/Makefile.am:76:   'src/Makefile-tray.am' included from here
src/Makefile-tray.am:17: warning: source file 'tray/na-tray-manager.c' is in a subdirectory,
src/Makefile-tray.am:17: but option 'subdir-objects' is disabled
src/Makefile.am:76:   'src/Makefile-tray.am' included from here
src/Makefile-hotplug-sniffer.am:5: warning: source file 'hotplug-sniffer/cinnamon-mime-sniffer.c' is in a subdirectory,
src/Makefile-hotplug-sniffer.am:5: but option 'subdir-objects' is disabled
src/Makefile.am:78:   'src/Makefile-hotplug-sniffer.am' included from here
src/Makefile-hotplug-sniffer.am:5: warning: source file 'hotplug-sniffer/hotplug-sniffer.c' is in a subdirectory,
src/Makefile-hotplug-sniffer.am:5: but option 'subdir-objects' is disabled
src/Makefile.am:78:   'src/Makefile-hotplug-sniffer.am' included from here
src/Makefile-st.am:188: warning: source file 'st/test-theme.c' is in a subdirectory,
src/Makefile-st.am:188: but option 'subdir-objects' is disabled
src/Makefile.am:75:   'src/Makefile-st.am' included from here
```