### PR TITLE
cs_backgrounds fix image close

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_backgrounds.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_backgrounds.py
@@ -512,10 +512,7 @@ class PixCache(object):
                     os.mkdir(tmp_cache_path)
                 cache_filename = tmp_cache_path + h
                 if os.path.exists(cache_filename):
-                    img = Image.open(cache_filename)
-                    i = Image.open(filename)
-                    (width, height) = i.size
-                    i.close()
+                    (width, height) = Image.open(filename).size
                 else:
                     if mimetype == "image/svg+xml":
                         tmp_pix = GdkPixbuf.Pixbuf.new_from_file(filename)


### PR DESCRIPTION
Errors in cs_backgrounds brought to my attention on the commit comment page [here](https://github.com/linuxmint/Cinnamon/commit/a4342d34f4cc84f3ce2eaea4a95e26c57915f508#commitcomment-17393968). I'm not sure why .close() is causing the issue, but this commit removes it.

@brownsr In case you'd like to test this change (though it's pretty much exactly the change you said you made)