### PR TITLE
Sound applet: Use .sound-button-container:small for quit and raise button

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -1192,7 +1192,7 @@ StScrollBar StButton#vhandle:hover {
 	background-gradient-end: rgba(255,144,144,0.5);
 }
 /* ===================================================================
- * Sound Applet (status/volume.js)
+ * Sound Applet (sound@cinnamon.org)
  * ===================================================================*/
 .sound-button-container {
 	padding-right: 3px;
@@ -1205,46 +1205,15 @@ StScrollBar StButton#vhandle:hover {
 	border-radius: 4px;
 	padding: 5px;
 }
+.sound-button:small {
+	width: 16px;
+	height: 8px;
+}
+.sound-button:small StIcon {
+	icon-size: 1em;
+}
 .sound-button:hover, .sound-button:active {
 	border: 1px solid white;
-}
-.sound-button StIcon {
-	icon-size: 1.4em;
-}
-.sound-track-infos {	
-	padding-left: 5px;
-	padding-right: 5px;
-	padding-top: 5px;
-	padding-bottom: 5px;
-}
-.sound-track-info {
-	padding-top: 2px;
-	padding-bottom: 2px;
-}
-.sound-track-info StIcon {
-	icon-size: 1em;
-
-}
-.sound-track-info StLabel {
-	padding-left: 5px;
-	padding-right: 5px;
-}
-.sound-track-box {	
-	padding-left: 15px;
-	padding-right: 15px;	
-	max-width: 220px;
-}
-.sound-seek-box {
-   padding-left: 20px;
-}
-.sound-seek-box StLabel {
-   padding-top: 2px;
-}
-.sound-seek-box StIcon {
-   icon-size: 1em;
-}
-.sound-seek-slider {
-   width: 140px;   
 }
 .sound-playback-control {
 	padding-top: 5px;

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -62,15 +62,19 @@ function ControlButton() {
 }
 
 ControlButton.prototype = {
-    _init: function(icon, tooltip, callback) {
+    _init: function(icon, tooltip, callback, small = false) {
         this.actor = new St.Bin({style_class: 'sound-button-container'});
+
         this.button = new St.Button({ style_class: 'sound-button' });
         this.button.connect('clicked', callback);
+
+        if(small)
+            this.button.add_style_pseudo_class("small");
+
         this.icon = new St.Icon({
             icon_type: St.IconType.SYMBOLIC,
             icon_name: icon,
-            icon_size: 16,
-            style_class: 'sound-button-icon',
+            style_class: "popup-menu-icon"
         });
         this.button.set_child(this.icon);
         this.actor.add_actor(this.button);
@@ -95,26 +99,6 @@ ControlButton.prototype = {
         this.button.change_style_pseudo_class("disabled", !status);
         this.button.can_focus = status;
         this.button.reactive = status;
-    }
-}
-
-function ActionButton(){
-    this._init.apply(this, arguments);
-}
-
-ActionButton.prototype = {
-    _init: function(icon, tooltip, callback) {
-        this.actor = new St.Button;
-        this.actor.connect("clicked", callback);
-
-        this.icon = new St.Icon({
-            icon_type: St.IconType.SYMBOLIC,
-            icon_name: icon,
-            style_class: "popup-menu-icon",
-        });
-        this.actor.set_child(this.icon);
-
-        this.tooltip = new Tooltips.Tooltip(this.actor, tooltip);
     }
 }
 
@@ -206,7 +190,7 @@ VolumeSlider.prototype = {
         }
         this.setValue(value);
 
-        //send data to applet
+        // send data to applet
         this.emit("values-changed", iconName, percentage);
     },
 
@@ -331,13 +315,10 @@ Player.prototype = {
         this._trackCoverFile = this._trackCoverFileTmp = false;
         this._trackCover = new St.Bin({style_class: 'sound-track-cover', x_align: St.Align.MIDDLE});
         this._trackCover.set_child(new St.Icon({icon_name: "media-optical-cd-audio", icon_size: 220, icon_type: St.IconType.FULLCOLOR}));
-        //this._trackInfosTop = new St.Bin({style_class: 'sound-track-infos', x_align: St.Align.START});
         this.infosTop = new PopupMenu.PopupMenuSection;
-        //this._trackInfosBottom = new St.Bin({style_class: 'sound-track-infos', x_align: St.Align.START});
         this.infosBottom = new PopupMenu.PopupMenuSection;
         this._trackControls = new St.Bin({style_class: 'sound-playback-control', x_align: St.Align.MIDDLE});
 
-        //let mainBox = new St.BoxLayout({style_class: 'sound-track-box', vertical: true});
         let mainBox = new PopupMenu.PopupMenuSection;
         mainBox.addMenuItem(this.infosTop)
         mainBox.addActor(this._trackCover);
@@ -348,7 +329,6 @@ Player.prototype = {
         this._artist = new TrackInfo(_("Unknown Artist"), "system-users");
         this._album = new TrackInfo(_("Unknown Album"), "media-optical");
         this._title = new TrackInfo(_("Unknown Title"), "audio-x-generic");
-        //this._time = new PopupMenu.PopupIconMenuItem("0:00 / 0:00", "document-open-recent", St.IconType.SYMBOLIC);
 
 
         this.infosTop.addMenuItem(this._artist);
@@ -418,7 +398,7 @@ Player.prototype = {
         this.addMenuItem(this._positionSlider);
 
         if (this._mediaServer.CanRaise) {
-            let btn = new ActionButton("go-up", _("Open Player"), Lang.bind(this, function(){
+            let btn = new ControlButton("go-up", _("Open Player"), Lang.bind(this, function(){
                 if (this._name === "spotify") {
                     // Spotify isn't able to raise via Dbus once its main UI is closed
                     Util.spawn(['spotify']);
@@ -427,14 +407,14 @@ Player.prototype = {
                     this._mediaServer.RaiseRemote();
                 }
                 this._applet.menu.close();
-            }));
+            }), true);
             this.playerInfo.buttons.add_actor(btn.actor);
         }
 
         if (this._mediaServer.CanQuit) {
-            let btn = new ActionButton("window-close", _("Quit Player"), Lang.bind(this, function(){
+            let btn = new ControlButton("window-close", _("Quit Player"), Lang.bind(this, function(){
                 this._mediaServer.QuitRemote();
-            }));
+            }), true);
             this.playerInfo.buttons.add_actor(btn.actor);
         }
 


### PR DESCRIPTION
Fixes #4305

Theme designers can use `.sound-button:small` (`width` and `height`) and `.sound-button:small StIcon` (`icon-size`) to resize the buttons. (I didn't want to screw with `!important`) 
![sound-applet-raise-quit-buttons 2](https://cloud.githubusercontent.com/assets/7093655/9114638/30035d00-3c5b-11e5-9a1a-904363b686e9.png)