### PR TITLE
xlet translation improvements

### DIFF
--- a/files/usr/lib/cinnamon-settings/bin/ExtensionCore.py
+++ b/files/usr/lib/cinnamon-settings/bin/ExtensionCore.py
@@ -11,6 +11,7 @@ from gi.repository import Gio, Gtk, GObject, Gdk, GdkPixbuf, Pango, GLib
 import dbus
 import cgi
 import subprocess
+import gettext
 
 home = os.path.expanduser("~")
 
@@ -1189,9 +1190,10 @@ Please contact the developer.""")
                             json_data=open("%s/%s/metadata.json" % (directory, extension)).read()
                             setting_type = 0
                             data = json.loads(json_data)
+
                             extension_uuid = data["uuid"]
-                            extension_name = data["name"]
-                            extension_description = data["description"]
+                            extension_name = XletSettings.translate(data["uuid"], data["name"])
+                            extension_description = XletSettings.translate(data["uuid"], data["description"])
                             try: extension_max_instances = int(data["max-instances"])
                             except KeyError: extension_max_instances = 1
                             except ValueError:

--- a/files/usr/lib/cinnamon-settings/bin/XletSettings.py
+++ b/files/usr/lib/cinnamon-settings/bin/XletSettings.py
@@ -18,6 +18,29 @@ except Exception, detail:
 
 home = os.path.expanduser("~")
 
+translations = {}
+
+def translate(uuid, string):
+    #check for a translation for this xlet
+    if uuid not in translations:
+        try:
+            translations[uuid] = gettext.translation(uuid, home + "/.local/share/locale").ugettext
+        except IOError:
+            try:
+                translations[uuid] = gettext.translation(uuid, "/usr/share/locale").ugettext
+            except IOError:
+                translations[uuid] = None
+
+    #do not translate whitespaces
+    if not string.strip():
+        return string
+
+    if translations[uuid]:
+        result = translations[uuid](string)
+        if result != string:
+            return result
+    return _(string)
+
 class XletSetting:
 
     def __init__(self, uuid, parent, _type):
@@ -42,7 +65,7 @@ class XletSetting:
             image = Gtk.Image().new_from_icon_name(self.applet_meta["icon"], Gtk.IconSize.BUTTON)
             self.back_to_list_button.set_image(image)
             self.back_to_list_button.get_property('image').set_padding(5, 0)
-        self.back_to_list_button.set_label(self.applet_meta["name"])
+        self.back_to_list_button.set_label(translate(uuid, self.applet_meta["name"]))
         self.back_to_list_button.set_tooltip_text(_("Back to list"))
         self.more_button.set_tooltip_text(_("More actions..."))
         self.remove_button.set_label(_("Remove"))

--- a/files/usr/share/cinnamon/applets/notifications@cinnamon.org/metadata.json
+++ b/files/usr/share/cinnamon/applets/notifications@cinnamon.org/metadata.json
@@ -2,5 +2,6 @@
 "uuid": "notifications@cinnamon.org",
 "name": "Notifications",
 "description": "Click to display and manage system notifications",
-"role": "notifications"
+"role": "notifications",
+"icon": "cs-notifications"
 }

--- a/makepot
+++ b/makepot
@@ -2,12 +2,11 @@
 
 intltool-extract --type=gettext/glade files/usr/lib/cinnamon-menu-editor/cinnamon-menu-editor.ui
 
-xgettext --language=C --keyword=_ --keyword=N_ --output=cinnamon-source.pot generate_additional_files.py src/*.c src/*/*.c js/*/*.js files/usr/share/cinnamon/applets/*/applet.js files/usr/share/cinnamon/desklets/*/desklet.js files/usr/lib/cinnamon-settings/*.py files/usr/lib/cinnamon-settings-users/*.py files/usr/lib/cinnamon-settings/modules/*.py files/usr/lib/cinnamon-settings/bin/ExtensionCore.py files/usr/lib/cinnamon-settings/bin/eyedropper.py files/usr/lib/cinnamon-settings/bin/Spices.py files/usr/lib/cinnamon-settings/bin/XletSettings.py files/usr/lib/cinnamon-settings/bin/XletSettingsWidgets.py files/usr/share/cinnamon/desklets/*/*.py files/usr/lib/cinnamon-screensaver-lock-dialog/*.py files/usr/bin/cinnamon-launcher files/usr/lib/cinnamon-menu-editor/cme/*.py files/usr/lib/cinnamon-menu-editor/cinnamon-menu-editor.ui.h
+xgettext --language=C --keyword=_ --keyword=N_ --output=cinnamon.pot src/*.c src/*/*.c files/usr/lib/cinnamon-menu-editor/cinnamon-menu-editor.ui.h
+xgettext --language=JavaScript --keyword=_ --keyword=N_ --output=cinnamon.pot --join-existing --from-code=UTF-8 js/*/*.js files/usr/share/cinnamon/*/*/*.js
+xgettext --language=Python --keyword=_ --output=cinnamon.pot --join-existing generate_additional_files.py files/usr/share/cinnamon/*/*/*.py files/usr/lib/*/*.py files/usr/lib/cinnamon-settings/*/*.py files/usr/bin/cinnamon-launcher files/usr/lib/cinnamon-menu-editor/cme/*.py
 cd files
-usr/lib/cinnamon-json-makepot/cinnamon-json-makepot.py ../cinnamon-json
+usr/lib/cinnamon-json-makepot/cinnamon-json-makepot.py ../cinnamon
 cd ..
-msguniq cinnamon-json.pot > uniq-cinnamon-json.pot
-msgcat cinnamon-source.pot uniq-cinnamon-json.pot > cinnamon.pot
-rm -f cinnamon-source.pot cinnamon-json.pot uniq-cinnamon-json.pot
 
 rm -f files/usr/lib/cinnamon-menu-editor/cinnamon-menu-editor.ui.h


### PR DESCRIPTION
translation improvements

cs settings:
- translate xlet metadata (name and description)
- moved translate method to a central point

cinnamon-json-makepot:
- don't create duplicates
- parse metadata.json

makepot:
- no more need to use msguniq, removed it
- separate each language (C, JavaScript, Python) into an own xgettext call, surpresses errors

notification applet:
- use cs-notifications as icon (not a translation improvement, only a general one)