### PR TITLE
Fix multi-instance tracking, highlighting

### DIFF
--- a/files/usr/lib/cinnamon-settings/bin/XletSettings.py
+++ b/files/usr/lib/cinnamon-settings/bin/XletSettings.py
@@ -129,7 +129,7 @@ class XletSetting:
         else:
             self.multi_instance = False
         if os.path.exists(path) and os.path.isdir(path):
-            instances = os.listdir(path)
+            instances = sorted(os.listdir(path))
             if len(instances) != 0:
                 for instance in instances:
                     raw_data = open("%s/%s" % (path, instance)).read()
@@ -205,8 +205,14 @@ class XletSetting:
             view.show()
             self.nb.append_page(view, Gtk.Label.new(_("Instance %d") % (i + 1)))
             view.key = instance_key
+            
+            if target_instance == -1:
+                target_instance = instance_key
+                self.current_id = instance_key
+
             if view.key == target_instance:
                 target_page = i
+
             i += 1
 
         self.content.pack_start(self.nb, True, True, 2)
@@ -224,7 +230,7 @@ class XletSetting:
         session_bus = dbus.SessionBus()
         cinnamon_dbus = session_bus.get_object("org.Cinnamon", "/org/Cinnamon")
         highlight_applet = cinnamon_dbus.get_dbus_method('highlightApplet', 'org.Cinnamon')
-        highlight_applet(self.current_id, self.multi_instance)
+        highlight_applet(self.uuid, self.current_id)
 
     def on_back_to_list_button_clicked(self, widget):
         self.parent._close_configure(self)

--- a/files/usr/lib/cinnamon-settings/bin/XletSettingsWidgets.py
+++ b/files/usr/lib/cinnamon-settings/bin/XletSettingsWidgets.py
@@ -1340,7 +1340,7 @@ class Button(Gtk.Button, BaseWidget):
         session_bus = dbus.SessionBus()
         cinnamon_dbus = session_bus.get_object("org.Cinnamon", "/org/Cinnamon")
         activate_cb = cinnamon_dbus.get_dbus_method('activateCallback', 'org.Cinnamon')
-        activate_cb(self.get_callback(), self.get_instance_id(), self.get_multi_instance())
+        activate_cb(self.get_callback(), self.uuid, self.get_instance_id())
 
     def update_dep_state(self, active):
         self.set_sensitive(active)

--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -457,10 +457,12 @@ function get_object_for_instance (appletId) {
     }
 }
 
-function get_object_for_uuid (uuid) {
-    for (let instanceid in appletObj) {
-        if (appletObj[instanceid]._uuid == uuid) {
-            return appletObj[instanceid]
+function get_object_for_uuid (uuid, instanceId) {
+    for (let thisInstanceId in appletObj) {
+        if (appletObj[thisInstanceId]._uuid == uuid) {
+            if (instanceId == uuid || thisInstanceId == instanceId) {
+                return appletObj[thisInstanceId]
+            }
         }
     }
     return null;

--- a/js/ui/cinnamonDBus.js
+++ b/js/ui/cinnamonDBus.js
@@ -51,7 +51,7 @@ const CinnamonIface =
             </method> \
             <method name="highlightApplet"> \
                 <arg type="s" direction="in" /> \
-                <arg type="b" direction="in" /> \
+                <arg type="s" direction="in" /> \
             </method> \
             <method name="highlightPanel"> \
                 <arg type="i" direction="in" /> \
@@ -64,7 +64,7 @@ const CinnamonIface =
             <method name="activateCallback"> \
                 <arg type="s" direction="in" /> \
                 <arg type="s" direction="in" /> \
-                <arg type="b" direction="in" /> \
+                <arg type="s" direction="in" /> \
             </method> \
             <method name="updateSetting"> \
                 <arg type="s" direction="in" /> \
@@ -250,17 +250,15 @@ Cinnamon.prototype = {
             Main.expo.hide();
     },
 
-    _getXletObject: function(id, id_is_instance) {
-        let obj = null;
-        if (id_is_instance) {
-            obj = AppletManager.get_object_for_instance(id)
-            if (!obj)
-                obj = DeskletManager.get_object_for_instance(id)
-        } else {
-            obj = AppletManager.get_object_for_uuid(id)
-            if (!obj)
-                obj = DeskletManager.get_object_for_uuid(id)
+    _getXletObject: function(uuid, instance_id) {
+        var obj = null;
+        
+        obj = AppletManager.get_object_for_uuid(uuid, instance_id);
+        
+        if (!obj) {
+            obj = DeskletManager.get_object_for_uuid(uuid, instance_id);
         }
+
         return obj
     },
 
@@ -292,8 +290,8 @@ Cinnamon.prototype = {
         return res;
     },
 
-    highlightApplet: function(id, id_is_instance) {
-        let obj = this._getXletObject(id, id_is_instance);
+    highlightApplet: function(uuid, instance_id) {
+        let obj = this._getXletObject(uuid, instance_id);
         if (!obj)
             return;
         let actor = obj.actor;
@@ -318,8 +316,8 @@ Cinnamon.prototype = {
         Main.panelManager._destroyDummyPanels();
     },
 
-    activateCallback: function(callback, id, id_is_instance) {
-        let obj = this._getXletObject(id, id_is_instance);
+    activateCallback: function(callback, uuid, instance_id) {
+        let obj = this._getXletObject(uuid, instance_id);
         let cb = Lang.bind(obj, obj[callback]);
         cb();
     },

--- a/js/ui/deskletManager.js
+++ b/js/ui/deskletManager.js
@@ -328,10 +328,12 @@ function get_object_for_instance (deskletId) {
     }
 }
 
-function get_object_for_uuid (uuid) {
-    for (let instanceid in deskletObj) {
-        if (deskletObj[instanceid]._uuid == uuid) {
-            return deskletObj[instanceid];
+function get_object_for_uuid (uuid, instanceId) {
+    for (let thisInstanceId in deskletObj) {
+        if (deskletObj[thisInstanceId]._uuid == uuid) {
+            if (instanceId == uuid || thisInstanceId == instanceId) {
+                return deskletObj[thisInstanceId]
+            }
         }
     }
     return null;


### PR DESCRIPTION
Fixes #4634 where an instance identifier was arbitrarily corresponding to the wrong type of xlet.

Additionally:
- Fixed initial instance not actually being selected on multi-instance xlet "Configuration" page (and so there's an error when clicking "Highlight" and nothing happens)
- Changes `cinnamonDBus.js` signatures for `activateCallback` and `highlightApplet`. Now passing just *uuid* and *instance_id* - both are equal when multi-instance is not allowed.
- Corrects order of instance tabs in XletSettings configuration to reflect the order instances were added in, previously this was determined by arbitrary order returned by `os.listdir` which meant it might load `15.json`, `14.json` and then `13.json`. The first tab will now correspond to the first instance you added, and so on.