### PR TITLE
Add extension versioning support

### DIFF
--- a/docs/reference/cinnamon-js/tutorials.xml
+++ b/docs/reference/cinnamon-js/tutorials.xml
@@ -7,5 +7,6 @@
 <part id="extension-system">
   <title>Extension system</title>
   <xi:include href="tutorials/write-applet.xml"/>
+  <xi:include href="tutorials/xlet-versioning.xml"/>
   <xi:include href="tutorials/xlet-settings.xml"/>
 </part>

--- a/docs/reference/cinnamon-js/tutorials/xlet-versioning.xml
+++ b/docs/reference/cinnamon-js/tutorials/xlet-versioning.xml
@@ -1,0 +1,43 @@
+<?xml version='1.0'?>
+<!DOCTYPE book PUBLIC '-//OASIS//DTD DocBook XML V4.3//EN'
+'http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd'
+[
+<!ENTITY % local.common.attrib "xmlns:xi  CDATA  #FIXED 'http://www.w3.org/2003/XInclude'">
+]>
+
+<chapter id="xlet-versioning">
+  <title>Supporting multiple versions</title>
+  <para>
+    With a new version of Cinnamon coming out every 6 months, there might be some cool new feature you want to use in your applet. However, you also don't want to leave out the poor users using the older versions of Cinnamon.
+  </para>
+
+  <para>
+    Alternatively, when a new version of Cinnamon comes out, your extension is no longer compatible with it. Updating it would, again, leave out the users running older Cinnamons.
+  </para>
+
+  <para>
+    Here extension versioning comes to the rescue. Since Cinnamon 2.6, it is possible to ship different versions of your extension for different versions of Cinnamon. Here "extension" will refer to all extensions, applets and desklets.
+  </para>
+
+  <para> To enable extension versioning, extensions have to add the line</para>
+  <informalexample>
+    <programlisting>
+      "multiversion": true
+    </programlisting>
+  </informalexample>
+  <para>
+    in <code>metadata.json</code>. The different versions should be put in different subdirectories. For example, the version for 2.6 should be put in <code>extension@uuid/2.6/</code>. The contents in <code>2.6/</code> should be exactly what you will normally put in <code>extension@uuid/</code>, apart from <code>metadata.json</code>, which should always be put in the parent directory, ie. <code>extension@uuid/</code>.
+  </para>
+
+  <para>
+    You do not need to create a subdirectory for every single Cinnamon version out there. Cinnamon looks for the most recent subdirectory that is not newer than the running Cinnamon version. For example, if you are running 2.6 and there are 2.4, 2.8 directories, the 2.4 directory will be loaded, until the you upgrade to 2.8 in which case the 2.8 directory will be used. Minor version numbers can also be used, eg. 2.6.4, and are sorted accordingly.
+  </para>
+
+  <para>
+    If no suitable directory is found, then the contents in <code>extension@uuid/</code> will be loaded. Note that Cinnamon versions prior to 2.6 will not understand this directory magic, and will always try to load the contents in <code>extension@uuid/</code>. Hence it is suggested that extension maintainers put the version for 2.4 in <code>extension@uuid</code>, and create new directories if changes <emphasis>specific to newer cinnamon versions</emphasis> are made. Don't make a new directory whenever a Cinnamon version is out since it is just a waste of space (and maintenance effort).
+  </para>
+
+  <para>
+   Note that this also allows you to support future versions of Cinnamon. For example, if you see a cool feature in the development branch of Cinnamon, you can modify your code and put it in the 2.6 folder (assuming the current version is 2.4). Then once the user upgrades their cinnamon version, the new code will be used instead. This also allows extensions to be smoothly upgraded between versions.
+ </para>
+</chapter>

--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -114,10 +114,12 @@ for(var key in Type) {
     Signals.addSignalMethods(type);
 
     let path = GLib.build_filenamev([global.userdatadir, type.folder]);
-    type.userDir = Gio.file_new_for_path(path);
+    type.userDir = path;
+
+    let dir = Gio.file_new_for_path(type.userDir)
     try {
-        if (!type.userDir.query_exists(null))
-            type.userDir.make_directory_with_parents(null);
+        if (!dir.query_exists(null))
+            dir.make_directory_with_parents(null);
     } catch (e) {
         global.logError(e);
     }

--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -149,15 +149,20 @@ Extension.prototype = {
         if (!force)
             this.validateMetaData();
 
-        this.ensureFileExists(dir.get_child(this.lowerType + '.js'));
-        this.loadStylesheet(dir.get_child('stylesheet.css'));
+        if (this.meta.multiversion) {
+            this.dir = findExtensionSubdirectory(this.dir);
+            this.meta.path = this.dir.get_path();
+        }
+
+        this.ensureFileExists(this.dir.get_child(this.lowerType + '.js'));
+        this.loadStylesheet(this.dir.get_child('stylesheet.css'));
         
         if (this.stylesheet) {
             Main.themeManager.connect('theme-set', Lang.bind(this, function() {
                 this.loadStylesheet(this.dir.get_child('stylesheet.css'));
             }));
         }
-        this.loadIconDirectory(dir);
+        this.loadIconDirectory(this.dir);
 
         try {
             CinnamonJS.add_extension_importer('imports.ui.extension.importObjects', this.uuid, this.meta.path);
@@ -399,6 +404,34 @@ function versionCheck(required, current) {
     return false;
 }
 
+/**
+ * versionLeq:
+ * @a (string): the first version
+ * @b (string): the second version
+ *
+ * Returns: whether a <= b
+ */
+function versionLeq(a, b) {
+    a = a.split('.');
+    b = b.split('.');
+
+    if (a.length == 2)
+        a.push(0);
+
+    if (b.length == 2)
+        b.push(0);
+
+    for (let i = 0; i < 3; i++) {
+        if (a[i] == b[i])
+            continue;
+        else if (a[i] > b[i])
+            return false;
+        else
+            return true;
+    }
+    return true;
+}
+
 // Returns a string version of a State value
 function getMetaStateString(state) {
     switch (state) {
@@ -418,7 +451,7 @@ function loadExtension(uuid, type) {
     let extension = objects[uuid];
     if(!extension) {
         try {
-            let dir = findExtensionDirectory(uuid.replace(/!/,''), type);
+            let dir = findExtensionDirectory(uuid.replace(/^!/,''), type);
             if (dir == null) {
                 throw ("not-found");
             }
@@ -500,6 +533,49 @@ function findExtensionDirectory(uuid, type) {
             return dir;
     }
     return null;
+}
+
+/**
+ * findExtensionSubdirectory:
+ * @dir (Gio.File): directory to search in
+ *
+ * For extensions that are shipped with multiple versions in different
+ * directories, look for the largest available version that is less than or
+ * equal to the current running version. If no such version is found, the
+ * original directory is returned.
+ *
+ * Returns (Gio.File): directory object of the desired directory.
+ */
+function findExtensionSubdirectory(dir) {
+    try {
+        let fileEnum = dir.enumerate_children('standard::*', Gio.FileQueryInfoFlags.NONE, null);
+
+        let info;
+        let largest = null;
+        while ((info = fileEnum.next_file(null)) != null) {
+            let fileType = info.get_file_type();
+            if (fileType != Gio.FileType.DIRECTORY)
+                continue;
+
+            let name = info.get_name();
+            if (!name.match(/^[0-9]+\.[0-9]+(\.[0-9]+)?$/))
+                continue;
+
+            if (versionLeq(name, Config.PACKAGE_VERSION) &&
+                (!largest || versionLeq(largest[0], name))) {
+                largest = [name, fileEnum.get_child(info)];
+            }
+        }
+
+        fileEnum.close(null);
+        if (largest)
+            return largest[1];
+        else
+            return dir;
+    } catch (e) {
+        global.logError('Error looking for extension version for ' + dir.get_basename() + ' in directory ' + dir, e);
+        return dir;
+    }
 }
 
 function get_max_instances (uuid) {


### PR DESCRIPTION
This commit provides the option for extensions to ship different
versions for different Cinnamon verions. To enable this, extensions have
to set
````
   "multiversion": true
````
in metadata.json. The different versions should be put in different
subdirectories. For example, the version for 2.6 should be put in
`<extension-uuid>/2.6/`. The contents in `2.6/` should be exactly what you
will normally put in `<extension-uuid>/`, apart from metadata.json, which
should always be put in the parent directory, ie. `<extension-uuid>/`.

You do not need to create a subdirectory for every single Cinnamon
version out there. Cinnamon looks for the most recent subdirectory that
is not newer than the running Cinnamon version. For example, if you are
running 2.6 and there are 2.4, 2.8 directories, the 2.4 directory will
be loaded, until the you upgrade to 2.8 in which case the 2.8 directory
will be used. Minor version numbers can also be used, eg. 2.6.4, and are
sorted accordingly.

If no suitable directory is found, then the contents in
`<extension-uuid>/` will be loaded. Note that Cinnamon versions prior to
2.6 will not understand this directory magic, and will always try to
load the contents in `<extension-uuid>/`. Hence it is suggested that
extension maintainers put the version for 2.4 in `<extension-uuid>/`, and
create new directories if changes _specific to newer cinnamon versions_
are made. Don't make a new directory whenever a Cinnamon version is out
since it is just a waste of space (and maintenance effort).

Note that here "extensions" refers to what is normally known as
extensions, applets and desklets (but not themes). All these extensions
can use this versioning scheme to support multiple versions.