### PR TITLE
Added st_widget_change_style_pseudo_class function

### DIFF
--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
@@ -98,14 +98,8 @@ MyApplet.prototype = {
 
     _updateButtons: function() {
         for ( let i=0; i<this.button.length; ++i ) {
-            if ( i == global.screen.get_active_workspace_index() ) {
-                this.button[i].get_child().set_text((i+1).toString());
-                this.button[i].add_style_pseudo_class('outlined');
-            }
-            else {
-                this.button[i].get_child().set_text((i+1).toString());
-                this.button[i].remove_style_pseudo_class('outlined');
-            }
+            this.button[i].get_child().set_text((i+1).toString());
+            this.button[i].change_style_pseudo_class('outlined', i == global.screen.get_active_workspace_index());
         }
     }
 };

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -1466,10 +1466,7 @@ Panel.prototype = {
      * Turns on/off the highlight of the panel
      */
     highlight: function(highlight) {
-        if (highlight)
-            this.actor.add_style_pseudo_class('highlight');
-        else
-            this.actor.remove_style_pseudo_class('highlight');
+        this.actor.change_style_pseudo_class('highlight', highlight);
     },
 
     isHideable: function() {
@@ -1556,18 +1553,11 @@ Panel.prototype = {
 
     _onPanelEditModeChanged: function() {
         let old_mode = this._panelEditMode;
-        if (global.settings.get_boolean("panel-edit-mode")) {
-            this._panelEditMode = true;
-            this._leftBox.add_style_pseudo_class('dnd');
-            this._centerBox.add_style_pseudo_class('dnd');
-            this._rightBox.add_style_pseudo_class('dnd');
-        }
-        else {
-            this._panelEditMode = false;
-            this._leftBox.remove_style_pseudo_class('dnd');
-            this._centerBox.remove_style_pseudo_class('dnd');
-            this._rightBox.remove_style_pseudo_class('dnd');
-        }
+
+        this._panelEditMode = global.settings.get_boolean("panel-edit-mode");
+        this._leftBox.change_style_pseudo_class('dnd', this._panelEditMode);
+        this._centerBox.change_style_pseudo_class('dnd', this._panelEditMode);
+        this._rightBox.change_style_pseudo_class('dnd', this._panelEditMode);
 
         if (old_mode != this._panelEditMode) {
             this._processPanelAutoHide();

--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -120,11 +120,9 @@ PopupBaseMenuItem.prototype = {
 
         if (activeChanged) {
             this.active = active;
-            if (active) {
-                this.actor.add_style_pseudo_class('active');
-                if (this.focusOnHover) this.actor.grab_key_focus();
-            } else
-                this.actor.remove_style_pseudo_class('active');
+            this.actor.change_style_pseudo_class('active', active);
+            if (this.focusOnHover && this.active) this.actor.grab_key_focus();
+
             this.emit('active-changed', active);
         }
     },
@@ -139,10 +137,7 @@ PopupBaseMenuItem.prototype = {
         this.actor.reactive = sensitive;
         this.actor.can_focus = sensitive;
 
-        if (sensitive)
-            this.actor.remove_style_pseudo_class('insensitive');
-        else
-            this.actor.add_style_pseudo_class('insensitive');
+        this.actor.change_style_pseudo_class('insensitive', !sensitive);
         this.emit('sensitive-changed', sensitive);
     },
 
@@ -745,10 +740,7 @@ Switch.prototype = {
     },
 
     setToggleState: function(state) {
-        if (state)
-            this.actor.add_style_pseudo_class('checked');
-        else
-            this.actor.remove_style_pseudo_class('checked');
+        this.actor.change_style_pseudo_class('checked', state);
         this.state = state;
     },
 
@@ -1554,10 +1546,7 @@ PopupSubMenuMenuItem.prototype = {
     },
 
     _subMenuOpenStateChanged: function(menu, open) {
-        if (open)
-            this.actor.add_style_pseudo_class('open');
-        else
-            this.actor.remove_style_pseudo_class('open');
+        this.actor.change_style_pseudo_class('open', open);
     },
 
     destroy: function() {

--- a/src/st/st-button.c
+++ b/src/st/st-button.c
@@ -657,10 +657,7 @@ st_button_set_checked (StButton *button,
     {
       button->priv->is_checked = checked;
 
-      if (checked)
-        st_widget_add_style_pseudo_class (ST_WIDGET (button), "checked");
-      else
-        st_widget_remove_style_pseudo_class (ST_WIDGET (button), "checked");
+      st_widget_change_style_pseudo_class (ST_WIDGET (button), "checked", checked);
     }
 
   g_object_notify (G_OBJECT (button), "checked");

--- a/src/st/st-widget.c
+++ b/src/st/st-widget.c
@@ -1421,6 +1421,28 @@ st_widget_set_style_pseudo_class (StWidget    *actor,
 }
 
 /**
+ * st_widget_change_style_pseudo_class:
+ * @actor: a #StWidget
+ * @pseudo_class: a pseudo class string
+ * @add: whether to add or remove pseudo class
+ *
+ * Adds @pseudo_class to @actor's pseudo class list if @add is true,
+ * removes if @add is false.
+ */
+void
+st_widget_change_style_pseudo_class (StWidget    *actor,
+                                     const gchar *pseudo_class,
+                                     gboolean     add)
+{
+  g_return_if_fail (ST_IS_WIDGET (actor));
+  g_return_if_fail (pseudo_class != NULL);
+
+  if (add)
+    st_widget_add_style_pseudo_class(actor, pseudo_class);
+  else
+    st_widget_remove_style_pseudo_class(actor, pseudo_class);
+}
+/**
  * st_widget_add_style_pseudo_class:
  * @actor: a #StWidget
  * @pseudo_class: a pseudo class string

--- a/src/st/st-widget.h
+++ b/src/st/st-widget.h
@@ -92,6 +92,9 @@ GType st_widget_get_type (void) G_GNUC_CONST;
 
 void                  st_widget_set_style_pseudo_class    (StWidget        *actor,
                                                            const gchar     *pseudo_class_list);
+void                  st_widget_change_style_pseudo_class (StWidget        *actor,
+                                                           const gchar     *pseudo_class,
+                                                           gboolean         add);
 void                  st_widget_add_style_pseudo_class    (StWidget        *actor,
                                                            const gchar     *pseudo_class);
 void                  st_widget_remove_style_pseudo_class (StWidget        *actor,


### PR DESCRIPTION
Replaces the frequently used

    if (foo)
        this.actor.add_style_pseudo_class('bar')
    else
        this.actor.remove_style_pseudo_class('bar')

with

    this.actor.change_style_pseudo_class('bar', foo)