### PR TITLE
settings-keyboard, On the Shortcuts tab, stop the keyboard bindings view...

### DIFF
--- a/files/usr/lib/cinnamon-settings/modules/cs_keyboard.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_keyboard.py
@@ -282,7 +282,6 @@ class Module:
             right_vbox.pack_start(kb_name_scroller, True, True, 2)
             right_vbox.pack_start(entry_scroller, True, True, 2)
             kb_name_scroller.set_property('min-content-height', 150)
-            entry_scroller.set_property('min-content-height', 100)
             self.cat_tree = Gtk.TreeView.new()
             self.kb_tree = Gtk.TreeView.new()
             self.entry_tree = Gtk.TreeView.new()
@@ -298,7 +297,7 @@ class Module:
             kb_name_scroller.add(self.kb_tree)
             kb_name_scroller.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
             entry_scroller.add(self.entry_tree)
-            entry_scroller.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.NEVER)
+            entry_scroller.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
 
             buttonbox = Gtk.ButtonBox.new(Gtk.Orientation.HORIZONTAL)
             self.add_custom_button = Gtk.Button.new_with_label(_("Add custom shortcut"))


### PR DESCRIPTION
... from jumping around when selecting an item in the keyboard shortcuts view