### PR TITLE
[2.8] Calendar applet: Avoid unnecessary wakeups

### DIFF
--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
@@ -114,7 +114,10 @@ MyApplet.prototype = {
     },
 
     on_settings_changed: function() {        
-        this._updateClockAndDate();
+        if (this._periodicTimeoutId){
+            Mainloop.source_remove(this._periodicTimeoutId);
+        }
+        this._updateClockAndDatePeriodic();
     },
 
     on_custom_format_button_pressed: function() {
@@ -128,6 +131,7 @@ MyApplet.prototype = {
 
     _updateClockAndDate: function() {
         let now = new Date();        
+        let nextUpdate = 60 - now.getSeconds() + 1;
         
         // Applet label
         if (this.use_custom_format) {
@@ -137,6 +141,9 @@ MyApplet.prototype = {
                 label_string = "~CLOCK FORMAT ERROR~ " + now.toLocaleFormat("%l:%M %p");
             }          
             this.set_applet_label(label_string);   
+            if(this.custom_format.search("%S") > 0 || this.custom_format.search("%c") > 0 || this.custom_format.search("%T") > 0 || this.custom_format.search("%X") > 0) {
+                nextUpdate = 1;
+            }
         }
         else {
             if (this.clock) { // We lose cinnamon-desktop temporarily during suspend
@@ -151,11 +158,13 @@ MyApplet.prototype = {
             this.set_applet_tooltip(dateFormattedFull);
             this._lastDateFormattedFull = dateFormattedFull;
         }
+
+        return nextUpdate;
     },
 
     _updateClockAndDatePeriodic: function() {
-        this._updateClockAndDate();
-        this._periodicTimeoutId = Mainloop.timeout_add_seconds(1, Lang.bind(this, this._updateClockAndDatePeriodic));
+        let nextUpdate = this._updateClockAndDate();
+        this._periodicTimeoutId = Mainloop.timeout_add_seconds(nextUpdate, Lang.bind(this, this._updateClockAndDatePeriodic));
     },
     
     on_applet_removed_from_panel: function() {


### PR DESCRIPTION
The calendar applet currently updates once per second, even if a date format that does not include seconds is used. This patch changes this behaviour such that unless a format specifier that includes seconds is used, the timeout is instead set such that the update is performed at the next full minute (one second later actually, to account for possible inaccuracy).