### PR TITLE
Replaced all uses of the commands module with subprocess

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings-users/cinnamon-settings-users.py
+++ b/files/usr/share/cinnamon/cinnamon-settings-users/cinnamon-settings-users.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python2
 
-import sys, os, commands
+import sys, os
 import pwd, grp
 from gi.repository import Gtk, GObject, Gio, GdkPixbuf, AccountsService
 import gettext
@@ -756,7 +756,8 @@ class Module:
             self.groups_label.set_text(", ".join(groups))
             self.builder.get_object("box_users").show()
 
-            connections = int(commands.getoutput("w -hs %s | wc -l" % user.get_user_name()))
+            # Count the number of connections for the currently logged-in user
+            connections = int(subprocess.check_output(["w", "-hs", user.get_user_name()]).count("\n"))
             if connections > 0:
                 self.builder.get_object("button_delete_user").set_sensitive(False)
                 self.builder.get_object("button_delete_user").set_tooltip_text(_("This user is currently logged in"))

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
@@ -4,10 +4,10 @@ from SettingsWidgets import *
 
 import platform
 import subprocess
+import shlex
 import os
 import re
 import threading
-import commands
 
 
 def killProcess(process):
@@ -87,7 +87,8 @@ def createSystemInfos():
         processorName = processorName + u" \u00D7 " + procInfos['cpu_cores']
 
     if os.path.exists("/etc/linuxmint/info"):
-        title = commands.getoutput("awk -F \"=\" '/GRUB_TITLE/ {print $2}' /etc/linuxmint/info")
+        args = shlex.split("awk -F \"=\" '/GRUB_TITLE/ {print $2}' /etc/linuxmint/info")
+        title = subprocess.check_output(args).rstrip("\n")
         infos.append((_("Operating System"), title))
     elif os.path.exists("/etc/arch-release"):
         contents = open("/etc/arch-release", 'r').readline().split()


### PR DESCRIPTION
```commands``` is deprecated, vulnerable to shell injection, and was dropped from Python 3