### PR TITLE
windowManger.js: use Tweener for timeout

### DIFF
--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -802,9 +802,9 @@ WindowManager.prototype = {
             }
         }
 
-        Mainloop.timeout_add(WINDOW_ANIMATION_TIME * 1000, function() {
+        Tweener.addTween(this, {time: WINDOW_ANIMATION_TIME, onComplete: function() {
             cinnamonwm.completed_switch_workspace();
-        });
+        }});
     },
 
     _showTilePreview: function(cinnamonwm, window, tileRect, monitorIndex, snapQueued) {


### PR DESCRIPTION
In windowManager.js, for workspace switch animations, we use Tweener to
perform the animation. However, to call the cleanup function after the
animation finishes, we use Mainloop.timeout_add instead. This cuases a
problem if cinnamon is run with CINNAMON_SLOWDOWN_FACTOR!=1, since the
CINNAMON_SLOWDOWN_FACTOR slows down tweening animations but not Mainloop
timeouts. The result is that if we have a slowdown factor > 1, the
workspace switch animation will be cut before it finishes.