### PR TITLE
Add file chooser dialog to Cinnamon javascript

### DIFF
--- a/files/usr/bin/cinnamon-file-dialog
+++ b/files/usr/bin/cinnamon-file-dialog
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+import sys
+from gi.repository import Gio, Gtk
+
+cancelButton = (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
+typeArg = int(sys.argv[1]) 
+fdType = typeArg % 3
+if fdType == 0:
+    msg = "Open"
+    action = Gtk.FileChooserAction.OPEN
+    okButton = (Gtk.STOCK_OPEN, Gtk.ResponseType.OK)
+elif fdType == 1:
+    msg = "Select Folder"
+    action = Gtk.FileChooserAction.SELECT_FOLDER
+    okButton = (Gtk.STOCK_OPEN, Gtk.ResponseType.OK)
+elif fdType == 2:
+    msg = "Save"
+    action = Gtk.FileChooserAction.SAVE
+    okButton = (Gtk.STOCK_SAVE, Gtk.ResponseType.OK)
+
+buttons = cancelButton + okButton
+filechooserdialog = Gtk.FileChooserDialog(title=msg, action=action, buttons=buttons)
+
+for i in range(2, len(sys.argv)):
+    if sys.argv[i] == "-p":
+        filechooserdialog.set_filename(sys.argv[i+1])
+    elif sys.argv[i] == "-n":
+        filechooserdialog.set_current_name(sys.argv[i+1])
+    elif sys.argv[i] == "-d":
+        filechooserdialog.set_current_folder(sys.argv[i+1])
+    elif sys.argv[i] == "-f":
+        filterList = sys.argv[i+1].split(",")
+        for filterInfo in filterList:
+            [name,filters] = filterInfo.split(";")
+            filterObj = Gtk.FileFilter()
+            filterObj.set_name(name)
+            rules = filters.split(":")
+            for rule in rules:
+                [ftype,value] = rule.split("=")
+                if ftype == "m":
+                    filterObj.add_mime_type(value)
+                elif ftype == "p":
+                    filterObj.add_pattern(value)
+            filechooserdialog.add_filter(filterObj)
+
+if fdType == 2:
+    filechooserdialog.set_do_overwrite_confirmation(True)
+
+if typeArg > 2:
+    filechooserdialog.set_select_multiple(True)
+
+response=filechooserdialog.run()
+if response == Gtk.ResponseType.OK:
+    if typeArg > 2:
+        print (filechooserdialog.get_filenames())
+    else:
+        print (filechooserdialog.get_filename())
+
+filechooserdialog.destroy()

--- a/js/Makefile.am
+++ b/js/Makefile.am
@@ -4,6 +4,7 @@ jsdir = $(pkgdatadir)/js
 nobase_dist_js_DATA = \
 	misc/config.js		\
 	misc/docInfo.js		\
+	misc/fileDialog.js	\
 	misc/fileUtils.js	\
 	misc/format.js		\
 	misc/gnomeSession.js	\

--- a/js/misc/fileDialog.js
+++ b/js/misc/fileDialog.js
@@ -1,0 +1,54 @@
+const Util = imports.misc.util;
+const GLib = imports.gi.GLib;
+
+function open(callback, params) {
+	_launchDialog(0, callback, params);
+}
+
+function openFolder(callback, params) {
+	_launchDialog(1, callback, params);
+}
+
+function save(callback, params) {
+	_launchDialog(2, callback, params);
+}
+
+function _launchDialog(type, callback, params) {
+	let args = ["cinnamon-file-dialog"];
+	if (params.selectMultiple) type += 3; //add 3 to use the select-multiple version
+	args.push(String(type));
+	if (params.path) args.push("-p", params.path.replace("~", GLib.get_home_dir()));
+	if (params.name) args.push("-n", params.name);
+	if (params.directory) args.push("-d", params.directory.replace("~", GLib.get_home_dir()));
+	if (params.filters) {
+		let filterList = [];
+		for (let i = 0; i < params.filters.length; i++) {
+			filterList.push(params.filters[i].getString());
+		}
+		args.push("-f", filterList.join(","));
+	}
+	Util.spawn_async(args, callback);
+}
+
+function Filter(name) {
+	this._init(name);
+}
+
+Filter.prototype = {
+	_init: function(name) {
+		this.name = name;
+		this.rules = [];
+	},
+
+	addMimeType: function(mime) {
+		this.rules.push("m="+mime);
+	},
+
+	addPattern: function(pattern) {
+		this.rules.push("p="+pattern);
+	},
+
+	getString: function() {
+		return this.name + ";" + this.rules.join(":");
+	}
+}


### PR DESCRIPTION
This introduces a file dialog to Cinnamon. The dialog itself is Gtk, but uses the Util.spawn_async method to open the dialog and return the results. It supports 
* open, save, and open folder types
* single or multiple selection
* setting default directory, path and/or name
* custom file filters

Typical usage might be something like:

    const FileDialog = imports.misc.fileDialog;
    
    let params = {};
    params.directory = "~/Pictures/";
    params.name = "untitled";
    params.selectMultiple = true;
    
    let anyFilter = new FileDialog.Filter("any");
    anyFilter.addPattern("*");
    
    let imageFilter = new FileDialog.Filter("image");
    imageFilter.addMimeType("image/jpeg");
    imageFilter.addMimeType("image/png");
    imageFilter.addMimeType("image/svg+xml");
    
    params.filters = [anyFilter, imageFilter];
    
    FileDialog.open(function(path){
        //do something with the path
    }, params);
