### PR TITLE
Minor improvements to System Info applet

### DIFF
--- a/files/usr/lib/cinnamon-settings/modules/cs_info.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_info.py
@@ -50,7 +50,7 @@ def getGraphicsInfos():
 
 def getDiskSize():
     disksize = 0
-    for line in getProcessOut("df"):
+    for line in getProcessOut(("df", "-l")):
         if line.startswith("/"):
             disksize += float(line.split()[1])
             
@@ -74,12 +74,11 @@ def getProcInfos():
 def createSystemInfos():    
     procInfos = getProcInfos()
     infos = []
-    (dname, dversion, dsuffix) = platform.linux_distribution()
     arch = platform.machine().replace("_", "-")    
     (memsize, memunit) = procInfos['mem_total'].split(" ")
     processorName = procInfos['cpu_name'].replace("(R)", u"\u00A9").replace("(TM)", u"\u2122")
     if 'cpu_cores' in procInfos:
-        processorName = processorName + " x " + procInfos['cpu_cores']
+        processorName = processorName + u" \u00D7 " + procInfos['cpu_cores']
     
     if os.path.exists("/etc/linuxmint/info"):
         title = commands.getoutput("awk -F \"=\" '/GRUB_TITLE/ {print $2}' /etc/linuxmint/info")
@@ -88,7 +87,10 @@ def createSystemInfos():
         title = "Arch Linux"
         infos.append((_("Operating System"), title))
     else:
-        infos.append((_("Operating System"), dname + " " + dversion +  " '" + dsuffix.title() + "' (" + arch + ")"))    
+        s = '%s (%s)' % (' '.join(platform.linux_distribution()), arch)
+        # Normalize spacing in distribution name
+        s = re.sub('\s{2,}', ' ', s)
+        infos.append((_("Operating System"), s))
     if 'CINNAMON_VERSION' in os.environ:            
         infos.append((_("Cinnamon Version"), os.environ['CINNAMON_VERSION']))
     infos.append((_("Linux Kernel"), platform.release()))


### PR DESCRIPTION
* Use `df -l` to find system hard disk size (Possible fix for #3801?)
* Use a × (U+00D7) instead of an x to count CPU cores.
* Reformat Operating System checking, preventing empty fields such as `debian 8.0 '' (x86-64)` from showing up.
  `platform.linux_distribution()` doesn't always have all 3 fields filled out: e.g. Arch Linux gives `('arch', '', '')`