### PR TITLE
Only get local users from /home - Take 2

### DIFF
--- a/files/usr/bin/cinnamon-preload
+++ b/files/usr/bin/cinnamon-preload
@@ -26,12 +26,17 @@ if __name__ == "__main__":
     if os.getuid() == 0:
         start = time.time()
         has_encrypted_home = False
-        for p in pwd.getpwall():
-            if p.pw_uid >= 1000 and p.pw_shell and p.pw_shell != '/bin/false' and p.pw_shell != '/usr/sbin/nologin':
-                if not os.path.exists("/home/.ecryptfs/%s" % p.pw_name):
-                    subprocess.call(["su", p.pw_name, "-c", os.path.realpath(sys.argv[0])])
-                else:
-                    has_encrypted_home = True
+        for name in os.listdir('/home'):
+            try:
+                p = pwd.getpwnam(name)
+            except:
+                continue
+            else:
+                if p.pw_uid >= 1000 and p.pw_shell and p.pw_shell != '/bin/false' and p.pw_shell != '/usr/sbin/nologin':
+                    if not os.path.exists("/home/.ecryptfs/%s" % p.pw_name):
+                        subprocess.call(["su", p.pw_name, "-c", os.path.realpath(sys.argv[0])])
+                    else:
+                        has_encrypted_home = True
         if has_encrypted_home:
             syslog.syslog("Encrypted home directories detected, loading default themes")
             theme_list = []


### PR DESCRIPTION
Main goal is to limit Cinnamon's network usage on systems with
a large number of users over LDAP or otherwise.

Take 2 on PR #4462, which was rejected mostly due to my changes breaking if there were extraneous files in `/home`. This version fixes that problem.

The issue with doing, as was suggested in #4462, `pwd.getpwall()` and then filtering on `/home` is that I don't actually care if a user is in `/home` for pre-loading. All I want to do is proxy for remote users by checking `/home` and if they are remote, then the value added by pre-loading the theme is definitely less than that of getting every user from the LDAP server.

I could check for ldap users directly, but that would add more requirements.

The issue this is designed to fix is a real world lab which has at most 1 local user on each machine, and over 500 users over LDAP. Startup times, the delays before a login to Cinnamon is even possible, and loads on the servers, are very high compared to the benefit of loading the custom themes for every user in the database.