### PR TITLE
Fix sound applet app list not refreshing when player is added

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -1220,13 +1220,7 @@ MyApplet.prototype = {
                 availablePlayers.push(app);
         }
 
-        //we call this instead of menu.removeAll(), because this would destroy the actors, but we need them, so use remove
-        let children = this._launchPlayerItem.menu._getMenuItems();
-        for(let i = 0; i < children.length; i++){
-            let item = children[i];
-            item.remove();
-            item.emit("destroy");
-        }
+        this._launchPlayerItem.menu.removeAll();
 
         if (availablePlayers.length > 0){
             for (var p = 0; p < availablePlayers.length; p++){


### PR DESCRIPTION
Since the recent rework of the sound applet, when a new player is added to the list of compatible players, the sound applet doesn't currently refresh the menu until after a restart because ```item.remove();``` is not a valid function, and causes ```this._updateLaunchPlayer()``` to fail silently. This fixes it (and simplifies the code in the process :) ).

Edit: added another similar fix from @pixunil that fixes a bug when multiple players are open and you try to switch between them.