### PR TITLE
Rework window-list applet

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -170,7 +170,7 @@ AppMenuButton.prototype = {
             this.rightClickMenu = new AppMenuButtonRightClickMenu(this, this.metaWindow, this._applet.orientation);
             this._menuManager.addMenu(this.rightClickMenu);
 
-            this._draggable = DND.makeDraggable(this.actor);
+            this._draggable = DND.makeDraggable(this.actor, null, this._applet.actor);
             this._draggable.connect('drag-begin', Lang.bind(this, this._onDragBegin));
             this._draggable.connect('drag-cancelled', Lang.bind(this, this._onDragCancelled));
             this._draggable.connect('drag-end', Lang.bind(this, this._onDragEnd));
@@ -242,6 +242,7 @@ AppMenuButton.prototype = {
     },
 
     _onDragBegin: function() {
+        this._draggable._overrideY = this.actor.get_transformed_position()[1];
         this.actor.hide();
         this._tooltip.hide();
         this._tooltip.preventShow = true;
@@ -945,7 +946,7 @@ MyApplet.prototype = {
         let children = this.actor.get_children();
 
         let pos = children.length;
-        while (pos-- && x < children[pos].get_allocation_box().x1 + children[pos].width / 2);
+        while (--pos && x < children[pos].get_allocation_box().x1 + children[pos].width / 2);
 
         this._dragPlaceholderPos = pos;
 

--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -860,6 +860,15 @@ MyApplet.prototype = {
                 window.setDisplayTitle();
     },
 
+    // Used by windowManager for traditional minimize and map effect
+    getOriginFromWindow: function(metaWindow) {
+        for (let window of this._windows)
+            if (window.metaWindow == metaWindow)
+                return window.actor;
+
+        return false;
+    },
+
     _updateWatchedMonitors: function() {
         let n_mons = Gdk.Screen.get_default().get_n_monitors();
         let on_primary = this.panel.monitorIndex == Main.layoutManager.primaryIndex;

--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/settings-schema.json
@@ -9,6 +9,11 @@
       "default" : false,
       "description" : "Enable mouse-wheel scrolling in the window list"
   },
+  "reverse-scrolling" : {
+      "type" : "checkbox",
+      "default" : false,
+      "description" : "Reverse the direction of mouse-wheel scrolling in the window list"
+  },
   "middle-click-close": {
       "type": "checkbox",
       "default": true,

--- a/js/ui/windowEffects.js
+++ b/js/ui/windowEffects.js
@@ -255,7 +255,9 @@ Minimize.prototype = {
     traditional: function(cinnamonwm, actor, time, transition){
         if(AppletManager.get_role_provider_exists(AppletManager.Roles.WINDOWLIST)){
             let windowApplet = AppletManager.get_role_provider(AppletManager.Roles.WINDOWLIST);
-            let actorOrigin = windowApplet.getOriginFromWindow(actor.get_meta_window());
+            let actorOrigin = windowApplet.getOriginFromWindow ?
+                windowApplet.getOriginFromWindow(actor.get_meta_window()) :
+                false;
 
             if(actorOrigin !== false){
                 actor.set_scale(1, 1);
@@ -292,7 +294,9 @@ Unminimize.prototype = {
     traditional: function(cinnamonwm, actor, time, transition){
         if(AppletManager.get_role_provider_exists(AppletManager.Roles.WINDOWLIST)){
             let windowApplet = AppletManager.get_role_provider(AppletManager.Roles.WINDOWLIST);
-            let actorOrigin = windowApplet.getOriginFromWindow(actor.get_meta_window());
+            let actorOrigin = windowApplet.getOriginFromWindow ?
+                windowApplet.getOriginFromWindow(actor.get_meta_window()) :
+                false;
 
             if(actorOrigin !== false){
                 actor.set_scale(0, 0);
@@ -306,10 +310,10 @@ Unminimize.prototype = {
 
                 this._moveWindow(cinnamonwm, actor, xDest, yDest, time, transition);
                 this._scaleWindow(cinnamonwm, actor, 1, 1, time, transition, true);
-                return;
+                return true;
             }
         }
-        throw "No origin found";
+        return false;
     }
 }
 

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -669,12 +669,9 @@ WindowManager.prototype = {
         }));
 
         if (actor.get_meta_window()._cinnamonwm_has_origin === true) {
-            try {
-                this._startWindowEffect(cinnamonwm, "unminimize", actor, null, "minimize");
+            // Returns false if unable to find window origin
+            if (this._startWindowEffect(cinnamonwm, "unminimize", actor, null, "minimize"))
                 return;
-            } catch(e){
-                //catch "no origin found"
-            }
         } else if (actor.meta_window.get_window_type() == Meta.WindowType.NORMAL) {
             Main.soundManager.play('map');
         }


### PR DESCRIPTION
 - Refactor code to make more sense - this applet was hack on top of
   hack and was a huge mess. A lot of things were done in convoluted
   ways.
 - Add option to scroll window list in the other direction with mouse
   scroll wheel
 - Disconnect signals properly when destroyed
 - Listen to windows demanding attention in addition to urgent-windows
   (might solve #3812)
 - Changed window-list dnd to firefox-tab style
 - Fix broken applet style when changing panel orientation (in the past,
   after changing panel orientation, it will simultaneously have top and
   bottom styles).
 - Added a brief overview of the code structure

Might fix #3574