### PR TITLE
use the new meta_screen_get_current_monitor() to place appswitchers a…

### DIFF
--- a/js/ui/appSwitcher/appSwitcher.js
+++ b/js/ui/appSwitcher/appSwitcher.js
@@ -224,15 +224,9 @@ AppSwitcher.prototype = {
 
     _updateActiveMonitor: function() {
         this._activeMonitor = null;
-        if(!this._enforcePrimaryMonitor) {
-            try {
-                let x, y, mask;
-                [x, y, mask] = global.get_pointer();
-                this._activeMonitor = Main.layoutManager._chrome._findMonitorForRect(x, y, 0, 0);
-            } catch(e) {
-            }
-        }
-        if(!this._activeMonitor)
+        if (!this._enforcePrimaryMonitor)
+            this._activeMonitor = Main.layoutManager.currentMonitor;
+        if (!this._activeMonitor)
             this._activeMonitor = Main.layoutManager.primaryMonitor;
 
         return this._activeMonitor;

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -176,6 +176,11 @@ LayoutManager.prototype = {
         return this.monitors[this.focusIndex];
     },
 
+    get currentMonitor() {
+        let index = global.screen.get_current_monitor();
+        return Main.layoutManager.monitors[index];
+    },
+
     _prepareStartupAnimation: function() {
         // During the initial transition, add a simple actor to block all events,
         // so they don't get delivered to X11 windows that have been transformed.

--- a/js/ui/modalDialog.js
+++ b/js/ui/modalDialog.js
@@ -252,16 +252,7 @@ ModalDialog.prototype = {
     },
 
     _fadeOpen: function() {
-        let monitor =  null;
-        try {
-            let x, y, mask;
-            [x, y, mask] = global.get_pointer();
-            monitor = Main.layoutManager._chrome._findMonitorForRect(x, y, 0, 0);
-        } catch(e) {
-        }
-
-        if (!monitor)
-            monitor = Main.layoutManager.primaryMonitor;
+        let monitor = Main.layoutManager.currentMonitor;
 
         this._backgroundBin.set_position(monitor.x, monitor.y);
         this._backgroundBin.set_size(monitor.width, monitor.height);


### PR DESCRIPTION
…nd modal dialogs on the proper monitor in multiple monitor setups

Requires: https://github.com/linuxmint/muffin/pull/202