### PR TITLE
Fix highlighting not working correctly for multiple instances of an a…

### DIFF
--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -436,7 +436,8 @@ function get_object_for_instance (appletId) {
 }
 
 function get_object_for_uuid (uuid, instanceId) {
-    return appletObj.find(x => x && (x._uuid == uuid || x.instance_id == instanceId));
+    return appletObj.find(x => x && x._uuid == uuid &&
+                               (x.instance_id == instanceId || instanceId == uuid));
 }
 
 


### PR DESCRIPTION
…pplet

You can reproduce the issue by adding two instances of the same applet, then highlighting each from cinnamon settings. The same instance of the applet will be highlighted each time, regardless of which one is selected.