### PR TITLE
Bug fixes and improvements for multiple battery laptops

### DIFF
--- a/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
@@ -169,7 +169,7 @@ MyApplet.prototype = {
                 this._batteryItem.actor.hide();                
                 return;
             }
-            let [device_id, device_type, icon, percentage, state, seconds] = device;
+            let [device_id, device_type, icon, percentage, state, seconds] = device[0];
             if (device_type == UPDeviceType.BATTERY) {
                 this._hasPrimary = true;
                 let time = Math.round(seconds / 60);

--- a/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
@@ -181,7 +181,7 @@ MyApplet.prototype = {
             if (error) {
                 this._hasPrimary = false;
                 this._primaryDeviceId = null;
-                this._batteryItem.actor.hide();                
+                //this._batteryItem.actor.hide();
                 return;
             }
             let [device_id, device_type, icon, percentage, state, time] = device[0];
@@ -215,7 +215,7 @@ MyApplet.prototype = {
                 this._batteryItem.actor.show();
             } else {
                 this._hasPrimary = false;
-                this._batteryItem.actor.hide();
+                //this._batteryItem.actor.hide();
             }
 
             this._primaryDeviceId = device_id;
@@ -232,8 +232,9 @@ MyApplet.prototype = {
             }
             let devices = result[0];
             let position = 0;
+            let timeToCharged = 0;
             for (let i = 0; i < devices.length; i++) {
-                let [device_id, device_type] = devices[i];
+                let [device_id, device_type, icon, percentage, state, time] = devices[i];
 
                 if (this._hasPrimary == false) {
                 	if (device_type == UPDeviceType.AC_POWER) {
@@ -246,6 +247,29 @@ MyApplet.prototype = {
 
                if (device_type == UPDeviceType.AC_POWER)
                     continue;
+
+               if (state == UPDeviceState.CHARGING) {
+                    global.log( i + " Time to charged " + timeToCharged + " > " + (timeToCharged+time));
+                    timeToCharged = timeToCharged + time;
+                    let convTime = secondsToTime(timeToCharged);
+                    let hours = convTime.h;
+                    let minutes = convTime.m;
+                    this._primaryPercentage.text = C_("percent of battery remaining", "%d%%").format(Math.round(percentage));
+
+                    if (minutes == 0) {
+                         if (hours == 0) {
+                              this._batteryItem.label.text = _("Fully charged");
+                         } else {
+                               this._batteryItem.label.text = _("Charging - " + hours + " hours remaining");
+                         }
+                    } else {
+                         if (hours == 0) {
+                              this._batteryItem.label.text = _("Charging - " + minutes + " minutes remaining");
+                         } else {
+                              this._batteryItem.label.text = _("Charging - " + hours + " hours " + minutes + " minutes remaining");
+                         }
+                     }
+                }
 
                 let item = new DeviceItem (devices[i]);
                 this._deviceItems.push(item);

--- a/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
@@ -94,13 +94,16 @@ DeviceItem.prototype = {
     }
 }
 
-function secondsToTime(sec){
-var d=new Date(0,0,0);
-d.setSeconds(+sec);   
+function secondsToTime(seconds){
+   let hours = Math.floor(seconds / 3600);
+   let remainingSeconds = Math.round(seconds % 3600);
+   let minutes = Math.floor(remainingSeconds / 60);
+   let seconds = Math.round(remainingSeconds % 60);
+
     return {
-        "h": d.getHours(),
-        "m": d.getMinutes(),
-        "s": d.getSeconds()
+        "h": hours,
+        "m": minutes,
+        "s": seconds
     };
 }
 

--- a/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
@@ -59,6 +59,7 @@ DeviceItem.prototype = {
         this._box.add_actor(this._label);
         this.addActor(this._box);
 
+
         let percentLabel = new St.Label({ text: C_("percent of battery remaining", "%d%%").format(Math.round(percentage)) });
         this.addActor(percentLabel, { align: St.Align.END });
     },
@@ -91,6 +92,16 @@ DeviceItem.prototype = {
                 return _("Unknown");
         }
     }
+}
+
+function secondsToTime(sec){
+var d=new Date(0,0,0);
+d.setSeconds(+sec);   
+    return {
+        "h": d.getHours(),
+        "m": d.getMinutes(),
+        "s": d.getSeconds()
+    };
 }
 
 function MyApplet(metadata, orientation, panel_height, instanceId) {
@@ -140,8 +151,9 @@ MyApplet.prototype = {
             this._primaryPercentage = new St.Label();
             this._batteryItem.addActor(this._primaryPercentage, { align: St.Align.END });
             this.menu.addMenuItem(this._batteryItem);
+            this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
-            this._otherDevicePosition = 1;
+            this._otherDevicePosition = 2;
             
             this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
             this.menu.addSettingsAction(_("Power Settings"), 'power');
@@ -169,19 +181,20 @@ MyApplet.prototype = {
                 this._batteryItem.actor.hide();                
                 return;
             }
-            let [device_id, device_type, icon, percentage, state, seconds] = device[0];
+            let [device_id, device_type, icon, percentage, state, time] = device[0];
             if (device_type == UPDeviceType.BATTERY) {
                 this._hasPrimary = true;
-                let time = Math.round(seconds / 60);
+                let convTime = secondsToTime(time);
+                let hours = convTime.h;
+                let minutes = convTime.m;
+
                 if (time == 0) {
                     // 0 is reported when UPower does not have enough data
                     // to estimate battery life
                     this._batteryItem.label.text = _("Estimating...");
                 } else {
-                    let minutes = time % 60;
-                    let hours = Math.floor(time / 60);
                     let timestring;
-                    if (time > 60) {
+                    if (hours > 0) {
                         if (minutes == 0) {
                             timestring = ngettext("%d hour remaining", "%d hours remaining", hours).format(hours);
                         } else {
@@ -228,7 +241,7 @@ MyApplet.prototype = {
                		}
                	}
 
-                if (device_type == UPDeviceType.AC_POWER || (this._hasPrimary && device_id == this._primaryDeviceId))
+               if (device_type == UPDeviceType.AC_POWER)
                     continue;
 
                 let item = new DeviceItem (devices[i]);
@@ -261,12 +274,12 @@ MyApplet.prototype = {
     },
     
     _updateLabel: function() {
-        this._proxy.GetDevicesRemote(Lang.bind(this, function(results, error) {
+        this._proxy.GetPrimaryDeviceRemote(Lang.bind(this, function(results, error) {
             if (error) {
             	this._mainLabel.set_text("");
                 return;
             }
-            let devices = results[0];
+            let devices = results;
             for (let i = 0; i < devices.length; i++) {
                 let [device_id, device_type, icon, percentage, state, time] = devices[i];
                 if (device_type == UPDeviceType.BATTERY || device_id == this._primaryDeviceId) {
@@ -275,10 +288,8 @@ MyApplet.prototype = {
                         ;
                     }
                     else if (this.labelinfo == "time" && time != 0) {
-                        let seconds = Math.round(time / 60);
-                        let minutes = Math.floor(seconds % 60);
-                        let hours = Math.floor(seconds / 60);
-                        labelText = C_("time of battery remaining", "%d:%02d").format(hours,minutes);
+                        let convTime = secondsToTime(time);
+                        labelText = C_("time of battery remaining", "%d:%02d").format(convTime.h,convTime.m);
                     }
                     else if (this.labelinfo == "percentage" ||
                              (this.labelinfo == "percentage_time" && time == 0)) {
@@ -286,11 +297,9 @@ MyApplet.prototype = {
                     }
 
                     else if (this.labelinfo == "percentage_time") {
-                        let seconds = Math.round(time / 60);
-                        let minutes = Math.floor(seconds % 60);
-                        let hours = Math.floor(seconds / 60);
+                        let convTime = secondsToTime(time);
                         labelText = C_("percent of battery remaining", "%d%%").format(Math.round(percentage)) + " (" +
-                                    C_("time of battery remaining", "%d:%02d").format(hours,minutes) + ")";
+                                    C_("time of battery remaining", "%d:%02d").format(convTime.h,convTime.m) + ")";
                     }
                     this._mainLabel.set_text(labelText);
                     if (device_id == this._primaryDeviceId) {

--- a/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
@@ -252,6 +252,11 @@ MyApplet.prototype = {
                 this.menu.addMenuItem(item, this._otherDevicePosition + position);
                 position++;
             }
+            /* Do not show the percent in the summary if there is only one battery */
+            if (position <= 1) {
+                    this._primaryPercentage.text = "";                        
+            }
+
         }));
     },
 


### PR DESCRIPTION
On T440s which has multiple batteries there were a number of issues:

1) The panel applet tooltip just says "Laptop battery" rather that "x hours and y minutes remaining"
2) The applet menu is missing the top item which says "x hours and y minutes remaining   x%"
3) The data feeding both those entries was being driven by the state of one of the two batteries rather than the primary device which provides the summary state for two batteries.

I could have extended to show the time remaining on each battery listed but it turns out that the battery not currently being discharged cannot provide accurate seconds remaining. So instead the individual laptop battery items in the popup menu show only the percent.

I am able to remove one battery and see that the applet still makes sense.

I don't currently have access to a single battery laptop and would appreciate some feedback on how this applet looks on a more standard laptop. 