### PR TITLE
Add missing import on 'cinnamon-settings user'  (Take a photo)

### DIFF
--- a/files/usr/lib/cinnamon-settings/modules/cs_user.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_user.py
@@ -11,6 +11,7 @@ import time
 from random import randint
 import shutil
 import PIL
+from PIL import Image
 import os
 
 class Module:


### PR DESCRIPTION
Fixes missing import on 'cinnamon-settings user'  (Take a photo)
```
Loading User module
global name 'Image' is not defined
global name 'Image' is not defined
global name 'Image' is not defined
```