### PR TITLE
Improve/Bugfixes to the password changer dialogs

### DIFF
--- a/files/usr/lib/cinnamon-settings-users/cinnamon-settings-users.py
+++ b/files/usr/lib/cinnamon-settings-users/cinnamon-settings-users.py
@@ -263,14 +263,11 @@ class PasswordDialog(Gtk.Dialog):
             else:
                 symbol += 1
         length = len(password)
-        if length > 5:
-            length = 5
-        if digit > 3:
-            digit = 3
-        if upper > 3:
-            upper = 3
-        if symbol > 3:
-            symbol = 3
+        
+        length = min(length,4)
+        digit = min(digit,3)
+        upper = min(upper,3)
+        symbol = min(symbol,3)
         strength = (
             ((length * 0.1) - 0.2) +
             (digit * 0.1) +

--- a/files/usr/lib/cinnamon-settings/modules/cs_user.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_user.py
@@ -224,7 +224,7 @@ class PasswordDialog(Gtk.Dialog):
         self.set_modal(True)
         self.set_skip_taskbar_hint(True)
         self.set_skip_pager_hint(True)
-        self.set_title("")
+        self.set_title(_("Change Password"))
 
         table = Gtk.Table(6, 3)
         table.set_border_width(6)
@@ -274,18 +274,18 @@ class PasswordDialog(Gtk.Dialog):
         self.show_password.connect('toggled', self._on_show_password_toggled)
         table.attach(self.show_password, 1, 3, 4, 5)
 
+        self.set_border_width(6)
+
+        box = self.get_content_area()
+        box.add(table)
+        self.show_all()
+
         self.infobar = Gtk.InfoBar()
         self.infobar.set_message_type(Gtk.MessageType.ERROR)
         label = Gtk.Label.new(_("An error occured. Your password was not changed."))
         content = self.infobar.get_content_area()
         content.add(label)
         table.attach(self.infobar, 0, 3, 5, 6)
-
-        self.set_border_width(6)
-
-        box = self.get_content_area()
-        box.add(table)
-        self.show_all()
 
         self.add_buttons(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL, _("Change"), Gtk.ResponseType.OK, )
 
@@ -361,10 +361,44 @@ class PasswordDialog(Gtk.Dialog):
                 self.correct_current_password = True
                 self.check_passwords()
 
+    # Based on setPasswordStrength() in Mozilla Seamonkey, which is tri-licensed under MPL 1.1, GPL 2.0, and LGPL 2.1.
+    # Forked from Ubiquity validation.py
+    def password_strength(self, password):
+        upper = lower = digit = symbol = 0
+        for char in password:
+            if char.isdigit():
+                digit += 1
+            elif char.islower():
+                lower += 1
+            elif char.isupper():
+                upper += 1
+            else:
+                symbol += 1
+        length = len(password)
+        if length > 5:
+            length = 5
+        if digit > 3:
+            digit = 3
+        if upper > 3:
+            upper = 3
+        if symbol > 3:
+            symbol = 3
+        strength = (
+            ((length * 0.1) - 0.2) +
+            (digit * 0.1) +
+            (symbol * 0.15) +
+            (upper * 0.1))
+        if strength > 1:
+            strength = 1
+        if strength < 0:
+            strength = 0
+        return strength
+
     def _on_passwords_changed(self, widget):
         self.infobar.hide()
         new_password = self.new_password.get_text()
         confirm_password = self.confirm_password.get_text()
+        strength = self.password_strength(new_password)
         if new_password != confirm_password:
             self.confirm_password.set_icon_from_stock(Gtk.EntryIconPosition.SECONDARY, Gtk.STOCK_DIALOG_WARNING)
             self.confirm_password.set_icon_tooltip_text(Gtk.EntryIconPosition.SECONDARY, _("Passwords do not match"))
@@ -373,8 +407,17 @@ class PasswordDialog(Gtk.Dialog):
         if len(new_password) < 8:
             self.strengh_label.set_text(_("Too short"))
             self.strengh_indicator.set_fraction(0.0)
+        elif strength < 0.5:
+            self.strengh_label.set_text(_("Weak"))
+            self.strengh_indicator.set_fraction(0.2)
+        elif strength < 0.75:
+            self.strengh_label.set_text(_("Fair"))
+            self.strengh_indicator.set_fraction(0.4)
+        elif strength < 0.9:
+            self.strengh_label.set_text(_("Good"))
+            self.strengh_indicator.set_fraction(0.6)
         else:
-            self.strengh_label.set_text(_("OK"))
+            self.strengh_label.set_text(_("Strong"))
             self.strengh_indicator.set_fraction(1.0)
 
         self.check_passwords()

--- a/files/usr/lib/cinnamon-settings/modules/cs_user.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_user.py
@@ -375,14 +375,11 @@ class PasswordDialog(Gtk.Dialog):
             else:
                 symbol += 1
         length = len(password)
-        if length > 5:
-            length = 5
-        if digit > 3:
-            digit = 3
-        if upper > 3:
-            upper = 3
-        if symbol > 3:
-            symbol = 3
+        
+        length = min(length,4)
+        digit = min(digit,3)
+        upper = min(upper,3)
+        symbol = min(symbol,3)
         strength = (
             ((length * 0.1) - 0.2) +
             (digit * 0.1) +
@@ -407,7 +404,7 @@ class PasswordDialog(Gtk.Dialog):
         if len(new_password) < 8:
             self.strengh_label.set_text(_("Too short"))
             self.strengh_indicator.set_fraction(0.0)
-        elif strength < 0.5:
+        elif strength < 0.6:
             self.strengh_label.set_text(_("Weak"))
             self.strengh_indicator.set_fraction(0.2)
         elif strength < 0.75:


### PR DESCRIPTION
-Stop "An error occured. Your password was not changed." from flash briefly when opening
-Add a window title so it doesn't show up as a question mark in the window list
-Make the strength bar use the same rules as Ubiquity apart from still having to be greater than 8 chars as that is a limitation of PAM

via https://trello.com/c/XvsiQ5my/38-user-password-dialog