### PR TITLE
Fix for #4588

### DIFF
--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
@@ -149,7 +149,13 @@ MyApplet.prototype = {
         }
         else {
             if (this.clock) { // We lose cinnamon-desktop temporarily during suspend
-                this.set_applet_label(this.clock.get_clock().capitalize());
+                let label_string = this.clock.get_clock().capitalize();
+                this.set_applet_label(label_string);
+
+                let first_colon = label_string.indexOf(":");
+                if(first_colon > 0 && label_string.length > first_colon - 1 && label_string.indexOf(":", first_colon + 1) > 0) {
+                    nextUpdate = 1;
+                }
             }
         }
 

--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
@@ -93,6 +93,12 @@ MyApplet.prototype = {
             this.settings.bindProperty(Settings.BindingDirection.IN, "use-custom-format", "use_custom_format", this.on_settings_changed, null);
             this.settings.bindProperty(Settings.BindingDirection.IN, "custom-format", "custom_format", this.on_settings_changed, null);        
 
+            // Track changes to date&time settings
+            this.datetime_settings = new Gio.Settings({ schema_id: "org.cinnamon.desktop.interface" });
+            this.datetime_settings.connect('changed::clock-show-seconds', Lang.bind(this, this.on_settings_changed));
+            this.datetime_settings.connect('changed::clock-use-24h', Lang.bind(this, this.on_settings_changed));
+            this.datetime_settings.connect('changed::clock-show-date', Lang.bind(this, this.on_settings_changed));
+
             // https://bugzilla.gnome.org/show_bug.cgi?id=655129
             this._upClient = new UPowerGlib.Client();
             try {

--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
@@ -158,8 +158,7 @@ MyApplet.prototype = {
                 let label_string = this.clock.get_clock().capitalize();
                 this.set_applet_label(label_string);
 
-                let first_colon = label_string.indexOf(":");
-                if(first_colon > 0 && label_string.length > first_colon - 1 && label_string.indexOf(":", first_colon + 1) > 0) {
+                if(this.datetime_settings.get_boolean("clock-show-seconds")) {
                     nextUpdate = 1;
                 }
             }


### PR DESCRIPTION
This fixes #4588, related to my previous pull request #4361. See the bug for the missing part.

The code checks if clock-show-seconds is set in org.cinnamon.desktop.interface, and connects to the changed::.. events for all related seconds for immediate updates on configuration changes.