### PR TITLE
JsonSettingsWidgets.py: Ignore dependency key that doesn't exist with…

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py
@@ -69,6 +69,9 @@ class JSONSettingsHandler(object):
     def has_property(self, key, prop):
         return prop in self.settings.keys()
 
+    def has_key(self, key):
+        return key in self.settings
+
     def object_value_changed(self, obj, value, key):
         for info in self.bindings[key]:
             if obj == info["obj"]:
@@ -223,7 +226,10 @@ def json_settings_factory(subclass):
             self.attach()
 
         def set_dep_key(self, dep_key):
-            self.settings.bind(dep_key, self, "sensitive", Gio.SettingsBindFlags.GET)
+            if self.settings.has_key(dep_key):
+                self.settings.bind(dep_key, self, "sensitive", Gio.SettingsBindFlags.GET)
+            else:
+                print("Ignoring dependency on key '%s': no such key in the schema" % dep_key)
 
     return NewClass
 


### PR DESCRIPTION
… a warning rather than failing with an error

Fixes #5581