### PR TITLE
Fixing sound applet issues #2807 and #3284

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -871,8 +871,8 @@ MyApplet.prototype = {
         }
         else if (direction == Clutter.ScrollDirection.UP) {
             this._output.volume = Math.min(this._volumeMax, currentVolume + this._volumeMax * VOLUME_ADJUSTMENT_STEP);
-            this._output.change_is_muted(false);
             this._output.push_volume();
+            this._output.change_is_muted(false);
         }
 
         this._notifyVolumeChange();


### PR DESCRIPTION
#2807: There was an issue that when sliding:
1. 1% with "low" icon
2. 0% with "low" icon
3. 0% with "mute" icon

In https://github.com/pixunil/Cinnamon/commit/e8a22a4046032aef26caba5f1db67b880037bdda step 2 is removed with a better mute handling [line 1133 - 1144]

A not reported issue was also closed: when the slider is at 100% and you scroll to decrement the value by 5% the value was 94% then 89% ..., now the expected value 95%, 90% ...
#3284: Added just two event handlers for the event `scroll-event`

https://github.com/pixunil/Cinnamon/commit/5f0712a50254450f8ccf306e9d4d4d123dedc77a
