### PR TITLE
Display cinnamon-menu-editor in menu applications

### DIFF
--- a/files/usr/share/applications/cinnamon-menu-editor.desktop
+++ b/files/usr/share/applications/cinnamon-menu-editor.desktop
@@ -6,6 +6,5 @@ Icon=alacarte
 OnlyShowIn=X-Cinnamon;
 Terminal=false
 Type=Application
-NoDisplay=true
 Categories=GNOME;GTK;Settings;DesktopSettings;
 StartupNotify=false


### PR DESCRIPTION
This is a useful tool for configuring menu items (similar to Alacarte and Menulibre), and only being able to access it via deep, nested Applet options isn't very convenient.