### PR TITLE
appletManager fix for callback buttons in applet settings

### DIFF
--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -436,7 +436,7 @@ function get_object_for_instance (appletId) {
 }
 
 function get_object_for_uuid (uuid, instanceId) {
-    return appletObj.find(x => x._uuid == uuid || x.instance_id == instanceId);
+    return appletObj.find(x => x && x._uuid == uuid || x.instance_id == instanceId);
 }
 
 
@@ -561,7 +561,7 @@ function pasteAppletConfiguration(panelId) {
 }
 
 function getRunningInstancesForUuid(uuid) {
-    return appletObj.filter(x => x._uuid == uuid);
+    return appletObj.filter(x => x && x._uuid == uuid);
 }
 
 function callAppletInstancesChanged(uuid) {


### PR DESCRIPTION
In arrow filter functions, check if the value exists (when iterating over appletObj)

Fixed the bug when the button in applet settings has no effect.
Error was:
```
(cinnamon:2680): Cjs-WARNING **: JS ERROR: Exception in method call: activateCallback: TypeError: x is undefined
get_object_for_uuid/<@/usr/share/cinnamon/js/ui/appletManager.js:439
overrideJS/Array.prototype.find@/usr/share/cinnamon/js/ui/overrides.js:149
get_object_for_uuid@/usr/share/cinnamon/js/ui/appletManager.js:439
Cinnamon.prototype._getXletObject@/usr/share/cinnamon/js/ui/cinnamonDBus.js:261
Cinnamon.prototype.activateCallback@/usr/share/cinnamon/js/ui/cinnamonDBus.js:329
_handleMethodCall@resource:///org/gnome/gjs/modules/overrides/Gio.js:261
_wrapJSObject/<@resource:///org/gnome/gjs/modules/overrides/Gio.js:331
```

_Note_: I only checked the issue on line `439`, but it should be right for line `564`.