### PR TITLE
Cinnamon-Settings: Fix some annoying bugs in the sound module

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_sound.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_sound.py
@@ -302,7 +302,7 @@ class BalanceBar(Slider):
     def setChannelMap(self, channelMap):
         self.channelMap = channelMap
         self.channelMap.connect("volume-changed", self.getLevel)
-        self.slider.set_sensitive(getattr(self.channelMap, "can_"+self.type)())
+        self.set_sensitive(getattr(self.channelMap, "can_"+self.type)())
         self.getLevel()
 
     def getLevel(self, a=None, b=None):

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_sound.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_sound.py
@@ -694,6 +694,7 @@ class Module:
         select.set_margin(0)
         select.set_pixbuf_column(4)
         select.set_text_column(0)
+        select.set_column_spacing(0)
 
         select.connect("selection-changed", self.setActiveDevice, type)
 


### PR DESCRIPTION
1. Make each BalanceBar insensitive when the channel map is changed so it's clearer that the user can't actually change balance, fade, sub etc.

2. Fix some device icon spacing issues, specifically for 4K