### PR TITLE
extensions: Fix the alignment of the rating number in the "Get more" …

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/ExtensionCore.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/ExtensionCore.py
@@ -375,9 +375,8 @@ class ExtensionSidePage (SidePage):
 
 
         right = Gtk.CellRendererText()
-        right.set_property('xalign', 1.0)
+        right.set_property('xalign', 0.5)
         gm_column4 = Gtk.TreeViewColumn("Score", right, markup=4)
-        gm_column4.set_alignment(1.0)
         gm_column4.set_expand(True)
 
         self.gm_treeview.append_column(gm_column1)

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
@@ -198,7 +198,7 @@ class Module:
         box = Gtk.VBox()
         window.add(box)
         window.set_title(_("Desktop themes"))
-        window.set_default_size(640, 480)
+        window.set_default_size(720, 480)
         window.set_border_width(6)
         window.set_position(Gtk.WindowPosition.CENTER)
         page = ExtensionSidePage(self.name, self.icon, self.keywords, box, "theme", None)


### PR DESCRIPTION
…pages so it won't get covered by overlay scrollbars
Fixes https://github.com/linuxmint/Cinnamon/issues/5101