### PR TITLE
Fix DST related weeknumber calculation errors

### DIFF
--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/calendar.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/calendar.js
@@ -84,8 +84,9 @@ function _getCalendarWeekForDate(date) {
     let midnightDate = new Date(date.getFullYear(), date.getMonth(), date.getDate());
     // Need to get Monday to be 1 ... Sunday to be 7
     let dayOfWeek = 1 + ((midnightDate.getDay() + 6) % 7);
+    // Need to use 12 noon instead of midnight to work around DST
     let nearestThursday = new Date(midnightDate.getFullYear(), midnightDate.getMonth(),
-                                   midnightDate.getDate() + (4 - dayOfWeek));
+                                   midnightDate.getDate() + (4 - dayOfWeek), 11);
 
     let jan1st = new Date(nearestThursday.getFullYear(), 0, 1);
     let diffDate = nearestThursday - jan1st;


### PR DESCRIPTION
In locales with DST diffDate is missing 1 hour which leads to dayNumber
being one off. This leads to wrong week numbers for the summer time
period, if Jan 1st is a Thursday.

For CET CW 13 was double every few years, e.g. 2009 and 2015, and
CW 43 is missing.

Using 12 noon instead of midnight for the next Thursday date works
around this, since the 1h DST difference has no influence and gets
floored either way in the dayNumber calculation.