### PR TITLE
[2.8] Be more selective when filter the mouse release events.

### DIFF
--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -64,7 +64,7 @@
  * @lg_log_file (Gio.FileOutputStream): The stream used to log looking messages
  *                                      to ~/.cinnamon/glass.log
  * @can_log (boolean): Whether looking glass log to file can be used
- * @popup_rendering (boolean): Whether a popup is in the process of rendering
+ * @popup_rendering_actor (Clutter.Actor): The popup actor that is in the process of rendering
  * @xlet_startup_error (boolean): Whether there was at least one xlet that did
  * not manage to load
  *
@@ -172,7 +172,7 @@ let software_rendering = false;
 let lg_log_file;
 let can_log = false;
 
-let popup_rendering = false;
+let popup_rendering_actor = null;
 
 let xlet_startup_error = false;
 
@@ -1131,7 +1131,9 @@ function _stageEventHandler(actor, event) {
     if (modalCount == 0)
         return false;
     if (event.type() != Clutter.EventType.KEY_PRESS) {
-        return popup_rendering && event.type() == Clutter.EventType.BUTTON_RELEASE;
+        if(!popup_rendering_actor || event.type() != Clutter.EventType.BUTTON_RELEASE)
+            return false;
+        return (event.get_source() && popup_rendering_actor.contain(event.get_source()));
     }
 
     let symbol = event.get_key_symbol();

--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -1450,7 +1450,7 @@ PopupMenu.prototype = {
         if (this.isOpen)
             return;
 
-        Main.popup_rendering = true;
+        Main.popup_rendering_actor = this.actor;
 
         if (animate)
             this.animating = animate;
@@ -1490,7 +1490,7 @@ PopupMenu.prototype = {
         }
 
         this.paint_count = 0;
-        Main.popup_rendering = false;
+        Main.popup_rendering_actor = null;
     },
 
     /**


### PR DESCRIPTION
This is an attempt to fix this type of problems: https://github.com/linuxmint/Cinnamon/issues/4044, partially reverted this commit https://github.com/linuxmint/Cinnamon/commit/0b7cbf894e27c22f12ad952dde885c550e405a00

The last one was produced with the intention of filter out button-release events while a popup is opening, to avoid unintentional selection of popup items due to busy event handling.  But also this prevented capture the button-release events in other actors who need to know the status of the mouse, leaving in an inconsistent state some applets.