### PR TITLE
fix 'genericpath.py:29:isfile:TypeError: coercing to Unicode: need strin...

### DIFF
--- a/files/usr/lib/cinnamon-settings-users/cinnamon-settings-users.py
+++ b/files/usr/lib/cinnamon-settings-users/cinnamon-settings-users.py
@@ -602,6 +602,8 @@ class Module:
 
     def update_preview_cb (self, dialog, preview):      
         filename = dialog.get_preview_filename()
+        if filename is None:
+            return        
         dialog.set_preview_widget_active(False)
         if os.path.isfile(filename):
             pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(filename, 128, 128)


### PR DESCRIPTION
...g or buffer, NoneType found'

https://bugzilla.redhat.com/show_bug.cgi?id=1173847
