### PR TITLE
[2.8] Packaging: fix and override more Lintian warnings

### DIFF
--- a/debian/cinnamon.links
+++ b/debian/cinnamon.links
@@ -1,0 +1,1 @@
+/usr/share/javascript/jquery/jquery.js   /usr/lib/cinnamon-settings/data/spices/jquery.js

--- a/debian/cinnamon.links
+++ b/debian/cinnamon.links
@@ -1,1 +1,0 @@
-/usr/share/javascript/jquery/jquery.js   /usr/lib/cinnamon-settings/data/spices/jquery.js

--- a/debian/cinnamon.lintian-overrides
+++ b/debian/cinnamon.lintian-overrides
@@ -1,4 +1,4 @@
 # It's the only way we have to let cinnamon find the private library it
 # links against through libcinnamon.so
 cinnamon: binary-or-shlib-defines-rpath usr/bin/cinnamon /usr/lib/gnome-bluetooth
-cinnamon: binary-or-shlib-defines-rpath ./usr/bin/cinnamon /usr/lib/gnome-bluetooth
+cinnamon: binary-or-shlib-defines-rpath usr/lib/cinnamon/libcinnamon.so /usr/lib/gnome-bluetooth

--- a/debian/cinnamon.lintian-overrides
+++ b/debian/cinnamon.lintian-overrides
@@ -2,3 +2,7 @@
 # links against through libcinnamon.so
 cinnamon: binary-or-shlib-defines-rpath usr/bin/cinnamon /usr/lib/gnome-bluetooth
 cinnamon: binary-or-shlib-defines-rpath usr/lib/cinnamon/libcinnamon.so /usr/lib/gnome-bluetooth
+
+# https://github.com/linuxmint/Cinnamon/pull/1750
+cinnamon: embedded-javascript-library usr/lib/cinnamon-settings/data/spices/jquery.js
+

--- a/debian/control
+++ b/debian/control
@@ -97,8 +97,7 @@ Depends: cinnamon-common (= ${source:Version}),
          gkbd-capplet,
          python-pyinotify,
          metacity,
-         gnome-panel | tint2,
-         libjs-jquery (>= 1.4)
+         gnome-panel | tint2
 Recommends: gnome-themes-standard, gnome-terminal, cinnamon-bluetooth
 Provides: notification-daemon, x-window-manager
 Description: Modern Linux desktop

--- a/debian/control
+++ b/debian/control
@@ -81,6 +81,7 @@ Depends: cinnamon-common (= ${source:Version}),
          gir1.2-nmgtk-1.0,
          gir1.2-notify-0.7,
          gksu,
+         ${python:Depends},
          python,
          python-dbus,
          python-gconf,
@@ -96,11 +97,14 @@ Depends: cinnamon-common (= ${source:Version}),
          gkbd-capplet,
          python-pyinotify,
          metacity,
-         gnome-panel | tint2
+         gnome-panel | tint2,
+         libjs-jquery (>= 1.4)
 Recommends: gnome-themes-standard, gnome-terminal, cinnamon-bluetooth
 Provides: notification-daemon, x-window-manager
-Description: Cinnamon desktop
- Cinnamon is a modern Linux desktop which provides advanced innovative features and a traditional user experience. It's easy to use, powerful and flexible.
+Description: Modern Linux desktop
+ Cinnamon is a modern Linux desktop which provides advanced innovative
+ features and a traditional user experience. It's easy to use, powerful
+ and flexible.
 
 Package: cinnamon-dbg
 Section: debug
@@ -109,7 +113,9 @@ Architecture: any
 Depends: cinnamon (= ${binary:Version}),
          ${misc:Depends}
 Description: Debugging symbols for the Cinnamon desktop
- Cinnamon is a modern Linux desktop which provides advanced innovative features and a traditional user experience. It's easy to use, powerful and flexible.
+ Cinnamon is a modern Linux desktop which provides advanced innovative
+ features and a traditional user experience. It's easy to use, powerful
+ and flexible.
  .
  This package contains the debugging symbols.
 
@@ -119,6 +125,8 @@ Breaks: cinnamon (<< 1.7.1)
 Architecture: all
 Depends: ${misc:Depends}, python
 Description: Cinnamon desktop (Common data files)
- Cinnamon is a modern Linux desktop which provides advanced innovative features and a traditional user experience. It's easy to use, powerful and flexible.
+ Cinnamon is a modern Linux desktop which provides advanced innovative
+ features and a traditional user experience. It's easy to use, powerful
+ and flexible.
  .
  This package contains the architecture independent files needed by Cinnamon

--- a/debian/rules
+++ b/debian/rules
@@ -4,6 +4,9 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
+# turn on Makefile verbose mode
+export V=1
+
 export LDFLAGS+=-Wl,--as-needed
 
 # To avoid running configure twice (because gnome-autogen.sh)
@@ -21,7 +24,7 @@ CINNAMON_VERSION := $(shell echo $(VERSION) | sed 's/\(.*.*\)\..*/\1.0/')
 DH_GENCONTROL_ARGS = -Vcinnamon:Version=$(CINNAMON_VERSION)
 
 %:
-	dh  $@ --with autoreconf,python2 $(DH_PARALLEL_OPTION)
+	dh  $@ --with autoreconf,python2,gir $(DH_PARALLEL_OPTION)
 
 
 override_dh_autoreconf:
@@ -43,10 +46,14 @@ override_dh_strip:
 	dh_strip --dbg-package=cinnamon-dbg
 
 override_dh_makeshlibs:
-	dh_makeshlibs -Xplugin
+	dh_makeshlibs -Xplugin -X/usr/lib/cinnamon
 
 override_dh_girepository:
 	dh_girepository -l src -p/usr/lib/$(DEB_HOST_MULTIARCH)/muffin /usr/lib/cinnamon
 
 override_dh_gencontrol:
 	dh_gencontrol -- $(DH_GENCONTROL_ARGS)
+
+override_dh_builddeb:
+	dh_builddeb -- -Zxz -z9
+

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -1,0 +1,2 @@
+# will be replaced with a symlink
+cinnamon source: source-is-missing files/usr/lib/cinnamon-settings/data/spices/jquery.js


### PR DESCRIPTION
Fixes:
```
W: cinnamon-common: extended-description-line-too-long
W: cinnamon-dbg: extended-description-line-too-long
E: cinnamon: description-starts-with-package-name
W: cinnamon: extended-description-line-too-long
E: cinnamon: pkg-has-shlibs-control-file-but-no-actual-shared-libs
W: cinnamon: postinst-has-useless-call-to-ldconfig
W: cinnamon: postrm-has-useless-call-to-ldconfig
```

Overrides:
```
W: cinnamon: embedded-javascript-library usr/lib/cinnamon-settings/data/spices/jquery.js
E: cinnamon: binary-or-shlib-defines-rpath usr/lib/cinnamon/libcinnamon.so /usr/lib/gnome-bluetooth
cinnamon source: source-is-missing files/usr/lib/cinnamon-settings/data/spices/jquery.js
```