### PR TITLE
Fix: user_data is not passed to callback

### DIFF
--- a/js/ui/settings.js
+++ b/js/ui/settings.js
@@ -839,7 +839,7 @@ _setting.prototype = {
             this._monitor_applet_var(false);
             this.obj[this.applet_var] = new_val;
             if (this.user_data) {
-                this.cb(user_data);
+                this.cb(this.user_data);
             } else {
                 this.cb();
             }


### PR DESCRIPTION
The user_data was not passed to the specified callback when binding a property via bindProperty().