### PR TITLE
Packaging: fix and override more Lintian warnings (new PR)

### DIFF
--- a/debian/cinnamon.lintian-overrides
+++ b/debian/cinnamon.lintian-overrides
@@ -1,4 +1,7 @@
 # It's the only way we have to let cinnamon find the private library it
 # links against through libcinnamon.so
 cinnamon: binary-or-shlib-defines-rpath usr/bin/cinnamon /usr/lib/gnome-bluetooth
-cinnamon: binary-or-shlib-defines-rpath ./usr/bin/cinnamon /usr/lib/gnome-bluetooth
+cinnamon: binary-or-shlib-defines-rpath usr/lib/cinnamon/libcinnamon.so /usr/lib/gnome-bluetooth
+
+# https://github.com/linuxmint/Cinnamon/pull/1750
+cinnamon: embedded-javascript-library usr/lib/cinnamon-settings/data/spices/jquery.js

--- a/debian/control
+++ b/debian/control
@@ -83,6 +83,7 @@ Depends: cinnamon-common (= ${source:Version}),
          gir1.2-notify-0.7,
          gksu,
          libglib2.0-bin,
+         ${python:Depends},
          python,
          python-dbus,
          python-gconf,
@@ -100,8 +101,10 @@ Depends: cinnamon-common (= ${source:Version}),
          gnome-panel | tint2
 Recommends: gnome-themes-standard, gnome-terminal, cinnamon-bluetooth
 Provides: notification-daemon, x-window-manager
-Description: Cinnamon desktop
- Cinnamon is a modern Linux desktop which provides advanced innovative features and a traditional user experience. It's easy to use, powerful and flexible.
+Description: Modern Linux desktop
+ Cinnamon is a modern Linux desktop which provides advanced innovative
+ features and a traditional user experience. It's easy to use, powerful
+ and flexible.
 
 Package: cinnamon-dbg
 Section: debug
@@ -111,7 +114,9 @@ Depends: cinnamon (= ${binary:Version}),
          ${misc:Depends},
          gnome-dbg
 Description: Debugging symbols for the Cinnamon desktop
- Cinnamon is a modern Linux desktop which provides advanced innovative features and a traditional user experience. It's easy to use, powerful and flexible.
+ Cinnamon is a modern Linux desktop which provides advanced innovative
+ features and a traditional user experience. It's easy to use, powerful
+ and flexible.
  .
  This package contains the debugging symbols.
 
@@ -121,7 +126,9 @@ Breaks: cinnamon (<< ${cinnamon:Version})
 Architecture: all
 Depends: ${misc:Depends}, python
 Description: Cinnamon desktop (Common data files)
- Cinnamon is a modern Linux desktop which provides advanced innovative features and a traditional user experience. It's easy to use, powerful and flexible.
+ Cinnamon is a modern Linux desktop which provides advanced innovative
+ features and a traditional user experience. It's easy to use, powerful
+ and flexible.
  .
  This package contains the architecture independent files needed by Cinnamon
 
@@ -130,6 +137,8 @@ Section: doc
 Architecture: all
 Depends: ${misc:Depends}, devhelp
 Description: Cinnamon documentation
- Cinnamon is a modern Linux desktop which provides advanced innovative features and a traditional user experience. It's easy to use, powerful and flexible.
+ Cinnamon is a modern Linux desktop which provides advanced innovative
+ features and a traditional user experience. It's easy to use, powerful
+ and flexible.
  .
  This package contains the code documentation for various Cinnamon components.

--- a/debian/rules
+++ b/debian/rules
@@ -4,6 +4,9 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
+# turn on Makefile verbose mode
+export V=1
+
 export DEB_LDFLAGS_MAINT_APPEND=-Wl,--as-needed
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
@@ -23,7 +26,7 @@ CINNAMON_VERSION := $(shell echo $(VERSION) | sed 's/\(.*.*\)\..*/\1.0/')
 DH_GENCONTROL_ARGS = -Vcinnamon:Version=$(CINNAMON_VERSION)
 
 %:
-	dh  $@ --with autoreconf,python2 $(DH_PARALLEL_OPTION)
+	dh  $@ --with autoreconf,python2,gir $(DH_PARALLEL_OPTION)
 
 
 override_dh_autoreconf:

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -1,0 +1,2 @@
+# https://github.com/linuxmint/Cinnamon/pull/1750
+cinnamon source: source-is-missing files/usr/lib/cinnamon-settings/data/spices/jquery.js


### PR DESCRIPTION
By the way the `binary-or-shlib-defines-rpath` warning could probably be turned off by replacing the absolute rpaths with relative rpaths using chrpath:
```
chrpath -r '$ORIGIN/../lib/gnome-bluetooth' usr/bin/cinnamon
chrpath -r '$ORIGIN/../gnome-bluetooth' usr/lib/cinnamon/libcinnamon.so
```
