### PR TITLE
Fix the activation of right side hot corners being blocked by the poi…

### DIFF
--- a/js/ui/hotCorner.js
+++ b/js/ui/hotCorner.js
@@ -60,7 +60,7 @@ HotCornerManager.prototype = {
         this.corners[0].iconActor.set_position(p_x + 1, p_y + 1);
 
         // Top Right: 1
-        this.corners[1].actor.set_position(p_x + primaryMonitor.width - 1, p_y);
+        this.corners[1].actor.set_position(p_x + primaryMonitor.width - 2, p_y);
         this.corners[1].iconActor.set_position(p_x + primaryMonitor.width - 33, p_y + 1);
 
         // Bottom Left: 2
@@ -68,7 +68,7 @@ HotCornerManager.prototype = {
         this.corners[2].iconActor.set_position(b_x + 1, b_y - 33);
 
         // Bottom Right: 3
-        this.corners[3].actor.set_position(b_x + bottomMonitor.width - 1, b_y - 1);
+        this.corners[3].actor.set_position(b_x + bottomMonitor.width - 2, b_y - 1);
         this.corners[3].iconActor.set_position(b_x + bottomMonitor.width - 33, b_y - 33);
         return true;
     }
@@ -101,7 +101,7 @@ HotCorner.prototype = {
                                          reactive: true });
 
         this._corner = new Clutter.Rectangle({ name: 'hot-corner',
-                                               width: 1,
+                                               width: 2,
                                                height: 1,
                                                opacity: 0,
                                                reactive: true });


### PR DESCRIPTION
…nter barrier.
The pointer barrier on the right side of the panel has to be inset by one pixel to prevent the cursor sometimes slipping through when there is an adjacent panel on another monitor. Because of that the corner currently sets directly on top of the barrier making almost impossible to trigger.

Fix that by moving the right side hot corner one pixel further to the left and upping the width to 2px. Also has the side effect of making the hot corner slightly easier to hit on shared monitor edges when the pointer barriers are disabled.

Closes: https://github.com/linuxmint/Cinnamon/issues/4243