### PR TITLE
Set the X-Gnome-AutoRestart hint to false. Stumbled across this in an…

### DIFF
--- a/data/cinnamon.desktop.in.in
+++ b/data/cinnamon.desktop.in.in
@@ -13,4 +13,4 @@ NoDisplay=true
 X-GNOME-Autostart-Phase=WindowManager
 X-GNOME-Provides=panel;windowmanager;
 X-GNOME-Autostart-Notify=true
-X-GNOME-AutoRestart=true
+X-GNOME-AutoRestart=false


### PR DESCRIPTION
… old gnome bug report. Fixes the issue with Cinnamon restarting twice with cinnamon --replace