### PR TITLE
Added null conditional to return empty array when get_devices returns…

### DIFF
--- a/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
@@ -2005,7 +2005,7 @@ MyApplet.prototype = {
                 if (a._type != NetworkManager.SETTING_VPN_SETTING_NAME) {
                     // find a good device to be considered primary
                     a._primaryDevice = null;
-                    let devices = a.get_devices();
+                    let devices = a.get_devices() || [ ];
                     for (let j = 0; j < devices.length; j++) {
                         let d = devices[j];
                         if (d._delegate) {


### PR DESCRIPTION
… null

If a.get_devices() returns null (as in my case) this throws an exception when getting devices.length.

Changed to return an empty array instead of null in that case.

As reported in #5177 