### PR TITLE
sound-applet: Don't use pseudo classes to denote new button types. Th…

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -1208,14 +1208,15 @@ StScrollBar StButton#vhandle:hover {
 	border-radius: 4px;
 	padding: 5px;
 }
-.sound-button:small {
+.sound-button.small {
 	width: 16px;
 	height: 8px;
 }
-.sound-button:small StIcon {
+.sound-button.small StIcon {
 	icon-size: 1em;
 }
-.sound-button:hover, .sound-button:active {
+.sound-button:hover,
+.sound-button:active {
 	border: 1px solid white;
 }
 .sound-playback-control {

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -69,12 +69,12 @@ ControlButton.prototype = {
         this.button.connect('clicked', callback);
 
         if(small)
-            this.button.add_style_pseudo_class("small");
+            this.button.add_style_class_name('small');
 
         this.icon = new St.Icon({
             icon_type: St.IconType.SYMBOLIC,
             icon_name: icon,
-            style_class: "popup-menu-icon"
+            style_class: 'popup-menu-icon'
         });
         this.button.set_child(this.icon);
         this.actor.add_actor(this.button);


### PR DESCRIPTION
…ey should be used for state changes such as "focus" and "hover" to help maintain some consistency in our theme. Add an additional "small" style class name to these buttons instead.