### PR TITLE
remove duplicated enum radiogroup

### DIFF
--- a/js/ui/settings.js
+++ b/js/ui/settings.js
@@ -130,14 +130,6 @@ var SETTINGS_TYPES = {
             "description"
         ]
     },
-    "radiogroup" : {
-        "required-fields": [
-            "type",
-            "default",
-            "description",
-            "options"
-        ]
-    },
     "generic" : {
         "required-fields": [
             "type",


### PR DESCRIPTION
duplicated enum in settings module triggers warning errors in log file