### PR TITLE
sound applet: player changes

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -1207,7 +1207,7 @@ StScrollBar StButton#vhandle:hover {
 	border-radius: 4px;
 	padding: 5px;
 }
-.sound-button:hover {
+.sound-button:hover, .sound-button:active {
 	border: 1px solid white;
 }
 .sound-button StIcon {

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/settings-schema.json
@@ -34,6 +34,32 @@
         "description" : "Hide system tray icons for compatible players",
         "default": true
     },
+    "separator": {
+        "type": "separator"
+    },
+    "playerControl": {
+        "type": "checkbox",
+        "default": true,
+        "description": "Control Players"
+    },
+    "extendedPlayerControl": {
+        "type": "checkbox",
+        "default": false,
+        "description": "Show Loop and Shuffle controls",
+        "dependency": "playerControl",
+        "indent": true
+    },
+    "positionLabelType": {
+        "type": "combobox",
+        "default": "length",
+        "description": "Position label",
+        "options": {
+            "Song length": "length",
+            "Countdown": "countdown"
+        },
+        "dependency": "playerControl",
+        "indent": true
+    },
     "_knownPlayers": {
         "type": "generic",
         "default": ["banshee", "vlc"]

--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -364,6 +364,10 @@ PopupBaseMenuItem.prototype = {
                     childBox.x1 = x;
                     childBox.x2 = x + naturalWidth;
                 }
+                
+                //when somehow the actor is wider than the box, cut it off
+                if(childBox.x2 > box.x2)
+                    childBox.x2 = box.x2;
             } else {
                 if (child.expand) {
                     childBox.x1 = x - availWidth;
@@ -380,6 +384,10 @@ PopupBaseMenuItem.prototype = {
                     childBox.x2 = x;
                     childBox.x1 = x - naturalWidth;
                 }
+                
+                //when somehow the actor is wider than the box, cut it off
+                if(childBox.x1 < box.x1)
+                    childBox.x1 = box.x1;
             }
 
             let [minHeight, naturalHeight] = child.actor.get_preferred_height(childBox.x2 - childBox.x1);
@@ -840,8 +848,8 @@ PopupIconMenuItem.prototype = {
         this.label = new St.Label({text: text});
         this._icon = new St.Icon({ style_class: 'popup-menu-icon',
             icon_name: iconName,
-            icon_type: iconType}); 
-        this.addActor(this._icon);
+            icon_type: iconType});
+        this.addActor(this._icon, {span: 0});
         this.addActor(this.label);
     },
 
@@ -853,15 +861,6 @@ PopupIconMenuItem.prototype = {
     setIconName: function (iconName) {
         this._icon.set_icon_name(iconName);
         this._icon.set_icon_type(St.IconType.FULLCOLOR);
-    },
-
-    // Override columnWidths so that the popup menu doesn't separate the icon and the label
-    setColumnWidths: function() {
-        this._columnWidths = null;
-    },
-
-    getColumnWidths: function() {
-        return [];
     }
 }
 


### PR DESCRIPTION
- moved raise and quit player buttons next to the player info
- setting for player control (closes #3332)
- loop and shuffle buttons, configurable, default off
- position slider styling: no icon, labels left and right to the slider (closes #2165)
- position slider countdown option
- track infos uses `PopupMenu.PopupIconMenuItem`

![sound applet](https://cloud.githubusercontent.com/assets/7093655/7338082/9a473ce2-ec40-11e4-8264-a0675c7131a9.png)
![sound applet settings](https://cloud.githubusercontent.com/assets/7093655/7338083/9e6fa520-ec40-11e4-94bb-ca7a0d3f0f7b.png)
