### PR TITLE
Remove kill-switch-workspace signal

### DIFF
--- a/src/cinnamon-plugin.c
+++ b/src/cinnamon-plugin.c
@@ -93,8 +93,6 @@ static void gnome_cinnamon_plugin_hide_hud_preview (MetaPlugin *plugin);
 
 static void gnome_cinnamon_plugin_kill_window_effects   (MetaPlugin      *plugin,
                                                       MetaWindowActor *actor);
-static void gnome_cinnamon_plugin_kill_switch_workspace (MetaPlugin      *plugin);
-
 
 static gboolean              gnome_cinnamon_plugin_xevent_filter (MetaPlugin *plugin,
                                                                XEvent     *event);
@@ -162,7 +160,6 @@ gnome_cinnamon_plugin_class_init (CinnamonPluginClass *klass)
 
 
   plugin_class->kill_window_effects   = gnome_cinnamon_plugin_kill_window_effects;
-  plugin_class->kill_switch_workspace = gnome_cinnamon_plugin_kill_switch_workspace;
 
   plugin_class->xevent_filter    = gnome_cinnamon_plugin_xevent_filter;
   plugin_class->plugin_info      = gnome_cinnamon_plugin_plugin_info;
@@ -344,12 +341,6 @@ gnome_cinnamon_plugin_kill_window_effects (MetaPlugin         *plugin,
                                         MetaWindowActor    *actor)
 {
   _cinnamon_wm_kill_window_effects (get_cinnamon_wm(), actor);
-}
-
-static void
-gnome_cinnamon_plugin_kill_switch_workspace (MetaPlugin         *plugin)
-{
-  _cinnamon_wm_kill_switch_workspace (get_cinnamon_wm());
 }
 
 static void

--- a/src/cinnamon-wm-private.h
+++ b/src/cinnamon-wm-private.h
@@ -54,7 +54,6 @@ void _cinnamon_wm_hide_hud_preview     (CinnamonWM         *wm);
 
 void _cinnamon_wm_kill_window_effects   (CinnamonWM             *wm,
                                       MetaWindowActor     *actor);
-void _cinnamon_wm_kill_switch_workspace (CinnamonWM             *wm);
 
 G_END_DECLS
 

--- a/src/cinnamon-wm.c
+++ b/src/cinnamon-wm.c
@@ -26,7 +26,6 @@ enum
   MAP,
   DESTROY,
   SWITCH_WORKSPACE,
-  KILL_SWITCH_WORKSPACE,
   KILL_WINDOW_EFFECTS,
   SHOW_TILE_PREVIEW,
   HIDE_TILE_PREVIEW,
@@ -121,14 +120,6 @@ cinnamon_wm_class_init (CinnamonWMClass *klass)
 		  _cinnamon_marshal_VOID__INT_INT_INT,
 		  G_TYPE_NONE, 3,
                   G_TYPE_INT, G_TYPE_INT, G_TYPE_INT);
-  cinnamon_wm_signals[KILL_SWITCH_WORKSPACE] =
-    g_signal_new ("kill-switch-workspace",
-		  G_TYPE_FROM_CLASS (klass),
-		  G_SIGNAL_RUN_LAST,
-		  0,
-		  NULL, NULL,
-		  g_cclosure_marshal_VOID__VOID,
-		  G_TYPE_NONE, 0);
   cinnamon_wm_signals[KILL_WINDOW_EFFECTS] =
     g_signal_new ("kill-window-effects",
 		  G_TYPE_FROM_CLASS (klass),
@@ -280,12 +271,6 @@ cinnamon_wm_completed_destroy (CinnamonWM         *wm,
                             MetaWindowActor *actor)
 {
   meta_plugin_destroy_completed (wm->plugin, actor);
-}
-
-void
-_cinnamon_wm_kill_switch_workspace (CinnamonWM      *wm)
-{
-  g_signal_emit (wm, cinnamon_wm_signals[KILL_SWITCH_WORKSPACE], 0);
 }
 
 void


### PR DESCRIPTION
The kill-switch-workspace signal is used when before switch-workspace
signal is fired for the existing switch animation to be cancelled.
However, this mechanism is not ideal since the switch-workspace and
kill-switch-workspace events are separated.

Using the old model, say we switch to left workspace, and during that
animation, we press Ctrl-Alt-Right to switch back to the right
workspace. What would happen is that we will finish the animation early,
land on the left workspace, and start a new animation.

By letting the wm handle the killing work when receiving the
switch-workspace, we can do better. We can immediately halt the windows'
movement, and let them animate to where Ctrl-Alt-Right would bring them
to, from the position where they started, which would look smoother.

This new way of doing things is already implemented in previous commits,
and this commit removes the kill-switch-workspace signal completely.