### PR TITLE
tweak a few labels in cinnamon settings

### DIFF
--- a/data/org.cinnamon.gschema.xml.in
+++ b/data/org.cinnamon.gschema.xml.in
@@ -562,17 +562,17 @@
       </_description>
     </key>
 
-    <key name="hide-snap-osd" type="b">
-      <default>false</default>
-      <_summary>Prevent the tile/snap OSD from showing</_summary>
+    <key name="show-snap-osd" type="b">
+      <default>true</default>
+      <_summary>Show the tile/snap OSD</_summary>
       <_description>
         Hide the snap OSD.
       </_description>
     </key>
 
-    <key name="hide-tile-hud" type="b">
-      <default>false</default>
-      <_summary>Prevent the tile HUD from showing</_summary>
+    <key name="show-tile-hud" type="b">
+      <default>true</default>
+      <_summary>Show the tile HUD</_summary>
       <_description>
         Hide the tile HUD.
       </_description>

--- a/files/usr/lib/cinnamon-settings/modules/cs_desklets.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_desklets.py
@@ -38,7 +38,7 @@ class DeskletsViewSidePage (ExtensionSidePage):
 
     def getAdditionalPage(self):
         page = SettingsPage()
-        page.label = _("General Desklets Settings")
+        page.label = _("General Settings")
 
         settings = page.add_section(_("General Desklets Settings"))
 

--- a/files/usr/lib/cinnamon-settings/modules/cs_tiling.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_tiling.py
@@ -34,8 +34,8 @@ class Module:
 
             settings.add_row(GSettingsSwitch(_("Maximize, instead of tile, when dragging a window to the top edge"), "org.cinnamon.muffin", "tile-maximize"))
 
-            settings.add_row(GSettingsSwitch(_("Prevent the snap on-screen-display from showing"), "org.cinnamon", "hide-snap-osd"))
+            settings.add_row(GSettingsSwitch(_("Show snap on-screen-display"), "org.cinnamon", "show-snap-osd"))
 
-            settings.add_row(GSettingsSwitch(_("Prevent the tile heads-up-display from showing"), "org.cinnamon", "hide-tile-hud"))
+            settings.add_row(GSettingsSwitch(_("Show tile heads-up-display"), "org.cinnamon", "show-tile-hud"))
 
             settings.add_row(GSettingsSwitch(_("Legacy window snapping (hold <Shift> while dragging a window)"), "org.cinnamon.muffin", "legacy-snap"))

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -826,7 +826,7 @@ WindowManager.prototype = {
     },
 
     _showHudPreview: function(cinnamonwm, currentProximityZone, workArea, snapQueued) {
-        if (!global.settings.get_boolean("hide-tile-hud")) {
+        if (global.settings.get_boolean("show-tile-hud")) {
             if (!this._hudPreview)
                 this._hudPreview = new HudPreview();
             this._hudPreview.show(currentProximityZone, workArea, snapQueued);
@@ -885,7 +885,7 @@ WindowManager.prototype = {
     },
 
     _showSnapOSD : function(metaScreen, monitorIndex) {
-        if (!global.settings.get_boolean("hide-snap-osd")) {
+        if (global.settings.get_boolean("show-snap-osd")) {
             if (this._snapOsd == null) {
                 this._snapOsd = new ModalDialog.InfoOSD();
 


### PR DESCRIPTION
cs_desklets: change "General desklet settings" to "General settings" to avoid an extra large stack swithcer button
cs_tiling: change a couple labels and adjust the settings to match