### PR TITLE
Configure first day of week in calendar

### DIFF
--- a/files/usr/lib/cinnamon-settings/modules/cs_calendar.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_calendar.py
@@ -33,5 +33,8 @@ class Module:
             section = Section(_("Date Format"))
             section.add(GSettingsCheckButton(_("Use 24h clock"), "org.cinnamon.desktop.interface", "clock-use-24h", None))
             section.add(GSettingsCheckButton(_("Display the date"), "org.cinnamon.desktop.interface", "clock-show-date", None))
-            section.add(GSettingsCheckButton(_("Display seconds"), "org.cinnamon.desktop.interface", "clock-show-seconds", None))        
+            section.add(GSettingsCheckButton(_("Display seconds"), "org.cinnamon.desktop.interface", "clock-show-seconds", None))
+
+            days = [[7, _("Use locale default")], [0, _("Sunday")], [1, _("Monday")]]
+            section.add(GSettingsIntComboBox(_("First day of week"), "org.cinnamon.desktop.interface", "first-day-of-week", None, days))
             vbox.add(section)

--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/calendar.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/calendar.js
@@ -13,6 +13,8 @@ const Settings = imports.ui.settings;
 const MSECS_IN_DAY = 24 * 60 * 60 * 1000;
 const WEEKDATE_HEADER_WIDTH_DIGITS = 3;
 const SHOW_WEEKDATE_KEY = 'show-weekdate';
+const FIRST_WEEKDAY_KEY = 'first-day-of-week';
+const DESKTOP_SCHEMA = 'org.cinnamon.desktop.interface';
 
 String.prototype.capitalize = function() {
     return this.charAt(0).toUpperCase() + this.slice(1);
@@ -175,6 +177,8 @@ Calendar.prototype = {
         this.settings = settings;
 
         this.settings.connect("changed::show-week-numbers", Lang.bind(this, this._onSettingsChange));
+        this.desktop_settings = new Gio.Settings({ schema: DESKTOP_SCHEMA });
+        this.desktop_settings.connect("changed::" + FIRST_WEEKDAY_KEY, Lang.bind(this, this._onSettingsChange));
         this.show_week_numbers = this.settings.getValue("show-week-numbers");
 
         // Find the ordering for month/year in the calendar heading
@@ -206,7 +210,14 @@ Calendar.prototype = {
     },
 
     _onSettingsChange: function(object, key, old_val, new_val) {
-        this.show_week_numbers = new_val;
+        switch (key) {
+	    case SHOW_WEEKDATE_KEY:
+		this.show_week_numbers = new_val;
+		break;
+	    case FIRST_WEEKDAY_KEY:
+		this._weekStart = Cinnamon.util_get_week_start();
+		break;
+	}
         this._buildHeader();
         this._update(false);
     },

--- a/src/cinnamon-util.c
+++ b/src/cinnamon-util.c
@@ -10,6 +10,9 @@
 #include <langinfo.h>
 #endif
 
+#define DESKTOP_SCHEMA "org.cinnamon.desktop.interface"
+#define FIRST_WEEKDAY_KEY "first-day-of-week"
+
 #include <libxml/parser.h>
 #include <libxml/tree.h>
 #include <libxml/xmlmemory.h>
@@ -540,7 +543,12 @@ cinnamon_util_format_date (const char *format,
 int
 cinnamon_util_get_week_start ()
 {
-  int week_start;
+  /* Try to get first weekday from gsettings */
+  /* If 7, continue to get the locale's first weekday */
+  GSettings *settings = g_settings_new (DESKTOP_SCHEMA);
+  int week_start = g_settings_get_int (settings, FIRST_WEEKDAY_KEY);
+  if (week_start != 7) return week_start;
+
 #ifdef HAVE__NL_TIME_FIRST_WEEKDAY
   union { unsigned int word; char *string; } langinfo;
   int week_1stday = 0;

--- a/src/cinnamon-util.c
+++ b/src/cinnamon-util.c
@@ -544,10 +544,11 @@ int
 cinnamon_util_get_week_start ()
 {
   /* Try to get first weekday from gsettings */
-  /* If 7, continue to get the locale's first weekday */
+  /* If the value from gsettings is not in the range 0-6,
+   * continue to get the locale's first weekday */
   GSettings *settings = g_settings_new (DESKTOP_SCHEMA);
   int week_start = g_settings_get_int (settings, FIRST_WEEKDAY_KEY);
-  if (week_start != 7) return week_start;
+  if (0 <= week_start && week_start < 7) return week_start;
 
 #ifdef HAVE__NL_TIME_FIRST_WEEKDAY
   union { unsigned int word; char *string; } langinfo;


### PR DESCRIPTION
Default setting is still the locale's default.
Sunday and Monday can be set in Cinnamon Settings, other days can be easily added in the python code if necessary.

#3655 
Requires linuxmint/cinnamon-desktop#28