### PR TITLE
Fix D-Bus methods for screenshots

### DIFF
--- a/js/ui/cinnamonDBus.js
+++ b/js/ui/cinnamonDBus.js
@@ -144,14 +144,11 @@ CinnamonDBus.prototype = {
         return [success, returnValue];
     },
 
-    _onScreenshotComplete: function(obj, result, area, flash, invocation) {
+    _onScreenshotComplete: function(obj, result, area, flash) {
         if (flash) {
             let flashspot = new Flashspot.Flashspot(area);
             flashspot.fire();
         }
-
-        let retval = GLib.Variant.new('(b)', [result]);
-        invocation.return_value(retval);
     },
 
     /**
@@ -169,12 +166,10 @@ CinnamonDBus.prototype = {
      * indicating whether the operation was successful or not.
      *
      */
-    ScreenshotAreaAsync : function (params, invocation) {
-        let [include_cursor, x, y, width, height, flash, filename, callback] = params;
+    ScreenshotArea: function (include_cursor, x, y, width, height, flash, filename) {
         let screenshot = new Cinnamon.Screenshot();
-        screenshot.screenshot_area (include_cursor, x, y, width, height, filename,
-                                Lang.bind(this, this._onScreenshotComplete,
-                                          flash, invocation));
+        screenshot.screenshot_area (include_cursor, x, y, width, 200, filename,
+                                Lang.bind(this, this._onScreenshotComplete, flash));
     },
 
     /**
@@ -189,8 +184,7 @@ CinnamonDBus.prototype = {
      * indicating whether the operation was successful or not.
      *
      */
-    ScreenshotWindowAsync : function (params, invocation) {
-        let [include_frame, include_cursor, flash, filename] = params;
+    ScreenshotWindow: function (include_frame, include_cursor, flash, filename) {
         let screenshot = new Cinnamon.Screenshot();
         screenshot.screenshot_window (include_frame, include_cursor, filename,
                                       Lang.bind(this, this._onScreenshotComplete,
@@ -208,8 +202,7 @@ CinnamonDBus.prototype = {
      * indicating whether the operation was successful or not.
      *
      */
-    ScreenshotAsync : function (params, invocation) {
-        let [include_cursor, flash, filename] = params;
+    Screenshot: function (include_cursor, flash, filename) {
         let screenshot = new Cinnamon.Screenshot();
         screenshot.screenshot(include_cursor, filename,
                           Lang.bind(this, this._onScreenshotComplete,


### PR DESCRIPTION
Methods are currently unreachable via D-Bus due to mismatched method names, and parameters. This error was my own.

Signatures exposed via D-Bus don't match the methods:
`qdbus org.Cinnamon /org/Cinnamon | grep Screenshot`

To repro, send a dbus message for one of the capture modes, e.g. area capture (x, y, width, height, flash, filename):
`dbus-send --print-reply --type=method_call --dest=org.Cinnamon /org/Cinnamon org.Cinnamon.ScreenshotArea boolean:true int32:50 int32:50 int32:200 int32:200 boolean:true string:"/home/radams/Pictures/blah.png"`

All of the screenshot-related methods could use an update, but this is at least corrects the problem and provides another route to the capture functionality.