### PR TITLE
Clean up output filenames on the tracker search provider

### DIFF
--- a/docs/search-providers-examples/trackerprovider@cinnamon.org/search_provider.js
+++ b/docs/search-providers-examples/trackerprovider@cinnamon.org/search_provider.js
@@ -37,7 +37,7 @@ function dbus_push_results(results, pattern)
                         break;
                     
                     default:
-                        results[i].label = decodeURIComponent(results[i]["url"]);
+                        results[i].label = (decodeURIComponent(results[i]["url"])).split("/").pop();
                         break;
                 }
                 final_results.push(results[i]);


### PR DESCRIPTION
remove the url garbage text that can take up a lot of space when searching in the menu