### PR TITLE
[3.2] Scale window buttons to fit the screen

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -530,13 +530,21 @@ AppMenuButton.prototype = {
         let [minSize, naturalSize] = this._iconBox.get_preferred_width(forHeight);
         // minimum size just enough for icon if we ever get that many apps going
         alloc.min_size = naturalSize + 2 * 3 * global.ui_scale;
-
+        
+        //Get the window to know the proper size of the buttons
+        let muffinWindow = this.metaWindow.get_compositor_private();
+        let windowTexture = muffinWindow.get_texture();
+        let [width, height] = windowTexture.get_size();
+        
+        //I found 9 to be a good constant, but if another number looks better, please change it.
+        let buttonWidth = width / 9;
+        
         if (this._applet.buttonsUseEntireSpace) {
             let [lminSize, lnaturalSize] = this._label.get_preferred_width(forHeight);
-            alloc.natural_size = Math.max(150 * global.ui_scale,
+            alloc.natural_size = Math.max(buttonWidth * global.ui_scale,
                     lnaturalSize + naturalSize + 3 * 3 * global.ui_scale);
         } else {
-            alloc.natural_size = 150 * global.ui_scale;
+            alloc.natural_size = buttonWidth * global.ui_scale;
         }
     },
 


### PR DESCRIPTION
I inserted new code into the window-list applet ([View master](https://github.com/linuxmint/Cinnamon/tree/master/files/usr/share/cinnamon/applets/window-list%40cinnamon.org)) to re-scale buttons for different screen sizes.

| Resolution  | With                                                                      | Without                      |
|----------------|--------------------------------------------------------------|----------------------------|
| 1920x1080 | ![1920x1080](https://cloud.githubusercontent.com/assets/17197562/16340486/68cae268-39f6-11e6-99c6-a4364660519a.png) | ![1920x1080 without](https://cloud.githubusercontent.com/assets/17197562/16341170/d0795432-39f9-11e6-919e-63057fdf6f14.png) |
| 1600x900 | ![1600x900](https://cloud.githubusercontent.com/assets/17197562/16340523/95a81026-39f6-11e6-8d76-192e011db082.png) | ![1600x900 without](https://cloud.githubusercontent.com/assets/17197562/16341190/e8577c6e-39f9-11e6-814c-5980f20d48b5.png) |
| 1280x720 | ![1280x720](https://cloud.githubusercontent.com/assets/17197562/16340532/a305e7a2-39f6-11e6-9beb-5947dd516e27.png) | ![1280x720 without](https://cloud.githubusercontent.com/assets/17197562/16341199/fc61d132-39f9-11e6-9249-9cebbe616a2d.png) |

(Sorry for any strange artifacts in the 1920x1080 and 1280x720 images; my screen's resolution is 1600x900.)