### PR TITLE
Improve workspace switch animation (fixes #3524)

### DIFF
--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -424,9 +424,7 @@ WindowManager.prototype = {
         this._animationBlockCount = 0;
 
         this._switchData = null;
-        this._cinnamonwm.connect('kill-switch-workspace', Lang.bind(this, this._switchWorkspaceDone));
         this._cinnamonwm.connect('kill-window-effects', Lang.bind(this, this._killWindowEffects));
-
         this._cinnamonwm.connect('switch-workspace', Lang.bind(this, this._switchWorkspace));
         this._cinnamonwm.connect('minimize', Lang.bind(this, this._minimizeWindow));
         this._cinnamonwm.connect('maximize', Lang.bind(this, this._maximizeWindow));
@@ -680,7 +678,6 @@ WindowManager.prototype = {
         this._startWindowEffect(cinnamonwm, "map", actor);
     },
 
-
     _destroyWindow : function(cinnamonwm, actor) {
 
         if (actor.meta_window.get_window_type() == Meta.WindowType.NORMAL) {
@@ -740,77 +737,62 @@ WindowManager.prototype = {
                  direction == Meta.MotionDirection.DOWN_RIGHT)
                 xDest = -global.screen_width;
 
-        let switchData = {};
-        this._switchData = switchData;
-        switchData.inGroup = new Clutter.Group();
-        switchData.outGroup = new Clutter.Group();
-        switchData.windows = [];
-
-        let wgroup = global.window_group;
-        wgroup.add_actor(switchData.inGroup);
-        wgroup.add_actor(switchData.outGroup);
-
         for (let i = 0; i < windows.length; i++) {
             let window = windows[i];
 
             if (!window.meta_window.showing_on_its_workspace())
                 continue;
 
-            if (window.get_workspace() == from) {
-                switchData.windows.push({ window: window,
-                                          parent: window.get_parent() });
-                global.reparentActor(window, switchData.outGroup);
+            if ((window.meta_window == this._movingWindow) ||
+                ((global.display.get_grab_op() == Meta.GrabOp.MOVING ||
+                  global.display.get_grab_op() == Meta.GrabOp.KEYBOARD_MOVING)
+                 && window.meta_window == global.display.get_focus_window())) {
+                /* We are moving this window to the other workspace. In fact,
+                 * it is already on the other workspace, so it is hidden. We
+                 * force it to show and then don't animate it, so it stays
+                 * there while other windows move. */
+                window.show_all();
+                this._movingWindow == undefined;
+            } else if (window.get_workspace() == from) {
+                if (window.origX == undefined) {
+                    window.origX = window.x;
+                    window.origY = window.y;
+                }
+                Tweener.addTween(window,
+                        { x: window.origX + xDest,
+                          y: window.origY + yDest,
+                          time: WINDOW_ANIMATION_TIME,
+                          transition: 'easeOutQuad',
+                          onComplete: function() {
+                              window.hide();
+                              window.set_position(window.origX, window.origY);
+                              window.origX = undefined;
+                              window.origY = undefined;
+                          }
+                        });
             } else if (window.get_workspace() == to) {
-                switchData.windows.push({ window: window,
-                                          parent: window.get_parent() });
-                global.reparentActor(window, switchData.inGroup);
+                if (window.origX == undefined) {
+                    window.origX = window.x;
+                    window.origY = window.y;
+                    window.set_position(window.origX - xDest, window.origY - yDest);
+                }
+                Tweener.addTween(window,
+                        { x: window.origX,
+                          y: window.origY,
+                          time: WINDOW_ANIMATION_TIME,
+                          transition: 'easeOutQuad',
+                          onComplete: Lang.bind(window, function() {
+                              window.origX = undefined;
+                              window.origY = undefined;
+                          })
+                        });
                 window.show_all();
             }
         }
 
-        switchData.inGroup.set_position(-xDest, -yDest);
-        switchData.inGroup.raise_top();
-
-        Tweener.addTween(switchData.outGroup,
-                         { x: xDest,
-                           y: yDest,
-                           time: WINDOW_ANIMATION_TIME,
-                           transition: 'easeOutQuad',
-                           onComplete: this._switchWorkspaceDone,
-                           onCompleteScope: this,
-                           onCompleteParams: [cinnamonwm]
-                         });
-        Tweener.addTween(switchData.inGroup,
-                         { x: 0,
-                           y: 0,
-                           time: WINDOW_ANIMATION_TIME,
-                           transition: 'easeOutQuad'
-                         });
-    },
-
-    _switchWorkspaceDone : function(cinnamonwm) {
-        let switchData = this._switchData;
-        if (!switchData)
-            return;
-        this._switchData = null;
-
-        for (let i = 0; i < switchData.windows.length; i++) {
-                let w = switchData.windows[i];
-                if (w.window.is_destroyed()) // Window gone
-                    continue;
-                if (w.window.get_parent() == switchData.outGroup) {
-                    global.reparentActor(w.window, w.parent);
-                    w.window.hide();
-                } else {
-                    global.reparentActor(w.window, w.parent);
-                }
-        }
-        Tweener.removeTweens(switchData.inGroup);
-        Tweener.removeTweens(switchData.outGroup);
-        switchData.inGroup.destroy();
-        switchData.outGroup.destroy();
-
-        cinnamonwm.completed_switch_workspace();
+        Mainloop.timeout_add(WINDOW_ANIMATION_TIME * 1000, function() {
+            cinnamonwm.completed_switch_workspace();
+        });
     },
 
     _showTilePreview: function(cinnamonwm, window, tileRect, monitorIndex, snapQueued) {
@@ -934,17 +916,12 @@ WindowManager.prototype = {
         if (window.get_window_type() === Meta.WindowType.DESKTOP) {
             return;
         }
+        this._movingWindow = window;
         let workspace = global.screen.get_active_workspace().get_neighbor(direction);
         if (workspace != global.screen.get_active_workspace()) {
             window.change_workspace(workspace);
-            workspace.activate(global.get_current_time());
+            workspace.activate_with_focus(window, global.get_current_time());
             this.showWorkspaceOSD();
-            Mainloop.idle_add(Lang.bind(this, function() {
-                // Unless this is done a bit later, window is sometimes not activated
-                if (window.get_workspace() == global.screen.get_active_workspace()) {
-                    window.activate(global.get_current_time());
-                }
-            }));
         }
     },
 

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -459,7 +459,9 @@ WindowManager.prototype = {
         Meta.keybindings_set_custom_handler('switch-group-backward',
                                             Lang.bind(this, this._startAppSwitcher));
         Meta.keybindings_set_custom_handler('switch-panels',
-                                            Lang.bind(this, this._startA11ySwitcher));
+                                            Lang.bind(this, this._startAppSwitcher));
+        Meta.keybindings_set_custom_handler('switch-panels-backward',
+                                            Lang.bind(this, this._startAppSwitcher));
 
         Main.overview.connect('showing', Lang.bind(this, function() {
             for (let i = 0; i < this._dimmedWindows.length; i++)
@@ -905,10 +907,6 @@ WindowManager.prototype = {
     },
 
     _startAppSwitcher : function(display, screen, window, binding) {
-        this._createAppSwitcher(binding);
-    },
-
-    _startA11ySwitcher : function(display, screen, window, binding) {
         this._createAppSwitcher(binding);
     },
 


### PR DESCRIPTION
This affects the animation in several cases:

- Animation of windows changing workspace:
  If you use Ctrl-Shift-Alt Left/Right to move a window to an adjacent workspace, or switch workspaces while dragging a window (which will move the window with you), what used to happen is that the window disappears from the "from" workspace, appears in the "to" workspace, and animates in like any other window from the "to" workspace. With this commit, the window stays at its position while the "from" and "to" windows animate.

- Stacking of "Visible in All Workspaces" windows:
  In the past, when we switch workspaces, "visible in all workspaces" windows are stacked oddly during animation. They are stacked below all windows on the "from" workspace, and above all windows on the "to" workspace.  With this commit, they are stacked correctly relative to the windows on the "to" workspace, while placed above all windows on the "from" workspace.

  The reason for it appearing above windows on the "from" workspace is that "visible on all workspaces" windows are treated as windows on the current workspace, and the workspace number changes accordingly when we switch workspaces. Hence once the animation starts, the stacker thinks the window is on the "to" workspace, and is hence stacked above all windows on the "from" workspace. If we freeze the stack before
  doing the switch, the effect is opposite - it is stacked correctly relative to the "from" windows while appears below all "to" windows. I have totally no idea why this happens.