### PR TITLE
Fix error from window list trying to disconnect non-existant signals

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -716,10 +716,6 @@ MyApplet.prototype = {
 
     on_applet_removed_from_panel: function() {
         this.signals.disconnectAllSignals();
-        for (let ws of this.workspaces) {
-            ws[0].disconnect(ws[1]);
-            ws[0].disconnect(ws[2]);
-        }
     },
 
     on_applet_instances_changed: function() {


### PR DESCRIPTION
An error appears in the looking glass log when the window list applet is removed from a panel. The object is caused by the object ```this.workspaces```, which doesn't exist anywhere else in the applet. All workspace signal connections elsewhere are handled by the connection manager, so the code is apparently useless. I therefore deleted it and it works fine.