### PR TITLE
cinnamon-settings: Remove the hardcoded theming in the main cinnamon …

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
@@ -193,6 +193,8 @@ class MainWindow:
         self.header_stack.set_transition_duration(150)
         self.side_view_container = self.builder.get_object("category_box")
         self.side_view_sw = self.builder.get_object("side_view_sw")
+        context = self.side_view_sw.get_style_context()
+        context.add_class("view")
         self.side_view_sw.show_all()
         self.content_box = self.builder.get_object("content_box")
         self.content_box_sw = self.builder.get_object("content_box_sw")
@@ -427,15 +429,6 @@ class MainWindow:
 
         area.add_attribute(text_renderer, "text", 0)
 
-        css_provider = Gtk.CssProvider()
-        css_provider.load_from_data("GtkIconView {                             \
-                                         background-color: transparent;        \
-                                     }                                         \
-                                     GtkIconView.view.cell:selected {          \
-                                         background-color: @selected_bg_color; \
-                                     }")
-        c = widget.get_style_context()
-        c.add_provider(css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
         self.side_view[category["id"]] = widget
         self.side_view_container.pack_start(self.side_view[category["id"]], False, False, 0)
         self.first_category_done = True


### PR DESCRIPTION
…settings icon view

This has never worked right in some themes since not all themes use the same convention for "selected_bg_color" or "theme_selected_bg_color"
Also fixes issues with how this looks under gtk3.20