### PR TITLE
[3.0] Signal manager: Timeouts and DBus

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -14,6 +14,7 @@ const Gio = imports.gi.Gio;
 const Signals = imports.signals;
 const GnomeSession = imports.misc.gnomeSession;
 const ScreenSaver = imports.misc.screenSaver;
+const SignalManager = imports.misc.signalManager;
 const FileUtils = imports.misc.fileUtils;
 const Util = imports.misc.util;
 const Tweener = imports.ui.tweener;
@@ -1066,6 +1067,8 @@ MyApplet.prototype = {
         this.menu = new Applet.AppletPopupMenu(this, orientation);
         this.menuManager.addMenu(this.menu);
 
+        this.signals = new SignalManager.SignalManager(this);
+
         this.actor.connect('key-press-event', Lang.bind(this, this._onSourceKeyPress));
 
         this.settings = new Settings.AppletSettings(this, "menu@cinnamon.org", instance_id);
@@ -1575,11 +1578,7 @@ MyApplet.prototype = {
     },
 
     maybeUpdateVectorBox: function() {
-        if (this.vector_update_loop) {
-            Mainloop.source_remove(this.vector_update_loop);
-            this.vector_update_loop = 0;
-        }
-        this.vector_update_loop = Mainloop.timeout_add(35, Lang.bind(this, this.updateVectorBox));
+        this.signals.addTimeout("vector-update", 35, this.updateVectorBox);
     },
 
     updateVectorBox: function(actor) {
@@ -1599,7 +1598,7 @@ MyApplet.prototype = {
                 this.destroyVectorBox(actor);
             }
         }
-        this.vector_update_loop = 0;
+
         return false;
     },
 
@@ -2148,7 +2147,6 @@ MyApplet.prototype = {
         this._activeActor = null;
         this.vectorBox = null;
         this.actor_motion_id = 0;
-        this.vector_update_loop = null;
         this.current_motion_actor = null;
         let section = new PopupMenu.PopupMenuSection();
         this.menu.addMenuItem(section);

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -1,5 +1,4 @@
 const Applet = imports.ui.applet;
-const Mainloop = imports.mainloop;
 const Gio = imports.gi.Gio;
 const Interfaces = imports.misc.interfaces;
 const Util = imports.misc.util;
@@ -14,6 +13,7 @@ const Pango = imports.gi.Pango;
 const Tooltips = imports.ui.tooltips;
 const Main = imports.ui.main;
 const Settings = imports.ui.settings;
+const SignalManager = imports.misc.signalManager;
 const Slider = imports.ui.slider;
 
 const MEDIA_PLAYER_2_PATH = "/org/mpris/MediaPlayer2";
@@ -282,6 +282,8 @@ Player.prototype = {
         if (!this._prop || !this._mediaServerPlayer || !this._mediaServer)
             return;
 
+        this.signals = new SignalManager.SignalManager(this);
+
         let mainBox = new PopupMenu.PopupMenuSection;
         this.addMenuItem(mainBox);
 
@@ -415,8 +417,6 @@ Player.prototype = {
             this._positionSlider.actor.hide();
         }
 
-        this._timeoutId = 0;
-
         this._setStatus(this._mediaServerPlayer.PlaybackStatus);
         this._trackId = {};
         this._setMetadata(this._mediaServerPlayer.Metadata);
@@ -425,7 +425,7 @@ Player.prototype = {
         this._wantedSeekValue = 0;
         this._updatePositionSlider();
 
-        this._mediaServerPlayerId = this._mediaServerPlayer.connectSignal('Seeked', Lang.bind(this, function(id, sender, value) {
+        this.signals.connect(this._mediaServerPlayer, "Seeked", function(id, sender, value){
             if (value > 0) {
                 this._setPosition(value);
             }
@@ -441,9 +441,9 @@ Player.prototype = {
                 this._setPosition(value);
 
             this._wantedSeekValue = 0;
-        }));
+        });
 
-        this._propChangedId = this._prop.connectSignal('PropertiesChanged', Lang.bind(this, function(proxy, sender, [iface, props]) {
+        this.signals.connect(this._prop, "PropertiesChanged", function(proxy, sender, [iface, props]){
                 if (props.PlaybackStatus)
                     this._setStatus(props.PlaybackStatus.unpack());
                 if (props.Metadata)
@@ -454,7 +454,7 @@ Player.prototype = {
                     this._setLoopStatus(props.LoopStatus.unpack());
                 if (props.Shuffle)
                     this._setShuffle(props.Shuffle.unpack());
-        }));
+        });
 
         //get the desktop entry and pass it to the applet
         this._prop.GetRemote(MEDIA_PLAYER_2_NAME, "DesktopEntry", Lang.bind(this, function(value){
@@ -716,24 +716,18 @@ Player.prototype = {
 
     _runTimer: function() {
         if (this._canSeek) {
-            if (this._timeoutId != 0) {
-                Mainloop.source_remove(this._timeoutId);
-                this._timeoutId = 0;
-            }
+            this.signals.removeTimeout("timer");
 
             if (this._playerStatus == 'Playing') {
                 this._getPosition();
                 this._timerTicker = 0;
-                this._timeoutId = Mainloop.timeout_add(1000, Lang.bind(this, this._runTimerCallback));
+                this.signals.addTimeout("timer", 1000, this._runTimerCallback);
             }
         }
     },
 
     _pauseTimer: function() {
-        if (this._timeoutId != 0) {
-            Mainloop.source_remove(this._timeoutId);
-            this._timeoutId = 0;
-        }
+        this.signals.removeTimeout("timer");
         this._updateTimer();
     },
 
@@ -814,14 +808,7 @@ Player.prototype = {
     },
 
     destroy: function() {
-        if (this._timeoutId != 0) {
-            Mainloop.source_remove(this._timeoutId);
-            this._timeoutId = 0;
-        }
-        if (this._mediaServerPlayer)
-            this._mediaServerPlayer.disconnectSignal(this._mediaServerPlayerId);
-        if (this._prop)
-            this._prop.disconnectSignal(this._propChangedId);
+        this.signals.finalize();
 
         PopupMenu.PopupMenuSection.prototype.destroy.call(this);
     }
@@ -895,6 +882,8 @@ MyApplet.prototype = {
 
             this.set_applet_icon_symbolic_name('audio-x-generic');
 
+            this.signals = new SignalManager.SignalManager(this);
+
             this._players = {};
             this._activePlayer = null;
 
@@ -920,7 +909,7 @@ MyApplet.prototype = {
                 ));
 
                 // watch players
-                this._ownerChangedId = this._dbus.connectSignal('NameOwnerChanged', Lang.bind(this,
+                this.signals.connect(this._dbus.connectSignal, "NameOwnerChanged",
                     function(proxy, sender, [name, old_owner, new_owner]) {
                         if (name_regex.test(name)) {
                             if (new_owner && !old_owner)
@@ -930,8 +919,7 @@ MyApplet.prototype = {
                             else
                                 this._changePlayerOwner(name, old_owner, new_owner);
                         }
-                    }
-                ));
+                    });
             }));
 
             this._control = new Gvc.MixerControl({ name: 'Cinnamon Volume Control' });
@@ -1021,11 +1009,8 @@ MyApplet.prototype = {
     on_applet_removed_from_panel : function() {
         if (this.hideSystray)
             this.unregisterSystrayIcons();
-        if (this._iconTimeoutId) {
-            Mainloop.source_remove(this._iconTimeoutId);
-        }
 
-        this._dbus.disconnectSignal(this._ownerChangedId);
+        this.signals.finalize();
 
         for(let i in this._players)
             this._players[i].destroy();
@@ -1090,10 +1075,7 @@ MyApplet.prototype = {
     },
 
     setIcon: function(icon, source) {
-        if(this._iconTimeoutId){
-            Mainloop.source_remove(this._iconTimeoutId);
-            this._iconTimeoutId = null;
-        }
+        this.signals.removeTimeout("icon");
 
         //save the icon
         if(source){
@@ -1107,11 +1089,11 @@ MyApplet.prototype = {
             if(source === "output"){
                 //if we have an active player, but are changing the volume, show the output icon and after three seconds change back to the player icon
                 this.set_applet_icon_symbolic_name(this._outputIcon);
-                this._iconTimeoutId = Mainloop.timeout_add(3000, Lang.bind(this, function(){
+                this.signals.addTimeout("icon", 3000, function(){
                     this._iconTimeoutId = null;
 
                     this.setIcon();
-                }));
+                });
             } else {
                 //if we have an active player and want to change the icon, change it immediately
                 if(this._playerIcon[1])

--- a/js/misc/docInfo.js
+++ b/js/misc/docInfo.js
@@ -1,7 +1,6 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
 const St = imports.gi.St;
-const Mainloop = imports.mainloop;
 const Cinnamon = imports.gi.Cinnamon;
 const Lang = imports.lang;
 const Signals = imports.signals;

--- a/js/misc/signalManager.js
+++ b/js/misc/signalManager.js
@@ -236,7 +236,7 @@ SignalManager.prototype = {
      * addTimeout:
      *
      * @name (string): an identifier
-     * @interval (integer): the time between calls to the function, in milliseconds
+     * @interval (integer|null): the time between calls to the function, in milliseconds or null for "idle"
      * @callback (function): the callback function
      * @bind (Object): (optional) the object to bind the function to. Leave
      * empty for the owner of the #SignalManager (which has no side effects if
@@ -261,7 +261,13 @@ SignalManager.prototype = {
         if(this._timeouts[name])
             this.removeTimeout(callback);
 
-        let id = Mainloop.timeout_add(interval, this._makeCallback(callback, bind));
+        let id;
+
+        // interval of null means "idle"
+        if(interval === null)
+            id = Mainloop.idle_add(this._makeCallback(callback, bind));
+        else
+            id = Mainloop.timeout_add(interval, this._makeCallback(callback, bind));
 
         this._timeouts[name] = id;
     },

--- a/js/ui/backgroundManager.js
+++ b/js/ui/backgroundManager.js
@@ -2,7 +2,6 @@
 
 const Gio = imports.gi.Gio;
 const Lang = imports.lang;
-const Mainloop = imports.mainloop;
 
 function BackgroundManager() {
     this._init();

--- a/js/ui/overview.js
+++ b/js/ui/overview.js
@@ -2,7 +2,6 @@
 const Clutter = imports.gi.Clutter;
 const Gtk = imports.gi.Gtk;
 const Meta = imports.gi.Meta;
-const Mainloop = imports.mainloop;
 const Signals = imports.signals;
 const Lang = imports.lang;
 const St = imports.gi.St;

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -5,7 +5,6 @@ const Lang = imports.lang;
 const Meta = imports.gi.Meta;
 const St = imports.gi.St;
 const Cinnamon = imports.gi.Cinnamon;
-const Mainloop = imports.mainloop;
 const Gio = imports.gi.Gio;
 const AppSwitcher = imports.ui.appSwitcher.appSwitcher;
 const CoverflowSwitcher = imports.ui.appSwitcher.coverflowSwitcher;


### PR DESCRIPTION
Adds following features to `SignalManager.SignalManager`:

- `SignalManager.addTimeout(name, interval, callback)`
 * `interval` is a number → milliseconds
 * `interval` is `null` → idle timeout
- `SignalManager.removeTimeout(name)`
- for `SignalManager.connect`, `obj` can also be a `Gio.DBusProxy`

I didn't convert all the old code, to have more security regarding regressions.