### PR TITLE
Fix a timer issue in TooltipBase

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -118,7 +118,7 @@ WindowPreview.prototype = {
     _onEnterEvent: function(actor, event) {
         if (this._applet._tooltipShowing)
             this.show();
-        else
+        else if (!this._showTimer)
             this._showTimer = Mainloop.timeout_add(300, Lang.bind(this, this._onTimerComplete));
 
         this.mousePosition = event.get_coords();

--- a/js/ui/tooltips.js
+++ b/js/ui/tooltips.js
@@ -88,8 +88,10 @@ TooltipBase.prototype = {
     },
 
     _onEnterEvent: function(actor, event) {
-        this._showTimer = Mainloop.timeout_add(300, Lang.bind(this, this._onTimerComplete));
-        this.mousePosition = event.get_coords();
+        if (!this._showTimer) {
+            this._showTimer = Mainloop.timeout_add(300, Lang.bind(this, this._onTimerComplete));
+            this.mousePosition = event.get_coords();
+        }
     },
 
     _onTimerComplete: function(){


### PR DESCRIPTION
In rare cases, two enter events occurred without a leave event in between, leaving an orphaned _showTimer behind. Maybe fixing #4750