### PR TITLE
Ensure a long applet description does not push applet status icons off the settings screen

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/ExtensionCore.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/ExtensionCore.py
@@ -130,6 +130,9 @@ class ExtensionSidePage (SidePage):
             column3.set_max_width(300)
             cr.set_property('wrap-mode', Pango.WrapMode.WORD_CHAR)
             cr.set_property('wrap-width', 200)
+        if self.collection_type == 'applet':
+            cr.set_property('wrap-mode', Pango.WrapMode.WORD_CHAR)
+            cr.set_property('wrap-width', 450)
 
         cr = Gtk.CellRendererPixbuf()
         cr.set_property("stock-size", Gtk.IconSize.DND)

--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -401,7 +401,7 @@ Applet.prototype = {
         let items = this._applet_context_menu._getMenuItems();
 
         if (this.context_menu_item_remove == null) {
-            this.context_menu_item_remove = new PopupMenu.PopupIconMenuItem(_("Remove this applet"),
+            this.context_menu_item_remove = new PopupMenu.PopupIconMenuItem(_("Remove applet '%s'").format(this._meta.name),
                     "edit-delete",
                    St.IconType.SYMBOLIC);
             this.context_menu_item_remove.connect('activate', Lang.bind(this, function() {

--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -401,7 +401,7 @@ Applet.prototype = {
         let items = this._applet_context_menu._getMenuItems();
 
         if (this.context_menu_item_remove == null) {
-            this.context_menu_item_remove = new PopupMenu.PopupIconMenuItem(_("Remove applet '%s'").format(this._meta.name),
+            this.context_menu_item_remove = new PopupMenu.PopupIconMenuItem(_("Remove this applet"),
                     "edit-delete",
                    St.IconType.SYMBOLIC);
             this.context_menu_item_remove.connect('activate', Lang.bind(this, function() {

--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -401,7 +401,7 @@ Applet.prototype = {
         let items = this._applet_context_menu._getMenuItems();
 
         if (this.context_menu_item_remove == null) {
-            this.context_menu_item_remove = new PopupMenu.PopupIconMenuItem(_("Remove '%s'").format(this._meta.name),
+            this.context_menu_item_remove = new PopupMenu.PopupIconMenuItem(_("Remove applet '%s'").format(this._meta.name),
                     "edit-delete",
                    St.IconType.SYMBOLIC);
             this.context_menu_item_remove.connect('activate', Lang.bind(this, function() {

--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -401,7 +401,7 @@ Applet.prototype = {
         let items = this._applet_context_menu._getMenuItems();
 
         if (this.context_menu_item_remove == null) {
-            this.context_menu_item_remove = new PopupMenu.PopupIconMenuItem(_("Remove applet '%s'").format(this._meta.name),
+            this.context_menu_item_remove = new PopupMenu.PopupIconMenuItem(_("Remove '%s'").format(this._meta.name),
                     "edit-delete",
                    St.IconType.SYMBOLIC);
             this.context_menu_item_remove.connect('activate', Lang.bind(this, function() {


### PR DESCRIPTION
A long applet description will push the applet status icons off the visible applet settings screen. This could confuse people. This PR wraps the applet description at a sensible point to avoid this happening.

Sorry about the clutter, I rather dumbly put a small change in master which carries it into every other PR.  reverted now, but my git skills are not able to remove all the evidence!  Can just cherry pick 	d7ad25b