### PR TITLE
cs_sound: Set selection mode to none on the SoundBox() object

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_sound.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_sound.py
@@ -83,6 +83,7 @@ class SoundBox(Gtk.Box):
         scw.add(self.box)
 
         self.list_box = Gtk.ListBox()
+        self.list_box.set_selection_mode(Gtk.SelectionMode.NONE)
         self.list_box.set_header_func(list_header_func, None)
         self.box.add(self.list_box)
 


### PR DESCRIPTION
There seems to be no reason to select the rows themselves and doing so just causes them to get the themes selected_bg_color which isn't really the look we're going for here.