### PR TITLE
change the maximum delay for backgrounds slideshow

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_backgrounds.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_backgrounds.py
@@ -231,7 +231,7 @@ class Module:
             widget = GSettingsSwitch(_("Play backgrounds as a slideshow"), "org.cinnamon.desktop.background.slideshow", "slideshow-enabled")
             settings.add_row(widget)
 
-            widget = GSettingsSpinButton(_("Delay"), "org.cinnamon.desktop.background.slideshow", "delay", _("minutes"), 1, 120)
+            widget = GSettingsSpinButton(_("Delay"), "org.cinnamon.desktop.background.slideshow", "delay", _("minutes"), 1, 1440)
             settings.add_reveal_row(widget, "org.cinnamon.desktop.background.slideshow", "slideshow-enabled")
 
             widget = GSettingsSwitch(_("Play images in random order"), "org.cinnamon.desktop.background.slideshow", "random-order")


### PR DESCRIPTION
I changed the maximum delay for the GSettingsSwitch from 120 minutes to 1440 minutes (24 hours).
This is to respond to this feature request:
linuxmint/cinnamon-control-center#151

It would be better if there are were two fields, one for minutes and another one for hours, but I encountered some complications while trying to implement them.