### PR TITLE
More informative applet menu item

### DIFF
--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -401,7 +401,7 @@ Applet.prototype = {
         let items = this._applet_context_menu._getMenuItems();
 
         if (this.context_menu_item_remove == null) {
-            this.context_menu_item_remove = new PopupMenu.PopupIconMenuItem(_("Remove this applet"),
+            this.context_menu_item_remove = new PopupMenu.PopupIconMenuItem(_("Remove '%s'").format(this._meta.name),
                     "edit-delete",
                    St.IconType.SYMBOLIC);
             this.context_menu_item_remove.connect('activate', Lang.bind(this, function() {


### PR DESCRIPTION
This small change introduces the applet name into the right click applet menu item that removes the applet, so instead of "Remove this applet" the user will see "Remove 'Systray'" for example. I hope this will make a user less likely to remove an applet in error.

fixes feature request #5214