### PR TITLE
Add texture monitors as an option for theme developers

### DIFF
--- a/data/org.cinnamon.gschema.xml.in
+++ b/data/org.cinnamon.gschema.xml.in
@@ -424,6 +424,14 @@
       </_description>
     </key>
 
+    <key name="enable-texture-monitors" type="b">
+      <default>false</default>
+      <_summary>Enable or disable watching textures for changes</_summary>
+      <_description>
+        Whether image files are monitored for changes in order to reload or not
+      </_description>
+    </key>
+
     <key name="workspace-expo-view-as-grid" type="b">
       <default>false</default>
       <summary>Display the Expo view as a grid</summary>

--- a/files/usr/lib/cinnamon-settings/modules/cs_general.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_general.py
@@ -52,3 +52,7 @@ class Module:
 
             switch = GSettingsSwitch(_("Log LookingGlass output to ~/.cinnamon/glass.log (Requires Cinnamon restart)"), "org.cinnamon", "enable-looking-glass-logs")
             settings.add_row(switch)
+
+            switch = GSettingsSwitch(_("Enable texture monitors (Requires Cinnamon restart)"), "org.cinnamon", "enable-texture-monitors")
+            switch.set_tooltip_text(_("Select this option to force Cinnamon to watch all texture files (images) for changes, and to reload them when necessary. This is more useful for theme developers."))
+            settings.add_row(switch)

--- a/src/st/st-texture-cache.c
+++ b/src/st/st-texture-cache.c
@@ -1132,29 +1132,24 @@ static void
 ensure_monitor_for_uri (StTextureCache *cache,
                         const gchar    *uri)
 {
-  /* Don't monitor changes at all.
-   * We're keeping this function for now, even if it doesn't do anything
-   * In case special cases come up in the future, where monitors are needed for particular uris.
+  StTextureCachePrivate *priv = cache->priv;
+  GFile *file = g_file_new_for_uri (uri);
+
+  /* No point in trying to monitor files that are part of a
+   * GResource, since it does not support file monitoring.
    */
+  if (!g_file_has_uri_scheme (file, "resource")) {
+    if (g_hash_table_lookup (priv->file_monitors, uri) == NULL)
+    {
+      GFileMonitor *monitor = g_file_monitor_file (file, G_FILE_MONITOR_NONE,
+                                                   NULL, NULL);
+      g_signal_connect (monitor, "changed",
+                        G_CALLBACK (file_changed_cb), cache);
+      g_hash_table_insert (priv->file_monitors, g_strdup (uri), monitor);
+    }
+  }
 
-  // StTextureCachePrivate *priv = cache->priv;
-  // GFile *file = g_file_new_for_uri (uri);
-
-  // /* No point in trying to monitor files that are part of a
-  //  * GResource, since it does not support file monitoring.
-  //  */
-  // if (!g_file_has_uri_scheme (file, "resource")) {
-  //   if (g_hash_table_lookup (priv->file_monitors, uri) == NULL)
-  //   {
-  //     GFileMonitor *monitor = g_file_monitor_file (file, G_FILE_MONITOR_NONE,
-  //                                                  NULL, NULL);
-  //     g_signal_connect (monitor, "changed",
-  //                       G_CALLBACK (file_changed_cb), cache);
-  //     g_hash_table_insert (priv->file_monitors, g_strdup (uri), monitor);
-  //   }
-  // }
-
-  // g_object_unref (file);
+  g_object_unref (file);
 }
 
 typedef struct {


### PR DESCRIPTION
Cinnamon 2.6.0 disabled the filesystem monitoring of assets used by textures for a performance bump (51942292a87b585d76402f6d0b6b1bd8d2081d9a). While that is a good idea for most users, it makes theme development much more of a challenge. This change set makes it an option in Cinnamon Settings "General" tab and defaults it to off.

Would resolve #4610 and #4472.

![screenshot-area-2015-09-19-132804](https://cloud.githubusercontent.com/assets/164802/9978036/632f47b2-5ed3-11e5-8d96-629ff748bb17.png)
