### PR TITLE
[2.8] Also translate xlet metadata in about dialogs

### DIFF
--- a/files/usr/lib/cinnamon-json-makepot/cinnamon-json-makepot.py
+++ b/files/usr/lib/cinnamon-json-makepot/cinnamon-json-makepot.py
@@ -209,10 +209,9 @@ class Main:
                     data = json.load(fp)
                     fp.close()
 
-                    for key in data:
-                        if key in ("name", "description"):
-                            comment = "%s->metadata.json->%s" % (os.path.split(root)[1], key)
-                            self.save_entry(data[key], comment)
+                    self.current_parent_dir = os.path.split(root)[1]
+                    self.extract_metadata_strings(data)
+
 
     def extract_strings(self, data, parent=""):
         for key in data.keys():
@@ -230,6 +229,21 @@ class Main:
                 self.extract_strings(data[key], key)
             except AttributeError:
                 pass
+
+    def extract_metadata_strings(self, data):
+        for key in data:
+            if key in ("name", "description", "comments"):
+                comment = "%s->metadata.json->%s" % (self.current_parent_dir, key)
+                self.save_entry(data[key], comment)
+            elif key == "contributors":
+                comment = "%s->metadata.json->%s" % (self.current_parent_dir, key)
+
+                values = data[key]
+                if isinstance(values, basestring):
+                    values = values.split(",")
+
+                for value in values:
+                    self.save_entry(value.strip(), comment)
 
     def save_entry(self, msgid, comment):
         try:


### PR DESCRIPTION
Addition to #4102, using the translations there.
Also compatible with 3rd party.

Provides following changes:

- hides the optional info box when there is no
- `contributors` can be an array (feels more natural imo), otherwise should be a string where all entries are comma-separated
- `name`, `description`, `contributors` and `comments` translated via xlet and Cinnamon domain
- labels translated via Cinnamon domain
- `cinnamon-json-makepot` updated to create pots translating `contributors` and `comments`