### PR TITLE
effects: Make several improvements to handling effects

### DIFF
--- a/data/org.cinnamon.gschema.xml.in
+++ b/data/org.cinnamon.gschema.xml.in
@@ -152,7 +152,7 @@
     </key>
     
     <key name="desktop-effects-on-dialogs" type="b">
-      <default>false</default>
+      <default>true</default>
       <_summary>Enable desktop effects on dialog boxes</_summary>
       <_description>
         Whether to enable desktop effects on dialog boxes.
@@ -160,7 +160,7 @@
     </key>
 
     <key name="desktop-effects-on-menus" type="b">
-      <default>false</default>
+      <default>true</default>
       <_summary>Enable desktop effects on Gtk menus</_summary>
       <_description>
         Whether to enable desktop effects on Gtk menus.
@@ -177,10 +177,11 @@
     </key>
 
     <key type="s" name="desktop-effects-close-effect">
-      <default>"traditional"</default>
+      <default>"fadeScale"</default>
       <_summary>Effect used when closing windows</_summary>
       <_description>
-       An effect: scale, fade, traditional, none
+       An effect: scale, fade, blend, move, flyUp, flyDown, 
+       fadeScale, collapse, rollup, none
       </_description>
     </key>
     
@@ -199,12 +200,38 @@
        Duration of the effect (in milliseconds)    
       </_description>
     </key>
+
+    <key type="s" name="desktop-effects-closedialog-effect">
+      <default>"collapse"</default>
+      <_summary>Effect used when closing dialogs</_summary>
+      <_description>
+       An effect: scale, fade, blend, move, flyUp, flyDown, 
+       fadeScale, collapse, rollup, none
+      </_description>
+    </key>
+    
+     <key name="desktop-effects-closedialog-transition" type="s">
+      <default>"easeInQuad"</default>
+      <_summary>Transition used when closing dialogs</_summary>
+      <_description>
+       A Tweener transition
+      </_description>
+    </key>
+    
+    <key type="i" name="desktop-effects-closedialog-time">
+      <default>175</default>
+      <_summary>Duration of the effect (in milliseconds)</_summary>
+      <_description>
+       Duration of the effect (in milliseconds)    
+      </_description>
+    </key>
     
     <key type="s" name="desktop-effects-map-effect">
-      <default>"traditional"</default>
+      <default>"fadeScale"</default>
       <_summary>Effect used when mapping windows</_summary>
       <_description>
-       An effect: scale, fade, traditional, none
+       An effect: scale, fade, blend, move, flyUp, flyDown,
+       fadeScale, expand, rolldown, none
       </_description>
     </key>
     
@@ -223,13 +250,62 @@
        Duration of the effect (in milliseconds)    
       </_description>
     </key>
+
+    <key type="s" name="desktop-effects-mapdialog-effect">
+      <default>"expand"</default>
+      <_summary>Effect used when mapping dialog windows</_summary>
+      <_description>
+       An effect: scale, fade, blend, move, flyUp, flyDown,
+       fadeScale, expand, rolldown, none
+      </_description>
+    </key>
     
+    <key name="desktop-effects-mapdialog-transition" type="s">
+      <default>"easeOutQuad"</default>
+      <_summary>Transition used when mapping dialog windows</_summary>
+      <_description>
+       A Tweener transition
+      </_description>
+    </key>
+    
+    <key type="i" name="desktop-effects-mapdialog-time">
+      <default>175</default>
+      <_summary>Duration of the effect (in milliseconds)</_summary>
+      <_description>
+       Duration of the effect (in milliseconds)    
+      </_description>
+    </key>
+
+    <key type="s" name="desktop-effects-mapmenu-effect">
+      <default>"rolldown"</default>
+      <_summary>Effect used when mapping menus</_summary>
+      <_description>
+       An effect: rolldown, none
+      </_description>
+    </key>
+    
+    <key name="desktop-effects-mapmenu-transition" type="s">
+      <default>"easeNone"</default>
+      <_summary>Transition used when mapping menus</_summary>
+      <_description>
+       A Tweener transition
+      </_description>
+    </key>
+    
+    <key type="i" name="desktop-effects-mapmenu-time">
+      <default>125</default>
+      <_summary>Duration of the effect (in milliseconds)</_summary>
+      <_description>
+       Duration of the effect (in milliseconds)    
+      </_description>
+    </key>
     
     <key type="s" name="desktop-effects-minimize-effect">
       <default>"traditional"</default>
       <_summary>Effect used when minimizing windows</_summary>
       <_description>
-       An effect: traditional, scale, fade, traditional, none
+       An effect: scale, fade, blend, move, flyUp, flyDown, 
+       fadeScale, traditional, collapse, rollup, none
       </_description>
     </key>
     
@@ -248,12 +324,36 @@
        Duration of the effect (in milliseconds)    
       </_description>
     </key>
+
+    <key type="s" name="desktop-effects-unminimize-effect">
+      <default>"traditional"</default>
+      <_summary>Effect used when minimizing windows</_summary>
+      <_description>
+       An effect: traditional, scale, fade, fadeScale, none
+      </_description>
+    </key>
+    
+     <key name="desktop-effects-unminimize-transition" type="s">
+      <default>"easeOutQuad"</default>
+      <_summary>Transition used when minimizing windows</_summary>
+      <_description>
+       A Tweener transition
+      </_description>
+    </key>
+    
+    <key type="i" name="desktop-effects-unminimize-time">
+      <default>200</default>
+      <_summary>Duration of the effect (in milliseconds)</_summary>
+      <_description>
+       Duration of the effect (in milliseconds)    
+      </_description>
+    </key>
     
     <key type="s" name="desktop-effects-maximize-effect">
       <default>"none"</default>
       <_summary>Effect used when maximizing windows</_summary>
       <_description>
-       An effect: none
+       An effect: scale, none
       </_description>
     </key>
     
@@ -277,7 +377,7 @@
       <default>"none"</default>
       <_summary>Effect used when unmaximizing windows</_summary>
       <_description>
-       An effect: none
+       An effect: scale, none
       </_description>
     </key>
     
@@ -301,7 +401,7 @@
       <default>"none"</default>
       <_summary>Effect used when maximizing windows</_summary>
       <_description>
-       An effect: none
+       An effect: scale, none
       </_description>
     </key>
     

--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -493,7 +493,9 @@ AppMenuButton.prototype = {
     },
 
     _toggleWindow: function(fromDrag){
-        if (!this._hasFocus()) {
+        if (this.metaWindow.minimized) {
+            this.metaWindow.unminimize(global.get_current_time());
+        } else if (!this._hasFocus()) {
             Main.activateWindow(this.metaWindow, global.get_current_time());
             this.actor.add_style_pseudo_class('focus');
         } else if (!fromDrag) {
@@ -766,7 +768,7 @@ AppMenuButtonRightClickMenu.prototype = {
         if (mw.minimized) {
             item = new PopupMenu.PopupMenuItem(_("Restore"));
             item.connect('activate', function() {
-                Main.activateWindow(mw, global.get_current_time());
+                mw.unminimize(global.get_current_time());
             });
         } else {
             item = new PopupMenu.PopupMenuItem(_("Minimize"));
@@ -780,11 +782,21 @@ AppMenuButtonRightClickMenu.prototype = {
             item = new PopupMenu.PopupMenuItem(_("Unmaximize"));
             item.connect('activate', function() {
                 mw.unmaximize(Meta.MaximizeFlags.HORIZONTAL | Meta.MaximizeFlags.VERTICAL);
+                if (mw.minimized) {
+                    Mainloop.timeout_add(500, Lang.bind(this, function () {
+                        mw.unminimize(global.get_current_time());
+                    }));
+                }
             });
         } else {
             item = new PopupMenu.PopupMenuItem(_("Maximize"));
             item.connect('activate', function() {
                 mw.maximize(Meta.MaximizeFlags.HORIZONTAL | Meta.MaximizeFlags.VERTICAL);
+                if (mw.minimized) {
+                    Mainloop.timeout_add(500, Lang.bind(this, function () {
+                        mw.unminimize(global.get_current_time());
+                    }));
+                }
             });
         }
         this.addMenuItem(item);

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_effects.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_effects.py
@@ -4,30 +4,30 @@ from SettingsWidgets import *
 import windowEffects
 import tweenEquations
 
-EFFECT_SETS = {
-    "cinnamon": ("traditional", "traditional", "traditional", "none",  "none",  "none"),
-    "scale":    ("scale",       "scale",       "scale",       "scale", "scale", "scale"),
-    "fade":     ("fade",        "fade",        "fade",        "scale", "scale", "scale"),
-    "blend":    ("blend",       "blend",       "blend",       "scale", "scale", "scale"),
-    "move":     ("move",        "move",        "move",        "scale", "scale", "scale"),
-    "flyUp":    ("flyUp",       "flyDown",     "flyDown",     "scale", "scale", "scale"),
-    "flyDown":  ("flyDown",     "flyUp",       "flyUp",       "scale", "scale", "scale"),
-    "default":  ("scale",       "scale",       "none",        "none",  "none",  "none")
+EFFECT_SETS = { #Map                #Close              #Minimize           #Unminimize     #Maximize       #Unmaximize         #Tile           #Mapdialog          #Closedialog     #Mapmenu
+    "cinnamon": ("fadeScale",       "fadeScale",        "traditional",      "traditional",  "none",         "none",             "none",         "expand",           "collapse",      "rolldown"  ),
+    "scale":    ("scale",           "scale",            "scale",            "scale",        "scale",        "scale",            "scale",        "scale",            "scale",         "rolldown"  ),
+    "fade":     ("fade",            "fade",             "fade",             "fade",         "scale",        "scale",            "scale",        "fade",             "fade",          "fade"      ),
+    "blend":    ("blend",           "blend",            "blend",            "fade",         "scale",        "scale",            "scale",        "blend",            "blend",         "rolldown"  ),
+    "move":     ("move",            "move",             "move",             "fade",         "scale",        "scale",            "scale",        "move",             "move",          "rolldown"  ),
+    "flyUp":    ("flyUp",           "flyDown",          "flyDown",          "fade",         "scale",        "scale",            "scale",        "flyUp",            "flyDown",       "rolldown"  ),
+    "flyDown":  ("flyDown",         "flyUp",            "flyUp",            "fade",         "scale",        "scale",            "scale",        "flyDown",          "flyUp",         "rolldown"  ),
+    "default":  ("scale",           "scale",            "none",             "none",         "none",         "none",             "none",         "scale",            "scale",         "none"      )
 }
 
 TRANSITIONS_SETS = {
-    "cinnamon": ("easeOutQuad",    "easeOutQuad",   "easeInQuad",  "easeInExpo", "easeNone",       "easeInQuad"),
-    "normal":   ("easeOutSine",    "easeInBack",    "easeInSine",  "easeInBack", "easeOutBounce",  "easeInBack"),
-    "extra":    ("easeOutElastic", "easeOutBounce", "easeOutExpo", "easeInExpo", "easeOutElastic", "easeInExpo"),
-    "fade":     ("easeOutQuart",   "easeInQuart",   "easeInQuart", "easeInBack", "easeOutBounce",  "easeInBack")
+    "cinnamon": ("easeOutQuad",     "easeInQuad",       "easeInQuad",       "easeOutQuad",  "easeInExpo",   "easeNone",         "easeInQuad",   "easeOutQuad",      "easeInQuad",    "easeNone"  ),
+    "normal":   ("easeOutSine",     "easeInBack",       "easeInSine",       "easeOutSine",  "easeInBack",   "easeOutBounce",    "easeInBack",   "easeOutSine",      "easeInBack",    "easeNone"  ),
+    "extra":    ("easeOutElastic",  "easeOutBounce",    "easeOutExpo",      "easeInExpo",   "easeInExpo",   "easeOutElastic",   "easeInExpo",   "easeOutElastic",   "easeOutBounce", "easeNone"  ),
+    "fade":     ("easeOutQuart",    "easeInQuart",      "easeInQuart",      "easeOutQuart", "easeInBack",   "easeOutBounce",    "easeInBack",   "easeOutQuart",     "easeInQuart",   "easeNone"  )
 }
 
 TIME_SETS = {
-    "cinnamon": (175, 175, 200, 100, 100, 100),
-    "slow":     (400, 400, 400, 100, 100, 100),
-    "normal":   (250, 250, 250, 100, 100, 100),
-    "fast":     (100, 100, 100, 100, 100, 100),
-    "default":  (250, 250, 150, 400, 400, 400)
+    "cinnamon": (175,               175,                200,                200,            100,            100,                100,            175,                175,             125         ),
+    "slow":     (400,               400,                400,                400,            100,            100,                100,            400,                400,             225         ),
+    "normal":   (250,               250,                250,                250,            100,            100,                100,            250,                250,             175         ),
+    "fast":     (100,               100,                100,                100,            100,            100,                100,            100,                100,             125         ),
+    "default":  (250,               250,                150,                150,            400,            400,                400,            250,                250,             125         )
 }
 
 COMBINATIONS = {
@@ -56,7 +56,65 @@ OPTIONS = (
    #for previous versions
     ("default",    _("Default"))
 )
-TYPES = ("map", "close", "minimize", "maximize", "unmaximize", "tile")
+
+OPEN_EFFECTS = [
+    ["none",        _("None")],
+    ["scale",       _("Scale")],
+    ["fade",        _("Fade")],
+    ["blend",       _("Blend")],
+    ["move",        _("Move")],
+    ["flyUp",       _("Fly up")],
+    ["flyDown",     _("Fly down")],
+    ["fadeScale",   _("Fade Scale")],
+    ["expand",      _("Expand")],
+    ["rolldown",    _("Rolldown")]
+]
+
+CLOSE_EFFECTS = [
+    ["none",        _("None")],
+    ["scale",       _("Scale")],
+    ["fade",        _("Fade")],
+    ["blend",       _("Blend")],
+    ["move",        _("Move")],
+    ["flyUp",       _("Fly up")],
+    ["flyDown",     _("Fly down")],
+    ["fadeScale",   _("Fade Scale")],
+    ["collapse",    _("Collapse")],
+    ["rollup",      _("Rollup")]
+]
+
+MINIMIZE_EFFECTS = [
+    ["none",        _("None")],
+    ["scale",       _("Scale")],
+    ["fade",        _("Fade")],
+    ["blend",       _("Blend")],
+    ["move",        _("Move")],
+    ["flyUp",       _("Fly up")],
+    ["flyDown",     _("Fly down")],
+    ["fadeScale",   _("Fade Scale")],
+    ["traditional", _("Traditional")],
+    ["collapse",    _("Collapse")],
+    ["rollup",      _("Rollup")]
+]
+
+UNMINIMIZE_EFFECTS = [
+    ["none",        _("None")],
+    ["scale",       _("Scale")],
+    ["fade",        _("Fade")],
+    ["fadeScale",   _("Fade Scale")],
+    ["traditional", _("Traditional")]
+]
+
+MENU_EFFECTS = [
+    ["none",     _("None")],
+    ["rolldown", _("Rolldown")]
+]
+
+MAXIMIZE_EFFECTS = [
+    ["none",  _("None")],
+    ["scale", _("Scale")]
+]
+TYPES = ("map", "close", "minimize", "unminimize", "maximize", "unmaximize", "tile", "mapdialog", "closedialog", "mapmenu")
 SCHEMA = "org.cinnamon"
 DEP_PATH = "org.cinnamon/desktop-effects"
 KEY_TEMPLATE = "desktop-effects-%s-%s"
@@ -129,45 +187,51 @@ class Module:
             self.revealer.set_transition_type(Gtk.RevealerTransitionType.SLIDE_DOWN)
             self.revealer.set_transition_duration(150)
             page.add(self.revealer)
-            settings = SettingsBox(_("Effect"))
-            self.revealer.add(settings)
+
+            box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+            box.set_spacing(15)
+            self.revealer.add(box)
 
             self.size_group = Gtk.SizeGroup.new(Gtk.SizeGroupMode.HORIZONTAL)
 
-            # MAPPING WINDOWS
-            effects = [
-                ["none",    _("None")],
-                ["scale",   _("Scale")],
-                ["fade",    _("Fade")],
-                ["blend",   _("Blend")],
-                ["move",    _("Move")],
-                ["flyUp",   _("Fly up")],
-                ["flyDown", _("Fly down")],
-                ["traditional", _("Traditional")]
-            ]
+            settings = SettingsBox(_("Windows"))
+            # self.revealer.add(settings)
+            box.add(settings)
 
-            widget = self.make_effect_group(_("Mapping windows"), "map", effects)
+            widget = self.make_effect_group(_("Opening windows"), "map", OPEN_EFFECTS)
             settings.add_row(widget)
 
-            # CLOSING WINDOWS
-            widget = self.make_effect_group(_("Closing windows"), "close", effects)
+            widget = self.make_effect_group(_("Closing windows"), "close", CLOSE_EFFECTS)
             settings.add_row(widget)
 
-            # MINIMIZING WINDOWS
-            widget = self.make_effect_group(_("Minimizing windows"), "minimize", effects)
+            widget = self.make_effect_group(_("Minimizing windows"), "minimize", MINIMIZE_EFFECTS)
             settings.add_row(widget)
 
-            # MAXIMIZING WINDOWS
-            effects = [["none", _("None")], ["scale", _("Scale")]]
-            widget = self.make_effect_group(_("Maximizing windows"), "maximize", effects)
+            widget = self.make_effect_group(_("Unminimizing windows"), "unminimize", UNMINIMIZE_EFFECTS)
             settings.add_row(widget)
 
-            # UNMAXIMIZING WINDOWS
-            widget = self.make_effect_group(_("Unmaximizing windows"), "unmaximize", effects)
+            widget = self.make_effect_group(_("Maximizing windows"), "maximize", MAXIMIZE_EFFECTS)
             settings.add_row(widget)
 
-            # TILING WINDOWS
-            widget = self.make_effect_group(_("Tiling and snapping windows"), "tile", effects)
+            widget = self.make_effect_group(_("Unmaximize windows"), "unmaximize", MAXIMIZE_EFFECTS)
+            settings.add_row(widget)
+
+            widget = self.make_effect_group(_("Tile and snap windows"), "tile", MAXIMIZE_EFFECTS)
+            settings.add_row(widget)
+
+            settings = SettingsBox(_("Dialogs"))
+            box.add(settings)
+
+            widget = self.make_effect_group(_("Opening dialogs"), "mapdialog", OPEN_EFFECTS)
+            settings.add_row(widget)
+
+            widget = self.make_effect_group(_("Closing dialogs"), "closedialog", CLOSE_EFFECTS)
+            settings.add_row(widget)
+
+            settings = SettingsBox(_("Menus"))
+            box.add(settings)
+
+            widget = self.make_effect_group(_("Opening menus"), "mapmenu", MENU_EFFECTS)
             settings.add_row(widget)
 
             self.update_effects(self.custom_switch, None)
@@ -175,7 +239,7 @@ class Module:
     def make_effect_group(self, group_label, key, effects):
         tmin, tmax, tstep, tdefault = (0, 2000, 50, 200)
 
-        row =SettingsWidget()
+        row = SettingsWidget()
         row.set_spacing(5)
 
         label = Gtk.Label()
@@ -240,6 +304,9 @@ class Module:
 
         if not active and schema.get_boolean("desktop-effects-on-dialogs"):
             schema.set_boolean("desktop-effects-on-dialogs", False)
+
+        if not active and schema.get_boolean("desktop-effects-on-menus"):
+            schema.set_boolean("desktop-effects-on-menus", False)
 
         self.update_effects(self.custom_switch, None)
 

--- a/js/ui/windowEffects.js
+++ b/js/ui/windowEffects.js
@@ -136,47 +136,48 @@ Map.prototype = {
         this._moveWindow(cinnamonwm, actor, xDest, yDest, time, transition);
     },
 
-    traditional: function(cinnamonwm, actor, time, transition) {
-        switch (actor._windowType) {
-            case Meta.WindowType.NORMAL:
-                actor.set_pivot_point(0, 0);
-                actor.scale_x = 0.01;
-                actor.scale_y = 0.05;
-                actor.opacity = 0;
-                this._fadeWindow(cinnamonwm, actor, actor.orig_opacity, time, transition);
-                this._scaleWindow(cinnamonwm, actor, 1, 1, time, transition);
-                break;
-            case Meta.WindowType.MENU:
-            case Meta.WindowType.DROPDOWN_MENU:
-            case Meta.WindowType.POPUP_MENU:
-                let [width, height] = actor.get_allocation_box().get_size();
-                let [destX, destY] = actor.get_transformed_position();
-                let [pointerX, pointerY] = global.get_pointer();
-                let top = destY + (height * 0.5);
+    fadeScale: function(cinnamonwm, actor, time, transition) {
+        actor.set_pivot_point(0, 0);
+        actor.scale_x = 0.01;
+        actor.scale_y = 0.05;
+        actor.opacity = 0;
+        this._fadeWindow(cinnamonwm, actor, actor.orig_opacity, time, transition);
+        this._scaleWindow(cinnamonwm, actor, 1, 1, time, transition);
+    },
 
-                if (pointerY < top)
-                    actor.set_pivot_point(0, 0);
-                else
-                    actor.set_pivot_point(0, 1);
+    expand: function(cinnamonwm, actor, time, transition) {
+        actor.set_pivot_point(0, 0);
+        actor.scale_x = 1;
+        actor.scale_y = 0;
+        actor.opacity = 0;
+        this._fadeWindow(cinnamonwm, actor, actor.orig_opacity, time, transition);
+        this._scaleWindow(cinnamonwm, actor, 1, 1, time, transition);
+    },
 
-                actor.scale_x = 1;
-                actor.scale_y = 0.9;
-                actor.opacity = 0;
-                this._scaleWindow(cinnamonwm, actor, 1, 1, time, transition, true);
-                this._fadeWindow(cinnamonwm, actor, actor.orig_opacity, time, transition);
-                break;
-            case Meta.WindowType.MODAL_DIALOG:
-            case Meta.WindowType.DIALOG:
+    rolldown: function(cinnamonwm, actor, time, transition) {
+        if (actor._windowType == Meta.WindowType.MENU ||
+            actor._windowType == Meta.WindowType.DROPDOWN_MENU ||
+            actor._windowType == Meta.WindowType.POPUP_MENU) {
+            let [width, height] = actor.get_allocation_box().get_size();
+            let [destX, destY] = actor.get_transformed_position();
+            let [pointerX, pointerY] = global.get_pointer();
+            let top = destY + (height * 0.5);
+
+            actor.scale_y = 0.9;
+
+            if (pointerY < top)
                 actor.set_pivot_point(0, 0);
-                actor.scale_x = 1;
-                actor.scale_y = 0;
-                actor.opacity = 0;
-                this._fadeWindow(cinnamonwm, actor, actor.orig_opacity, time, transition);
-                this._scaleWindow(cinnamonwm, actor, 1, 1, time, transition);
-                break;
-            default:
-                this._fadeWindow(cinnamonwm, actor, actor.orig_opacity, time, transition);
+            else
+                actor.set_pivot_point(0, 1);
+        } else {
+            actor.set_pivot_point(0, 0);
+            actor.scale_y = 0.1;
         }
+
+        actor.scale_x = 1;
+        actor.opacity = 0;
+        this._scaleWindow(cinnamonwm, actor, 1, 1, time, transition, true);
+        this._fadeWindow(cinnamonwm, actor, actor.orig_opacity, time, transition);
     }
 }
 
@@ -239,22 +240,22 @@ Close.prototype = {
         this._moveWindow(cinnamonwm, actor, xDest, yDest, time, transition);
     },
 
-    traditional: function(cinnamonwm, actor, time, transition) {
-        switch (actor._windowType) {
-            case Meta.WindowType.NORMAL:
-                actor.set_pivot_point(0, 0);
-                this._scaleWindow(cinnamonwm, actor, 0.8, 0.8, time, transition);
-                this._fadeWindow(cinnamonwm, actor, 0, time, transition);
-                break;
-            case Meta.WindowType.MODAL_DIALOG:
-            case Meta.WindowType.DIALOG:
-                actor.set_pivot_point(0, 0);
-                this._fadeWindow(cinnamonwm, actor, 0.5, time, transition);
-                this._scaleWindow(cinnamonwm, actor, 1.0, 0, time, transition);
-                break;
-            default:
-                this.scale(cinnamonwm, actor, time, transition);
-        }
+    fadeScale: function(cinnamonwm, actor, time, transition) {
+        actor.set_pivot_point(0, 0);
+        this._scaleWindow(cinnamonwm, actor, 0.8, 0.8, time, transition);
+        this._fadeWindow(cinnamonwm, actor, 0, time, transition);
+    },
+
+    collapse: function(cinnamonwm, actor, time, transition) {
+        actor.set_pivot_point(0, 0);
+        this._fadeWindow(cinnamonwm, actor, 0.5, time, transition);
+        this._scaleWindow(cinnamonwm, actor, 1.0, 0, time, transition);
+    },
+
+    rollup: function(cinnamonwm, actor, time, transition) {
+        actor.set_pivot_point(0, 0);
+        this._scaleWindow(cinnamonwm, actor, 1.0, 0, time, transition, true);
+        this._fadeWindow(cinnamonwm, actor, 0.0, time, transition);
     }
 }
 
@@ -297,13 +298,31 @@ function Unminimize(){
 }
 
 Unminimize.prototype = {
-    //unminimizing is a "map" effect but should use "minimize" setting values
     __proto__: Effect.prototype,
     name: "unminimize",
-    arrayName: "_mapping",
-    wmCompleteName: "completed_map",
+    arrayName: "_unminimizing",
+    wmCompleteName: "completed_unminimize",
 
-    _end: Map.prototype._end,
+    _end: Effect.prototype._end,
+
+    scale: function(cinnamonwm, actor, time, transition){
+        actor.set_scale(0, 0);
+        this._scaleWindow(cinnamonwm, actor, 1, 1, time, transition);
+    },
+
+    fade: function(cinnamonwm, actor, time, transition){
+        actor.opacity = 0;
+        this._fadeWindow(cinnamonwm, actor, actor.orig_opacity, time, transition);
+    },
+
+    fadeScale: function(cinnamonwm, actor, time, transition) {
+        actor.set_pivot_point(0, 0);
+        actor.scale_x = 0.01;
+        actor.scale_y = 0.05;
+        actor.opacity = 0;
+        this._fadeWindow(cinnamonwm, actor, actor.orig_opacity, time, transition);
+        this._scaleWindow(cinnamonwm, actor, 1, 1, time, transition);
+    },
 
     traditional: function(cinnamonwm, actor, time, transition) {
         let success;
@@ -321,6 +340,7 @@ Unminimize.prototype = {
             this._fadeWindow(cinnamonwm, actor, actor.orig_opacity, time, transition);
         } else {
             throw "No origin found";
+            this._fadeWindow(cinnamonwm, actor, actor.orig_opacity, time, transition);
         }
     }
 }

--- a/src/cinnamon-plugin.c
+++ b/src/cinnamon-plugin.c
@@ -48,34 +48,36 @@ static void gnome_cinnamon_plugin_finalize    (GObject *object);
 
 static void gnome_cinnamon_plugin_start            (MetaPlugin          *plugin);
 static void gnome_cinnamon_plugin_minimize         (MetaPlugin          *plugin,
-                                                 MetaWindowActor     *actor);
+                                                    MetaWindowActor     *actor);
+static void gnome_cinnamon_plugin_unminimize       (MetaPlugin          *plugin,
+                                                    MetaWindowActor     *actor);
 static void gnome_cinnamon_plugin_maximize         (MetaPlugin          *plugin,
-                                                 MetaWindowActor     *actor,
-                                                 gint                 x,
-                                                 gint                 y,
-                                                 gint                 width,
-                                                 gint                 height);
+                                                    MetaWindowActor     *actor,
+                                                    gint                 x,
+                                                    gint                 y,
+                                                    gint                 width,
+                                                    gint                 height);
 static void gnome_cinnamon_plugin_unmaximize       (MetaPlugin          *plugin,
-                                                 MetaWindowActor     *actor,
-                                                 gint                 x,
-                                                 gint                 y,
-                                                 gint                 width,
-                                                 gint                 height);
+                                                    MetaWindowActor     *actor,
+                                                    gint                 x,
+                                                    gint                 y,
+                                                    gint                 width,
+                                                    gint                 height);
 static void gnome_cinnamon_plugin_tile             (MetaPlugin          *plugin,
-                                                 MetaWindowActor     *actor,
-                                                 gint                 x,
-                                                 gint                 y,
-                                                 gint                 width,
-                                                 gint                 height);
+                                                    MetaWindowActor     *actor,
+                                                    gint                 x,
+                                                    gint                 y,
+                                                    gint                 width,
+                                                    gint                 height);
 static void gnome_cinnamon_plugin_map              (MetaPlugin          *plugin,
-                                                 MetaWindowActor     *actor);
+                                                    MetaWindowActor     *actor);
 static void gnome_cinnamon_plugin_destroy          (MetaPlugin          *plugin,
-                                                 MetaWindowActor     *actor);
+                                                    MetaWindowActor     *actor);
 
 static void gnome_cinnamon_plugin_switch_workspace (MetaPlugin          *plugin,
-                                                 gint                 from,
-                                                 gint                 to,
-                                                 MetaMotionDirection  direction);
+                                                    gint                 from,
+                                                    gint                 to,
+                                                    MetaMotionDirection  direction);
 
 static void gnome_cinnamon_plugin_show_tile_preview (MetaPlugin     *plugin,
                                                      MetaWindow     *window,
@@ -92,10 +94,10 @@ static void gnome_cinnamon_plugin_show_hud_preview (MetaPlugin      *plugin,
 static void gnome_cinnamon_plugin_hide_hud_preview (MetaPlugin *plugin);
 
 static void gnome_cinnamon_plugin_kill_window_effects   (MetaPlugin      *plugin,
-                                                      MetaWindowActor *actor);
+                                                         MetaWindowActor *actor);
 
 static gboolean              gnome_cinnamon_plugin_xevent_filter (MetaPlugin *plugin,
-                                                               XEvent     *event);
+                                                                  XEvent     *event);
 static const MetaPluginInfo *gnome_cinnamon_plugin_plugin_info   (MetaPlugin *plugin);
 
 
@@ -145,6 +147,7 @@ gnome_cinnamon_plugin_class_init (CinnamonPluginClass *klass)
   plugin_class->start            = gnome_cinnamon_plugin_start;
   plugin_class->map              = gnome_cinnamon_plugin_map;
   plugin_class->minimize         = gnome_cinnamon_plugin_minimize;
+  plugin_class->unminimize       = gnome_cinnamon_plugin_unminimize;
   plugin_class->maximize         = gnome_cinnamon_plugin_maximize;
   plugin_class->tile             = gnome_cinnamon_plugin_tile;
   plugin_class->unmaximize       = gnome_cinnamon_plugin_unmaximize;
@@ -268,23 +271,31 @@ get_cinnamon_wm (void)
 
 static void
 gnome_cinnamon_plugin_minimize (MetaPlugin         *plugin,
-			     MetaWindowActor    *actor)
+                                MetaWindowActor    *actor)
 {
   _cinnamon_wm_minimize (get_cinnamon_wm (),
-                      actor);
+                         actor);
 
 }
 
 static void
+gnome_cinnamon_plugin_unminimize (MetaPlugin      *plugin,
+                                  MetaWindowActor *actor)
+{
+  _cinnamon_wm_unminimize (get_cinnamon_wm (),
+                           actor);
+}
+
+static void
 gnome_cinnamon_plugin_maximize (MetaPlugin         *plugin,
-                             MetaWindowActor    *actor,
-                             gint                x,
-                             gint                y,
-                             gint                width,
-                             gint                height)
+                                MetaWindowActor    *actor,
+                                gint                x,
+                                gint                y,
+                                gint                width,
+                                gint                height)
 {
   _cinnamon_wm_maximize (get_cinnamon_wm (),
-                      actor, x, y, width, height);
+                         actor, x, y, width, height);
 }
 
 static void
@@ -301,44 +312,44 @@ gnome_cinnamon_plugin_tile  (MetaPlugin         *plugin,
 
 static void
 gnome_cinnamon_plugin_unmaximize (MetaPlugin         *plugin,
-                               MetaWindowActor    *actor,
-                               gint                x,
-                               gint                y,
-                               gint                width,
-                               gint                height)
+                                  MetaWindowActor    *actor,
+                                  gint                x,
+                                  gint                y,
+                                  gint                width,
+                                  gint                height)
 {
   _cinnamon_wm_unmaximize (get_cinnamon_wm (),
-                        actor, x, y, width, height);
+                           actor, x, y, width, height);
 }
 
 static void
 gnome_cinnamon_plugin_map (MetaPlugin         *plugin,
-                        MetaWindowActor    *actor)
+                           MetaWindowActor    *actor)
 {
   _cinnamon_wm_map (get_cinnamon_wm (),
-                 actor);
+                    actor);
 }
 
 static void
 gnome_cinnamon_plugin_destroy (MetaPlugin         *plugin,
-                            MetaWindowActor    *actor)
+                               MetaWindowActor    *actor)
 {
   _cinnamon_wm_destroy (get_cinnamon_wm (),
-                     actor);
+                        actor);
 }
 
 static void
 gnome_cinnamon_plugin_switch_workspace (MetaPlugin         *plugin,
-                                     gint                from,
-                                     gint                to,
-                                     MetaMotionDirection direction)
+                                        gint                from,
+                                        gint                to,
+                                        MetaMotionDirection direction)
 {
   _cinnamon_wm_switch_workspace (get_cinnamon_wm(), from, to, direction);
 }
 
 static void
 gnome_cinnamon_plugin_kill_window_effects (MetaPlugin         *plugin,
-                                        MetaWindowActor    *actor)
+                                           MetaWindowActor    *actor)
 {
   _cinnamon_wm_kill_window_effects (get_cinnamon_wm(), actor);
 }
@@ -378,7 +389,7 @@ gnome_cinnamon_plugin_hide_hud_preview (MetaPlugin *plugin)
 
 static gboolean
 gnome_cinnamon_plugin_xevent_filter (MetaPlugin *plugin,
-                                  XEvent     *xev)
+                                     XEvent     *xev)
 {
   MetaScreen *screen = meta_plugin_get_screen (plugin);
   ClutterStage *stage = CLUTTER_STAGE (meta_get_stage_for_screen (screen));
@@ -396,8 +407,8 @@ gnome_cinnamon_plugin_xevent_filter (MetaPlugin *plugin,
        * by ignoring such events */
       if (swap_complete_event->ust != 0)
         cinnamon_perf_log_event_x (cinnamon_perf_log_get_default (),
-                                "glx.swapComplete",
-                                swap_complete_event->ust);
+                                   "glx.swapComplete",
+                                   swap_complete_event->ust);
     }
 #endif
 

--- a/src/cinnamon-wm-private.h
+++ b/src/cinnamon-wm-private.h
@@ -9,34 +9,36 @@ G_BEGIN_DECLS
 /* These forward along the different effects from CinnamonPlugin */
 
 void _cinnamon_wm_minimize   (CinnamonWM         *wm,
-                           MetaWindowActor *actor);
+                              MetaWindowActor *actor);
+void _cinnamon_wm_unminimize (CinnamonWM         *wm,
+                              MetaWindowActor *actor);
 void _cinnamon_wm_maximize   (CinnamonWM         *wm,
-                           MetaWindowActor *actor,
-                           gint             x,
-                           gint             y,
-                           gint             width,
-                           gint             height);
+                              MetaWindowActor *actor,
+                              gint             x,
+                              gint             y,
+                              gint             width,
+                              gint             height);
 void _cinnamon_wm_unmaximize (CinnamonWM         *wm,
-                           MetaWindowActor *actor,
-                           gint             x,
-                           gint             y,
-                           gint             width,
-                           gint             height);
+                              MetaWindowActor *actor,
+                              gint             x,
+                              gint             y,
+                              gint             width,
+                              gint             height);
 void _cinnamon_wm_tile       (CinnamonWM         *wm,
-                           MetaWindowActor *actor,
-                           gint             x,
-                           gint             y,
-                           gint             width,
-                           gint             height);
+                              MetaWindowActor *actor,
+                              gint             x,
+                              gint             y,
+                              gint             width,
+                              gint             height);
 void _cinnamon_wm_map        (CinnamonWM         *wm,
-                           MetaWindowActor *actor);
+                              MetaWindowActor *actor);
 void _cinnamon_wm_destroy    (CinnamonWM         *wm,
-                           MetaWindowActor *actor);
+                              MetaWindowActor *actor);
 
 void _cinnamon_wm_switch_workspace      (CinnamonWM             *wm,
-                                      gint                 from,
-                                      gint                 to,
-                                      MetaMotionDirection  direction);
+                                         gint                 from,
+                                         gint                 to,
+                                         MetaMotionDirection  direction);
 
 void _cinnamon_wm_show_tile_preview     (CinnamonWM         *wm,
                                          MetaWindow         *window,
@@ -53,7 +55,7 @@ void _cinnamon_wm_show_hud_preview     (CinnamonWM          *wm,
 void _cinnamon_wm_hide_hud_preview     (CinnamonWM         *wm);
 
 void _cinnamon_wm_kill_window_effects   (CinnamonWM             *wm,
-                                      MetaWindowActor     *actor);
+                                         MetaWindowActor     *actor);
 
 G_END_DECLS
 

--- a/src/cinnamon-wm.c
+++ b/src/cinnamon-wm.c
@@ -20,6 +20,7 @@ struct _CinnamonWM {
 enum
 {
   MINIMIZE,
+  UNMINIMIZE,
   MAXIMIZE,
   UNMAXIMIZE,
   TILE,
@@ -60,6 +61,15 @@ cinnamon_wm_class_init (CinnamonWMClass *klass)
 
   cinnamon_wm_signals[MINIMIZE] =
     g_signal_new ("minimize",
+                  G_TYPE_FROM_CLASS (klass),
+                  G_SIGNAL_RUN_LAST,
+                  0,
+                  NULL, NULL,
+                  g_cclosure_marshal_VOID__OBJECT,
+                  G_TYPE_NONE, 1,
+                  META_TYPE_WINDOW_ACTOR);
+  cinnamon_wm_signals[UNMINIMIZE] =
+    g_signal_new ("unminimize",
                   G_TYPE_FROM_CLASS (klass),
                   G_SIGNAL_RUN_LAST,
                   0,
@@ -114,70 +124,70 @@ cinnamon_wm_class_init (CinnamonWMClass *klass)
                   META_TYPE_WINDOW_ACTOR);
   cinnamon_wm_signals[SWITCH_WORKSPACE] =
     g_signal_new ("switch-workspace",
-		  G_TYPE_FROM_CLASS (klass),
-		  G_SIGNAL_RUN_LAST,
-		  0,
-		  NULL, NULL,
-		  _cinnamon_marshal_VOID__INT_INT_INT,
-		  G_TYPE_NONE, 3,
+                  G_TYPE_FROM_CLASS (klass),
+                  G_SIGNAL_RUN_LAST,
+                  0,
+                  NULL, NULL,
+                  _cinnamon_marshal_VOID__INT_INT_INT,
+                  G_TYPE_NONE, 3,
                   G_TYPE_INT, G_TYPE_INT, G_TYPE_INT);
   cinnamon_wm_signals[SWITCH_WORKSPACE_COMPLETE] =
     g_signal_new ("switch-workspace-complete",
-		  G_TYPE_FROM_CLASS (klass),
-		  G_SIGNAL_RUN_LAST,
-		  0,
-		  NULL, NULL, NULL,
-		  G_TYPE_NONE, 0);
+                  G_TYPE_FROM_CLASS (klass),
+                  G_SIGNAL_RUN_LAST,
+                  0,
+                  NULL, NULL, NULL,
+                  G_TYPE_NONE, 0);
   cinnamon_wm_signals[KILL_WINDOW_EFFECTS] =
     g_signal_new ("kill-window-effects",
-		  G_TYPE_FROM_CLASS (klass),
-		  G_SIGNAL_RUN_LAST,
-		  0,
-		  NULL, NULL,
-		  g_cclosure_marshal_VOID__OBJECT,
-		  G_TYPE_NONE, 1,
-		  META_TYPE_WINDOW_ACTOR);
-    cinnamon_wm_signals[SHOW_TILE_PREVIEW] =
-        g_signal_new ("show-tile-preview",
-                     G_TYPE_FROM_CLASS (klass),
-                     G_SIGNAL_RUN_LAST,
-                     0, NULL, NULL, NULL,
-                     G_TYPE_NONE, 4,
-                     META_TYPE_WINDOW,
-                     META_TYPE_RECTANGLE,
-                     G_TYPE_INT,
-                     G_TYPE_UINT);
-    cinnamon_wm_signals[HIDE_TILE_PREVIEW] =
-        g_signal_new ("hide-tile-preview",
-                     G_TYPE_FROM_CLASS (klass),
-                     G_SIGNAL_RUN_LAST,
-                     0,
-                     NULL, NULL, NULL,
-                     G_TYPE_NONE, 0);
-    cinnamon_wm_signals[SHOW_HUD_PREVIEW] =
-        g_signal_new ("show-hud-preview",
-                     G_TYPE_FROM_CLASS (klass),
-                     G_SIGNAL_RUN_LAST,
-                     0,
-                     NULL, NULL, NULL,
-                     G_TYPE_NONE, 3,
-                     G_TYPE_UINT,
-                     META_TYPE_RECTANGLE,
-                     G_TYPE_UINT);
-    cinnamon_wm_signals[HIDE_HUD_PREVIEW] =
-        g_signal_new ("hide-hud-preview",
-                     G_TYPE_FROM_CLASS (klass),
-                     G_SIGNAL_RUN_LAST,
-                     0,
-                     NULL, NULL, NULL,
-                     G_TYPE_NONE, 0);
+                  G_TYPE_FROM_CLASS (klass),
+                  G_SIGNAL_RUN_LAST,
+                  0,
+                  NULL, NULL,
+                  g_cclosure_marshal_VOID__OBJECT,
+                  G_TYPE_NONE, 1,
+                  META_TYPE_WINDOW_ACTOR);
+  cinnamon_wm_signals[SHOW_TILE_PREVIEW] =
+    g_signal_new ("show-tile-preview",
+                  G_TYPE_FROM_CLASS (klass),
+                  G_SIGNAL_RUN_LAST,
+                  0, NULL, NULL, NULL,
+                  G_TYPE_NONE, 4,
+                  META_TYPE_WINDOW,
+                  META_TYPE_RECTANGLE,
+                  G_TYPE_INT,
+                  G_TYPE_UINT);
+  cinnamon_wm_signals[HIDE_TILE_PREVIEW] =
+    g_signal_new ("hide-tile-preview",
+                  G_TYPE_FROM_CLASS (klass),
+                  G_SIGNAL_RUN_LAST,
+                  0,
+                  NULL, NULL, NULL,
+                  G_TYPE_NONE, 0);
+  cinnamon_wm_signals[SHOW_HUD_PREVIEW] =
+    g_signal_new ("show-hud-preview",
+                  G_TYPE_FROM_CLASS (klass),
+                  G_SIGNAL_RUN_LAST,
+                  0,
+                  NULL, NULL, NULL,
+                  G_TYPE_NONE, 3,
+                  G_TYPE_UINT,
+                  META_TYPE_RECTANGLE,
+                  G_TYPE_UINT);
+  cinnamon_wm_signals[HIDE_HUD_PREVIEW] =
+    g_signal_new ("hide-hud-preview",
+                  G_TYPE_FROM_CLASS (klass),
+                  G_SIGNAL_RUN_LAST,
+                  0,
+                  NULL, NULL, NULL,
+                  G_TYPE_NONE, 0);
 }
 
 void
 _cinnamon_wm_switch_workspace (CinnamonWM      *wm,
-                            gint          from,
-                            gint          to,
-                            MetaMotionDirection direction)
+                               gint          from,
+                               gint          to,
+                               MetaMotionDirection direction)
 {
   g_signal_emit (wm, cinnamon_wm_signals[SWITCH_WORKSPACE], 0,
                  from, to, direction);
@@ -206,9 +216,23 @@ cinnamon_wm_completed_switch_workspace (CinnamonWM *wm)
  **/
 void
 cinnamon_wm_completed_minimize (CinnamonWM         *wm,
-                             MetaWindowActor *actor)
+                                MetaWindowActor *actor)
 {
   meta_plugin_minimize_completed (wm->plugin, actor);
+}
+
+/**
+ * cinnamon_wm_completed_unminimize:
+ * @wm: the CinnamonWM
+ * @actor: the MetaWindowActor actor
+ *
+ * The plugin must call this when it has completed a window unminimize effect.
+ **/
+void
+cinnamon_wm_completed_unminimize (CinnamonWM         *wm,
+                                  MetaWindowActor *actor)
+{
+  meta_plugin_unminimize_completed (wm->plugin, actor);
 }
 
 /**
@@ -220,7 +244,7 @@ cinnamon_wm_completed_minimize (CinnamonWM         *wm,
  **/
 void
 cinnamon_wm_completed_maximize (CinnamonWM         *wm,
-                             MetaWindowActor *actor)
+                                MetaWindowActor *actor)
 {
   meta_plugin_maximize_completed (wm->plugin, actor);
 }
@@ -249,7 +273,7 @@ cinnamon_wm_completed_tile  (CinnamonWM         *wm,
  **/
 void
 cinnamon_wm_completed_unmaximize (CinnamonWM         *wm,
-                               MetaWindowActor *actor)
+                                  MetaWindowActor *actor)
 {
   meta_plugin_unmaximize_completed (wm->plugin, actor);
 }
@@ -263,7 +287,7 @@ cinnamon_wm_completed_unmaximize (CinnamonWM         *wm,
  **/
 void
 cinnamon_wm_completed_map (CinnamonWM         *wm,
-                        MetaWindowActor *actor)
+                           MetaWindowActor *actor)
 {
   meta_plugin_map_completed (wm->plugin, actor);
 }
@@ -277,14 +301,14 @@ cinnamon_wm_completed_map (CinnamonWM         *wm,
  **/
 void
 cinnamon_wm_completed_destroy (CinnamonWM         *wm,
-                            MetaWindowActor *actor)
+                               MetaWindowActor *actor)
 {
   meta_plugin_destroy_completed (wm->plugin, actor);
 }
 
 void
 _cinnamon_wm_kill_window_effects (CinnamonWM         *wm,
-                               MetaWindowActor *actor)
+                                  MetaWindowActor *actor)
 {
   g_signal_emit (wm, cinnamon_wm_signals[KILL_WINDOW_EFFECTS], 0, actor);
 }
@@ -324,29 +348,36 @@ _cinnamon_wm_hide_hud_preview (CinnamonWM *wm)
 
 void
 _cinnamon_wm_minimize (CinnamonWM         *wm,
-                    MetaWindowActor *actor)
+                       MetaWindowActor    *actor)
 {
   g_signal_emit (wm, cinnamon_wm_signals[MINIMIZE], 0, actor);
 }
 
 void
+_cinnamon_wm_unminimize (CinnamonWM         *wm,
+                         MetaWindowActor    *actor)
+{
+  g_signal_emit (wm, cinnamon_wm_signals[UNMINIMIZE], 0, actor);
+}
+
+void
 _cinnamon_wm_maximize (CinnamonWM         *wm,
-                    MetaWindowActor *actor,
-                    int              target_x,
-                    int              target_y,
-                    int              target_width,
-                    int              target_height)
+                       MetaWindowActor    *actor,
+                       int                 target_x,
+                       int                 target_y,
+                       int                 target_width,
+                       int                 target_height)
 {
   g_signal_emit (wm, cinnamon_wm_signals[MAXIMIZE], 0, actor, target_x, target_y, target_width, target_height);
 }
 
 void
 _cinnamon_wm_unmaximize (CinnamonWM         *wm,
-                      MetaWindowActor *actor,
-                      int              target_x,
-                      int              target_y,
-                      int              target_width,
-                      int              target_height)
+                         MetaWindowActor    *actor,
+                         int                 target_x,
+                         int                 target_y,
+                         int                 target_width,
+                         int                 target_height)
 {
   g_signal_emit (wm, cinnamon_wm_signals[UNMAXIMIZE], 0, actor, target_x, target_y, target_width, target_height);
 }
@@ -364,14 +395,14 @@ _cinnamon_wm_tile (CinnamonWM         *wm,
 
 void
 _cinnamon_wm_map (CinnamonWM         *wm,
-               MetaWindowActor *actor)
+                  MetaWindowActor    *actor)
 {
   g_signal_emit (wm, cinnamon_wm_signals[MAP], 0, actor);
 }
 
 void
 _cinnamon_wm_destroy (CinnamonWM         *wm,
-                   MetaWindowActor *actor)
+                      MetaWindowActor    *actor)
 {
   g_signal_emit (wm, cinnamon_wm_signals[DESTROY], 0, actor);
 }

--- a/src/cinnamon-wm.h
+++ b/src/cinnamon-wm.h
@@ -25,20 +25,22 @@ struct _CinnamonWMClass
 
 GType    cinnamon_wm_get_type                    (void) G_GNUC_CONST;
 
-CinnamonWM *cinnamon_wm_new                        (MetaPlugin      *plugin);
+CinnamonWM *cinnamon_wm_new                      (MetaPlugin      *plugin);
 
 void     cinnamon_wm_completed_minimize         (CinnamonWM         *wm,
-                                              MetaWindowActor *actor);
+                                                 MetaWindowActor    *actor);
+void     cinnamon_wm_completed_unminimize       (CinnamonWM         *wm,
+                                                 MetaWindowActor    *actor);
 void     cinnamon_wm_completed_maximize         (CinnamonWM         *wm,
-                                              MetaWindowActor *actor);
+                                                 MetaWindowActor    *actor);
 void     cinnamon_wm_completed_tile             (CinnamonWM         *wm,
-                                              MetaWindowActor *actor);
+                                                 MetaWindowActor    *actor);
 void     cinnamon_wm_completed_unmaximize       (CinnamonWM         *wm,
-                                              MetaWindowActor *actor);
+                                                 MetaWindowActor    *actor);
 void     cinnamon_wm_completed_map              (CinnamonWM         *wm,
-                                              MetaWindowActor *actor);
+                                                 MetaWindowActor    *actor);
 void     cinnamon_wm_completed_destroy          (CinnamonWM         *wm,
-                                              MetaWindowActor *actor);
+                                                 MetaWindowActor    *actor);
 void     cinnamon_wm_completed_switch_workspace (CinnamonWM         *wm);
 
 G_END_DECLS


### PR DESCRIPTION
* Add an unminimize effect to the meta-plugin instead of using the map effect

* Add more fine grained control of the effect settings internally and expose those
  changes in Effects settings ui

* Enable effects on dialogs and menus by default

* Add new rollup/down and expand/collapse effects

* Fix an issue where maximizing/unmaximizing minimized windows from the window list
  didn't unminimize them

Requires https://github.com/linuxmint/muffin/pull/216