### PR TITLE
window-list applet: Tiny fix on funcionality

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -406,10 +406,10 @@ AppMenuButton.prototype = {
             }
         }
         let target;
-        if (direction == 1) {
+        if (direction == 0) {
             target = ((current - 1) >= 0) ? (current - 1) : (num_windows - 1);
         }
-        if (direction == 0) {
+        if (direction == 1) {
             target = ((current + 1) <= num_windows - 1) ? (current + 1) : 0;
         }
         Main.activateWindow(this.window_list[vis_windows[target]].metaWindow, global.get_current_time());


### PR DESCRIPTION
Changed the flow on which you change between windows using the mouse scroll. At first I thought it was just me, but hey, this is inconsistent with the workspace switcher, for example. And also other programs like Google Chrome(changing between tabs with the scroll).

(This is my first contribution to a project, so sorry if I was inconvenient in any way)