### PR TITLE
vertical panels: put the notification count under the notification icon

### DIFF
--- a/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
@@ -29,6 +29,7 @@ MyApplet.prototype = {
 
         // Layout
         this._orientation = orientation;
+        this.set_orientation();
         this.menuManager = new PopupMenu.PopupMenuManager(this);
 
         // Lists
@@ -164,6 +165,7 @@ MyApplet.prototype = {
                 this.actor.show();
                 this.clear_action.actor.show();
                 this.set_applet_label(count.toString());
+                this._applet_label.show();
                 // Find max urgency and derive list icon.
                 let max_urgency = -1;
                 for (let i = 0; i < count; i++) {
@@ -191,6 +193,7 @@ MyApplet.prototype = {
             } else {	// There are no notifications.
                 this._blinking = false;
                 this.set_applet_label('');
+                this._applet_label.hide();
                 this.set_applet_icon_symbolic_name("empty-notif");
                 this.clear_action.actor.hide();
                 if (!this.showEmptyTray) {
@@ -232,8 +235,19 @@ MyApplet.prototype = {
         this.on_orientation_changed(this._orientation);
     },
 
+    set_orientation: function() {
+	    if (this._orientation == St.Side.LEFT || this.orientation == St.Side.RIGHT) {
+            this.actor.set_vertical(true);
+        }
+        else {
+            this.actor.set_vertical(false);
+        }
+    },
+
     on_orientation_changed: function (orientation) {
         this._orientation = orientation;
+        this.set_orientation();
+
         if (this.menu) {
             this.menu.destroy();
         }


### PR DESCRIPTION
This keeps things central in the panel and avoids problems with the panel width being able to accommodate icon+text label unless there are many, many notifications [should never happen in normal use, would probably need 1000 unread notifications].

Feels like a 'least bad' solution to be honest.  The icon+text style does not really suit a vertical panel, whether the text is to the side or below.