### PR TITLE
Only get local users

### DIFF
--- a/files/usr/bin/cinnamon-preload
+++ b/files/usr/bin/cinnamon-preload
@@ -26,7 +26,7 @@ if __name__ == "__main__":
     if os.getuid() == 0:
         start = time.time()
         has_encrypted_home = False
-        for p in pwd.getpwall():
+        for p in [pwd.getpwnam(name) for name in os.listdir('/home')]:
             if p.pw_uid >= 1000 and p.pw_shell and p.pw_shell != '/bin/false' and p.pw_shell != '/usr/sbin/nologin':
                 if not os.path.exists("/home/.ecryptfs/%s" % p.pw_name):
                     subprocess.call(["su", p.pw_name, "-c", os.path.realpath(sys.argv[0])])


### PR DESCRIPTION
Avoid hitting the network if LDAP users present by only looking at users with home folders in `/home`.

This is a problem on one network I am aware of which has about 800 users via LDAP, and is additionally the source of #4411.

This has the extra bonus of not including system users.