### PR TITLE
Fix crash in power settings when using multiple batteries.

### DIFF
--- a/files/usr/lib/cinnamon-settings/modules/cs_power.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_power.py
@@ -267,7 +267,7 @@ class Module:
                         self.show_battery_page = True
                     have_primary = True
                 else:
-                    widget = set_device_battery_additional(device)
+                    widget = self.set_device_battery_additional(device)
                     if widget:
                         primary_settings.add_row(widget)
             else:


### PR DESCRIPTION
To reproduce:

cinnamon-settings power

Python module
Loading Power module
Traceback (most recent call last):
  File "/usr/lib/cinnamon-settings/cinnamon-settings.py", line 594, in <module>
    window = MainWindow()
  File "/usr/lib/cinnamon-settings/cinnamon-settings.py", line 89, in wrapper
    res = func(*arg)
  File "/usr/lib/cinnamon-settings/cinnamon-settings.py", line 309, in __init__
    self.go_to_sidepage(cat, path)
  File "/usr/lib/cinnamon-settings/cinnamon-settings.py", line 121, in go_to_sidepage
    sidePage.build()
  File "/usr/lib/cinnamon-settings/bin/SettingsWidgets.py", line 329, in build
    self.module.on_module_selected()
  File "/usr/lib/cinnamon-settings/modules/cs_power.py", line 168, in on_module_selected
    self.build_battery_page()
  File "/usr/lib/cinnamon-settings/modules/cs_power.py", line 270, in build_battery_page
    widget = set_device_battery_additional(device)
NameError: global name 'set_device_battery_additional' is not defined