### PR TITLE
cs_startup: set modal to true for both the "Choose application" and "…

### DIFF
--- a/files/usr/lib/cinnamon-settings/modules/cs_startup.py
+++ b/files/usr/lib/cinnamon-settings/modules/cs_startup.py
@@ -684,6 +684,7 @@ class AppDialog(Gtk.Dialog):
     def __init__(self, app=None):
         super(AppDialog, self).__init__()
         self.app = app
+        self.set_modal(True)
 
         self.add_button(_("Cancel"), Gtk.ResponseType.CANCEL)
 


### PR DESCRIPTION
…Add custom command" dialogs so the behavior is the same for both when using attached dialogs