### PR TITLE
Little cinnamon settings themes fix

### DIFF
--- a/files/usr/lib/cinnamon-settings/bin/ExtensionCore.py
+++ b/files/usr/lib/cinnamon-settings/bin/ExtensionCore.py
@@ -1095,6 +1095,9 @@ Please contact the developer.""")
                 self.model.set_value(row.iter, 2, 0)
         self._selection_changed()
 
+    def fromSettingString(self, string):
+        return string
+
     def _add_another_instance(self):
         model, treeiter = self.treeview.get_selection().get_selected()
         if treeiter:

--- a/files/usr/lib/cinnamon-settings/modules/cs_extensions.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_extensions.py
@@ -28,9 +28,3 @@ class ExtensionViewSidePage (ExtensionSidePage):
     def toSettingString(self, uuid, instanceId):
         return uuid
 
-    def fromSettingString(self, string):
-        return string
-
-    def getAdditionalPage(self):
-        return None
-


### PR DESCRIPTION
Added missing method to `ExtensionSidePage` class, which blocked the update of the indicator of the active theme.