### PR TITLE
Fix handling of device icon where gicon is None (mostly fixes #5248)

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_sound.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_sound.py
@@ -704,10 +704,12 @@ class Module:
         
         iconTheme = Gtk.IconTheme.get_default()        
         gicon = device.get_gicon()
-        lookup = iconTheme.lookup_by_gicon(gicon, 32, 0)
-        if lookup is not None:
-            icon = lookup.load_icon()
-        else:
+        icon = None
+        if gicon is not None:
+            lookup = iconTheme.lookup_by_gicon(gicon, 32, 0)
+            if lookup is not None:
+                icon = lookup.load_icon()
+        if icon is not None:
             if ("bluetooth" in device.get_icon_name()):
                 icon = iconTheme.load_icon("bluetooth", 32, 0)
             else:


### PR DESCRIPTION
Not addressed by this pr:
- Some icon themes do not include the "audio-card" icon name (e.g. Numix)