### PR TITLE
More informative menu item to remove an applet 

### DIFF
--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -401,7 +401,7 @@ Applet.prototype = {
         let items = this._applet_context_menu._getMenuItems();
 
         if (this.context_menu_item_remove == null) {
-            this.context_menu_item_remove = new PopupMenu.PopupIconMenuItem(_("Remove this applet"),
+            this.context_menu_item_remove = new PopupMenu.PopupIconMenuItem(_("Remove '%s'").format(this._meta.name),
                     "edit-delete",
                    St.IconType.SYMBOLIC);
             this.context_menu_item_remove.connect('activate', Lang.bind(this, function() {

--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -401,7 +401,7 @@ Applet.prototype = {
         let items = this._applet_context_menu._getMenuItems();
 
         if (this.context_menu_item_remove == null) {
-            this.context_menu_item_remove = new PopupMenu.PopupIconMenuItem(_("Remove this applet"),
+            this.context_menu_item_remove = new PopupMenu.PopupIconMenuItem(_("Remove applet '%s'").format(this._meta.name),
                     "edit-delete",
                    St.IconType.SYMBOLIC);
             this.context_menu_item_remove.connect('activate', Lang.bind(this, function() {

--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -401,7 +401,7 @@ Applet.prototype = {
         let items = this._applet_context_menu._getMenuItems();
 
         if (this.context_menu_item_remove == null) {
-            this.context_menu_item_remove = new PopupMenu.PopupIconMenuItem(_("Remove applet '%s'").format(this._meta.name),
+            this.context_menu_item_remove = new PopupMenu.PopupIconMenuItem(_("Remove this applet"),
                     "edit-delete",
                    St.IconType.SYMBOLIC);
             this.context_menu_item_remove.connect('activate', Lang.bind(this, function() {

--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -401,7 +401,7 @@ Applet.prototype = {
         let items = this._applet_context_menu._getMenuItems();
 
         if (this.context_menu_item_remove == null) {
-            this.context_menu_item_remove = new PopupMenu.PopupIconMenuItem(_("Remove '%s'").format(this._meta.name),
+            this.context_menu_item_remove = new PopupMenu.PopupIconMenuItem(_("Remove applet '%s'").format(this._meta.name),
                     "edit-delete",
                    St.IconType.SYMBOLIC);
             this.context_menu_item_remove.connect('activate', Lang.bind(this, function() {

--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -401,7 +401,7 @@ Applet.prototype = {
         let items = this._applet_context_menu._getMenuItems();
 
         if (this.context_menu_item_remove == null) {
-            this.context_menu_item_remove = new PopupMenu.PopupIconMenuItem(_("Remove applet '%s'").format(this._meta.name),
+            this.context_menu_item_remove = new PopupMenu.PopupIconMenuItem(_("Remove '%s'").format(this._meta.name),
                     "edit-delete",
                    St.IconType.SYMBOLIC);
             this.context_menu_item_remove.connect('activate', Lang.bind(this, function() {


### PR DESCRIPTION
This small change introduces the applet name into the right click applet menu item that removes the applet, so instead of "Remove this applet"  the user will see "Remove 'Systray'"  for example. I hope this will make a user less likely to remove an applet in error.  Sorry about the git clutter caused by moving the original PR which I unfortunately put in master, my limited git skills do not run as far as removing the evidence.  Perhaps you can just cherry pick 43f99d4 ? 