### PR TITLE
Fixing https://github.com/linuxmint/Cinnamon/issues/5199 - 

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_startup.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_startup.py
@@ -573,7 +573,7 @@ class AutostartBox(Gtk.Box):
 
     def find_app_with_basename(self, basename):
         for app in AUTOSTART_APPS:
-            if basename == app.basename:
+            if hasattr(app, 'basename') and basename == app.basename:
                 return app
 
         return None


### PR DESCRIPTION
Unable to add app into startup session apps.