### PR TITLE
Menu applet: Show 'Run with nVidia GPU' in context menu

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -161,6 +161,10 @@ ApplicationContextMenuItem.prototype = {
                 Util.spawnCommandLine("gksu -m '" + _("Please provide your password to uninstall this application") + "' /usr/bin/cinnamon-remove-application '" + this._appButton.app.get_app_info().get_filename() + "'");
                 this._appButton.appsMenuButton.menu.close();
                 break;
+            case "run_with_nvidia_gpu":
+                Util.spawnCommandLine("optirun gtk-launch " + this._appButton.app.get_id());
+                this._appButton.appsMenuButton.menu.close();
+                break;
         }
         return false;
     }
@@ -246,6 +250,10 @@ GenericApplicationButton.prototype = {
             }
             if (this.appsMenuButton._canUninstallApps) {
                 menuItem = new ApplicationContextMenuItem(this, _("Uninstall"), "uninstall");
+                this.menu.addMenuItem(menuItem);
+            }
+            if (this.appsMenuButton._isBumblebeeInstalled) {
+                menuItem = new ApplicationContextMenuItem(this, _("Run with nVidia GPU"), "run_with_nvidia_gpu");
                 this.menu.addMenuItem(menuItem);
             }
         }
@@ -1144,6 +1152,7 @@ MyApplet.prototype = {
         this._knownApps = new Array(); // Used to keep track of apps that are already installed, so we can highlight newly installed ones
         this._appsWereRefreshed = false;
         this._canUninstallApps = GLib.file_test("/usr/bin/cinnamon-remove-application", GLib.FileTest.EXISTS);
+        this._isBumblebeeInstalled = GLib.file_test("/usr/bin/optirun", GLib.FileTest.EXISTS);
         this.RecentManager = new DocInfo.DocManager();
         this.privacy_settings = new Gio.Settings( {schema_id: PRIVACY_SCHEMA} );
         this._display();


### PR DESCRIPTION
With this commit Cinnamon menu applet shows in the right click context menu a new option: "Run with nVidia GPU", useful in systems using Bumblebee to manage the GPUs. 

I made this change because I found annoying the fact that I had to open a terminal, than type _optirun ..._ and keep the terminal window in the background while working. This solution is much cleaner: right click, run with nVidia, and you're done.

It isn't too much annoying, in fact it only shows up when _optirun_ (part of Bumblebee) is installed.

I could have made a more general mechanism, such as nemo actions, but I don't think it is necessary, because, apart from adding to the favourites, adding to the panel, adding to the desktop, uninstalling and running with dedicated GPU, there aren't many other possible actions for an application.