### PR TITLE
attentionhandler suppress autofocus

### DIFF
--- a/js/ui/windowAttentionHandler.js
+++ b/js/ui/windowAttentionHandler.js
@@ -29,6 +29,8 @@ WindowAttentionHandler.prototype = {
             (window.get_wm_class() && (window.get_wm_class().indexOf("Skype") > -1 ||
                                        window.get_wm_class().indexOf("Quassel") > -1 ||
                                        window.get_wm_class().indexOf("Pidgin") > -1 ||
+                                       window.get_wm_class().indexOf("RetroShare") > -1 ||
+                                       window.get_wm_class().indexOf("Psi-plus") > -1 ||                                       
                                        window.get_wm_class().indexOf("Kadu") > -1)))
             return;
 


### PR DESCRIPTION
update windowAttentionHandler.js to suppress stealing of Autofocus for Instant messenger Psi+ (http://psi-plus.com/) and RetroShare (http://retroshare.org/)