### PR TITLE
cinnamon-settings: Remove hard-coded theming for the main cinnamon-se…

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
@@ -194,6 +194,9 @@ class MainWindow:
         self.header_stack.set_transition_duration(150)
         self.side_view_container = self.builder.get_object("category_box")
         self.side_view_sw = self.builder.get_object("side_view_sw")
+        context = self.side_view_sw.get_style_context()
+        context.add_class("cs-category-view")
+        context.add_class("view")
         self.side_view_sw.show_all()
         self.content_box = self.builder.get_object("content_box")
         self.content_box_sw = self.builder.get_object("content_box_sw")
@@ -439,15 +442,6 @@ class MainWindow:
 
         area.add_attribute(text_renderer, "text", 0)
 
-        css_provider = Gtk.CssProvider()
-        css_provider.load_from_data("GtkIconView {                             \
-                                         background-color: transparent;        \
-                                     }                                         \
-                                     GtkIconView.view.cell:selected {          \
-                                         background-color: @selected_bg_color; \
-                                     }")
-        c = widget.get_style_context()
-        c.add_provider(css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
         self.side_view[category["id"]] = widget
         self.side_view_container.pack_start(self.side_view[category["id"]], False, False, 0)
         self.first_category_done = True


### PR DESCRIPTION
…ttings icon view

Replace it with a new style class. This fixes the appearance of the icon view under gtk3.20 and fixes some old issues with the themes that use a naming convention that didn't match what we were using

This replaces https://github.com/linuxmint/Cinnamon/pull/5303