### PR TITLE
Panel launchers applet: fix TypeError

### DIFF
--- a/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
@@ -333,7 +333,7 @@ MyApplet.prototype = {
     },
 
     sync_settings_proxy_to_settings: function() {
-        this.launcherList = this._settings_proxy[i].map(x => x.file);
+        this.launcherList = this._settings_proxy.map(x => x.file);
     },
 
     _remove_launcher_from_proxy: function(visible_index) {


### PR DESCRIPTION
Caused issues when adding, moving or removing items

Fixes a regression of 402c5be6 and closes #4745