### PR TITLE
Looking glass work

### DIFF
--- a/files/usr/lib/cinnamon-looking-glass/cinnamon-looking-glass.py
+++ b/files/usr/lib/cinnamon-looking-glass/cinnamon-looking-glass.py
@@ -50,7 +50,6 @@ class MenuButton(Gtk.Button):
                 allocation.width,
                 allocation.height)
 
-
 class ResizeGrip(Gtk.Widget):
     def __init__(self, parent):
         Gtk.Widget.__init__(self)
@@ -367,7 +366,8 @@ class CinnamonLog(dbus.service.Object):
         global lookingGlassProxy
         lookingGlassProxy = LookingGlassProxy()
         self.lookingGlassProxy = lookingGlassProxy
-        lookingGlassProxy.addStatusChangeCallback(self.setStatus)
+        # The status label is shown iff we are not okay
+        lookingGlassProxy.addStatusChangeCallback(lambda x: self.statusLabel.set_visible(not x))
 
         self.window = None
         self.run()
@@ -482,7 +482,7 @@ class CinnamonLog(dbus.service.Object):
             if not done_one:
                 done_one = True
 
-        keybinding = Gtk.Label("Current Keybinding")
+        keybinding = Gtk.Label()
         keybinding.set_markup('<i>Toggle shortcut: %s</i>' % accel)
 
         actionButton = self.createActionButton()
@@ -497,7 +497,7 @@ class CinnamonLog(dbus.service.Object):
         table.attach(grip, 0, numColumns, 2, 3, Gtk.AttachOptions.EXPAND|Gtk.AttachOptions.FILL, 0, 0, 0)
 
         self.activatePage("results")
-        self.setStatus(True)
+        self.statusLabel.hide()
         self.window.set_focus(self.commandline)
 
     def createMenuItem(self, text, callback):
@@ -509,18 +509,15 @@ class CinnamonLog(dbus.service.Object):
         menu = Gtk.Menu()
         menu.append(self.createMenuItem('Add File Watcher', self.onAddFileWatcher))
         menu.append(Gtk.SeparatorMenuItem())
-        menu.append(self.createMenuItem('Restart Cinnamon', self.onRestartClicked))
-        menu.append(self.createMenuItem('Crash Cinnamon', self.onCrashClicked))
+        menu.append(self.createMenuItem('Restart Cinnamon', lambda x: os.system("nohup cinnamon --replace > /dev/null 2>&1 &")))
+        menu.append(self.createMenuItem('Crash Cinnamon', lambda x: self.commandline.doCrash()))
         menu.append(self.createMenuItem('Reset Cinnamon Settings', self.onResetClicked))
         menu.append(Gtk.SeparatorMenuItem())
         menu.append(self.createMenuItem('About Melange', self.onAboutClicked))
-        menu.append(self.createMenuItem('Quit', self.onExitClicked))
+        menu.append(self.createMenuItem('Quit', lambda x: Gtk.main_quit()))
         menu.show_all()
 
-        if hasattr(Gtk, 'MenuButton'):
-            button = Gtk.MenuButton(u"Actions \u25BE")
-        else:
-            button = MenuButton(u"Actions \u25BE")
+        button = Gtk.MenuButton(u"Actions \u25BE")
         button.set_popup(menu)
         return button
 
@@ -542,27 +539,21 @@ class CinnamonLog(dbus.service.Object):
         self.notebook.remove_page(self.notebook.page_num(content))
         content.destroy()
         
-    def onRestartClicked(self, menuItem):
-        os.system("nohup cinnamon --replace > /dev/null 2>&1 &")
-
-    def onCrashClicked(self, menuItem):
-        self.commandline.doCrash();
-
     def onAboutClicked(self, menuItem):
         dialog = Gtk.MessageDialog(self.window, 0,
                                    Gtk.MessageType.QUESTION, Gtk.ButtonsType.CLOSE);
 
         dialog.set_title("About Melange")
-        dialog.set_markup("<b>Melange</b> is a GTK3 alternative to the built-in javascript debugger <i>Looking Glass</i>"
-                           + "\n\nPressing <i>Escape</i> while Melange has focus will hide the window."
-                           +"\nIf you want to exit Melange, use ALT+F4 or the <u>Actions</u> menu button."
-                           + "\n\nIf you defined a hotkey for Melange, pressing it while Melange is visible it will be hidden.")
+        dialog.set_markup("""\
+<b>Melange</b> is a GTK3 alternative to the built-in javascript debugger <i>Looking Glass</i>
+
+Pressing <i>Escape</i> while Melange has focus will hide the window.
+If you want to exit Melange, use ALT+F4 or the <u>Actions</u> menu button.
+
+If you defined a hotkey for Melange, pressing it while Melange is visible it will be hidden.""")
 
         dialog.run()
         dialog.destroy()
-
-    def onExitClicked(self, menuItem):
-        Gtk.main_quit()
 
     def onResetClicked(self, menuItem):
         dialog = Gtk.MessageDialog(self.window, 0,
@@ -603,12 +594,6 @@ class CinnamonLog(dbus.service.Object):
     def activatePage(self, moduleName):
         page = self.notebook.page_num(self.pages[moduleName])
         self.notebook.set_current_page(page)
-
-    def setStatus(self, status):
-        if status:
-            self.statusLabel.hide()
-        else:
-            self.statusLabel.show()
 
 if __name__ == "__main__":
     GObject.type_register(ResizeGrip)

--- a/files/usr/lib/cinnamon-looking-glass/cinnamon-looking-glass.py
+++ b/files/usr/lib/cinnamon-looking-glass/cinnamon-looking-glass.py
@@ -3,8 +3,6 @@
 # Todo:
 # - TextTag.invisible does not work nicely with scrollheight, find out why
 #   - (Sometimes scrollbars think there is more or less to scroll than there actually is after showing/hiding entries in page_log.py)
-# - if cinnamon --replace was called from Melange, it will be killed when this process is closed
-#   - Currently only occurs when Melange is started by Geany.
 # - Add insert button to "simple types" inspect dialog ? is there actual use for these types inserted as results ?
 # - Load all enabled log categories and window height from gsettings
 # - Make CommandLine entry & history work more like a normal terminal
@@ -545,8 +543,7 @@ class CinnamonLog(dbus.service.Object):
         content.destroy()
         
     def onRestartClicked(self, menuItem):
-        #todo: gets killed when the python process ends, separate it!
-        os.system("cinnamon --replace &")
+        os.system("nohup cinnamon --replace > /dev/null 2>&1 &")
 
     def onCrashClicked(self, menuItem):
         self.commandline.doCrash();

--- a/files/usr/lib/cinnamon-looking-glass/cinnamon-looking-glass.py
+++ b/files/usr/lib/cinnamon-looking-glass/cinnamon-looking-glass.py
@@ -5,7 +5,6 @@
 #   - (Sometimes scrollbars think there is more or less to scroll than there actually is after showing/hiding entries in page_log.py)
 # - if cinnamon --replace was called from Melange, it will be killed when this process is closed
 #   - Currently only occurs when Melange is started by Geany.
-# - List extensions that failed to load ?
 # - Add insert button to "simple types" inspect dialog ? is there actual use for these types inserted as results ?
 # - Load all enabled log categories and window height from gsettings
 # - Make CommandLine entry & history work more like a normal terminal

--- a/files/usr/lib/cinnamon-looking-glass/page_extensions.py
+++ b/files/usr/lib/cinnamon-looking-glass/page_extensions.py
@@ -4,7 +4,7 @@ from gi.repository import Gio, Gtk, GObject, Gdk, Pango, GLib
 
 class ModulePage(pageutils.BaseListView):
     def __init__(self, parent):
-        store = Gtk.ListStore(str, str, str, str, str, str, str)
+        store = Gtk.ListStore(str, str, str, str, str, str, str, bool, str)
         pageutils.BaseListView.__init__(self, store)
         self.parent = parent;
 
@@ -15,6 +15,7 @@ class ModulePage(pageutils.BaseListView):
         self.getUpdates()
         lookingGlassProxy.connect("ExtensionListUpdate", self.getUpdates)
         lookingGlassProxy.addStatusChangeCallback(self.onStatusChange)
+        self.treeView.set_tooltip_column(8)
 
         self.popup = Gtk.Menu()
 
@@ -49,20 +50,21 @@ class ModulePage(pageutils.BaseListView):
         url = self.store.get_value(iter, 6)
         os.system("gnome-open \"" + url + "\" &")
 
-
     def on_button_press_event(self, treeview, event):
-        if event.button == 3:
-            x = int(event.x)
-            y = int(event.y)
-            time = event.time
-            pthinfo = treeview.get_path_at_pos(x, y)
-            if pthinfo is not None:
-                path, col, cellx, celly = pthinfo
-                self.selectedPath = path
-                treeview.grab_focus()
-                treeview.set_cursor( path, col, 0)
+        x = int(event.x)
+        y = int(event.y)
+        time = event.time
+        pthinfo = treeview.get_path_at_pos(x, y)
+        if pthinfo is not None:
+            path, col, cellx, celly = pthinfo
+            self.selectedPath = path
+            treeview.grab_focus()
+            treeview.set_cursor( path, col, 0)
 
-                iter = self.store.get_iter(self.selectedPath)
+            iter = self.store.get_iter(self.selectedPath)
+
+        if event.button == 3:
+            if pthinfo is not None:
                 uuid = self.store.get_value(iter, 4)
                 url = self.store.get_value(iter, 6)
 
@@ -70,7 +72,11 @@ class ModulePage(pageutils.BaseListView):
                 self.viewSource.set_label(uuid + " (View Source)")
                 self.popup.popup( None, None, None, None, event.button, event.time)
             return True
-
+        elif event.type == Gdk.EventType.DOUBLE_BUTTON_PRESS:
+            if pthinfo is not None:
+                error = self.store.get_value(iter, 7)
+                if error:
+                    self.parent.activatePage("log")
 
     def onStatusChange(self, online):
         if online:
@@ -81,4 +87,4 @@ class ModulePage(pageutils.BaseListView):
         if success:
             self.store.clear()
             for item in data:
-                self.store.append([item["status"], item["type"], item["name"], item["description"], item["uuid"], item["folder"], item["url"]])
+                self.store.append([item["status"], item["type"], item["name"], item["description"], item["uuid"], item["folder"], item["url"], item["error"] == "true", item["error_message"]])

--- a/files/usr/lib/cinnamon-looking-glass/page_extensions.py
+++ b/files/usr/lib/cinnamon-looking-glass/page_extensions.py
@@ -38,7 +38,7 @@ class ModulePage(pageutils.BaseListView):
     def onViewSource(self, menuItem):
         iter = self.store.get_iter(self.selectedPath)
         folder = self.store.get_value(iter, 5)
-        os.system("gnome-open \"" + folder + "\" &")
+        os.system("xdg-open \"" + folder + "\" &")
 
     def onReloadCode(self, menuItem):
         iter = self.store.get_iter(self.selectedPath)
@@ -48,7 +48,7 @@ class ModulePage(pageutils.BaseListView):
     def onViewWebPage(self, menuItem):
         iter = self.store.get_iter(self.selectedPath)
         url = self.store.get_value(iter, 6)
-        os.system("gnome-open \"" + url + "\" &")
+        os.system("xdg-open \"" + url + "\" &")
 
     def on_button_press_event(self, treeview, event):
         x = int(event.x)

--- a/files/usr/lib/cinnamon-settings/bin/ExtensionCore.py
+++ b/files/usr/lib/cinnamon-settings/bin/ExtensionCore.py
@@ -1397,6 +1397,7 @@ Please contact the developer.""")
                                 icon = ""
                             self.model.set_value(iter, 11, icon)
                             self.model.set_value(iter, 13, SETTING_TYPE_NONE)
+                            self.model.set_value(iter, 14, True)
                     except Exception, detail:
                         print "Failed to load extension %s: %s" % (theme, detail)
 

--- a/js/ui/lookingGlass.js
+++ b/js/ui/lookingGlass.js
@@ -639,11 +639,12 @@ Melange.prototype = {
                         uuid: uuid,
                         folder: meta.path,
                         url: meta.url ? meta.url : '',
-                        type: Extension.objects[uuid].type.name
+                        type: meta.type.name,
+                        error_message: meta.error ? meta.error : _("Loaded successfully"),
+                        error: meta.error ? "true" : "false" // Must use string due to dbus restrictions
                     });
                 }
             }
-        
             return [true, extensionList];
         } catch (e) {
             global.logError('Error getting the extension list', e);

--- a/js/ui/lookingGlass.js
+++ b/js/ui/lookingGlass.js
@@ -1,25 +1,18 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
+const Cinnamon = imports.gi.Cinnamon;
 const Clutter = imports.gi.Clutter;
 const Cogl = imports.gi.Cogl;
-const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
-const Gtk = imports.gi.Gtk;
-const Meta = imports.gi.Meta;
-const Pango = imports.gi.Pango;
-const St = imports.gi.St;
-const Cinnamon = imports.gi.Cinnamon;
-const Signals = imports.signals;
 const Lang = imports.lang;
-const CinnamonJS = imports.gi.CinnamonJS;
-
-const History = imports.misc.history;
-const Extension = imports.ui.extension;
-const Link = imports.ui.link;
-const CinnamonEntry = imports.ui.cinnamonEntry;
-const Tweener = imports.ui.tweener;
-const Main = imports.ui.main;
+const Meta = imports.gi.Meta;
+const Signals = imports.signals;
+const St = imports.gi.St;
 const System = imports.system;
+
+const Extension = imports.ui.extension;
+const History = imports.misc.history;
+const Main = imports.ui.main;
 
 /* Imports...feel free to add here as needed */
 var commandHeader = 'const Clutter = imports.gi.Clutter; ' +


### PR DESCRIPTION
- Remove unused imports in lookingGlass.js (leftover from legacy St lg)
- Show xlet that failed to load correctly in page_extensions
  - The tooltip displays the relevant error message (albeit not always helpful)
  - Double clicking errored xlet brings you to page_log
- Use xdg-open instead of gnome-open in page_extensions to open xlet website (on gnome-like sessions, xdg-open simply calls gnome-open if available, but this will still work if gnome-open is not installed)
- Fix theme installer complaining theme not compatible with current version (we don't do version check for themes, partly because themes don't have a metadata.json)