### PR TITLE
Update xlet stylesheet as well on rt

### DIFF
--- a/js/ui/runDialog.js
+++ b/js/ui/runDialog.js
@@ -206,7 +206,7 @@ __proto__: ModalDialog.ModalDialog.prototype,
 
                                    // rt is short for "reload theme"
                                    'rt': Lang.bind(this, function() {
-                                       Main.loadTheme();
+                                       Main.themeManager._changeTheme();
                                    })
                                  };
 


### PR DESCRIPTION
If you run rt (reload theme) at Alt-F2, xlets' stylesheet do not get reloaded and they will look broken. xlets listen to theme manager to reload stylesheet when necessary, so calling themeManager instead of main can solve the problem