### PR TITLE
debian/control: bump Conflicts: version to "<< ${cinnamon:Version}"

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -114,8 +114,8 @@ Description: Debugging symbols for the Cinnamon desktop
  This package contains the debugging symbols.
 
 Package: cinnamon-common
-Replaces: cinnamon (<< 1.7.1)
-Breaks: cinnamon (<< 1.7.1)
+Replaces: cinnamon (<< ${cinnamon:Version})
+Breaks: cinnamon (<< ${cinnamon:Version})
 Architecture: all
 Depends: ${misc:Depends}, python
 Description: Cinnamon desktop (Common data files)


### PR DESCRIPTION
This eases upgrades from earlier versions of Cinnamon (such as the 2.2.x in Debian's repos), as they have clashing files with the current cinnamon-common.