### PR TITLE
Settings: Add xlet widget of type=label for plaintext labels

### DIFF
--- a/files/usr/lib/cinnamon-settings/bin/XletSettingsWidgets.py
+++ b/files/usr/lib/cinnamon-settings/bin/XletSettingsWidgets.py
@@ -20,6 +20,7 @@ home = os.path.expanduser("~")
 setting_dict = {
     "header"          :   "Header", # Not a setting, just a boldface header text
     "separator"       :   "Separator", # not a setting, a horizontal separator
+    "label"           :   "Label", # Not a setting, just a text label
     "entry"           :   "Entry",
     "textview"        :   "TextView",    
     "checkbox"        :   "CheckButton",
@@ -445,6 +446,15 @@ class Header(Gtk.HBox, BaseWidget):
         self.label = Gtk.Label()
         self.label.set_use_markup(True)
         self.label.set_markup("<b>%s</b>" % self.get_desc())
+        self.pack_start(self.label, False, False, 2)
+
+class Label(Gtk.HBox, BaseWidget):
+    def __init__(self, key, settings_obj, uuid):
+        BaseWidget.__init__(self, key, settings_obj, uuid)
+        super(Label, self).__init__()
+        self.label = Gtk.Label()
+        self.label.set_use_markup(True)
+        self.label.set_markup(self.get_desc())
         self.pack_start(self.label, False, False, 2)
 
 class Separator(Gtk.HSeparator, BaseWidget):

--- a/js/ui/settings.js
+++ b/js/ui/settings.js
@@ -162,6 +162,12 @@ var NON_SETTING_TYPES = {
             "description",
             "callback"
         ]
+    },
+    "label" : {
+        "required-fields": [
+            "type",
+            "description"
+        ]
     }
 };
 


### PR DESCRIPTION
As an applet author, I want to clarify what certain settings do when applied together, or give additional instruction to the user within the configuration pane of my applet. Currently the only way to do this is through extensive use of tooltips, which the user may or may not see (or bother to read if they are too long).

This `label` type is the same as `header`, except the markup comes from the description. It may read as duplication of code but I'd like the ability to use regular labels amongst settings and not have bolded text everywhere.

@mtwebster please review and consider either this or another way of supplying parameters to the `header` type such that it could be used as a label. The ability to use our own limited markup from settings schemas would be very nice though.

Sample use between a `header` and a `filechooser`:
![screenshot-area-2014-12-29-110404](https://cloud.githubusercontent.com/assets/164802/5571776/7da1c1be-8f4a-11e4-8c21-38069c4cbbcf.png)
