### PR TITLE
List icon themes with cursor theme

### DIFF
--- a/files/usr/lib/cinnamon-settings/modules/cs_themes.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_themes.py
@@ -244,7 +244,7 @@ class Module:
     
     def _load_icon_themes(self):
         dirs = ("/usr/share/icons", os.path.join(os.path.expanduser("~"), ".icons"))
-        valid = walk_directories(dirs, lambda d: os.path.isdir(d) and not os.path.exists(os.path.join(d, "cursors")) and os.path.exists(os.path.join(d, "index.theme")))
+        valid = walk_directories(dirs, lambda d: os.path.isdir(d) and os.path.exists(os.path.join(d, "index.theme")))
         valid.sort(lambda a,b: cmp(a.lower(), b.lower()))
         res = []
         for i in valid:


### PR DESCRIPTION
Some icon theme (e.g. the new Adwaita icon theme) contains both icon and cursor theme, so don't filter out.