### PR TITLE
Add proper panel center region. Applets are actually at the center if possible

### DIFF
--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -294,11 +294,7 @@ function addAppletToPanels(extension, appletDefinition) {
             appletDefinition.location.remove_actor(appletsToMove[i]);
         }
 
-        if (appletDefinition.center) {
-            appletDefinition.location.add(applet.actor, {x_align: St.Align.CENTER_SPECIAL});
-        } else {
-            appletDefinition.location.add(applet.actor);
-        }
+        appletDefinition.location.add(applet.actor);
 
         applet._panelLocation = appletDefinition.location;
         for (let i=0; i<appletsToMove.length; i++) {

--- a/src/st/st-box-layout.h
+++ b/src/st/st-box-layout.h
@@ -86,6 +86,10 @@ void     st_box_layout_set_pack_start (StBoxLayout *box,
                                        gboolean     pack_start);
 gboolean st_box_layout_get_pack_start (StBoxLayout *box);
 
+void     st_box_layout_set_align_end (StBoxLayout *box,
+                                      gboolean     align_end);
+gboolean st_box_layout_get_align_end (StBoxLayout *box);
+
 void     st_box_layout_insert_actor (StBoxLayout  *self,
                                      ClutterActor *actor,
                                      int           pos);

--- a/src/st/st-types.h
+++ b/src/st/st-types.h
@@ -37,8 +37,7 @@ G_BEGIN_DECLS
 typedef enum {
   ST_ALIGN_START,
   ST_ALIGN_MIDDLE,
-  ST_ALIGN_END,
-  ST_ALIGN_CENTER_SPECIAL
+  ST_ALIGN_END
 } StAlign;
 
 typedef enum {


### PR DESCRIPTION
If there is enough space, centered applets will be placed at the very center of the applet. Otherwise, the centered applets will appear as close to the center as possible. See centered menu applet:

![screenshot from 2015-04-12 14-40-09](https://cloud.githubusercontent.com/assets/1336336/7104634/f128d234-e121-11e4-871a-354afba8d42a.png)

#3849, #3100