### PR TITLE
popupMenu: Don't always ignore Submenu children in width requests. St…

### DIFF
--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -1208,7 +1208,8 @@ PopupMenuBase.prototype = {
         let columnWidths = [];
         let items = this.box.get_children();
         for (let i = 0; i < items.length; i++) {
-            if (!items[i].visible)
+            if (!items[i].visible &&
+                !(items[i]._delegate instanceof PopupSubMenu && items[i-1].visible))
                 continue;
             if (items[i]._delegate instanceof PopupBaseMenuItem || items[i]._delegate instanceof PopupMenuBase) {
                 let itemColumnWidths = items[i]._delegate.getColumnWidths();


### PR DESCRIPTION
…ops the menu size from jumping around when opening submenus.