### PR TITLE
[show-desktop applet] new feature added: Peek at desktop

### DIFF
--- a/files/usr/share/cinnamon/applets/show-desktop@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/show-desktop@cinnamon.org/applet.js
@@ -1,5 +1,10 @@
 const Applet = imports.ui.applet;
+const Settings = imports.ui.settings;  // Needed for settings API
 const Main = imports.ui.main;
+const Mainloop = imports.mainloop;
+const Tweener = imports.ui.tweener;
+const Clutter = imports.gi.Clutter;
+const Lang = imports.lang;
 
 function MyApplet(orientation, panel_height, instance_id) {
     this._init(orientation, panel_height, instance_id);
@@ -11,12 +16,84 @@ MyApplet.prototype = {
     _init: function(orientation, panel_height, instance_id) {
         Applet.IconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
         
+        /* Initialize your settings handler instance      this,            the uuid              instance id  */
+        this.settings = new Settings.AppletSettings(this, "show-desktop@cinnamon.org", instance_id);
+        
+        this.settings.bindProperty(Settings.BindingDirection.IN, "peek-at-desktop", "peek_at_desktop", null, null);
+        this.settings.bindProperty(Settings.BindingDirection.IN, "peek-delay", "peek_delay", null, null);
+        this.settings.bindProperty(Settings.BindingDirection.IN, "peek-opacity", "peek_opacity", null, null);
+        this.settings.bindProperty(Settings.BindingDirection.IN, "peek-blur", "peek_blur", null, null);
+                                  
+        this.actor.connect('enter-event', Lang.bind(this, this._onEntered));
+        this.actor.connect('leave-event', Lang.bind(this, this._onLeaved));
+        
+        this.didpeek=false;
+        
         this.set_applet_icon_name("user-desktop");
         this.set_applet_tooltip(_("Show desktop"));
     },
     
+    show_all_windows: function(time) {
+        let windows = global.get_window_actors();
+        for(let i=0; i<windows.length; i++){
+            let window = windows[i].meta_window;
+            let compositor = windows[i];
+            if(window.get_title()=="Desktop"){
+                Tweener.addTween(compositor, { opacity: 255, time: time, transition: "easeOutSine" });
+            }       
+            if (this.peek_blur && compositor.eff){
+                compositor.remove_effect(compositor.eff);
+            }
+        }
+        Tweener.addTween(global.window_group, {  opacity: 255, time: time, transition: "easeOutSine" });
+    },
+    
+    _onEntered: function(event) {
+        if (this.peek_at_desktop){  
+        
+            if (this._peektimeoutid) 
+                Mainloop.source_remove(this._peektimeoutid);
+                
+            this._peektimeoutid = Mainloop.timeout_add(this.peek_delay, Lang.bind(this,function () { 
+            
+                if(this.actor.hover && !this._applet_context_menu.isOpen && ! global.settings.get_boolean("panel-edit-mode")){
+                    Tweener.addTween(global.window_group, {opacity: this.peek_opacity, time: 0.275, transition: "easeInSine" });
+                    
+                    let windows = global.get_window_actors();
+                    for(let i=0; i<windows.length; i++){
+                        let window = windows[i].meta_window;
+                        let compositor = windows[i];
+                            
+                        if (this.peek_blur){
+                            if (!compositor.eff) 
+                                compositor.eff = new Clutter.BlurEffect();
+                            compositor.add_effect_with_name('peek-blur',compositor.eff);
+                        }
+                    }
+                
+                    this.didpeek=true;
+                }
+                
+            }));
+            
+        }
+    },
+    
+    _onLeaved: function(event) {
+        if(this.didpeek){
+            this.show_all_windows(0.2);
+            this.didpeek=false;
+        }
+        if (this._peektimeoutid)
+            Mainloop.source_remove(this._peektimeoutid);
+    },
+    
     on_applet_clicked: function(event) {
         global.screen.toggle_desktop(global.get_current_time());
+        this.show_all_windows(0);
+        if (this._peektimeoutid)
+            Mainloop.source_remove(this._peektimeoutid);
+        this.didpeek=false;
     }
 };
 

--- a/files/usr/share/cinnamon/applets/show-desktop@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/show-desktop@cinnamon.org/settings-schema.json
@@ -1,0 +1,43 @@
+{
+ "head" : {
+    "type" : "header",
+    "description" : "Peek settings"
+ },
+ "peek-at-desktop" : {
+    "type" : "switch",
+    "default" : false,
+    "description": "Use Peek at desktop",
+    "tooltip": "Use Peek to preview the desktop when you move your mouse to the show desktop applet"
+ },
+  "peek-blur" : {
+    "type" : "switch",
+    "default" : false,
+    "dependency" : "peek-at-desktop",
+    "indent" : true,
+    "description" : "Blur effect for Peek",
+    "tooltip" : "Windows will be blurred when Peek shows desktop"
+ },
+ "peek-delay" : {
+    "type": "spinbutton",
+    "default" : 400,
+    "min" : 0,
+    "max" : 1000,
+    "step" : 50,
+    "units" : "milliseconds",
+    "dependency" : "peek-at-desktop",
+    "indent" : true,
+    "description": "Peek hover delay: ",
+    "tooltip": "Delay before Peek shows desktop"
+ },
+ "peek-opacity": {
+    "type": "scale",
+    "default" : 10,
+    "min" : 0,
+    "max" : 255,
+    "step" : 10,
+    "dependency" : "peek-at-desktop",
+    "indent" : true,
+    "description" : "Opacity of Peek: ",
+    "tooltip" : "Change the degree of opacity for Peek"
+ }
+}


### PR DESCRIPTION
This feature allows you to take a peek at the desktop, if you hover with your mouse over the show-desktop applet. (If you want to take a quick look at your files or desklets (for example weather) stored on the desktop and you are to lazy to press the show-desktop applet for that ;)
![peek-at-desktop](https://cloud.githubusercontent.com/assets/8415124/18619077/7e2728c4-7df3-11e6-99dd-e9b3e80e8725.png)

You are in control of the following settings:
![peek_settings](https://cloud.githubusercontent.com/assets/8415124/18619104/e08022fa-7df3-11e6-9bd4-631a4d96b7e0.png)

(1) It's up to you using this feature. Turned off by default
(2) Blur effect for the transparent windows, when peeking at desktop
(3) Time you have to wait, till windows are getting transparent, after you hovered over the applet
(4) You decide how transparent you want the windows to be

This commit tidies this previous messy pull request: https://github.com/linuxmint/Cinnamon/pull/5703