### PR TITLE
GUI option for gsettings > org.cinnamon.muffin > edge-resistance-window

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_windows.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_windows.py
@@ -97,6 +97,10 @@ class Module:
             widget = GSettingsSpinButton(_("Window drag/resize threshold"), "org.cinnamon.muffin", "resize-threshold", _("Pixels"), 1, 100, size_group=size_group)
             settings.add_row(widget)
 
+            widget = GSettingsSwitch(_("Ease windows alignment"), "org.cinnamon.muffin", "edge-resistance-window")
+            widget.set_tooltip_text(_("When moving or resizing a window, its borders will snap with other windows borders."))
+            settings.add_row(widget)
+
             # Alt Tab
 
             page = SettingsPage()


### PR DESCRIPTION
Located in Settings > Windows > Behavior > Moving And Resizing Windows.