### PR TITLE
cs_startup: fix crash on NameError when copying a desktop file fails

### DIFF
--- a/files/usr/lib/cinnamon-settings/modules/cs_startup.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_startup.py
@@ -529,7 +529,7 @@ class AutostartBox(Gtk.Box):
             try:
                 shutil.copyfile(desktop_file_dir, user_desktop_file)
             except IOError:
-                print "Failed to copy desktop file %s" % desktop_file
+                print "Failed to copy desktop file %s" % desktop_file_name
 
             app = AutostartApp(user_desktop_file, user_position=os.path.dirname(user_desktop_file))
 


### PR DESCRIPTION
Closes #4422.