### PR TITLE
effects: Add effects to gtk menus. These are disabled by default the …

### DIFF
--- a/data/org.cinnamon.gschema.xml.in
+++ b/data/org.cinnamon.gschema.xml.in
@@ -159,6 +159,14 @@
       </_description>
     </key>
 
+    <key name="desktop-effects-on-menus" type="b">
+      <default>false</default>
+      <_summary>Enable desktop effects on Gtk menus</_summary>
+      <_description>
+        Whether to enable desktop effects on Gtk menus.
+      </_description>
+    </key>
+
     <key type="s" name="desktop-effects-style">
       <default>"cinnamon"</default>
       <_summary>The style of desktop effects</_summary>

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_effects.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_effects.py
@@ -96,6 +96,9 @@ class Module:
             widget = GSettingsSwitch(_("Effects on dialog boxes"), "org.cinnamon", "desktop-effects-on-dialogs")
             settings.add_reveal_row(widget, "org.cinnamon", "desktop-effects")
 
+            widget = GSettingsSwitch(_("Effects on Gtk menus"), "org.cinnamon", "desktop-effects-on-menus")
+            settings.add_reveal_row(widget, "org.cinnamon", "desktop-effects")
+
             self.chooser = GSettingsComboBox(_("Effects style"), "org.cinnamon", "desktop-effects-style", OPTIONS)
             self.chooser.content_widget.connect("changed", self.on_value_changed)
             settings.add_reveal_row(self.chooser, "org.cinnamon", "desktop-effects")

--- a/js/ui/windowEffects.js
+++ b/js/ui/windowEffects.js
@@ -146,6 +146,25 @@ Map.prototype = {
                 this._fadeWindow(cinnamonwm, actor, actor.orig_opacity, time, transition);
                 this._scaleWindow(cinnamonwm, actor, 1, 1, time, transition);
                 break;
+            case Meta.WindowType.MENU:
+            case Meta.WindowType.DROPDOWN_MENU:
+            case Meta.WindowType.POPUP_MENU:
+                let [width, height] = actor.get_allocation_box().get_size();
+                let [destX, destY] = actor.get_transformed_position();
+                let [pointerX, pointerY] = global.get_pointer();
+                let top = destY + (height * 0.5);
+
+                if (pointerY < top)
+                    actor.set_pivot_point(0, 0);
+                else
+                    actor.set_pivot_point(0, 1);
+
+                actor.scale_x = 1;
+                actor.scale_y = 0.9;
+                actor.opacity = 0;
+                this._scaleWindow(cinnamonwm, actor, 1, 1, time, transition, true);
+                this._fadeWindow(cinnamonwm, actor, actor.orig_opacity, time, transition);
+                break;
             case Meta.WindowType.MODAL_DIALOG:
             case Meta.WindowType.DIALOG:
                 actor.set_pivot_point(0, 0);

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -511,6 +511,11 @@ WindowManager.prototype = {
         if (type == Meta.WindowType.DIALOG || type == Meta.WindowType.MODAL_DIALOG) {
             return global.settings.get_boolean("desktop-effects-on-dialogs");
         }
+        if (type == Meta.WindowType.MENU ||
+            type == Meta.WindowType.DROPDOWN_MENU ||
+            type == Meta.WindowType.POPUP_MENU) {
+            return global.settings.get_boolean("desktop-effects-on-menus");
+        }
         return false;
     },
 


### PR DESCRIPTION
…same as dialog effects. Animation direction is based on the menu position with regard to the mouse pointer positon. Works well in most cases. The one area it seems it could be improved a bit is when opening the window titlebar menu using Alt+Space