### PR TITLE
[Menu applet] Fix not cleared drag placeholder in favorites box

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -381,6 +381,7 @@ ApplicationButton.prototype = {
         this.label.set_style(MAX_BUTTON_WIDTH);
         this.addActor(this.label);
         this._draggable = DND.makeDraggable(this.actor);
+        this._draggable.connect('drag-end', Lang.bind(this, this._onDragEnd));
         this.isDraggableApp = true;
         this.actor.label_actor = this.label;
         if (showIcon) {
@@ -408,6 +409,10 @@ ApplicationButton.prototype = {
     // we show as the item is being dragged.
     getDragActorSource: function() {
         return this.actor;
+    },
+
+    _onDragEnd: function() {
+        this.appsMenuButton.favoritesBox._delegate._clearDragPlaceholder();
     }
 };
 


### PR DESCRIPTION
This fixes the uncleared drag placeholder in the favorites box,
if an application was dragged over, but not dropped on the favorites box
This is for #5322