### PR TITLE
Show additional audio device description in sound applet

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -1420,6 +1420,11 @@ MyApplet.prototype = {
             this._control["change_" + type](device);
         });
 
+        let bin = new St.Bin({ x_align: St.Align.END, style_class: 'menuitem-detail' });
+        let label = new St.Label({ text: device.origin });
+        bin.add_actor(label);
+        item.addActor(bin, { expand: false, span: 1, align: St.Align.END });
+
         let selectItem = this["_select" + type[0].toUpperCase() + type.slice(1) + "DeviceItem"];
         selectItem.menu.addMenuItem(item);
         //show the menu if we have more than two devices


### PR DESCRIPTION
When there are many devices present, the current list isn't helpful. Example:

![screenshot-cinnamon-2015-09-19-203908](https://cloud.githubusercontent.com/assets/164802/9979137/ff9186f2-5f0e-11e5-9bf9-13f9190cf9f4.png)

This minimal change adds a trailing label with the second line description so devices can more easily be identified. Example:

![screenshot-cinnamon-2015-09-19-202819](https://cloud.githubusercontent.com/assets/164802/9979135/fd38c7a8-5f0e-11e5-9b49-9557ff81d3e0.png)

**Note**: the style applied on the right is `menuitem-detail`, inherited from the desktop-capture applet. Cinnamon *should* have a similar style, and when that style is selected and implemented this pull request can be updated and considered.