### PR TITLE
Fix allocation error when STBoxLayout is align_end

### DIFF
--- a/src/st/st-box-layout.c
+++ b/src/st/st-box-layout.c
@@ -757,7 +757,7 @@ st_box_layout_allocate (ClutterActor          *actor,
   if (reverse_order)
     {
       l = g_list_last (children);
-      i = g_list_length (children);
+      i = g_list_length (children) - 1;
     }
   else
     {


### PR DESCRIPTION
This fixes an off-by-one error in the allocation of STBoxLayout, fixing #4778