### PR TITLE
build: append ST_CFLAGS when building test-recorder

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -199,7 +199,8 @@ libcinnamon_la_SOURCES += $(cinnamon_recorder_sources) $(cinnamon_recorder_non_g
 
 noinst_PROGRAMS += test-recorder
 
-test_recorder_CPPFLAGS = $(TEST_CINNAMON_RECORDER_CFLAGS)
+test_recorder_CPPFLAGS = $(TEST_CINNAMON_RECORDER_CFLAGS) \
+                       $(ST_CFLAGS)
 test_recorder_LDADD = $(TEST_CINNAMON_RECORDER_LIBS) \
                        libst-1.0.la
 


### PR DESCRIPTION
test-recorder #includes st.h, which pulls in lots of headers, some of which might not be in TEST_CINNAMON_RECORDER_CFLAGS, depending on how clutter and gstreamer were configured.

Fixes build failure reported at https://bugs.gentoo.org/559794 :

    In file included from ./st/st-bin.h:27:0,
                     from st.h:4,
                     from cinnamon-recorder.c:19:
    ./st/st-types.h:26:21: fatal error: gtk/gtk.h: No such file or directory