### PR TITLE
menu applet: added checkbox to show/hide recent files in the menu

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/settings-schema.json
@@ -48,6 +48,12 @@
     "description": "Show bookmarks and places",
     "tooltip": "Choose whether or not to show bookmarks and places in the menu."
  },
+ "show-recent" : {
+    "type" : "checkbox",
+    "default" : true,
+    "description": "Show recent files",
+    "tooltip": "Choose whether or not to show recent files in the menu."
+ },
 "enable-autoscroll" : {
     "type" : "checkbox",
     "default" : true,


### PR DESCRIPTION
The comparison between the old and the new code in the applet.js is a little bit confusing.

There are only 3 lines of new code in the applet.js, i.e.
`this.settings.bindProperty(Settings.BindingDirection.IN, "show-recent", "showRecent", this._refreshBelowApps, null);`
and
`if(this.showRecent) {
}`
Everything between the brackets of the if-case is the same old code, just indented.


