### PR TITLE
wrap a long applet description in applet settings

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/ExtensionCore.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/ExtensionCore.py
@@ -130,6 +130,9 @@ class ExtensionSidePage (SidePage):
             column3.set_max_width(300)
             cr.set_property('wrap-mode', Pango.WrapMode.WORD_CHAR)
             cr.set_property('wrap-width', 200)
+        if self.collection_type == 'applet':
+            cr.set_property('wrap-mode', Pango.WrapMode.WORD_CHAR)
+            cr.set_property('wrap-width', 450)
 
         cr = Gtk.CellRendererPixbuf()
         cr.set_property("stock-size", Gtk.IconSize.DND)


### PR DESCRIPTION
At the moment a long applet description will push the subsequent icons off the visible screen
which is likely to confuse some.  Scaling up font or text scaling exacerbates this
Some simple column wrapping avoids the issue