### PR TITLE
Fix missing battery summary in applet menu and missing "time left" tooltip

### DIFF
--- a/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
@@ -169,7 +169,7 @@ MyApplet.prototype = {
                 this._batteryItem.actor.hide();                
                 return;
             }
-            let [device_id, device_type, icon, percentage, state, seconds] = device;
+            let [device_id, device_type, icon, percentage, state, seconds] = device[0];
             if (device_type == UPDeviceType.BATTERY) {
                 this._hasPrimary = true;
                 let time = Math.round(seconds / 60);


### PR DESCRIPTION
On a T440s which has two batteries this one liner restored the tool tip and menu summary indicating the battery time left across both batteries.

It has not been tried on a standard laptop with one battery as I don't have one - someone please test