### PR TITLE
Settings: Add missing tooltip for Keybinding xlet widget

### DIFF
--- a/files/usr/lib/cinnamon-settings/bin/XletSettingsWidgets.py
+++ b/files/usr/lib/cinnamon-settings/bin/XletSettingsWidgets.py
@@ -1045,6 +1045,7 @@ class Keybinding(Gtk.HBox, BaseWidget):
         self.value = self.get_val()
         if self.get_desc() != "":
             self.pack_start(self.label, False, False, 2)
+            set_tt(self.get_tooltip(), self.label)
 
         self.buttons = []
         self.teach_button = None


### PR DESCRIPTION
Currently all settings widgets allow the use of a `tooltip` property except the Keybinding widget. This is a minor and harmless change to enable it here as well.