### PR TITLE
Add missing import to modalDialog.js

### DIFF
--- a/js/ui/modalDialog.js
+++ b/js/ui/modalDialog.js
@@ -10,6 +10,7 @@ const Gio = imports.gi.Gio;
 const Pango = imports.gi.Pango;
 
 const Params = imports.misc.params;
+const Util = imports.misc.util;
 
 const Lightbox = imports.ui.lightbox;
 const Main = imports.ui.main;


### PR DESCRIPTION
This fixes the website link in the spices about dialog.