### PR TITLE
Support keybindings to toggle horizontal/vertical maximized state

### DIFF
--- a/files/usr/lib/cinnamon-settings/modules/cs_keyboard.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_keyboard.py
@@ -80,6 +80,8 @@ KEYBINDINGS = [
     [_("Show desktop"), MUFFIN_KEYBINDINGS_SCHEMA, "show-desktop", "windows"],
     [_("Activate window menu"), MUFFIN_KEYBINDINGS_SCHEMA, "activate-window-menu", "windows"],
     [_("Toggle maximization state"), MUFFIN_KEYBINDINGS_SCHEMA, "toggle-maximized", "windows"],
+    [_("Toggle maximization state vertically"), MUFFIN_KEYBINDINGS_SCHEMA, "toggle-maximized-vertically", "windows"],
+    [_("Toggle maximization state horizontally"), MUFFIN_KEYBINDINGS_SCHEMA, "toggle-maximized-horizontally", "windows"],
     [_("Toggle fullscreen state"), MUFFIN_KEYBINDINGS_SCHEMA, "toggle-fullscreen", "windows"],
     [_("Toggle shaded state"), MUFFIN_KEYBINDINGS_SCHEMA, "toggle-shaded", "windows"],
     [_("Toggle always on top"), MUFFIN_KEYBINDINGS_SCHEMA, "toggle-above", "windows"],


### PR DESCRIPTION
Some graphical applications are ment to be controlled mainly though the
keyboard, think terminal windows.  For these it's extremely handy to have
keybindings to toggle horizontal or vertical maximized state, so one
doesn't have to reach out to the mouse.

Support setting keybindings for 'toggle-maximized-horizontally' and
'toggle-maximized-vertically' in Cinnamon Settings.

See my related pull requests in the [cinnamon-desktop](https://github.com/linuxmint/cinnamon-desktop/pull/47) and [muffin](https://github.com/linuxmint/muffin/pull/192) repositories.