### PR TITLE
several window effects changes

### DIFF
--- a/data/org.cinnamon.gschema.xml.in
+++ b/data/org.cinnamon.gschema.xml.in
@@ -156,7 +156,15 @@
         Whether to enable desktop effects on dialog boxes.
       </_description>
     </key>
-    
+
+    <key type="s" name="desktop-effects-style">
+      <default>"cinnamon"</default>
+      <_summary>The style of desktop effects</_summary>
+      <_description>
+        An overall style used for desktop effects
+      </_description>
+    </key>
+
     <key type="s" name="desktop-effects-close-effect">
       <default>"none"</default>
       <_summary>Effect used when closing windows</_summary>

--- a/files/usr/lib/cinnamon-settings/bin/SettingsWidgets.py
+++ b/files/usr/lib/cinnamon-settings/bin/SettingsWidgets.py
@@ -23,6 +23,7 @@ try:
     import tempfile
     import math
     import subprocess
+    import tweenEquations
 
 except Exception, detail:
     print detail
@@ -90,15 +91,9 @@ class EditableEntry (Gtk.Notebook):
     def get_text(self):
         return self.entry.get_text()
 
-class PictureChooserButton (Gtk.Button):
-
-    def __init__ (self, num_cols=4, button_picture_size=None, menu_pictures_size=None, has_button_label=False):        
-        super(PictureChooserButton, self).__init__()
-        self.num_cols = num_cols
-        self.button_picture_size = button_picture_size
-        self.menu_pictures_size = menu_pictures_size
-        self.row = 0
-        self.col = 0
+class BaseChooserButton(Gtk.Button):
+    def __init__ (self, has_button_label=False):
+        super(BaseChooserButton, self).__init__()
         self.menu = Gtk.Menu()
         self.button_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=2)
         self.button_image = Gtk.Image()
@@ -108,6 +103,47 @@ class PictureChooserButton (Gtk.Button):
             self.button_box.add(self.button_label)
         self.add(self.button_box)
         self.connect("button-release-event", self._on_button_clicked)
+
+    def popup_menu_below_button (self, menu, widget):
+        window = widget.get_window()
+        screen = window.get_screen()
+        monitor = screen.get_monitor_at_window(window)
+
+        warea = screen.get_monitor_workarea(monitor)
+        wrect = widget.get_allocation()
+        mrect = menu.get_allocation()
+
+        unused_var, window_x, window_y = window.get_origin()
+
+        # Position left edge of the menu with the right edge of the button
+        x = window_x + wrect.x + wrect.width
+        # Center the menu vertically with respect to the monitor
+        y = warea.y + (warea.height / 2) - (mrect.height / 2)
+
+        # Now, check if we're still touching the button - we want the right edge
+        # of the button always 100% touching the menu
+
+        if y > (window_y + wrect.y):
+            y = y - (y - (window_y + wrect.y))
+        elif (y + mrect.height) < (window_y + wrect.y + wrect.height):
+            y = y + ((window_y + wrect.y + wrect.height) - (y + mrect.height))
+
+        push_in = True # push_in is True so all menu is always inside screen
+        return (x, y, push_in)
+
+    def _on_button_clicked(self, widget, event):
+        if event.button == 1:
+            self.menu.show_all()
+            self.menu.popup(None, None, self.popup_menu_below_button, self, event.button, event.time)
+
+class PictureChooserButton(BaseChooserButton):
+    def __init__ (self, num_cols=4, button_picture_size=None, menu_pictures_size=None, has_button_label=False):
+        super(PictureChooserButton, self).__init__(has_button_label)
+        self.num_cols = num_cols
+        self.button_picture_size = button_picture_size
+        self.menu_pictures_size = menu_pictures_size
+        self.row = 0
+        self.col = 0
         self.progress = 0.0
 
         context = self.get_style_context()
@@ -158,38 +194,6 @@ class PictureChooserButton (Gtk.Button):
 
     def set_button_label(self, label):
         self.button_label.set_markup(label)
-
-    def popup_menu_below_button (self, menu, widget):  
-        window = widget.get_window()
-        screen = window.get_screen()
-        monitor = screen.get_monitor_at_window(window)
-
-        warea = screen.get_monitor_workarea(monitor)
-        wrect = widget.get_allocation()
-        mrect = menu.get_allocation()
-
-        unused_var, window_x, window_y = window.get_origin()
-
-        # Position left edge of the menu with the right edge of the button
-        x = window_x + wrect.x + wrect.width
-        # Center the menu vertically with respect to the monitor
-        y = warea.y + (warea.height / 2) - (mrect.height / 2)
-
-        # Now, check if we're still touching the button - we want the right edge
-        # of the button always 100% touching the menu
-
-        if y > (window_y + wrect.y):
-            y = y - (y - (window_y + wrect.y))
-        elif (y + mrect.height) < (window_y + wrect.y + wrect.height):
-            y = y + ((window_y + wrect.y + wrect.height) - (y + mrect.height))
-
-        push_in = True # push_in is True so all menu is always inside screen
-        return (x, y, push_in)
-
-    def _on_button_clicked(self, widget, event):
-        if event.button == 1:
-            self.menu.show_all()
-            self.menu.popup(None, None, self.popup_menu_below_button, self, event.button, event.time)
 
     def _on_picture_selected(self, menuitem, path, callback, id=None):
         if id is not None:

--- a/files/usr/lib/cinnamon-settings/bin/tweenEquations.py
+++ b/files/usr/lib/cinnamon-settings/bin/tweenEquations.py
@@ -1,0 +1,309 @@
+"""
+    made with the file cjs/tweener/equations.js
+
+    Original copyright notice of the source file:
+
+    Copyright 2008 litl, LLC.
+
+    Equations
+    Main equations for the Tweener class
+
+    @author              Zeh Fernando, Nate Chatellier
+    @version             1.0.2
+
+    Disclaimer for Robert Penner's Easing Equations license:
+
+    TERMS OF USE - EASING EQUATIONS
+
+    Open source under the BSD License.
+
+    Copyright (c) 2001 Robert Penner
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+    * Neither the name of the author nor the names of contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+    TWEENING EQUATIONS functions
+    (the original equations are Robert Penner's work as mentioned on the disclaimer)
+"""
+
+import math
+
+def easeNone(t, b, c, d):
+    return c * t / d + b
+
+
+def easeInQuad(t, b, c, d):
+    t /= d
+    return c * t * t + b
+
+
+def easeOutQuad(t, b, c, d):
+    t /= d
+    return -c * t * (t - 2) + b
+
+
+def easeInOutQuad(t, b, c, d):
+    t /= d / 2
+    if t < 1:
+        return c / 2 * t * t + b
+    t -= 1
+    return -c / 2 * (t * (t - 2) - 1) + b
+
+
+def easeOutInQuad(t, b, c, d):
+    if t < d / 2:
+        return easeOutQuad(t * 2, b, c / 2, d)
+    return easeInQuad((t * 2) - d, b + c / 2, c / 2, d)
+
+
+def easeInCubic(t, b, c, d):
+    t /= d
+    return c * t ** 3 + b
+
+
+def easeOutCubic(t, b, c, d):
+    t = t / d - 1
+    return c * (t ** 3 + 1) + b
+
+
+def easeInOutCubic(t, b, c, d):
+    t /= d / 2
+    if t < 1:
+        return c / 2 * t ** 3 + b
+    t -= 2
+    return c / 2 * (t ** 3 + 2) + b
+
+
+def easeOutInCubic(t, b, c, d):
+    if t < d / 2:
+        return easeOutCubic (t * 2, b, c / 2, d)
+    return easeInCubic((t * 2) - d, b + c / 2, c / 2, d)
+
+
+def easeInQuart(t, b, c, d):
+    t /= d
+    return c * t ** 4 + b
+
+
+def easeOutQuart(t, b, c, d):
+    t = t / d - 1
+    return -c * (t ** 4 - 1) + b
+
+
+def easeInOutQuart(t, b, c, d):
+    t /= d / 2
+    if t < 1:
+        return c / 2 * t ** 4 + b
+    t -= 2
+    return -c / 2 * (t ** 4 - 2) + b
+
+
+def easeOutInQuart(t, b, c, d):
+    if t < d / 2:
+        return easeOutQuart(t * 2, b, c / 2, d)
+    return easeInQuart((t * 2) - d, b + c / 2, c / 2, d)
+
+
+def easeInQuint(t, b, c, d):
+    t /= d
+    return c * t ** 5 + b
+
+
+def easeOutQuint(t, b, c, d):
+    t = t / d - 1
+    return c * (t ** 5 + 1) + b
+
+
+def easeInOutQuint(t, b, c, d):
+    t /= d / 2
+    if t < 1:
+        return c / 2 * t ** 5 + b
+    t -= 2
+    return c / 2 * (t ** 5 + 2) + b
+
+
+def easeOutInQuint(t, b, c, d):
+    if t < d / 2:
+        return easeOutQuint (t * 2, b, c / 2, d)
+    return easeInQuint((t * 2) - d, b + c / 2, c / 2, d)
+
+
+def easeInSine(t, b, c, d):
+    return -c * math.cos(t / d * (math.pi / 2)) + c + b
+
+
+def easeOutSine(t, b, c, d):
+    return c * math.sin(t / d * (math.pi / 2)) + b
+
+
+def easeInOutSine(t, b, c, d):
+    return -c / 2 * (math.cos(math.pi * t / d) - 1) + b
+
+
+def easeOutInSine(t, b, c, d):
+    if t < d / 2:
+        return easeOutSine(t * 2, b, c / 2, d)
+    return easeInSine((t * 2) - d, b + c / 2, c / 2, d)
+
+
+def easeInExpo(t, b, c, d):
+    if t <= 0:
+        return b
+    return c * pow(2, 10 * (t / d - 1)) + b
+
+
+def easeOutExpo(t, b, c, d):
+    if t >= d:
+        return b + c
+    return c * (-pow(2, -10 * t / d) + 1) + b
+
+
+def easeInOutExpo(t, b, c, d):
+    if t <= 0:
+        return b
+    if t >= d:
+        return b + c
+    t /= d / 2
+    if t < 1:
+        return c / 2 * pow(2, 10 * (t - 1)) + b
+    return c / 2 * (-pow(2, -10 * (t - 1)) + 2) + b
+
+
+def easeOutInExpo(t, b, c, d):
+    if t < d / 2:
+        return easeOutExpo (t * 2, b, c / 2, d)
+    return easeInExpo((t * 2) - d, b + c / 2, c / 2, d)
+
+
+def easeInCirc(t, b, c, d):
+    t /= d
+    return -c * (math.sqrt(1 - t * t) - 1) + b
+
+
+def easeOutCirc(t, b, c, d):
+    t = t / d - 1
+    return c * math.sqrt(1 - t * t) + b
+
+
+def easeInOutCirc(t, b, c, d):
+    t /= d / 2
+    if t < 1:
+        return -c / 2 * (math.sqrt(1 - t * t) - 1) + b
+    t -= 2
+    return c / 2 * (math.sqrt(1 - t * t) + 1) + b
+
+
+def easeOutInCirc(t, b, c, d):
+    if t < d / 2:
+        return easeOutCirc(t * 2, b, c / 2, d)
+    return easeInCirc((t * 2) - d, b + c / 2, c / 2, d)
+
+
+def easeInElastic(t, b, c, d):
+    if t <= 0:
+        return b
+    t /= d
+    if t >= 1:
+        return b + c
+    p = d * .3
+    a = c
+    s = p / 4
+    t -= 1
+    return -(a * pow(2, 10 * t) * math.sin((t * d - s) * (2 * math.pi) / p)) + b
+
+
+def easeOutElastic(t, b, c, d):
+    if t <= 0:
+        return b
+    t /= d
+    if t >= 1:
+        return b + c
+    p = d * .3
+    a = c
+    s = p / 4
+    return (a * pow(2, -10 * t) * math.sin((t * d - s) * 2 * math.pi / p) + c + b)
+
+
+def easeInOutElastic(t, b, c, d):
+    if t <= 0:
+        return b
+    t /= d / 2
+    if t >= 2:
+        return b + c
+    p = d * (.3 * 1.5)
+    s = p / 4
+    a = c
+    if t < 1:
+        t -= 1
+        return -.5 * (a * pow(2, (10 * t)) * math.sin((t * d - s) * 2 * math.pi / p)) + b
+    t -= 1
+    return a * pow(2, (-10 * t)) * math.sin((t * d - s) * 2 * math.pi / p) * .5 + c + b
+
+
+def easeOutInElastic(t, b, c, d):
+    if t < d / 2:
+        return easeOutElastic (t * 2, b, c / 2, d)
+    return easeInElastic((t * 2) - d, b + c / 2, c / 2, d)
+
+
+def easeInBack(t, b, c, d):
+    s = 1.70158
+    t /= d
+    return c * t * t * ((s + 1) * t - s) + b
+
+
+def easeOutBack(t, b, c, d):
+    s = 1.70158
+    t = t / d - 1
+    return c * (t * t * ((s + 1) * t + s) + 1) + b
+
+
+def easeInOutBack(t, b, c, d):
+    s = 1.70158 * 1.525
+    t /= d / 2
+    if t < 1:
+        return c / 2 * (t * t * ((s + 1) * t - s)) + b
+    t -= 2
+    return c / 2 * (t * t * ((s + 1) * t + s) + 2) + b
+
+
+def easeOutInBack(t, b, c, d):
+    if t < d / 2:
+        return easeOutBack (t * 2, b, c / 2, d)
+    return easeInBack((t * 2) - d, b + c / 2, c / 2, d)
+
+
+def easeInBounce(t, b, c, d):
+    return c - easeOutBounce (d - t, 0, c, d) + b
+
+
+def easeOutBounce(t, b, c, d):
+    t /= d
+    if t < (1 / 2.75):
+        return c * (7.5625 * t * t) + b
+    elif t < (2 / 2.75):
+        t -= (1.5 / 2.75)
+        return c * (7.5625 * t * t + .75) + b
+    elif t < (2.5 / 2.75):
+        t -= (2.25 / 2.75)
+        return c * (7.5625 * t * t + .9375) + b
+    t -= (2.625 / 2.75)
+    return c * (7.5625 * t * t + .984375) + b
+
+
+def easeInOutBounce(t, b, c, d):
+    if t < d / 2:
+        return easeInBounce (t * 2, 0, c, d) * .5 + b
+    return easeOutBounce (t * 2 - d, 0, c, d) * .5 + c*.5 + b
+
+
+def easeOutInBounce(t, b, c, d):
+    if t < d / 2:
+        return easeOutBounce (t * 2, b, c / 2, d)
+    return easeInBounce((t * 2) - d, b + c / 2, c / 2, d)

--- a/files/usr/lib/cinnamon-settings/bin/windowEffects.py
+++ b/files/usr/lib/cinnamon-settings/bin/windowEffects.py
@@ -1,0 +1,219 @@
+from gi.repository import Gtk, GObject
+import cairo
+
+class Previews(object):
+    def scale(self, ctx, window, x, y, c):
+        steps = 3
+        for i in range(steps):
+            window(ctx, x, y, (steps - i) * 1. / steps, (i + 1.) / steps)
+
+    def fade(self, ctx, window, x, y, c):
+        window(ctx, x, y, .5)
+
+    def blend(self, ctx, window, x, y, c):
+        steps = 3
+        for i in range(steps):
+            window(ctx, x, y, (steps - i) * 1. / steps, 1 + i / (steps - 1.) / 2)
+
+    def traditional(self, ctx, window, x, y, c):
+        gradient = cairo.LinearGradient(x, y * 2, x, y)
+        gradient.add_color_stop_rgba(0, c.red, c.green, c.blue, 0)
+        gradient.add_color_stop_rgb(1, c.red, c.green, c.blue)
+        ctx.set_source(gradient)
+        ctx.move_to(x, y * 2)
+        ctx.line_to(x * 1.5, y * 1.5)
+        ctx.line_to(x * 1.5, y * .5)
+        ctx.line_to(x * .5, y * .5)
+        ctx.line_to(x * .5, y * 1.5)
+        ctx.fill()
+
+    def move(self, ctx, window, x, y, c):
+        gradient = cairo.LinearGradient(0, 0, x, y)
+        gradient.add_color_stop_rgba(0, c.red, c.green, c.blue, 0)
+        gradient.add_color_stop_rgb(1, c.red, c.green, c.blue)
+        ctx.set_source(gradient)
+        ctx.move_to(x / 5, y / 5)
+        ctx.line_to(x * 1.5, y * .5)
+        ctx.line_to(x * 1.5, y * 1.5)
+        ctx.line_to(x * .5, y * 1.5)
+        ctx.fill()
+
+    def flyUp(self, ctx, window, x, y, c):
+        gradient = cairo.LinearGradient(0, y * 2, 0, y * 1.5)
+        gradient.add_color_stop_rgba(0, c.red, c.green, c.blue, 0)
+        gradient.add_color_stop_rgb(1, c.red, c.green, c.blue)
+        ctx.set_source(gradient)
+        ctx.rectangle(x / 2, y / 2, x, y * 1.5)
+        ctx.fill()
+
+    def flyDown(self, ctx, window, x, y, c):
+        gradient = cairo.LinearGradient(0, 0, 0, y / 2)
+        gradient.add_color_stop_rgba(0, c.red, c.green, c.blue, 0)
+        gradient.add_color_stop_rgb(1, c.red, c.green, c.blue)
+        ctx.set_source(gradient)
+        ctx.rectangle(x / 2, 0, x, y * 1.5)
+        ctx.fill()
+
+class Map(object):
+    def scale(self, ctx, window, x, y, value):
+        window(ctx, x, y, scale=value)
+
+    def fade(self, ctx, window, x, y, value):
+        window(ctx, x, y, value)
+
+    def blend(self, ctx, window, x, y, value):
+        scale = 1.5 - value / 2
+        window(ctx, x, y, value, scale)
+
+    def move(self, ctx, window, x, y, value):
+        window(ctx, x * value, y * value, scale=value)
+
+    def flyUp(self, ctx, window, x, y, value):
+        y *= 2.5 - value * 1.5
+        window(ctx, x, y)
+
+    def flyDown(self, ctx, window, x, y, value):
+        y *= -.5 + value * 1.5
+        window(ctx, x, y)
+
+    def traditional(self, ctx, window, x, y, value):
+        window(ctx, x, y, value, value)
+
+class Close(object):
+    def scale(self, ctx, window, x, y, value):
+        scale = 1 - value
+        window(ctx, x, y, scale=scale)
+
+    def fade(self, ctx, window, x, y, value):
+        window(ctx, x, y, 1 - value)
+
+    def blend(self, ctx, window, x, y, value):
+        scale = 1 + value / 2
+        window(ctx, x, y, 1 - value, scale)
+
+    def move(self, ctx, window, x, y, value):
+        value = 1 - value
+        window(ctx, x * value, y * value, scale=value)
+
+    def flyUp(self, ctx, window, x, y, value):
+        y *= 1 - value * 1.5
+        window(ctx, x, y)
+
+    def flyDown(self, ctx, window, x, y, value):
+        y *= 1 + value * 1.5
+        window(ctx, x, y)
+
+    def traditional(self, ctx, window, x, y, value):
+        scale = 1 - value / 5
+        window(ctx, x, y, 1 - value, scale)
+
+class Minimize(Close):
+    def traditional(self, ctx, window, x, y, value):
+        y *= 1 + value
+        scale = 1 - value
+        window(ctx, x, y, scale=scale)
+
+class Maximize(object):
+    def scale(self, ctx, window, x, y, value):
+        scale = 1 + value
+        window(ctx, x, y, scale=scale)
+
+class Unmaximize(object):
+    def scale(self, ctx, window, x, y, value):
+        scale = 2 - value
+        window(ctx, x, y, scale=scale)
+
+ANIMATIONS = {
+    "map": Map(),
+    "close": Close(),
+    "minimize": Minimize(),
+    "maximize": Maximize(),
+    "unmaximize": Unmaximize(),
+    "tile": Maximize()
+}
+
+PREVIEWS = Previews()
+
+
+class Effect(Gtk.DrawingArea):
+    width = 96
+    height = 48
+
+    state = -2
+    duration = 50
+
+    timer = None
+
+    animation = None
+    transition = None
+
+    def __init__(self, effect, name):
+        super(Effect, self).__init__()
+
+        self.set_size_request(self.width, self.height)
+        self.style = self.get_style_context()
+
+        self.connect("draw", self.draw)
+
+        if name in dir(PREVIEWS):
+            self.preview = getattr(PREVIEWS, name)
+
+        if name in dir(ANIMATIONS[effect]):
+            self.animation = getattr(ANIMATIONS[effect], name)
+
+    def start(self, a, b):
+        if self.state == -2:
+            self.state = -1.
+            self.queue_draw()
+            self.timer = GObject.timeout_add(400, self.frame)
+
+    def stop(self, a, b):
+        if self.timer:
+            GObject.source_remove(self.timer)
+            self.timer = None
+        self.state = -2
+        self.queue_draw()
+
+    def frame(self):
+        self.timer = None
+        self.state += 1
+
+        if self.state >= self.duration or (not self.animation and self.state >= 0):
+            return
+
+        self.queue_draw()
+
+        self.timer = GObject.timeout_add(10, self.frame)
+
+    def draw(self, widget, ctx):
+        x = self.width / 2.
+        y = self.height / 2.
+
+        if self.state < 0:
+            self.preview(ctx, self.window, x, y, self.get_color())
+        else:
+            value = self.transition(self.state % self.duration, 0, 1, self.duration - 1)
+            self.animation(ctx, self.window, x, y, value)
+
+    def get_color(self):
+        if self.state == -2:
+            return self.style.get_background_color(Gtk.StateFlags.SELECTED)
+        return self.style.get_color(Gtk.StateFlags.NORMAL)
+
+    def window(self, ctx, x, y, alpha = 1, scale = 1):
+        if scale <= 0:
+            return
+        alpha = min(max(alpha, 0), 1)
+
+        c = self.get_color()
+        ctx.set_source_rgba(c.red, c.green, c.blue, alpha)
+        ctx.save()
+        ctx.translate(x, y)
+        ctx.scale(scale, scale)
+
+        ctx.rectangle(-self.width / 4., -self.height / 4., self.width / 2., self.height / 2.)
+        ctx.fill()
+        ctx.restore()
+
+    def preview(self, ctx, window, x, y, c):
+        window(ctx, x, y)

--- a/files/usr/lib/cinnamon-settings/modules/cs_effects.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_effects.py
@@ -1,113 +1,455 @@
 #!/usr/bin/env python
 
 from SettingsWidgets import *
-from gi.repository.Gtk import SizeGroup, SizeGroupMode
+import windowEffects
+
+EFFECT_SETS = {
+    "cinnamon": ("traditional", "traditional", "traditional", "scale", "scale", "scale"),
+    "scale":    ("scale",       "scale",       "scale",       "scale", "scale", "scale"),
+    "fade":     ("fade",        "fade",        "fade",        "scale", "scale", "scale"),
+    "blend":    ("blend",       "blend",       "blend",       "scale", "scale", "scale"),
+    "move":     ("move",        "move",        "move",        "scale", "scale", "scale"),
+    "flyUp":    ("flyUp",       "flyDown",     "flyDown",     "scale", "scale", "scale"),
+    "flyDown":  ("flyDown",     "flyUp",       "flyUp",       "scale", "scale", "scale"),
+    "default":  ("scale",       "scale",       "none",        "none",  "none",  "none")
+}
+
+TRANSITIONS_SETS = {
+    "cinnamon": ("easeOutQuad",    "easeInExpo",    "easeOutExpo", "easeInExpo", "easeNone",       "easeInQuad"),
+    "normal":   ("easeOutSine",    "easeInBack",    "easeInSine",  "easeInBack", "easeOutBounce",  "easeInBack"),
+    "extra":    ("easeOutElastic", "easeOutBounce", "easeOutExpo", "easeInExpo", "easeOutElastic", "easeInExpo"),
+    "fade":     ("easeOutQuart",   "easeInQuart",   "easeInQuart", "easeInBack", "easeOutBounce",  "easeInBack")
+}
+
+TIME_SETS = {
+    "cinnamon": (150, 150, 200, 100, 100, 100),
+    "slow":     (400, 400, 400, 100, 100, 100),
+    "normal":   (250, 250, 250, 100, 100, 100),
+    "fast":     (100, 100, 100, 100, 100, 100),
+    "default":  (250, 250, 150, 400, 400, 400)
+}
+
+COMBINATIONS = {
+   #  name           effect    transition    time
+    "cinnamon":   ("cinnamon", "cinnamon", "cinnamon"),
+    "scale":      ("scale",    "normal",   "normal"),
+    "fancyScale": ("scale",    "extra",    "slow"),
+    "fade":       ("fade",     "fade",     "normal"),
+    "blend":      ("blend",    "fade",     "normal"),
+    "move":       ("move",     "normal",   "fast"),
+    "flyUp":      ("flyUp",    "normal",   "fast"),
+    "flyDown":    ("flyDown",  "normal",   "fast"),
+   #for previous versions
+    "default":    ("default",  "normal",   "default")
+}
+
+OPTIONS = (
+    ("cinnamon",   _("Cinnamon")),
+    ("scale",      _("Scale")),
+    ("fancyScale", _("Fancy Scale")),
+    ("fade",       _("Fade")),
+    ("blend",      _("Blend")),
+    ("move",       _("Move")),
+    ("flyUp",      _("Fly up, down")),
+    ("flyDown",    _("Fly down, up")),
+   #for previous versions
+    ("default",    _("Default"))
+)
 
 class Module:
+    types = ("map", "close", "minimize", "maximize", "unmaximize", "tile")
+    root = "org.cinnamon"
+    path = "org.cinnamon/desktop-effects"
+    template = "desktop-effects-%s-%s"
+
     def __init__(self, content_box):
         keywords = _("effects, fancy, window")
         sidePage = SidePage(_("Effects"), "cs-desktop-effects", keywords, content_box, module=self)
         self.sidePage = sidePage
         self.name = "effects"
         self.category = "appear"
-        self.comment = _("Control Cinnamon visual effects.")            
+        self.comment = _("Control Cinnamon visual effects.")
 
-        # Destroy window effects
-        self.transition_effects = [[effect] * 2 for effect in
-                              ["easeInQuad",
-                               "easeOutQuad",
-                               "easeInOutQuad",
-                               "easeInCubic",
-                               "easeOutCubic",
-                               "easeInOutCubic",
-                               "easeInQuart",
-                               "easeOutQuart",
-                               "easeInOutQuart",
-                               "easeInQuint",
-                               "easeOutQuint",
-                               "easeInOutQuint",
-                               "easeInSine",
-                               "easeOutSine",
-                               "easeInOutSine",
-                               "easeInExpo",
-                               "easeOutExpo",
-                               "easeInOutExpo",
-                               "easeInCirc",
-                               "easeOutCirc",
-                               "easeInOutCirc",
-                               "easeInElastic",
-                               "easeOutElastic",
-                               "easeInOutElastic",
-                               "easeInBack",
-                               "easeOutBack",
-                               "easeInOutBack",
-                               "easeInBounce",
-                               "easeOutBounce",
-                               "easeInOutBounce"]]              
-      
     def on_module_selected(self):
         if not self.loaded:
             print "Loading Effects module"
-            bg = SectionBg()        
+            bg = SectionBg()
             self.sidePage.add_widget(bg)
             vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
             bg.add(vbox)
 
-            section = Section(_("Enable Effects"))  
+            self.schema = Gio.Settings(self.root)
+            self.effect_sets = {}
+            for name, sets in COMBINATIONS.items():
+                self.effect_sets[name] = (EFFECT_SETS[sets[0]], TRANSITIONS_SETS[sets[1]], TIME_SETS[sets[2]])
+
+            self.chooser = GSettingsComboBox(_("Effects style"), "org.cinnamon", "desktop-effects-style", "org.cinnamon/desktop-effects", OPTIONS)
+            self.chooser.content_widget.connect("changed", self.on_value_changed)
+
+            section = Section(_("Enable Effects"))
+            section.add(GSettingsCheckButton(_("Enable fade effect on Cinnamon scrollboxes (like the Menu application list)"), "org.cinnamon", "enable-vfade", None))
             section.add(GSettingsCheckButton(_("Enable desktop effects"), "org.cinnamon", "desktop-effects", None))
             section.add_indented(GSettingsCheckButton(_("Enable session startup animation"), "org.cinnamon", "startup-animation", "org.cinnamon/desktop-effects"))
             section.add_indented(GSettingsCheckButton(_("Enable desktop effects on dialog boxes"), "org.cinnamon", "desktop-effects-on-dialogs", "org.cinnamon/desktop-effects"))
-            section.add(GSettingsCheckButton(_("Enable fade effect on Cinnamon scrollboxes (like the Menu application list)"), "org.cinnamon", "enable-vfade", None))
+            section.add_indented(self.chooser)
             vbox.add(section)
+
+            self.schema.connect("changed::desktop-effects", self.on_desktop_effects_enabled_changed)
 
             vbox.add(Gtk.Separator.new(Gtk.Orientation.HORIZONTAL))
 
-            section = Section(_("Customize Effects"))
-            #CLOSING WINDOWS
-            effects = [["none", _("None")], ["scale", _("Scale")], ["fade", _("Fade")]]        
-            section.add(self.make_effect_group(_("Closing windows:"), "close", effects))
-            
+            self.custom_checkbutton = Gtk.CheckButton(active = self.is_custom(), label = "<b>%s</b>" % _("Customize Effects"), margin_left = 5)
+            self.custom_checkbutton.get_children()[0].set_use_markup(True)
+            self.custom_checkbutton.connect("toggled", self.update_effects)
+            vbox.pack_start(self.custom_checkbutton, False, True, 0)
+
+            self.grid = Gtk.Grid(row_spacing = 5, column_spacing = 5, border_width = 12)
+
+            i = 1
+            for text in [_("Effect"), _("Transition"), _("Duration")]:
+                label = Gtk.Label(text)
+                self.grid.attach(label, i, 0, 1, 1)
+                i += 1
+
             #MAPPING WINDOWS
-            effects = [["none", _("None")], ["scale", _("Scale")], ["fade", _("Fade")]]        
-            section.add(self.make_effect_group(_("Mapping windows:"), "map", effects))
-            
+            effects = [
+                ["none",    _("None")],
+                ["scale",   _("Scale")],
+                ["fade",    _("Fade")],
+                ["blend",   _("Blend")],
+                ["move",    _("Move")],
+                ["flyUp",   _("Fly up")],
+                ["flyDown", _("Fly down")],
+                ["traditional", _("Traditional")]
+            ]
+            self.make_effect_group(_("Mapping windows:"), "map", effects, 1)
+
+            #CLOSING WINDOWS
+            self.make_effect_group(_("Closing windows:"), "close", effects, 2)
+
             #MINIMIZING WINDOWS
-            effects = [["none", _("None")], ["traditional", _("Traditional")], ["scale", _("Scale")], ["fade", _("Fade")]]
-            section.add(self.make_effect_group(_("Minimizing windows:"), "minimize", effects))
-            
+            self.make_effect_group(_("Minimizing windows:"), "minimize", effects, 3)
+
             #MAXIMIZING WINDOWS
-            effects = [["none", _("None")], ["scale", _("Scale")]]        
-            section.add(self.make_effect_group(_("Maximizing windows:"), "maximize", effects))
-            
-            #UNMAXIMIZING WINDOWS
             effects = [["none", _("None")], ["scale", _("Scale")]]
-            section.add(self.make_effect_group(_("Unmaximizing windows:"), "unmaximize", effects))
+            self.make_effect_group(_("Maximizing windows:"), "maximize", effects, 4)
+
+            #UNMAXIMIZING WINDOWS
+            self.make_effect_group(_("Unmaximizing windows:"), "unmaximize", effects, 5)
 
             #TILING WINDOWS
-            effects = [["none", _("None")], ["scale", _("Scale")]]
-            section.add(self.make_effect_group(_("Tiling and snapping windows:"), "tile", effects))
-            
-            vbox.add(section)
+            self.make_effect_group(_("Tiling and snapping windows:"), "tile", effects, 6)
 
-    def make_effect_group(self, group_label, key, effects):
+            vbox.add(self.grid)
+            self.update_effects(self.custom_checkbutton)
+
+    def make_effect_group(self, group_label, key, effects, row):
         tmin, tmax, tstep, tdefault = (0, 2000, 50, 200)
-        self.size_groups = getattr(self, "size_groups", [SizeGroup.new(SizeGroupMode.HORIZONTAL) for x in range(4)])
-        root = "org.cinnamon"
-        path = "org.cinnamon/desktop-effects"
-        template = "desktop-effects-%s-%s"
-        box = Gtk.HBox()
+
         label = Gtk.Label()
         label.set_markup(group_label)
         label.props.xalign = 0.0
-        self.size_groups[0].add_widget(label)
-        box.add(label)
-        w = GSettingsComboBox("", root, template % (key, "effect"), path, effects)
-        self.size_groups[1].add_widget(w)
-        box.add(w)
-        w = GSettingsComboBox("", root, template % (key, "transition"), path, self.transition_effects)
-        self.size_groups[2].add_widget(w)
-        box.add(w)
-        w = GSettingsSpinButton("", root, template % (key, "time"), path, tmin, tmax, tstep, tdefault, _("milliseconds"))
-        self.size_groups[3].add_widget(w)
-        box.add(w)
-        return box
+        self.grid.attach(label, 0, row, 1, 1)
+
+        effect = GSettingsEffectChooserButton(self.root, self.template % (key, "effect"), self.path, effects, key)
+        tween = GSettingsTweenChooserButton(self.root, self.template % (key, "transition"), self.path)
+        time = GSettingsSpinButton("", self.root, self.template % (key, "time"), self.path, tmin, tmax, tstep, tdefault, _("milliseconds"))
+
+        self.grid.attach(effect, 1, row, 1, 1)
+        self.grid.attach(tween, 2, row, 1, 1)
+        self.grid.attach(time, 3, row, 1, 1)
+
+        effect.bind_transition(self.template % (key, "transition"))
+        effect.bind_time(self.template % (key, "time"))
+        tween.bind_time(self.template % (key, "time"))
+
+    def is_custom(self):
+        effects = []
+        transitions = []
+        times = []
+
+        for i in self.types:
+            effects.append(self.schema.get_string(self.template % (i, "effect")))
+            transitions.append(self.schema.get_string(self.template % (i, "transition")))
+            times.append(self.schema.get_int(self.template % (i, "time")))
+
+        value = (tuple(effects), tuple(transitions), tuple(times))
+        return value != self.effect_sets[self.chooser.value]
+
+    def on_value_changed(self, widget):
+        value = self.effect_sets[self.schema.get_string("desktop-effects-style")]
+        j = 0
+        for i in self.types:
+            self.schema.set_string(self.template % (i, "effect"), value[0][j])
+            self.schema.set_string(self.template % (i, "transition"), value[1][j])
+            self.schema.set_int(self.template % (i, "time"), value[2][j])
+            j += 1
+
+    def update_effects(self, checkbutton):
+        active = checkbutton.get_active()
+
+        self.grid.set_sensitive(active)
+        #when unchecking the checkbutton, reset the values
+        if not active:
+            self.on_value_changed(self.chooser)
+
+    def on_desktop_effects_enabled_changed(self, schema, key):
+        active = schema.get_boolean(key)
+
+        self.custom_checkbutton.set_sensitive(active)
+        self.update_effects(self.custom_checkbutton)
+
+class GSettingsEffectChooserButton(BaseChooserButton):
+    def __init__(self, schema, key, dep_key, options, effect):
+        super(GSettingsEffectChooserButton, self).__init__()
+
+        self._schema = Gio.Settings.new(schema)
+        self._key = key
+        self.options = options
+        self.effect = effect
+        self.value = self._schema.get_string(key)
+
+        col = 0
+        row = 0
+        for i in options:
+            self.build_menuitem(i, col, row)
+            if i[0] == self.value:
+                self.set_label(i[1])
+            col += 1
+            if col >= 4:
+                col = 0
+                row += 1
+
+        self.set_size_request(72, -1)
+
+        self.dep_key = dep_key
+        self.dependency_invert = False
+        if self.dep_key is not None:
+            if self.dep_key[0] == '!':
+                self.dependency_invert = True
+                self.dep_key = self.dep_key[1:]
+            split = self.dep_key.split('/')
+            self.dep_settings = Gio.Settings.new(split[0])
+            self.dep_key = split[1]
+            self.dep_settings.connect("changed::" + self.dep_key, self.on_dependency_setting_changed)
+            self.on_dependency_setting_changed(self, None)
+
+        self._schema.connect("changed::" + key, self.on_gsettings_value_changed)
+
+    def build_menuitem(self, option, col, row):
+        menuitem = EffectMenuItem(option[0], option[1], self.effect)
+        menuitem.connect("activate", self.change_value)
+        self.menu.attach(menuitem, col, col + 1, row, row + 1)
+
+    def bind_transition(self, transition_key):
+        self._schema.connect("changed::" + transition_key, self.update_transition)
+        self.update_transition(self._schema, transition_key)
+
+    def update_transition(self, settings, key):
+        transition = settings.get_string(key)
+        for item in self.menu.get_children():
+            item.graph.transition = getattr(tweenEquations, transition, tweenEquations.easeNone)
+
+    def bind_time(self, key):
+        self._schema.connect("changed::" + key, self.update_time)
+        self.update_time(self._schema, key)
+
+    def update_time(self, settings, key):
+        time = settings.get_int(key) / 10
+        for item in self.menu.get_children():
+            item.graph.duration = time
+
+    def on_dependency_setting_changed(self, settings, dep_key):
+        if not self.dependency_invert:
+            self.set_sensitive(self.dep_settings.get_boolean(self.dep_key))
+        else:
+            self.set_sensitive(not self.dep_settings.get_boolean(self.dep_key))
+
+    def change_value(self, widget):
+        self.value = widget.value
+        self.set_label(widget.name)
+        self._schema.set_string(self._key, self.value)
+
+    def on_gsettings_value_changed(self, a, b):
+        self.value = self._schema.get_string(self._key)
+        for i in self.options:
+            if i[0] == self.value:
+                self.set_label(i[1])
+
+class EffectMenuItem(Gtk.MenuItem):
+    def __init__(self, value, name, effect):
+        super(EffectMenuItem, self).__init__()
+        self.graph = windowEffects.Effect(effect, value)
+        self.value = value
+        self.name = name
+
+        self.vbox = Gtk.VBox()
+        self.add(self.vbox)
+
+        self.connect("enter-notify-event", self.graph.start)
+        self.connect("leave-notify-event", self.graph.stop)
+        self.vbox.add(self.graph)
+
+        label = Gtk.Label()
+        self.vbox.add(label)
+        label.set_text(name)
+
+class GSettingsTweenChooserButton(BaseChooserButton):
+    def __init__(self, schema, key, dep_key):
+        super(GSettingsTweenChooserButton, self).__init__()
+
+        self._schema = Gio.Settings.new(schema)
+        self._key = key
+        self.dep_key = dep_key
+        self.value = self._schema.get_string(key)
+        self.options = []
+
+        self.set_label(self.value)
+        self.set_size_request(128, -1)
+
+        self.build_menuitem("None", 0, 0)
+
+        row = 1
+        for main in ["Quad", "Cubic", "Quart", "Quint", "Sine", "Expo", "Circ", "Elastic", "Back", "Bounce"]:
+            col = 0
+            for prefix in ["In", "Out", "InOut", "OutIn"]:
+                self.build_menuitem(prefix + main, col, row)
+                self.options.append("ease" + prefix + main)
+                col += 1
+            row += 1
+
+        self._schema.connect("changed::" + key, self.on_gsettings_value_changed)
+
+        self.dependency_invert = False
+        if self.dep_key is not None:
+            if self.dep_key[0] == '!':
+                self.dependency_invert = True
+                self.dep_key = self.dep_key[1:]
+            split = self.dep_key.split('/')
+            self.dep_settings = Gio.Settings.new(split[0])
+            self.dep_key = split[1]
+            self.dep_settings.connect("changed::" + self.dep_key, self.on_dependency_setting_changed)
+            self.on_dependency_setting_changed(self, None)
+
+    def on_dependency_setting_changed(self, settings, dep_key):
+        if not self.dependency_invert:
+            self.set_sensitive(self.dep_settings.get_boolean(self.dep_key))
+        else:
+            self.set_sensitive(not self.dep_settings.get_boolean(self.dep_key))
+
+    def build_menuitem(self, name, col, row):
+        menuitem = TweenMenuItem("ease" + name)
+        menuitem.connect("activate", self.change_value)
+        self.menu.attach(menuitem, col, col + 1, row, row + 1)
+
+    def bind_time(self, key):
+        self._schema.connect("changed::" + key, self.update_time)
+        self.update_time(self._schema, key)
+
+    def update_time(self, settings, key):
+        time = settings.get_int(key) / 10
+        for item in self.menu.get_children():
+            item.duration = time
+
+    def change_value(self, widget):
+        self.value = widget.name
+        self.set_label(self.value)
+        self._schema.set_string(self._key, self.value)
+
+    def on_gsettings_value_changed(self, a, b):
+        self.value = self._schema.get_string(self._key)
+        for i in self.options:
+            if i == self.value:
+                self.set_label(i)
+
+class TweenMenuItem(Gtk.MenuItem):
+    width = 96
+    height = 48
+
+    state = -1
+    duration = 50
+
+    timer = None
+
+    def __init__(self, name):
+        super(TweenMenuItem, self).__init__()
+
+        self.name = name
+        self.function = getattr(tweenEquations, name)
+
+        self.vbox = Gtk.VBox()
+        self.add(self.vbox)
+
+        box = Gtk.Box()
+        self.vbox.add(box)
+
+        self.graph = Gtk.DrawingArea()
+        box.add(self.graph)
+        self.graph.set_size_request(self.width, self.height)
+        self.graph.connect("draw", self.draw_graph)
+
+        self.arr = Gtk.DrawingArea()
+        box.pack_end(self.arr, False, False, 0)
+        self.arr.set_size_request(5, self.height)
+        self.arr.connect("draw", self.draw_arr)
+
+        self.connect("enter-notify-event", self.start_animation)
+        self.connect("leave-notify-event", self.end_animation)
+
+        label = Gtk.Label()
+        self.vbox.add(label)
+        label.set_text(name)
+
+    def draw_graph(self, widget, ctx):
+        width = self.width - 2.
+        height = self.height / 8.
+
+        context = widget.get_style_context()
+        if self.state == -1:
+            c = context.get_background_color(Gtk.StateFlags.SELECTED)
+        else:
+            c = context.get_color(Gtk.StateFlags.NORMAL)
+        ctx.set_source_rgb(c.red, c.green, c.blue)
+
+        ctx.move_to(1, height * 6)
+        for i in range(int(width)):
+            ctx.line_to(i + 2, self.function(i + 1., height * 6, -height * 4, width))
+        ctx.stroke()
+
+    def draw_arr(self, widget, ctx):
+        if self.state < 0:
+            return
+        height = self.height / 8.
+
+        context = widget.get_style_context()
+        c = context.get_color(Gtk.StateFlags.NORMAL)
+        ctx.set_source_rgb(c.red, c.green, c.blue)
+
+        ctx.arc(5, self.function(self.state, height * 6, -height * 4, self.duration - 1), 5, math.pi / 2, math.pi * 1.5)
+        ctx.fill()
+
+    def start_animation(self, a, b):
+        self.state = 0.
+        self.graph.queue_draw()
+        self.arr.queue_draw()
+
+        self.timer = GObject.timeout_add(400, self.frame)
+
+    def end_animation(self, a, b):
+        if self.timer:
+            GObject.source_remove(self.timer)
+            self.timer = None
+
+        self.state = -1
+        self.graph.queue_draw()
+        self.arr.queue_draw()
+
+    def frame(self):
+        self.timer = None
+        self.state += 1
+
+        if self.state >= self.duration:
+            return
+
+        self.arr.queue_draw()
+        self.timer = GObject.timeout_add(10, self.frame)

--- a/files/usr/share/cinnamon/applets/settings-example@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/settings-example@cinnamon.org/applet.js
@@ -3,7 +3,8 @@ const Lang = imports.lang;
 const PopupMenu = imports.ui.popupMenu;
 const Mainloop = imports.mainloop;
 const Settings = imports.ui.settings;  // Needed for settings API
-const Gio = imports.gi.Gio
+const Gio = imports.gi.Gio;
+const Tweener = imports.ui.tweener;
 const Main = imports.ui.main;
 
 function MyApplet(orientation, panel_height, instance_id) {
@@ -58,6 +59,11 @@ MyApplet.prototype = {
         this.settings.bindProperty(Settings.BindingDirection.IN,
                                  "custom-label",
                                  "custom_label",
+                                 this.on_settings_changed,
+                                 null);
+        this.settings.bindProperty(Settings.BindingDirection.IN,
+                                 "tween-function",
+                                 "tween_function",
                                  this.on_settings_changed,
                                  null);
         this.settings.bindProperty(Settings.BindingDirection.IN,
@@ -131,6 +137,21 @@ MyApplet.prototype = {
         let timeoutId = Mainloop.timeout_add(3000, Lang.bind(this, function() {
             this.on_settings_changed();
         }));
+
+        //animate icon
+        Tweener.addTween(this._applet_icon, {
+            margin_left: 10,
+            time: .5,
+            transition: this.tween_function,
+            onComplete: function(){
+                Tweener.addTween(this._applet_icon, {
+                    margin_left: 0,
+                    time: .5,
+                    transition: this.tween_function
+                });
+            },
+           onCompleteScope: this
+        });
     },
 
     on_hotkey_triggered: function() {

--- a/files/usr/share/cinnamon/applets/settings-example@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/settings-example@cinnamon.org/settings-schema.json
@@ -67,6 +67,12 @@
     "dependency" : "use-custom-label",
     "tooltip" : "Set your custom label here.  This field is unavailable unless the checkbox above is enabled"
  },
+ "tween-function" : {
+    "type" : "tween",
+    "default" : "EaseNone",
+    "description" : "Animation type",
+    "tooltip": "A tween chooser has as value a string, which you can pass as transition to Tweener.addTween()"
+ },
  "demo-button" : {
     "type" : "button",
     "description" : "Don't Press This Button!!!",

--- a/js/Makefile.am
+++ b/js/Makefile.am
@@ -77,6 +77,7 @@ nobase_dist_js_DATA = \
 	ui/tweener.js		\
 	ui/windowAttentionHandler.js	\
 	ui/windowManager.js	\
+	ui/windowEffects.js	\
 	ui/workspace.js		\
 	ui/workspacesView.js	\
 	ui/xdndHandler.js

--- a/js/ui/settings.js
+++ b/js/ui/settings.js
@@ -83,6 +83,13 @@ var STRING_TYPES = {
             "options"
         ]
     },
+    "tween" : {
+        "required-fields": [
+            "type",
+            "default",
+            "description"
+        ]
+    },
     "keybinding" : {
         "required-fields": [
             "type",

--- a/js/ui/windowEffects.js
+++ b/js/ui/windowEffects.js
@@ -1,0 +1,364 @@
+const Clutter = imports.gi.Clutter;
+const Meta = imports.gi.Meta;
+
+const AppletManager = imports.ui.appletManager;
+const Main = imports.ui.main;
+const Tweener = imports.ui.tweener;
+
+function Effect(){
+    throw new TypeError("Trying to instantiate abstract class WindowEffects.Effect");
+}
+
+Effect.prototype = {
+    _init: function(wm){
+        //wm is the instance of windowManger.js
+        this.wm = wm;
+    },
+
+    _end: function(actor){
+        actor.set_scale(1, 1);
+        actor.opacity = actor.orig_opacity || 255;
+        actor.move_anchor_point_from_gravity(Clutter.Gravity.NORTH_WEST);
+    },
+
+    _fadeWindow: function(cinnamonwm, actor, opacity, time, transition){
+        Tweener.addTween(actor, {
+            opacity: opacity,
+            time: time,
+            min: 0,
+            max: 255,
+            transition: transition,
+            onComplete: this.wm._endWindowEffect,
+            onCompleteScope: this.wm,
+            onCompleteParams: [cinnamonwm, this.name, actor]
+        });
+    },
+
+    _scaleWindow: function(cinnamonwm, actor, scale_x, scale_y, time, transition, keepAnchorPoint){
+        if (!keepAnchorPoint)
+            actor.move_anchor_point_from_gravity(Clutter.Gravity.CENTER);
+
+        Tweener.addTween(actor, {
+            scale_x: scale_x,
+            scale_y: scale_y,
+            time: time,
+            min: 0,
+            transition: transition,
+            onComplete: this.wm._endWindowEffect,
+            onCompleteScope: this.wm,
+            onCompleteParams: [cinnamonwm, this.name, actor]
+        });
+    },
+
+    _moveWindow: function(cinnamonwm, actor, x, y, time, transition){
+        Tweener.addTween(actor, {
+            x: x,
+            y: y,
+            time: time,
+            transition: transition,
+            onComplete: this.wm._endWindowEffect,
+            onCompleteScope: this.wm,
+            onCompleteParams: [cinnamonwm, this.name, actor]
+        });
+    }
+};
+
+function Map(){
+    this._init.apply(this, arguments);
+}
+
+Map.prototype = {
+    __proto__: Effect.prototype,
+    name: "map",
+    arrayName: "_mapping",
+    wmCompleteName: "completed_map",
+
+    scale: function(cinnamonwm, actor, time, transition){
+        actor.set_scale(0, 0);
+        this._scaleWindow(cinnamonwm, actor, 1, 1, time, transition);
+    },
+
+    fade: function(cinnamonwm, actor, time, transition){
+        actor.opacity = 0;
+        this._fadeWindow(cinnamonwm, actor, actor.orig_opacity, time, transition);
+    },
+
+    blend: function(cinnamonwm, actor, time, transition){
+        actor.opacity = 0;
+        actor.set_scale(1.5, 1.5);
+        this._fadeWindow(cinnamonwm, actor, actor.orig_opacity, time, transition);
+        this._scaleWindow(cinnamonwm, actor, 1, 1, time, transition);
+    },
+
+    move: function(cinnamonwm, actor, time, transition){
+        let [width, height] = actor.get_allocation_box().get_size();
+        let [xDest, yDest] = actor.get_transformed_position();
+        xDest += width /= 2;
+        yDest += height /= 2;
+
+        let [xSrc, ySrc] = global.get_pointer();
+        xSrc -= width;
+        ySrc -= height;
+        actor.set_position(xSrc, ySrc);
+
+        actor.set_scale(0, 0);
+
+        this._scaleWindow(cinnamonwm, actor, 1, 1, time, transition);
+        this._moveWindow(cinnamonwm, actor, xDest, yDest, time, transition);
+    },
+
+    flyUp: function(cinnamonwm, actor, time, transition){
+        //FIXME: somehow we need this line to get the correct position, without it will return [0, 0]
+        actor.get_allocation_box().get_size();
+        let [xDest, yDest] = actor.get_transformed_position();
+        let ySrc = global.stage.get_height();
+
+        actor.set_position(xDest, ySrc);
+
+        let dist = Math.abs(ySrc - yDest);
+        time *= dist / Main.layoutManager.primaryMonitor.height * 2; // The transition time set is the time if the animation starts/ends at the middle of the screen. Scale it proportional to the actual distance so that the speed of all animations will be constant.
+
+        this._moveWindow(cinnamonwm, actor, xDest, yDest, time, transition);
+
+    },
+
+    flyDown: function(cinnamonwm, actor, time, transition){
+        //FIXME - see also flyUp
+        actor.get_allocation_box().get_size();
+        let [xDest, yDest] = actor.get_transformed_position();
+        let ySrc = -actor.get_allocation_box().get_height();
+
+        actor.set_position(xDest, ySrc);
+
+        let dist = Math.abs(ySrc - yDest);
+        time *= dist / Main.layoutManager.primaryMonitor.height * 2; // The time time set is the time if the animation starts/ends at the middle of the screen. Scale it proportional to the actual distance so that the speed of all animations will be constant.
+
+        this._moveWindow(cinnamonwm, actor, xDest, yDest, time, transition);
+    },
+
+    traditional: function(cinnamonwm, actor, time, transition) {
+        switch (actor._windowType) {
+            case Meta.WindowType.NORMAL:
+                actor.set_pivot_point(0, 0);
+                actor.scale_x = 0.01;
+                actor.scale_y = 0.05;
+                actor.opacity = 0;
+                this._fadeWindow(cinnamonwm, actor, actor.orig_opacity, time, transition);
+                this._scaleWindow(cinnamonwm, actor, 1, 1, time, transition);
+                break;
+            case Meta.WindowType.MODAL_DIALOG:
+            case Meta.WindowType.DIALOG:
+                actor.set_pivot_point(0, 0);
+                actor.scale_x = 1;
+                actor.scale_y = 0;
+                actor.opacity = 0;
+                this._fadeWindow(cinnamonwm, actor, actor.orig_opacity, time, transition);
+                this._scaleWindow(cinnamonwm, actor, 1, 1, time, transition);
+                break;
+            default:
+                this._fadeWindow(cinnamonwm, actor, actor.orig_opacity, time, transition);
+        }
+    }
+}
+
+function Close(){
+    this._init.apply(this, arguments);
+}
+
+Close.prototype = {
+    __proto__: Effect.prototype,
+    name: "close",
+    arrayName: "_destroying",
+    wmCompleteName: "completed_destroy",
+
+    _end: function(actor){
+        let parent = actor.get_meta_window().get_transient_for();
+        if(parent && actor._parentDestroyId){
+            parent.disconnect(actor._parentDestroyId);
+            actor._parentDestroyId = 0;
+        }
+    },
+
+    scale: function(cinnamonwm, actor, time, transition){
+        this._scaleWindow(cinnamonwm, actor, 0, 0, time, transition);
+    },
+
+    fade: function(cinnamonwm, actor, time, transition){
+        Tweener.removeTweens(actor);
+        this._fadeWindow(cinnamonwm, actor, 0, time, transition);
+    },
+
+    blend: function(cinnamonwm, actor, time, transition){
+        this._fadeWindow(cinnamonwm, actor, 0, time, transition);
+        this._scaleWindow(cinnamonwm, actor, 1.5, 1.5, time, transition);
+    },
+
+    move: function(cinnamonwm, actor, time, transition){
+        let [xDest, yDest] = global.get_pointer();
+
+        this._scaleWindow(cinnamonwm, actor, 0, 0, time, transition);
+        this._moveWindow(cinnamonwm, actor, xDest, yDest, time, transition);
+    },
+
+    flyUp: function(cinnamonwm, actor, time, transition){
+        let xDest = actor.get_transformed_position()[0];
+        let yDest = -actor.get_allocation_box().get_height();
+
+        let dist = Math.abs(actor.get_transformed_position()[1] - yDest);
+        time *= dist / Main.layoutManager.primaryMonitor.height * 2; // The time time set is the time if the animation starts/ends at the middle of the screen. Scale it proportional to the actual distance so that the speed of all animations will be constant.
+
+        this._moveWindow(cinnamonwm, actor, xDest, yDest, time, transition);
+    },
+
+    flyDown: function(cinnamonwm, actor, time, transition){
+        let xDest = actor.get_transformed_position()[0];
+        let yDest = global.stage.get_height();
+
+        let dist = Math.abs(actor.get_transformed_position()[1] - yDest);
+        time *= dist / Main.layoutManager.primaryMonitor.height * 2; // The transition time set is the time if the animation starts/ends at the middle of the screen. Scale it proportional to the actual distance so that the speed of all animations will be constant.
+
+        this._moveWindow(cinnamonwm, actor, xDest, yDest, time, transition);
+    },
+
+    traditional: function(cinnamonwm, actor, time, transition) {
+        switch (actor._windowType) {
+            case Meta.WindowType.NORMAL:
+                actor.set_pivot_point(0, 0);
+                this._scaleWindow(cinnamonwm, actor, 0.8, 0.8, time, transition);
+                this._fadeWindow(cinnamonwm, actor, 0.5, time, transition);
+                break;
+            case Meta.WindowType.MODAL_DIALOG:
+            case Meta.WindowType.DIALOG:
+                actor.set_pivot_point(0, 0);
+                this._fadeWindow(cinnamonwm, actor, 0.5, time, transition);
+                this._scaleWindow(cinnamonwm, actor, 1.0, 0, time, transition);
+                break;
+            default:
+                this.scale(cinnamonwm, actor, time, transition);
+        }
+    }
+}
+
+function Minimize(){
+    this._init.apply(this, arguments);
+}
+
+Minimize.prototype = {
+    __proto__: Close.prototype,
+    name: "minimize",
+    arrayName: "_minimizing",
+    wmCompleteName: "completed_minimize",
+
+    //use default _end method
+    _end: Effect.prototype._end,
+
+    traditional: function(cinnamonwm, actor, time, transition){
+        if(AppletManager.get_role_provider_exists(AppletManager.Roles.WINDOWLIST)){
+            let windowApplet = AppletManager.get_role_provider(AppletManager.Roles.WINDOWLIST);
+            let actorOrigin = windowApplet.getOriginFromWindow(actor.get_meta_window());
+
+            if(actorOrigin !== false){
+                actor.set_scale(1, 1);
+                let [xDest, yDest] = actorOrigin.get_transformed_position();
+                // Adjust horizontal destination or it'll appear to zoom
+                // down to our button's left (or right in RTL) edge.
+                // To center it, we'll add half its width.
+                // We use the allocation box because otherwise our
+                // pseudo-class ":focus" may be larger when not minimized.
+                xDest += actorOrigin.get_allocation_box().get_size()[0] / 2;
+                actor.get_meta_window()._cinnamonwm_has_origin = true;
+                this._moveWindow(cinnamonwm, actor, xDest, yDest, time, transition);
+                this._scaleWindow(cinnamonwm, actor, 0, 0, time, transition, true);
+                return; // done
+            }
+        }
+        this.scale(cinnamonwm, actor, time, transition); // fall-back effect
+    }
+}
+
+function Unminimize(){
+    this._init.apply(this, arguments);
+}
+
+Unminimize.prototype = {
+    //unminimizing is a "map" effect but should use "minimize" setting values
+    __proto__: Effect.prototype,
+    name: "unminimize",
+    arrayName: "_mapping",
+    wmCompleteName: "completed_map",
+
+    _end: Map.prototype._end,
+
+    traditional: function(cinnamonwm, actor, time, transition){
+        if(AppletManager.get_role_provider_exists(AppletManager.Roles.WINDOWLIST)){
+            let windowApplet = AppletManager.get_role_provider(AppletManager.Roles.WINDOWLIST);
+            let actorOrigin = windowApplet.getOriginFromWindow(actor.get_meta_window());
+
+            if(actorOrigin !== false){
+                actor.set_scale(0, 0);
+                let [xDest, yDest] = actor.get_transformed_position();
+                let [xSrc, ySrc] = actorOrigin.get_transformed_position();
+                // Adjust horizontal destination or it'll appear to zoom
+                // down to our button's left (or right in RTL) edge.
+                // To center it, we'll add half its width.
+                xSrc += actorOrigin.get_allocation_box().get_size()[0] / 2;
+                actor.set_position(xSrc, ySrc);
+
+                this._moveWindow(cinnamonwm, actor, xDest, yDest, time, transition);
+                this._scaleWindow(cinnamonwm, actor, 1, 1, time, transition, true);
+                return;
+            }
+        }
+        throw "No origin found";
+    }
+}
+
+function Tile(){
+    this._init.apply(this, arguments);
+}
+
+Tile.prototype = {
+    __proto__: Effect.prototype,
+    name: "tile",
+    arrayName: "_tiling",
+    wmCompleteName: "completed_tile",
+
+    scale: function(cinnamonwm, actor, time, transition, args){
+        let [targetX, targetY, targetWidth, targetHeight] = args;
+        if(targetWidth == actor.width)
+            targetWidth -= 1;
+        if(targetHeight == actor.height)
+            targetHeight -= 1;
+
+        let scale_x = targetWidth / actor.width;
+        let scale_y = targetHeight / actor.height;
+        let anchor_x = (actor.x - targetX) * actor.width / (targetWidth - actor.width);
+        let anchor_y = (actor.y - targetY) * actor.height / (targetHeight - actor.height);
+
+        actor.move_anchor_point(anchor_x, anchor_y);
+
+        this._scaleWindow(cinnamonwm, actor, scale_x, scale_y, time, transition, true);
+    }
+}
+
+function Maximize(){
+    this._init.apply(this, arguments);
+}
+
+Maximize.prototype = {
+    __proto__: Tile.prototype,
+    name: "maximize",
+    arrayName: "_maximizing",
+    wmCompleteName: "completed_maximize",
+}
+
+function Unmaximize(){
+    this._init.apply(this, arguments);
+}
+
+Unmaximize.prototype = {
+    __proto__: Tile.prototype,
+    name: "unmaximize",
+    arrayName: "_unmaximizing",
+    wmCompleteName: "completed_unmaximize"
+}


### PR DESCRIPTION
Depends on linuxmint/cjs#18

## setting widgets
new super class `BaseChooserButton`
### EffectChooserButton
- For cs_effects
- displays static previews (can be improved)
- starts an animation on hover
![shot](https://cloud.githubusercontent.com/assets/7093655/5062042/2e0fc5e8-6db1-11e4-8f39-e1e5a4649785.png)

### TweenChooserButton
#3603
- For cs_effects and Xlet settings
- displays static graphs
- starts an animation (a little arc moving up)
![shot](https://cloud.githubusercontent.com/assets/7093655/4797483/e7b95f32-5e0b-11e4-9ed9-17449f3a8b6f.png)

## window effects
#1682

### New effects
Effect | Mapping | Closing and Minimizing
-----|-------|------
Blend | Window fades in and scales from 1.5 down to 1 | Window fades out and scales to 1.5
Move | starts at the current mouse pointer position and then scales and moves to the destination. | scales down to 0 and moves to the current mouse pointer position
Fly up | starts at the bottom edge and moves to the destination | moves to the top edge
Fly down | starts at the top edge and moves to the destination | moves to the bottom edge

All effects are now in a new file `windowEffects.js`

## other changes
- scale tweens can't go under 0 anymore (like in the elastic and back transitions)
- opacity tweens can't go under 0 or above 255 anymore