### PR TITLE
fixed two issues #4723 and #4720

### DIFF
--- a/data/org.cinnamon.gschema.xml.in
+++ b/data/org.cinnamon.gschema.xml.in
@@ -555,6 +555,7 @@
     </key>
 
     <child name="applets" schema="org.cinnamon.applets"/>
+    <child name="panel" schema="org.cinnamon.panel"/>
     <child name="theme" schema="org.cinnamon.theme"/>   
     <child name="recorder" schema="org.cinnamon.recorder"/>
     <child name="keyboard" schema="org.cinnamon.keyboard"/>
@@ -617,6 +618,17 @@
       <range min="0.0" max="1.0"/>
       <default>0.8</default>
       <summary>systray applet icon scaling factor</summary>
+    </key>
+  </schema>
+
+  <schema id="org.cinnamon.panel" path="/org/cinnamon/panel/"
+        gettext-domain="@GETTEXT_PACKAGE@">
+    <key name="locked" type="b">
+      <default>false</default>
+      <_summary>panel locked</_summary>
+      <_description>
+       by checking this key the panels lock i.e. you can not change panel layout or applet configurations through panel unless you uncheck this key again.
+      </_description>
     </key>
   </schema>
 

--- a/data/org.cinnamon.gschema.xml.in
+++ b/data/org.cinnamon.gschema.xml.in
@@ -554,6 +554,7 @@
       </_description>
     </key>
 
+    <child name="applets" schema="org.cinnamon.applets"/>
     <child name="theme" schema="org.cinnamon.theme"/>   
     <child name="recorder" schema="org.cinnamon.recorder"/>
     <child name="keyboard" schema="org.cinnamon.keyboard"/>
@@ -601,6 +602,24 @@
 
   </schema>
  
+  <schema id="org.cinnamon.applets" path="/org/cinnamon/applets/"
+        gettext-domain="@GETTEXT_PACKAGE@">  
+    <child name="systray" schema="org.cinnamon.applets.systray" />
+  </schema>
+
+  <schema id="org.cinnamon.applets.systray" path="/org/cinnamon/applets/systray/"
+        gettext-domain="@GETTEXT_PACKAGE@">
+    <key type="i" name="icon-size">
+      <default>16</default>
+      <summary>systray applet icon size</summary>
+    </key>
+    <key type="d" name="icon-scaling-factor">
+      <range min="0.0" max="1.0"/>
+      <default>0.8</default>
+      <summary>systray applet icon scaling factor</summary>
+    </key>
+  </schema>
+
   <schema id="org.cinnamon.theme" path="/org/cinnamon/theme/"
         gettext-domain="@GETTEXT_PACKAGE@">
     <key name="name" type="s">

--- a/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
@@ -1,14 +1,16 @@
 const Lang = imports.lang;
 const St = imports.gi.St;
 const Clutter = imports.gi.Clutter;
-
+const Gio = imports.gi.Gio;
 const Applet = imports.ui.applet;
 const PopupMenu = imports.ui.popupMenu;
 const Main = imports.ui.main;
 const Mainloop = imports.mainloop;
 const SignalManager = imports.misc.signalManager;
 
-const ICON_SCALE_FACTOR = .8; // for custom panel heights, 20 (default icon size) / 25 (default panel height)
+let Schema = new Gio.Settings({ schema: 'org.cinnamon.applets.systray' });
+const ICON_SCALE_FACTOR = Schema.get_double('icon-scaling-factor'); // for custom panel heights, 20 (default icon size) / 25 (default panel height)
+const ICON_SIZE = Schema.get_int('icon-size');
 
 // Override the factory and create an AppletPopupMenu instead of a PopupMenu
 function IndicatorMenuFactory() {
@@ -143,7 +145,7 @@ MyApplet.prototype = {
     _getIndicatorSize: function(appIndicator) {
         if (this._scaleMode)
             return this._panelHeight * ICON_SCALE_FACTOR;
-        return 16;
+        return ICON_SIZE;
     },
 
     _onIndicatorRemoved: function(manager, appIndicator) {

--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -22,6 +22,9 @@ const PANEL_SYMBOLIC_ICON_DEFAULT_HEIGHT = 1.14 * PANEL_FONT_DEFAULT_HEIGHT; // 
 const DEFAULT_PANEL_HEIGHT = 25;
 const FALLBACK_ICON_HEIGHT = 22;
 
+let panel_schema = new Gio.Settings({ schema: 'org.cinnamon.panel' });
+const PANEL_LOCKED = panel_schema.get_boolean('locked');
+
 /**
  * #MenuItem
  * @short_description: Deprecated. Use #PopupMenu.PopupIconMenuItem instead.
@@ -242,6 +245,8 @@ Applet.prototype = {
             if (event.get_button()==3){            
                 if (this._applet_context_menu._getMenuItems().length > 0) {
                     this._applet_context_menu.toggle();			
+                }else{
+                    this.on_applet_clicked(event);
                 }
             }
         }
@@ -398,6 +403,9 @@ Applet.prototype = {
     
     finalizeContextMenu: function () {
         // Add default context menus if we're in panel edit mode, ensure their removal if we're not       
+        if (PANEL_LOCKED){
+            return;
+        }
         let items = this._applet_context_menu._getMenuItems();
 
         if (this.context_menu_item_remove == null) {

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -15,7 +15,7 @@ const Meta = imports.gi.Meta;
 const Pango = imports.gi.Pango;
 const Cinnamon = imports.gi.Cinnamon;
 const St = imports.gi.St;
-
+const Gio = imports.gi.Gio;
 const Applet = imports.ui.applet;
 const AppletManager = imports.ui.appletManager;
 const DND = imports.ui.dnd;
@@ -55,6 +55,8 @@ const Direction = {
     LEFT  : 0,
     RIGHT : 1
 }
+let panel_schema = new Gio.Settings({ schema: 'org.cinnamon.panel' });
+const PANEL_LOCKED = panel_schema.get_boolean('locked');
 
 // To make sure the panel corners blend nicely with the panel,
 // we draw background and borders the same way, e.g. drawing
@@ -972,7 +974,9 @@ SettingsLauncher.prototype = {
 };
 
 function populateSettingsMenu(menu, panelId) {
-
+    if (PANEL_LOCKED){
+        return;
+    } 
     menu.troubleshootItem = new PopupMenu.PopupSubMenuMenuItem(_("Troubleshoot"));
     menu.troubleshootItem.menu.addAction(_("Restart Cinnamon"), function(event) {
         global.reexec_self();


### PR DESCRIPTION
I have fixed two issues already reported by me. The issues where:
1. systray-applet icon size is hardcoded: linuxmint/cinnamon#4723
2. add lock/unlock panel setting: linuxmint/Cinnamon#4720

The second bug is partially fixed i.e. the gsettings schema which controls panel lock/unlock feature is implemented for power users but it's up to dev team to consider adding this option as a setting for normal user or not.