### PR TITLE
Make sure notification applet always stays hidden when it's supposed to

### DIFF
--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -298,7 +298,9 @@ function addAppletToPanels(extension, appletDefinition) {
 
         applet._panelLocation = appletDefinition.location;
         for (let i=0; i<appletsToMove.length; i++) {
+            let hidden = !appletsToMove[i].visible;
             appletDefinition.location.add(appletsToMove[i]);
+            if (hidden) appletsToMove[i].hide();
         }
         
         if(!extension._loadedDefinitions) {


### PR DESCRIPTION
Whenever an applet gets added to the panel and causes the notification applet to be re-added to the panel, it automatically causes it to unhide. You can test this bug by setting the notification applet to hide when the tray is empty and then dragging other applets around it.

This checks the state of the applet before it gets re-added, and sets it to the same state after. It should work for any other applets that get hidden as well, though I haven't tested.