### PR TITLE
Sound applet: make sure player controls are destroyed when multiple n…

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -953,19 +953,19 @@ MyApplet.prototype = {
                     }
                 ));
 
-               // watch players
-               this._ownerChangedId = this._dbus.connectSignal('NameOwnerChanged', Lang.bind(this,
-                   function(proxy, sender, [name, old_owner, new_owner]) {
-                       if (name_regex.test(name)) {
-                           if (new_owner && !old_owner)
-                               this._addPlayer(name, new_owner);
-                           else if (old_owner && !new_owner && this._players[old_owner])
-                               this._removePlayer(name, old_owner);
-                           else
-                               this._changePlayerOwner(name, old_owner, new_owner);
-                       }
-                   }
-               ));
+                // watch players
+                this._ownerChangedId = this._dbus.connectSignal('NameOwnerChanged', Lang.bind(this,
+                    function(proxy, sender, [name, old_owner, new_owner]) {
+                        if (name_regex.test(name)) {
+                            if (new_owner && !old_owner)
+                                this._addPlayer(name, new_owner);
+                            else if (old_owner && !new_owner)
+                                this._removePlayer(name, old_owner);
+                            else
+                                this._changePlayerOwner(name, old_owner, new_owner);
+                        }
+                    }
+                ));
             }));
 
             this._control = new Gvc.MixerControl({ name: 'Cinnamon Volume Control' });
@@ -1210,7 +1210,7 @@ MyApplet.prototype = {
     },
 
     _removePlayer: function(busName, owner) {
-        if (this._players[owner]) {
+        if (this._players[owner] && this._players[owner]._busName == busName) {
             this._players[owner].destroy();
             delete this._players[owner];
 


### PR DESCRIPTION
…ames are used

Fixes VLC controls sticking after the player is closed.
May fix #4370, but I can't test due to being on LM 17.2.