### PR TITLE
Fix regression in multi-instance applets

### DIFF
--- a/files/usr/lib/cinnamon-settings/bin/XletSettings.py
+++ b/files/usr/lib/cinnamon-settings/bin/XletSettings.py
@@ -100,7 +100,7 @@ class XletSetting:
     def get_settings_for_applet(self, path):
         if "max-instances" in self.applet_meta:
             try:
-                self.multi_instance = int(self.applet_meta["max-instances"]) > 1
+                self.multi_instance = int(self.applet_meta["max-instances"]) != 1
             except:
                 if "infinite" in self.applet_meta["max-instances"]:
                     self.multi_instance = True

--- a/js/ui/settings.js
+++ b/js/ui/settings.js
@@ -783,7 +783,7 @@ AppletSettings.prototype = {
     },
 
     _get_is_multi_instance_xlet: function(uuid) {
-        return Extension.get_max_instances(uuid) > 1;
+        return Extension.get_max_instances(uuid) != 1;
     },
 };
 


### PR DESCRIPTION
There was a regression introduced by https://github.com/linuxmint/Cinnamon/commit/b1a6bce1dd879a05b480cc78f3496cab9d0ef3e2 which was causing multi-instance applets to not be recognized as multi-instance by certain Cinnamon components, which was causing it to not recognize the settings for the first instance of the applet.