### PR TITLE
js: Explicitly dispose of all cairo contexts. A long read on why you …

### DIFF
--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
@@ -30,6 +30,8 @@ function _onVertSepRepaint (area)
     cr.setDash([1, 3], 1); // Hard-code for now
     cr.setLineWidth(stippleWidth);
     cr.stroke();
+
+    cr.$dispose();
 };
 
 function MyApplet(orientation, panel_height, instance_id) {

--- a/js/ui/appSwitcher/classicSwitcher.js
+++ b/js/ui/appSwitcher/classicSwitcher.js
@@ -1039,4 +1039,6 @@ function _drawArrow(area, side) {
 
     Clutter.cairo_set_source_color(cr, bodyColor);
     cr.fill();
+
+    cr.$dispose();
 }

--- a/js/ui/boxpointer.js
+++ b/js/ui/boxpointer.js
@@ -321,6 +321,8 @@ BoxPointer.prototype = {
         Clutter.cairo_set_source_color(cr, borderColor);
         cr.setLineWidth(borderWidth);
         cr.stroke();
+
+        cr.$dispose();
     },
 
     setPosition: function(sourceActor, alignment) {

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -939,6 +939,8 @@ PanelCorner.prototype = {
         cr.appendPath(savedPath);
         cr.fill();
         cr.restore();
+
+        cr.$dispose();
     },
 
     _styleChanged: function() {

--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -205,6 +205,8 @@ PopupBaseMenuItem.prototype = {
             color.alpha / 255);
         cr.arc(width / 2, height / 2, width / 3, 0, 2 * Math.PI);
         cr.fill();
+        
+        cr.$dispose();
     },
 
     // This returns column widths in logical order (i.e. from the dot
@@ -454,6 +456,8 @@ PopupSeparatorMenuItem.prototype = {
         cr.setSource(pattern);
         cr.rectangle(margin, gradientOffset, gradientWidth, gradientHeight);
         cr.fill();
+
+        cr.$dispose();
     }
 };
 


### PR DESCRIPTION
…want to do this here: https://bugzilla.gnome.org/show_bug.cgi?id=685513