### PR TITLE
effects: Currently when setting the minimize animation to "traditiona…

### DIFF
--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -672,6 +672,7 @@ WindowManager.prototype = {
         }
 
         if (actor.get_meta_window()._cinnamonwm_has_origin === true) {
+            Main.soundManager.play('minimize');
             try {
                 this._startWindowEffect(cinnamonwm, "unminimize", actor, null, "minimize")
                 return;


### PR DESCRIPTION
…l" no sound effect is used when restoring the window. Change this so the minimize sound is played in this case.
Fixes: https://github.com/linuxmint/Cinnamon/issues/4628