### PR TITLE
cs_backgrounds.py: Don't check mimetype if filename is None

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_backgrounds.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_backgrounds.py
@@ -527,6 +527,8 @@ class PixCache(object):
         self._data = {}
 
     def get_pix(self, filename, size=None):
+        if filename is None:
+            return None
         mimetype = mimetypes.guess_type(filename)[0]
         if mimetype is None or not mimetype.startswith("image/"):
             return None


### PR DESCRIPTION
This prevents a crash introduced with the mimtypes change if
mimetypes.guess_type() is called when filename = None.