### PR TITLE
popupMenu: Add back the expander arrow on PopupSubMenuMenuItem but wi…

### DIFF
--- a/data/icons/Makefile.am
+++ b/data/icons/Makefile.am
@@ -5,6 +5,12 @@ public_icons_themes = \
 	$(NULL)
 
 public_icons = \
+	hicolor_actions_scalable_pan-down-symbolic.svg \
+	hicolor_actions_scalable_pan-end-symbolic.svg \
+	hicolor_actions_scalable_pan-end-symbolic-rtl.svg \
+	hicolor_actions_scalable_pan-start-symbolic.svg \
+	hicolor_actions_scalable_pan-start-symbolic-rtl.svg \
+	hicolor_actions_scalable_pan-up-symbolic.svg \
 	hicolor_categories_16x16_cs-desklets.svg \
 	hicolor_categories_16x16_cs-backgrounds.svg \
 	hicolor_categories_scalable_cs-applets.svg \

--- a/data/icons/hicolor_actions_scalable_pan-down-symbolic.svg
+++ b/data/icons/hicolor_actions_scalable_pan-down-symbolic.svg
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' sodipodi:docname='pan-down-symbolic.svg' inkscape:export-filename='/home/sam/dev/RESOURCES/gnome-icon-theme-symbolic/src/gnome-stencils.png' inkscape:export-xdpi='90' inkscape:export-ydpi='90' height='16' id='svg7384' xmlns:inkscape='http://www.inkscape.org/namespaces/inkscape' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:sodipodi='http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' inkscape:version='0.91 r13258 custom' width='16' xmlns='http://www.w3.org/2000/svg'>
+  <metadata id='metadata90'>
+    <rdf:RDF>
+      <cc:Work rdf:about=''>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview inkscape:bbox-nodes='false' inkscape:bbox-paths='true' bordercolor='#666666' borderopacity='1' inkscape:current-layer='layer12' inkscape:cx='-15.931175' inkscape:cy='103.26379' gridtolerance='10' inkscape:guide-bbox='true' guidetolerance='10' id='namedview88' inkscape:object-nodes='false' inkscape:object-paths='false' objecttolerance='10' pagecolor='#3a3b39' inkscape:pageopacity='1' inkscape:pageshadow='2' showborder='false' showgrid='false' showguides='true' inkscape:snap-bbox='true' inkscape:snap-bbox-midpoints='false' inkscape:snap-global='true' inkscape:snap-grids='true' inkscape:snap-nodes='true' inkscape:snap-others='false' inkscape:snap-to-guides='true' inkscape:window-height='734' inkscape:window-maximized='1' inkscape:window-width='1280' inkscape:window-x='0' inkscape:window-y='27' inkscape:zoom='1'>
+    <inkscape:grid dotted='false' empspacing='2' enabled='true' id='grid4866' originx='-100px' originy='590.00001px' snapvisiblegridlinesonly='true' spacingx='1px' spacingy='1px' type='xygrid' visible='true'/>
+  </sodipodi:namedview>
+  <title id='title9167'>Gnome Symbolic Icon Theme</title>
+  <defs id='defs7386'/>
+  <g inkscape:groupmode='layer' id='layer9' inkscape:label='status' style='display:inline' transform='translate(-341.0002,-807.00001)'/>
+  <g inkscape:groupmode='layer' id='layer10' inkscape:label='devices' style='display:inline' transform='translate(-341.0002,-807.00001)'/>
+  <g inkscape:groupmode='layer' id='layer11' inkscape:label='apps' transform='translate(-341.0002,-807.00001)'/>
+  <g inkscape:groupmode='layer' id='layer13' inkscape:label='places' style='display:inline' transform='translate(-341.0002,-807.00001)'/>
+  <g inkscape:groupmode='layer' id='layer14' inkscape:label='mimetypes' transform='translate(-341.0002,-807.00001)'/>
+  <g inkscape:groupmode='layer' id='layer15' inkscape:label='emblems' style='display:inline' transform='translate(-341.0002,-807.00001)'/>
+  <g inkscape:groupmode='layer' id='g71291' inkscape:label='emotes' style='display:inline' transform='translate(-341.0002,-807.00001)'/>
+  <g inkscape:groupmode='layer' id='g4953' inkscape:label='categories' style='display:inline' transform='translate(-341.0002,-807.00001)'/>
+  <g inkscape:groupmode='layer' id='layer12' inkscape:label='actions' style='display:inline' transform='translate(-341.0002,-807.00001)'>
+    <path inkscape:connector-curvature='0' d='m 354.0002,812.93751 -5,5 -5,-5 z' id='path6424' sodipodi:nodetypes='cccc' style='fill:#bebebe;fill-opacity:1;stroke:none'/>
+    
+  </g>
+</svg>

--- a/data/icons/hicolor_actions_scalable_pan-end-symbolic-rtl.svg
+++ b/data/icons/hicolor_actions_scalable_pan-end-symbolic-rtl.svg
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' sodipodi:docname='pan-start-symbolic.svg' inkscape:export-filename='/home/sam/dev/RESOURCES/gnome-icon-theme-symbolic/src/gnome-stencils.png' inkscape:export-xdpi='90' inkscape:export-ydpi='90' height='16' id='svg7384' xmlns:inkscape='http://www.inkscape.org/namespaces/inkscape' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:sodipodi='http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' inkscape:version='0.48.4 r9939' width='16' xmlns='http://www.w3.org/2000/svg'>
+  <metadata id='metadata90'>
+    <rdf:RDF>
+      <cc:Work rdf:about=''>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview inkscape:bbox-nodes='false' inkscape:bbox-paths='true' bordercolor='#666666' borderopacity='1' inkscape:current-layer='layer12' inkscape:cx='402.21323' inkscape:cy='209.78205' gridtolerance='10' inkscape:guide-bbox='true' guidetolerance='10' id='namedview88' inkscape:object-nodes='false' inkscape:object-paths='false' objecttolerance='10' pagecolor='#3a3b39' inkscape:pageopacity='1' inkscape:pageshadow='2' showborder='false' showgrid='false' showguides='true' inkscape:snap-bbox='true' inkscape:snap-bbox-midpoints='false' inkscape:snap-global='true' inkscape:snap-grids='true' inkscape:snap-nodes='true' inkscape:snap-others='false' inkscape:snap-to-guides='true' inkscape:window-height='1374' inkscape:window-maximized='1' inkscape:window-width='2560' inkscape:window-x='0' inkscape:window-y='27' inkscape:zoom='1'>
+    <inkscape:grid dotted='false' empspacing='2' enabled='true' id='grid4866' originx='-39.999998px' originy='590px' snapvisiblegridlinesonly='true' spacingx='1px' spacingy='1px' type='xygrid' visible='true'/>
+  </sodipodi:namedview>
+  <title id='title9167'>Gnome Symbolic Icon Theme</title>
+  <defs id='defs7386'/>
+  <g inkscape:groupmode='layer' id='layer9' inkscape:label='status' style='display:inline' transform='translate(-281.0002,-807)'/>
+  <g inkscape:groupmode='layer' id='layer10' inkscape:label='devices' style='display:inline' transform='translate(-281.0002,-807)'/>
+  <g inkscape:groupmode='layer' id='layer11' inkscape:label='apps' transform='translate(-281.0002,-807)'/>
+  <g inkscape:groupmode='layer' id='layer13' inkscape:label='places' style='display:inline' transform='translate(-281.0002,-807)'/>
+  <g inkscape:groupmode='layer' id='layer14' inkscape:label='mimetypes' transform='translate(-281.0002,-807)'/>
+  <g inkscape:groupmode='layer' id='layer15' inkscape:label='emblems' style='display:inline' transform='translate(-281.0002,-807)'/>
+  <g inkscape:groupmode='layer' id='g71291' inkscape:label='emotes' style='display:inline' transform='translate(-281.0002,-807)'/>
+  <g inkscape:groupmode='layer' id='g4953' inkscape:label='categories' style='display:inline' transform='translate(-281.0002,-807)'/>
+  <g inkscape:groupmode='layer' id='layer12' inkscape:label='actions' style='display:inline' transform='translate(-281.0002,-807)'>
+    <path inkscape:connector-curvature='0' d='m 291.0627,820 -5,-5 5,-5 z' id='path6400' sodipodi:nodetypes='cccc' style='fill:#bebebe;fill-opacity:1;stroke:none'/>
+    
+  </g>
+</svg>

--- a/data/icons/hicolor_actions_scalable_pan-end-symbolic.svg
+++ b/data/icons/hicolor_actions_scalable_pan-end-symbolic.svg
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' sodipodi:docname='pan-end-symbolic.svg' inkscape:export-filename='/home/sam/dev/RESOURCES/gnome-icon-theme-symbolic/src/gnome-stencils.png' inkscape:export-xdpi='90' inkscape:export-ydpi='90' height='16' id='svg7384' xmlns:inkscape='http://www.inkscape.org/namespaces/inkscape' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:sodipodi='http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' inkscape:version='0.48.4 r9939' width='16' xmlns='http://www.w3.org/2000/svg'>
+  <metadata id='metadata90'>
+    <rdf:RDF>
+      <cc:Work rdf:about=''>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview inkscape:bbox-nodes='false' inkscape:bbox-paths='true' bordercolor='#666666' borderopacity='1' inkscape:current-layer='layer12' inkscape:cx='382.21323' inkscape:cy='209.78205' gridtolerance='10' inkscape:guide-bbox='true' guidetolerance='10' id='namedview88' inkscape:object-nodes='false' inkscape:object-paths='false' objecttolerance='10' pagecolor='#3a3b39' inkscape:pageopacity='1' inkscape:pageshadow='2' showborder='false' showgrid='false' showguides='true' inkscape:snap-bbox='true' inkscape:snap-bbox-midpoints='false' inkscape:snap-global='true' inkscape:snap-grids='true' inkscape:snap-nodes='true' inkscape:snap-others='false' inkscape:snap-to-guides='true' inkscape:window-height='1374' inkscape:window-maximized='1' inkscape:window-width='2560' inkscape:window-x='0' inkscape:window-y='27' inkscape:zoom='1'>
+    <inkscape:grid dotted='false' empspacing='2' enabled='true' id='grid4866' originx='-60.000002px' originy='590px' snapvisiblegridlinesonly='true' spacingx='1px' spacingy='1px' type='xygrid' visible='true'/>
+  </sodipodi:namedview>
+  <title id='title9167'>Gnome Symbolic Icon Theme</title>
+  <defs id='defs7386'/>
+  <g inkscape:groupmode='layer' id='layer9' inkscape:label='status' style='display:inline' transform='translate(-301.0002,-807)'/>
+  <g inkscape:groupmode='layer' id='layer10' inkscape:label='devices' style='display:inline' transform='translate(-301.0002,-807)'/>
+  <g inkscape:groupmode='layer' id='layer11' inkscape:label='apps' transform='translate(-301.0002,-807)'/>
+  <g inkscape:groupmode='layer' id='layer13' inkscape:label='places' style='display:inline' transform='translate(-301.0002,-807)'/>
+  <g inkscape:groupmode='layer' id='layer14' inkscape:label='mimetypes' transform='translate(-301.0002,-807)'/>
+  <g inkscape:groupmode='layer' id='layer15' inkscape:label='emblems' style='display:inline' transform='translate(-301.0002,-807)'/>
+  <g inkscape:groupmode='layer' id='g71291' inkscape:label='emotes' style='display:inline' transform='translate(-301.0002,-807)'/>
+  <g inkscape:groupmode='layer' id='g4953' inkscape:label='categories' style='display:inline' transform='translate(-301.0002,-807)'/>
+  <g inkscape:groupmode='layer' id='layer12' inkscape:label='actions' style='display:inline' transform='translate(-301.0002,-807)'>
+    <path inkscape:connector-curvature='0' d='m 306.9377,820 5,-5 -5,-5 z' id='path6412' sodipodi:nodetypes='cccc' style='fill:#bebebe;fill-opacity:1;stroke:none'/>
+    
+  </g>
+</svg>

--- a/data/icons/hicolor_actions_scalable_pan-start-symbolic-rtl.svg
+++ b/data/icons/hicolor_actions_scalable_pan-start-symbolic-rtl.svg
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' sodipodi:docname='pan-end-symbolic.svg' inkscape:export-filename='/home/sam/dev/RESOURCES/gnome-icon-theme-symbolic/src/gnome-stencils.png' inkscape:export-xdpi='90' inkscape:export-ydpi='90' height='16' id='svg7384' xmlns:inkscape='http://www.inkscape.org/namespaces/inkscape' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:sodipodi='http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' inkscape:version='0.48.4 r9939' width='16' xmlns='http://www.w3.org/2000/svg'>
+  <metadata id='metadata90'>
+    <rdf:RDF>
+      <cc:Work rdf:about=''>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview inkscape:bbox-nodes='false' inkscape:bbox-paths='true' bordercolor='#666666' borderopacity='1' inkscape:current-layer='layer12' inkscape:cx='382.21323' inkscape:cy='209.78205' gridtolerance='10' inkscape:guide-bbox='true' guidetolerance='10' id='namedview88' inkscape:object-nodes='false' inkscape:object-paths='false' objecttolerance='10' pagecolor='#3a3b39' inkscape:pageopacity='1' inkscape:pageshadow='2' showborder='false' showgrid='false' showguides='true' inkscape:snap-bbox='true' inkscape:snap-bbox-midpoints='false' inkscape:snap-global='true' inkscape:snap-grids='true' inkscape:snap-nodes='true' inkscape:snap-others='false' inkscape:snap-to-guides='true' inkscape:window-height='1374' inkscape:window-maximized='1' inkscape:window-width='2560' inkscape:window-x='0' inkscape:window-y='27' inkscape:zoom='1'>
+    <inkscape:grid dotted='false' empspacing='2' enabled='true' id='grid4866' originx='-60.000002px' originy='590px' snapvisiblegridlinesonly='true' spacingx='1px' spacingy='1px' type='xygrid' visible='true'/>
+  </sodipodi:namedview>
+  <title id='title9167'>Gnome Symbolic Icon Theme</title>
+  <defs id='defs7386'/>
+  <g inkscape:groupmode='layer' id='layer9' inkscape:label='status' style='display:inline' transform='translate(-301.0002,-807)'/>
+  <g inkscape:groupmode='layer' id='layer10' inkscape:label='devices' style='display:inline' transform='translate(-301.0002,-807)'/>
+  <g inkscape:groupmode='layer' id='layer11' inkscape:label='apps' transform='translate(-301.0002,-807)'/>
+  <g inkscape:groupmode='layer' id='layer13' inkscape:label='places' style='display:inline' transform='translate(-301.0002,-807)'/>
+  <g inkscape:groupmode='layer' id='layer14' inkscape:label='mimetypes' transform='translate(-301.0002,-807)'/>
+  <g inkscape:groupmode='layer' id='layer15' inkscape:label='emblems' style='display:inline' transform='translate(-301.0002,-807)'/>
+  <g inkscape:groupmode='layer' id='g71291' inkscape:label='emotes' style='display:inline' transform='translate(-301.0002,-807)'/>
+  <g inkscape:groupmode='layer' id='g4953' inkscape:label='categories' style='display:inline' transform='translate(-301.0002,-807)'/>
+  <g inkscape:groupmode='layer' id='layer12' inkscape:label='actions' style='display:inline' transform='translate(-301.0002,-807)'>
+    <path inkscape:connector-curvature='0' d='m 306.9377,820 5,-5 -5,-5 z' id='path6412' sodipodi:nodetypes='cccc' style='fill:#bebebe;fill-opacity:1;stroke:none'/>
+    
+  </g>
+</svg>

--- a/data/icons/hicolor_actions_scalable_pan-start-symbolic.svg
+++ b/data/icons/hicolor_actions_scalable_pan-start-symbolic.svg
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' sodipodi:docname='pan-start-symbolic.svg' inkscape:export-filename='/home/sam/dev/RESOURCES/gnome-icon-theme-symbolic/src/gnome-stencils.png' inkscape:export-xdpi='90' inkscape:export-ydpi='90' height='16' id='svg7384' xmlns:inkscape='http://www.inkscape.org/namespaces/inkscape' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:sodipodi='http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' inkscape:version='0.48.4 r9939' width='16' xmlns='http://www.w3.org/2000/svg'>
+  <metadata id='metadata90'>
+    <rdf:RDF>
+      <cc:Work rdf:about=''>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview inkscape:bbox-nodes='false' inkscape:bbox-paths='true' bordercolor='#666666' borderopacity='1' inkscape:current-layer='layer12' inkscape:cx='402.21323' inkscape:cy='209.78205' gridtolerance='10' inkscape:guide-bbox='true' guidetolerance='10' id='namedview88' inkscape:object-nodes='false' inkscape:object-paths='false' objecttolerance='10' pagecolor='#3a3b39' inkscape:pageopacity='1' inkscape:pageshadow='2' showborder='false' showgrid='false' showguides='true' inkscape:snap-bbox='true' inkscape:snap-bbox-midpoints='false' inkscape:snap-global='true' inkscape:snap-grids='true' inkscape:snap-nodes='true' inkscape:snap-others='false' inkscape:snap-to-guides='true' inkscape:window-height='1374' inkscape:window-maximized='1' inkscape:window-width='2560' inkscape:window-x='0' inkscape:window-y='27' inkscape:zoom='1'>
+    <inkscape:grid dotted='false' empspacing='2' enabled='true' id='grid4866' originx='-39.999998px' originy='590px' snapvisiblegridlinesonly='true' spacingx='1px' spacingy='1px' type='xygrid' visible='true'/>
+  </sodipodi:namedview>
+  <title id='title9167'>Gnome Symbolic Icon Theme</title>
+  <defs id='defs7386'/>
+  <g inkscape:groupmode='layer' id='layer9' inkscape:label='status' style='display:inline' transform='translate(-281.0002,-807)'/>
+  <g inkscape:groupmode='layer' id='layer10' inkscape:label='devices' style='display:inline' transform='translate(-281.0002,-807)'/>
+  <g inkscape:groupmode='layer' id='layer11' inkscape:label='apps' transform='translate(-281.0002,-807)'/>
+  <g inkscape:groupmode='layer' id='layer13' inkscape:label='places' style='display:inline' transform='translate(-281.0002,-807)'/>
+  <g inkscape:groupmode='layer' id='layer14' inkscape:label='mimetypes' transform='translate(-281.0002,-807)'/>
+  <g inkscape:groupmode='layer' id='layer15' inkscape:label='emblems' style='display:inline' transform='translate(-281.0002,-807)'/>
+  <g inkscape:groupmode='layer' id='g71291' inkscape:label='emotes' style='display:inline' transform='translate(-281.0002,-807)'/>
+  <g inkscape:groupmode='layer' id='g4953' inkscape:label='categories' style='display:inline' transform='translate(-281.0002,-807)'/>
+  <g inkscape:groupmode='layer' id='layer12' inkscape:label='actions' style='display:inline' transform='translate(-281.0002,-807)'>
+    <path inkscape:connector-curvature='0' d='m 291.0627,820 -5,-5 5,-5 z' id='path6400' sodipodi:nodetypes='cccc' style='fill:#bebebe;fill-opacity:1;stroke:none'/>
+    
+  </g>
+</svg>

--- a/data/icons/hicolor_actions_scalable_pan-up-symbolic.svg
+++ b/data/icons/hicolor_actions_scalable_pan-up-symbolic.svg
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' sodipodi:docname='pan-up-symbolic.svg' inkscape:export-filename='/home/sam/dev/RESOURCES/gnome-icon-theme-symbolic/src/gnome-stencils.png' inkscape:export-xdpi='90' inkscape:export-ydpi='90' height='16' id='svg7384' xmlns:inkscape='http://www.inkscape.org/namespaces/inkscape' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:sodipodi='http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' inkscape:version='0.91 r13258 custom' width='16' xmlns='http://www.w3.org/2000/svg'>
+  <metadata id='metadata90'>
+    <rdf:RDF>
+      <cc:Work rdf:about=''>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview inkscape:bbox-nodes='false' inkscape:bbox-paths='true' bordercolor='#666666' borderopacity='1' inkscape:current-layer='layer12' inkscape:cx='4.068825' inkscape:cy='103.26379' gridtolerance='10' inkscape:guide-bbox='true' guidetolerance='10' id='namedview88' inkscape:object-nodes='false' inkscape:object-paths='false' objecttolerance='10' pagecolor='#3a3b39' inkscape:pageopacity='1' inkscape:pageshadow='2' showborder='false' showgrid='false' showguides='true' inkscape:snap-bbox='true' inkscape:snap-bbox-midpoints='false' inkscape:snap-global='true' inkscape:snap-grids='true' inkscape:snap-nodes='true' inkscape:snap-others='false' inkscape:snap-to-guides='true' inkscape:window-height='734' inkscape:window-maximized='1' inkscape:window-width='1280' inkscape:window-x='0' inkscape:window-y='27' inkscape:zoom='1'>
+    <inkscape:grid dotted='false' empspacing='2' enabled='true' id='grid4866' originx='-80px' originy='590.00001px' snapvisiblegridlinesonly='true' spacingx='1px' spacingy='1px' type='xygrid' visible='true'/>
+  </sodipodi:namedview>
+  <title id='title9167'>Gnome Symbolic Icon Theme</title>
+  <defs id='defs7386'/>
+  <g inkscape:groupmode='layer' id='layer9' inkscape:label='status' style='display:inline' transform='translate(-321.0002,-807.00001)'/>
+  <g inkscape:groupmode='layer' id='layer10' inkscape:label='devices' style='display:inline' transform='translate(-321.0002,-807.00001)'/>
+  <g inkscape:groupmode='layer' id='layer11' inkscape:label='apps' transform='translate(-321.0002,-807.00001)'/>
+  <g inkscape:groupmode='layer' id='layer13' inkscape:label='places' style='display:inline' transform='translate(-321.0002,-807.00001)'/>
+  <g inkscape:groupmode='layer' id='layer14' inkscape:label='mimetypes' transform='translate(-321.0002,-807.00001)'/>
+  <g inkscape:groupmode='layer' id='layer15' inkscape:label='emblems' style='display:inline' transform='translate(-321.0002,-807.00001)'/>
+  <g inkscape:groupmode='layer' id='g71291' inkscape:label='emotes' style='display:inline' transform='translate(-321.0002,-807.00001)'/>
+  <g inkscape:groupmode='layer' id='g4953' inkscape:label='categories' style='display:inline' transform='translate(-321.0002,-807.00001)'/>
+  <g inkscape:groupmode='layer' id='layer12' inkscape:label='actions' style='display:inline' transform='translate(-321.0002,-807.00001)'>
+    <path inkscape:connector-curvature='0' d='m 334.0002,817.06251 -5,-5 -5,5 z' id='path6418' sodipodi:nodetypes='cccc' style='fill:#bebebe;fill-opacity:1;stroke:none'/>
+    
+  </g>
+</svg>

--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -101,6 +101,9 @@ StScrollBar StButton#vhandle:hover {
 	font-size: 9.5pt;
 	min-width: 100px;
 }
+.popup-menu-arrow {
+    icon-size: 1.14em;
+}
 .popup-submenu-menu-item:open {
 	background-color: #4c4c4c;
 }

--- a/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
@@ -592,7 +592,7 @@ NMDevice.prototype = {
 
                 if (j + activeOffset >= NUM_VISIBLE_NETWORKS) {
                     if (!this._overflowItem) {
-                        this._overflowItem = new PopupMenu.PopupSubMenuMenuItem(_("More..."), true);
+                        this._overflowItem = new PopupMenu.PopupSubMenuMenuItem(_("More"));
                         this.section.addMenuItem(this._overflowItem);
                     }
                     this._overflowItem.menu.addMenuItem(obj.item);
@@ -1567,7 +1567,7 @@ NMDeviceWireless.prototype = {
             this.section.addMenuItem(apObj.item, position);
         } else {
             if (!this._overflowItem) {
-                this._overflowItem = new PopupMenu.PopupSubMenuMenuItem(_("More..."), true);
+                this._overflowItem = new PopupMenu.PopupSubMenuMenuItem(_("More"));
                 this.section.addMenuItem(this._overflowItem);
             }
             this._overflowItem.menu.addMenuItem(apObj.item, position - NUM_VISIBLE_NETWORKS);

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -1232,11 +1232,11 @@ MyApplet.prototype = {
 
     _showFixedElements: function() {
         //we'll show the launch player item or the selector item + a player section
-        this._launchPlayerItem = new PopupMenu.PopupSubMenuMenuItem(_("Launch player..."), true);
+        this._launchPlayerItem = new PopupMenu.PopupSubMenuMenuItem(_("Launch player"));
         this.menu.addMenuItem(this._launchPlayerItem);
         this._updateLaunchPlayer();
 
-        this._playerSelector = new PopupMenu.PopupSubMenuMenuItem("", true);
+        this._playerSelector = new PopupMenu.PopupSubMenuMenuItem("");
         this._playerSelector.actor.remove_style_class_name("popup-submenu-menu-item");
         this._playerSelector.actor.hide();
         this.menu.addMenuItem(this._playerSelector);
@@ -1246,10 +1246,11 @@ MyApplet.prototype = {
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem);
         this._outputVolumeSection = new VolumeSlider(this, null, _("Volume"), null);
         this._outputVolumeSection.connect("values-changed", Lang.bind(this, this._outputValuesChanged));
-        this._outputApplicationsMenu = new PopupMenu.PopupSubMenuMenuItem(_("Applications..."), true);
-        this._selectOutputDeviceItem = new PopupMenu.PopupSubMenuMenuItem(_("Output device..."), true);
+        this._outputApplicationsMenu = new PopupMenu.PopupSubMenuMenuItem(_("Applications"));
+        this._selectOutputDeviceItem = new PopupMenu.PopupSubMenuMenuItem(_("Output device"));
 
         this.menu.addMenuItem(this._outputVolumeSection);
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem);
         this.menu.addMenuItem(this._outputApplicationsMenu);
         this.menu.addMenuItem(this._selectOutputDeviceItem);
 
@@ -1258,7 +1259,7 @@ MyApplet.prototype = {
 
         this._inputSection = new PopupMenu.PopupMenuSection;
         this._inputVolumeSection = new VolumeSlider(this, null, _("Microphone"), null);
-        this._selectInputDeviceItem = new PopupMenu.PopupSubMenuMenuItem(_("Input device..."), true);
+        this._selectInputDeviceItem = new PopupMenu.PopupSubMenuMenuItem(_("Input device"));
 
         this._inputSection.addMenuItem(this._inputVolumeSection);
         this._inputSection.addMenuItem(this._selectInputDeviceItem);

--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -517,39 +517,6 @@ AppMenuButtonRightClickMenu.prototype = {
 
         this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
-        // Move to workspace
-        if ((length = global.screen.n_workspaces) > 1) {
-            if (mw.is_on_all_workspaces()) {
-                item = new PopupMenu.PopupMenuItem(_("Only on this workspace"));
-                item.connect('activate', function() {
-                    mw.unstick();
-                });
-                this.addMenuItem(item);
-            } else {
-                item = new PopupMenu.PopupMenuItem(_("Visible on all workspaces"));
-                item.connect('activate', function() {
-                    mw.stick();
-                });
-                this.addMenuItem(item);
-
-                item = new PopupMenu.PopupSubMenuMenuItem(_("Move to another workspace ..."), true);
-                this.addMenuItem(item);
-
-                let curr_index = mw.get_workspace().index();
-                for (let i = 0; i < length; i++) {
-                    if (i == curr_index) continue;
-
-                    // Make the index a local variable to pass to function
-                    let j = i;
-                    item.menu.addAction(
-                            Main.workspace_names[i] ? Main.workspace_names[i] : Main._makeDefaultWorkspaceName(i),
-                            function() {
-                                mw.change_workspace(global.screen.get_workspace_by_index(j));
-                            });
-                }
-            }
-        }
-
         // Move to monitor
         if ((length = Main.layoutManager.monitors.length) == 2) {
             Main.layoutManager.monitors.forEach(function (monitor, index) {
@@ -570,6 +537,40 @@ AppMenuButtonRightClickMenu.prototype = {
                 });
                 this.addMenuItem(item);
             }, this);
+        }
+
+        // Move to workspace
+        if ((length = global.screen.n_workspaces) > 1) {
+            if (mw.is_on_all_workspaces()) {
+                item = new PopupMenu.PopupMenuItem(_("Only on this workspace"));
+                item.connect('activate', function() {
+                    mw.unstick();
+                });
+                this.addMenuItem(item);
+            } else {
+                item = new PopupMenu.PopupMenuItem(_("Visible on all workspaces"));
+                item.connect('activate', function() {
+                    mw.stick();
+                });
+                this.addMenuItem(item);
+
+                item = new PopupMenu.PopupSubMenuMenuItem(_("Move to another workspace"));
+                this.addMenuItem(item);
+
+                let curr_index = mw.get_workspace().index();
+                for (let i = 0; i < length; i++) {
+                    if (i == curr_index) continue;
+
+                    // Make the index a local variable to pass to function
+                    let j = i;
+                    item.menu.addAction(
+                            Main.workspace_names[i] ? Main.workspace_names[i] : Main._makeDefaultWorkspaceName(i),
+                            function() {
+                                mw.change_workspace(global.screen.get_workspace_by_index(j));
+                            });
+                }
+
+            }
         }
 
         this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -973,7 +973,7 @@ SettingsLauncher.prototype = {
 
 function populateSettingsMenu(menu, panelId) {
 
-    menu.troubleshootItem = new PopupMenu.PopupSubMenuMenuItem(_("Troubleshoot ..."), true);
+    menu.troubleshootItem = new PopupMenu.PopupSubMenuMenuItem(_("Troubleshoot"));
     menu.troubleshootItem.menu.addAction(_("Restart Cinnamon"), function(event) {
         global.reexec_self();
     });
@@ -995,9 +995,7 @@ function populateSettingsMenu(menu, panelId) {
 
     menu.addMenuItem(menu.troubleshootItem);
 
-    menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-
-    let panelSettingsSection = new PopupMenu.PopupSubMenuMenuItem(_("Modify panel ..."), true);
+    let panelSettingsSection = new PopupMenu.PopupSubMenuMenuItem(_("Modify panel"));
 
     let menuItem = new PopupMenu.PopupIconMenuItem(_("Remove panel"), "list-remove", St.IconType.SYMBOLIC);
     menuItem.activate = Lang.bind(menu, function() {
@@ -1048,8 +1046,9 @@ function populateSettingsMenu(menu, panelId) {
     });
     panelSettingsSection.menu.addMenuItem(menu.clearAppletItem);
 
-
     menu.addMenuItem(panelSettingsSection);
+
+    menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
     // Panel Edit mode
     let editMode = global.settings.get_boolean("panel-edit-mode");

--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -30,6 +30,36 @@ function _ensureStyle(actor) {
         actor.ensure_style();
 }
 
+/**
+ * @side Side to which the arrow points.
+ */
+function arrowIcon(side) {
+    let iconName;
+    switch (side) {
+        case St.Side.TOP:
+            iconName = 'pan-up';
+            break;
+        case St.Side.RIGHT:
+            iconName = 'pan-end';
+            break;
+        case St.Side.BOTTOM:
+            iconName = 'pan-down';
+            break;
+        case St.Side.LEFT:
+            iconName = 'pan-start';
+            break;
+    }
+
+    let arrow = new St.Icon({ style_class: 'popup-menu-arrow',
+                              icon_name: iconName,
+                              icon_type: St.IconType.SYMBOLIC,
+                              y_expand: true,
+                              y_align: Clutter.ActorAlign.CENTER,
+                              important: true });
+
+    return arrow;
+}
+
 function PopupBaseMenuItem(params) {
     this._init(params);
 }
@@ -1615,7 +1645,6 @@ PopupSubMenu.prototype = {
         PopupMenuBase.prototype._init.call(this, sourceActor);
 
         this._arrow = sourceArrow;
-        if (this._arrow) this._arrow.rotation_center_z_gravity = Clutter.Gravity.CENTER;
 
         this.actor = new St.ScrollView({ style_class: 'popup-sub-menu',
                                          hscrollbar_policy: Gtk.PolicyType.NEVER,
@@ -1698,23 +1727,19 @@ PopupSubMenu.prototype = {
         if (animate && needsScrollbar)
             animate = false;
 
-        let rotation_angle = 90;
-        if (this.actor.get_direction() == St.TextDirection.RTL) {
-            rotation_angle = 270;
-        }
+        let targetAngle = this.actor.text_direction == Clutter.TextDirection.RTL ? -90 : 90;
 
         if (animate) {
             let [minHeight, naturalHeight] = this.actor.get_preferred_height(-1);
             this.actor.height = 0;
-            if (this._arrow) this.actor._arrow_rotation = this._arrow.rotation_angle_z;
-            else this.actor._arrow_rotation = 0;
+            this.actor._arrowRotation = this._arrow.rotation_angle_z;
             Tweener.addTween(this.actor,
-                             { _arrow_rotation: rotation_angle,
+                             { _arrowRotation: targetAngle,
                                height: naturalHeight,
                                time: 0.25,
                                onUpdateScope: this,
                                onUpdate: function() {
-                                   if (this._arrow) this._arrow.rotation_angle_z = this.actor._arrow_rotation;
+                                   this._arrow.rotation_angle_z = this.actor._arrowRotation;
                                },
                                onCompleteScope: this,
                                onComplete: function() {
@@ -1723,7 +1748,7 @@ PopupSubMenu.prototype = {
                                }
                              });
         } else {
-            if (this._arrow) this._arrow.rotation_angle_z = rotation_angle;
+            this._arrow.rotation_angle_z = targetAngle;
             this.emit('open-state-changed', true);
         }
     },
@@ -1745,17 +1770,11 @@ PopupSubMenu.prototype = {
 
         if (animate && this._needsScrollbar())
             animate = false;
-            
-        let rotation_angle = 90;
-        if (this.actor.get_direction() == St.TextDirection.RTL) {
-            rotation_angle = 270;
-        }
 
         if (animate) {
-            if (this._arrow) this.actor._arrow_rotation = this._arrow.rotation_angle_z;
-            else this.actor._arrow_rotation = rotation_angle;
+            this.actor._arrowRotation = this._arrow.rotation_angle_z;
             Tweener.addTween(this.actor,
-                             { _arrow_rotation: 0,
+                             { _arrowRotation: 0,
                                height: 0,
                                time: 0.25,
                                onCompleteScope: this,
@@ -1767,11 +1786,11 @@ PopupSubMenu.prototype = {
                                },
                                onUpdateScope: this,
                                onUpdate: function() {
-                                   if (this._arrow) this._arrow.rotation_angle_z = this.actor._arrow_rotation;
+                                   this._arrow.rotation_angle_z = this.actor._arrowRotation;
                                }
                              });
             } else {
-                if (this._arrow) this._arrow.rotation_angle_z = 0;
+                this._arrow.rotation_angle_z = 0;
                 this.actor.hide();
 
                 this.isOpen = false;
@@ -1835,34 +1854,25 @@ function PopupSubMenuMenuItem() {
 PopupSubMenuMenuItem.prototype = {
     __proto__: PopupBaseMenuItem.prototype,
 
-    _init: function(text, hide_expander) {
+    _init: function(text) {
         PopupBaseMenuItem.prototype._init.call(this);
 
         this.actor.add_style_class_name('popup-submenu-menu-item');
 
-        let table = new St.Table({ homogeneous: false,
-                                      reactive: true });
-
-        if (!hide_expander) {
-            this._triangle = new St.Icon({ icon_name: "media-playback-start",
-                                icon_type: St.IconType.SYMBOLIC,
-                                style_class: 'popup-menu-icon' });
-
-            table.add(this._triangle,
-                    {row: 0, col: 0, col_span: 1, x_expand: false, x_align: St.Align.START});
-
-            this.label = new St.Label({ text: text });
-            this.label.set_margin_left(6.0);
-            table.add(this.label,
-                    {row: 0, col: 1, col_span: 1, x_align: St.Align.START});
-        }
-        else {
-            this.label = new St.Label({ text: text });
-            table.add(this.label,
-                    {row: 0, col: 0, col_span: 1, x_align: St.Align.START});
-        }
+        this.label = new St.Label({ text: text,
+                                    y_expand: true,
+                                    y_align: Clutter.ActorAlign.CENTER });
+        this.addActor(this.label);
         this.actor.label_actor = this.label;
-        this.addActor(table, { expand: true, span: 1, align: St.Align.START });
+
+        this._triangleBin = new St.Bin({ x_align: St.Align.END });
+        this.addActor(this._triangleBin, { expand: true,
+                                           span: -1,
+                                           align: St.Align.END });
+        
+        this._triangle = arrowIcon(St.Side.RIGHT);
+        this._triangle.pivot_point = new Clutter.Point({ x: 0.5, y: 0.6 });
+        this._triangleBin.child = this._triangle;
 
         this.menu = new PopupSubMenu(this.actor, this._triangle);
         this.menu.connect('open-state-changed', Lang.bind(this, this._subMenuOpenStateChanged));


### PR DESCRIPTION
…th a different layout. Also tweak the layout of a couple of our applet menus to look nicer with this change. The addition of the icons to Cinnamon itself is a workaround for Mint. Newer versions of the gnome icon theme have these as built in icons but not in the version supplied with Mint 17. They can be removed in the future.