### PR TITLE
signalManager.js: fix iteration of the object map

### DIFF
--- a/js/misc/signalManager.js
+++ b/js/misc/signalManager.js
@@ -136,7 +136,7 @@ SignalManager.prototype = {
         if (!this._storage.has(sigName))
             return false;
 
-        for (let signal of this._storage.get(sigName))
+        for (let [key, signal] of this._storage) 
             if ((!obj || signal[0] == obj) &&
                 (!callback || signal[2] == callback) &&
                 signal[0] &&


### PR DESCRIPTION
This was causing errors when the systray applet was moved around in the panel, either directly, or by moving other applets near it.