### PR TITLE
Add "xscreensaver" as a depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -95,6 +95,7 @@ Depends: cinnamon-common (= ${source:Version}),
          gkbd-capplet,
          python-pyinotify,
          metacity,
+         xscreensaver,
          gnome-panel | tint2
 Recommends: gnome-themes-standard, gnome-terminal, cinnamon-bluetooth
 Provides: notification-daemon, x-window-manager


### PR DESCRIPTION
Otherwise cinnamon-settings will crash when launching the screensaver module if xscreensaver is not installed