### PR TITLE
fix applet name in 'About' modal

### DIFF
--- a/js/ui/modalDialog.js
+++ b/js/ui/modalDialog.js
@@ -364,7 +364,7 @@ SpicesAboutDialog.prototype = {
             if (metadata.version) {
                 let versionBin = new St.Bin({x_align: St.Align.START, y_align: St.Align.END});
                 titleBox.add_actor(versionBin);
-                let version = new St.Label({text: "v " + metadata.version, style_class: "about-version"});
+                let version = new St.Label({text: " v" + metadata.version, style_class: "about-version"});
                 versionBin.add_actor(version);
             }
             


### PR DESCRIPTION
`Weatherv`:

![screencap](https://cloud.githubusercontent.com/assets/705804/5104667/4daaed94-6fb2-11e4-8049-71e0ea857f8a.jpg)
