### PR TITLE
Resize a thumbnail when the window resizes

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -93,6 +93,8 @@ WindowPreview.prototype = {
         Main.uiGroup.add_actor(this.actor);
 
         this.metaWindow = metaWindow;
+        this.muffinWindow = null;
+        this._sizeChangedId = null;
 
         let box = new St.BoxLayout({ vertical: true });
         let hbox = new St.BoxLayout();
@@ -134,8 +136,8 @@ WindowPreview.prototype = {
         if (!this.actor || this._applet._menuOpen)
             return
 
-        let muffinWindow = this.metaWindow.get_compositor_private();
-        let windowTexture = muffinWindow.get_texture();
+        this.muffinWindow = this.metaWindow.get_compositor_private();
+        let windowTexture = this.muffinWindow.get_texture();
         let [width, height] = windowTexture.get_size();
         let scale = Math.min(1.0, WINDOW_PREVIEW_WIDTH / width, WINDOW_PREVIEW_HEIGHT / height);
 
@@ -149,6 +151,14 @@ WindowPreview.prototype = {
             width: width * scale * this.scaleFactor,
             height: height * scale * this.scaleFactor
         });
+
+        this._setSize = function() {
+            [width, height] = windowTexture.get_size();
+            scale = Math.min(1.0, WINDOW_PREVIEW_WIDTH / width, WINDOW_PREVIEW_HEIGHT / height);
+            this.thumbnail.set_size(width * scale * this.scaleFactor, height * scale * this.scaleFactor);
+        };
+        this._sizeChangedId = this.muffinWindow.connect('size-changed',
+            Lang.bind(this, this._setSize));
 
         this.thumbnailBin.set_child(this.thumbnail);
 
@@ -178,6 +188,10 @@ WindowPreview.prototype = {
     },
 
     hide: function() {
+        if (this._sizeChangedId != null) {
+            this.muffinWindow.disconnect(this._sizeChangedId);
+            this._sizeChangedId = null;
+        }
         if (this.thumbnail) {
             this.thumbnailBin.set_child(null);
             this.thumbnail.destroy();
@@ -193,6 +207,10 @@ WindowPreview.prototype = {
     },
 
     _destroy: function() {
+        if (this._sizeChangedId != null) {
+            this.muffinWindow.disconnect(this._sizeChangedId);
+            this.sizeChangedId = null;
+        }
         if (this.thumbnail) {
             this.thumbnailBin.set_child(null);
             this.thumbnail.destroy();


### PR DESCRIPTION
I tiled a window by keyboard shortcut while the window preview was open, and the preview became stretched. That is fixed with this pull request.

The problem is seen in this image:
![mint-y-bugs](https://cloud.githubusercontent.com/assets/1248033/15875885/c2152298-2cf9-11e6-85ae-89fc2fb7652a.png)