### PR TITLE
Fix some problems with the checkbox api

### DIFF
--- a/js/ui/checkBox.js
+++ b/js/ui/checkBox.js
@@ -9,6 +9,7 @@ const Lang = imports.lang;
 function CheckBoxContainer() {
    this._init();
 }
+
 CheckBoxContainer.prototype = {
     _init: function() {
         this.actor = new Cinnamon.GenericContainer({ y_align: St.Align.MIDDLE });
@@ -95,12 +96,12 @@ CheckBoxContainer.prototype = {
     }
 };
 
-function CheckButton() {
+function CheckBoxBase() {
     this._init.apply(this, arguments);
 }
 
-CheckButton.prototype = {
-    _init: function(state, params) {
+CheckBoxBase.prototype = {
+    _init: function(checkedState, params) {
         this._params = { style_class: 'check-box',
                          button_mask: St.ButtonMask.ONE,
                          toggle_mode: true,
@@ -115,16 +116,11 @@ CheckButton.prototype = {
 
         this.actor = new St.Button(this._params);
         this.actor._delegate = this;
-        this.actor.checked = state;
-        // FIXME: The current size is big and the container only is useful,
-        // because the current theme. Can be fixed the theme also?
-        this.actor.style = 'width: 12px;';
-        this._container = new St.Bin();
-        this.actor.set_child(this._container);
+        this.actor.checked = checkedState;
     },
 
-    setToggleState: function(state) {
-        this.actor.checked = state;
+    setToggleState: function(checkedState) {
+        this.actor.checked = checkedState;
     },
 
     toggle: function() {
@@ -136,16 +132,29 @@ CheckButton.prototype = {
     }
 };
 
+function CheckButton() {
+    this._init.apply(this, arguments);
+}
+
+CheckButton.prototype = {
+    __proto__: CheckBoxBase.prototype,
+
+    _init: function(checkedState, params) {
+        CheckBoxBase.prototype._init.call(this, checkedState, params);
+        this.checkmark = new St.Bin();
+        this.actor.set_child(this.checkmark);
+    },
+};
+
 function CheckBox() {
     this._init.apply(this, arguments);
 }
 
 CheckBox.prototype = {
-    __proto__: CheckButton.prototype,
+    __proto__: CheckBoxBase.prototype,
 
-    _init: function(label, params) {
-        CheckButton.prototype._init.call(this, false, params);
-        this._container.destroy();
+    _init: function(label, params, checkedState) {
+        CheckBoxBase.prototype._init.call(this, checkedState, params);
         this._container = new CheckBoxContainer();
         this.actor.set_child(this._container.actor);
 


### PR DESCRIPTION
This fixes some issues with checkboxes introduced by #4298:
* Hard-coded style removed (this caused the CheckBox class to not work properly with a label, and should be handled in the theme anyway - especially since different themes use different sizes for the checkbox image)
* CheckBox and CheckButton classes now both inherit from a new CheckButtonBase class - this is both a more correct way of doing this, and also prevents the unnecessary adding and immediate removal of an actor in the CheckBox class
* Renamed some variables to make more sense

One issue that still needs to be resolved is the styling of checkboxes in menuitems - they don't line up properly in some themes, and are huge in some as well (e.g. Cinnamon and Mint-x themes). It can currently be styled separately with a child selector, but I wasn't sure if it would be better to create a new style-class to make it easier or not, so I left it alone.