### PR TITLE
Vertical panel applet layout improvements

### DIFF
--- a/files/usr/share/cinnamon/applets/a11y@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/a11y@cinnamon.org/applet.js
@@ -242,13 +242,6 @@ MyApplet.prototype = {
 
     on_applet_removed_from_panel: function() {
         Main.systrayManager.unregisterRole("a11y", this.metadata.uuid);
-    },
-//
-//override getDisplayLayout to declare that this applet is suitable for both horizontal and
-// vertical orientations
-//
-    getDisplayLayout: function() {
-        return Applet.DisplayLayout.BOTH;
     }
 };
 

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1181,6 +1181,8 @@ MyApplet.prototype = {
 
         St.TextureCache.get_default().connect("icon-theme-changed", Lang.bind(this, this.onIconThemeChanged));
         this._recalc_height();
+
+        this.update_label_visible();
     },
 
     _updateKeybinding: function() {
@@ -1271,8 +1273,18 @@ MyApplet.prototype = {
         this.applicationsScrollBox.style = "height: "+scrollBoxHeight / global.ui_scale +"px;";
     },
 
+    update_label_visible: function () {
+        if (this.orientation == St.Side.LEFT || this.orientation == St.Side.RIGHT)
+            this.hide_applet_label(true);
+        else
+            this.hide_applet_label(false);
+    },
+
     on_orientation_changed: function (orientation) {
         this.orientation = orientation;
+
+        this.update_label_visible();
+
         this.menu.destroy();
         this.menu = new Applet.AppletPopupMenu(this, orientation);
         this.menuManager.addMenu(this.menu);
@@ -1286,10 +1298,6 @@ MyApplet.prototype = {
         this._updateIconAndLabel();
     },
 
-//
-//override getDisplayLayout to declare that this applet is suitable for both horizontal and
-// vertical orientations
-//
     getDisplayLayout: function() {
         return Applet.DisplayLayout.BOTH;
     },

--- a/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
@@ -29,7 +29,6 @@ MyApplet.prototype = {
 
         // Layout
         this._orientation = orientation;
-        this.set_orientation();
         this.menuManager = new PopupMenu.PopupMenuManager(this);
 
         // Lists
@@ -165,7 +164,7 @@ MyApplet.prototype = {
                 this.actor.show();
                 this.clear_action.actor.show();
                 this.set_applet_label(count.toString());
-                this._applet_label.show();
+                this.hide_applet_label(false);
                 // Find max urgency and derive list icon.
                 let max_urgency = -1;
                 for (let i = 0; i < count; i++) {
@@ -193,7 +192,7 @@ MyApplet.prototype = {
             } else {	// There are no notifications.
                 this._blinking = false;
                 this.set_applet_label('');
-                this._applet_label.hide();
+                this.hide_applet_label(true);
                 this.set_applet_icon_symbolic_name("empty-notif");
                 this.clear_action.actor.hide();
                 if (!this.showEmptyTray) {
@@ -235,17 +234,8 @@ MyApplet.prototype = {
         this.on_orientation_changed(this._orientation);
     },
 
-    set_orientation: function() {
-        if (this._orientation == St.Side.LEFT || this.orientation == St.Side.RIGHT) {
-            this.actor.set_vertical(true);
-        } else {
-            this.actor.set_vertical(false);
-        }
-    },
-
     on_orientation_changed: function (orientation) {
         this._orientation = orientation;
-        this.set_orientation();
 
         if (this.menu) {
             this.menu.destroy();
@@ -255,10 +245,6 @@ MyApplet.prototype = {
         this._display();
     },
 
-//
-//override getDisplayLayout to declare that this applet is suitable for both horizontal and
-// vertical orientations
-//
     getDisplayLayout: function() {
         return Applet.DisplayLayout.BOTH;
     },

--- a/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
@@ -249,6 +249,7 @@ MyApplet.prototype = {
         Applet.TextIconApplet.prototype._init.call(this, orientation, panel_height, instanceId);
 
         this.metadata = metadata;
+        this.orientation = orientation;
 
         this.settings = new Settings.AppletSettings(this, metadata.uuid, instanceId);
 
@@ -290,6 +291,8 @@ MyApplet.prototype = {
 
             this._devicesChanged();
         }));
+
+        this.update_label_visible();
     },
 
     _on_device_aliases_changed: function() {
@@ -544,10 +547,19 @@ MyApplet.prototype = {
     on_applet_removed_from_panel: function() {
         Main.systrayManager.unregisterId(this.metadata.uuid);
     },
-//
-//override getDisplayLayout to declare that this applet is suitable for both horizontal and
-// vertical orientations
-//
+
+    update_label_visible: function() {
+        if (this.orientation == St.Side.LEFT || this.orientation == St.Side.RIGHT)
+            this.hide_applet_label(true);
+        else
+            this.hide_applet_label(false);
+    },
+
+    on_orientation_changed: function(orientation) {
+        this.orientation = orientation;
+        this.update_label_visible();
+    },
+
     getDisplayLayout: function() {
         return Applet.DisplayLayout.BOTH;
     }

--- a/files/usr/share/cinnamon/applets/separator@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/separator@cinnamon.org/applet.js
@@ -15,10 +15,7 @@ MyApplet.prototype = {
 
         this.on_orientation_changed(orientation);
     },
-//
-// override getDisplayLayout to declare that this applet is suitable for both horizontal and
-// vertical orientations
-//
+
     getDisplayLayout: function() {
         return Applet.DisplayLayout.BOTH;
     },
@@ -31,15 +28,14 @@ MyApplet.prototype = {
 
         this.orientation = neworientation;
 
-	if (this.orientation == St.Side.TOP || this.orientation == St.Side.BOTTOM) {
+        if (this.orientation == St.Side.TOP || this.orientation == St.Side.BOTTOM) {
             if (this._line) {
                 this._line.destroy();
             }
 
             this._line = new St.BoxLayout({ style_class: 'applet-separator-line', reactive: false, track_hover: false});
             this.actor.add(this._line, { y_align: Clutter.ActorAlign.CENTER, x_align: Clutter.ActorAlign.CENTER, y_fill: true, y_expand: true});
-	}
-	else {		// vertical panel
+        } else {
             if (this._line) {
                 this._line.destroy();
             }
@@ -48,7 +44,7 @@ MyApplet.prototype = {
             this.actor.add(this._line, { y_align: Clutter.ActorAlign.CENTER, x_align: Clutter.ActorAlign.CENTER});
 
             this._line.set_height(2);
-            this._line.set_width((this._panelHeight-8));
+            this._line.set_width((this._panelHeight - 8));
         }
     },
 }; 

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -1008,6 +1008,7 @@ MyApplet.prototype = {
             this._volumeControlShown = false;
 
             this._showFixedElements();
+            this.updateLabelVisible();
 
             let appsys = Cinnamon.AppSystem.get_default();
             appsys.connect("installed-changed", Lang.bind(this, this._updateLaunchPlayer));

--- a/files/usr/share/cinnamon/applets/spacer@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/spacer@cinnamon.org/applet.js
@@ -12,6 +12,9 @@ MyApplet.prototype = {
     _init: function(metadata, orientation, panelHeight, instance_id) {
         Applet.IconApplet.prototype._init.call(this, orientation, panelHeight, instance_id);
 
+        this.bin = new St.Bin();
+        this.actor.add(this.bin);
+
         this.settings = new Settings.AppletSettings(this, "spacer@cinnamon.org", this.instance_id);
 
         this.settings.bindProperty(Settings.BindingDirection.IN,  // Setting type
@@ -20,26 +23,29 @@ MyApplet.prototype = {
                                      this.width_changed,  // Callback when value changes
                                      null);               // Optional callback data
 
-        this.panelheight = panelHeight;
+        this.orientation = orientation;
 
-        this.on_orientation_changed(orientation);
-        },
-
-    on_orientation_changed: function(neworientation) {
-
-        this.orientation = neworientation;
         this.width_changed();
     },
 
-    width_changed: function() {
+    on_orientation_changed: function(neworientation) {
+        this.orientation = neworientation;
 
-	if (this.orientation == St.Side.TOP || this.orientation == St.Side.BOTTOM) {
-            this.actor.width = this.width;
-	}
-	else {		// vertical panel
-            this.actor.width = this.panelheight - 4;
-            this.actor.height = this.width;
+        if (this.bin) {
+            this.bin.destroy();
+
+            this.bin = new St.Bin;
+            this.actor.add(this.bin);
+
+            this.width_changed();
         }
+    },
+
+    width_changed: function() {
+        if (this.orientation == St.Side.TOP || this.orientation == St.Side.BOTTOM)
+            this.bin.width = this.width;
+        else
+            this.bin.height = this.width;
     },
 
     on_applet_removed_from_panel: function() {

--- a/files/usr/share/cinnamon/applets/user@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/user@cinnamon.org/applet.js
@@ -144,7 +144,7 @@ MyApplet.prototype = {
             this._userLoadedId = this._user.connect('notify::is_loaded', Lang.bind(this, this._onUserChanged));
             this._userChangedId = this._user.connect('changed', Lang.bind(this, this._onUserChanged));
             this._onUserChanged();
-
+            this.on_orientation_changed(orientation);
         }
         catch (e) {
             global.logError(e);
@@ -186,6 +186,13 @@ MyApplet.prototype = {
     
     on_applet_removed_from_panel: function() {
         this.settings.finalize();
+    },
+
+    on_orientation_changed: function(orientation) {
+        if (orientation == St.Side.LEFT || orientation == St.Side.RIGHT)
+            this.hide_applet_label(true);
+        else
+            this.hide_applet_label(false);
     },
 //
 //override getDisplayLayout to declare that this applet is suitable for both horizontal and

--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
@@ -56,6 +56,7 @@ function WorkspaceGraph(index, applet) {
 
 WorkspaceGraph.prototype = {
     __proto__: WorkspaceButton.prototype,
+
     _init: function(index, applet) {
         WorkspaceButton.prototype._init.call(this, index, applet);
 
@@ -70,12 +71,10 @@ WorkspaceGraph.prototype = {
         this.workspace_size = new Meta.Rectangle();
         this.workspace.get_work_area_all_monitors(this.workspace_size);
         this.sizeRatio = this.workspace_size.width / this.workspace_size.height;
-        let height = applet._panelHeight - 6;;
+        let height = applet._panelHeight - 6;
 
-	if (applet.orientation == St.Side.LEFT || applet.orientation == St.Side.RIGHT)
-	{
+        if (applet.orientation == St.Side.LEFT || applet.orientation == St.Side.RIGHT)
             height = height / this.sizeRatio;
-	}
 
         this.actor.set_size(this.sizeRatio * height, height);
         this.graphArea.set_size(this.sizeRatio * height, height);
@@ -86,12 +85,12 @@ WorkspaceGraph.prototype = {
     },
 
     scale: function (windows_rect, workspace_rect, area_width, area_height) {
-        let scaled_rect    = new Meta.Rectangle();
-        let x_ratio        = area_width / workspace_rect.width;
-        let y_ratio        = area_height / workspace_rect.height;
-        scaled_rect.x      = windows_rect.x * x_ratio;
-        scaled_rect.y      = windows_rect.y * y_ratio;
-        scaled_rect.width  = windows_rect.width * x_ratio;
+        let scaled_rect = new Meta.Rectangle();
+        let x_ratio = area_width / workspace_rect.width;
+        let y_ratio = area_height / workspace_rect.height;
+        scaled_rect.x = windows_rect.x * x_ratio;
+        scaled_rect.y = windows_rect.y * y_ratio;
+        scaled_rect.width = windows_rect.width * x_ratio;
         scaled_rect.height = windows_rect.height * y_ratio;
         return scaled_rect;
     },
@@ -104,10 +103,10 @@ WorkspaceGraph.prototype = {
 
     onRepaint: function(area) {
         try {
-            let graphThemeNode     = this.graphArea.get_theme_node();
+            let graphThemeNode = this.graphArea.get_theme_node();
             let workspaceThemeNode = this.panelApplet.actor.get_theme_node();
-            let height             = this.panelApplet._panelHeight - workspaceThemeNode.get_vertical_padding();
-            let borderWidth        = workspaceThemeNode.get_border_width(St.Side.TOP) + workspaceThemeNode.get_border_width(St.Side.BOTTOM);
+            let height = this.panelApplet._panelHeight - workspaceThemeNode.get_vertical_padding();
+            let borderWidth = workspaceThemeNode.get_border_width(St.Side.TOP) + workspaceThemeNode.get_border_width(St.Side.BOTTOM);
 
             this.graphArea.set_size(this.sizeRatio * height, height - borderWidth);
             let cr = area.get_context();
@@ -131,7 +130,7 @@ WorkspaceGraph.prototype = {
                 let windowBackgroundColor;
                 let windowBorderColor;
                 for (let i = 0; i < windows.length; ++i) {
-                    let metaWindow  = windows[i];
+                    let metaWindow = windows[i];
                     let scaled_rect = this.scale(metaWindow.get_outer_rect(), this.workspace_size, area_width, area_height);
 
                     cr.setLineWidth(1);
@@ -159,9 +158,7 @@ WorkspaceGraph.prototype = {
             }
 
             cr.$dispose();
-        }
-        catch(e)
-        {
+        } catch(e) {
             global.logError(e);
         }
     },
@@ -192,8 +189,8 @@ SimpleButton.prototype = {
             if (applet.orientation == St.Side.TOP || applet.orientation == St.Side.BOTTOM) {
                 this.actor.set_height(applet._panelHeight);
             } else {
-                this.actor.set_height(0.6*applet._panelHeight);  // factors are completely empirical
-                this.actor.set_width(0.9*applet._panelHeight);
+                this.actor.set_height(0.6 * applet._panelHeight);  // factors are completely empirical
+                this.actor.set_width(0.9 * applet._panelHeight);
             }
         }
         let label = new St.Label({ text: (index + 1).toString() });
@@ -223,17 +220,16 @@ MyApplet.prototype = {
 
             let manager;
             if (this.orientation == St.Side.TOP || this.orientation == St.Side.BOTTOM) {
-                manager = new Clutter.BoxLayout( { spacing: 2 * global.ui_scale,
-		                                   homogeneous: true,
-		                                   orientation: Clutter.Orientation.HORIZONTAL });
-            }
-	    else {
-                manager = new Clutter.BoxLayout( { spacing: 2 * global.ui_scale,
-		                                   homogeneous: true,
-		                                   orientation: Clutter.Orientation.VERTICAL });
+                manager = new Clutter.BoxLayout({ spacing: 2 * global.ui_scale,
+                                                  homogeneous: true,
+                                                  orientation: Clutter.Orientation.HORIZONTAL });
+            } else {
+                manager = new Clutter.BoxLayout({ spacing: 2 * global.ui_scale,
+                                                  homogeneous: true,
+                                                  orientation: Clutter.Orientation.VERTICAL });
             }
             this.manager = manager;
-            this.manager_container = new Clutter.Actor( { layout_manager: manager } );
+            this.manager_container = new Clutter.Actor({ layout_manager: manager });
             this.actor.add_actor (this.manager_container);
             this.manager_container.show();
 
@@ -304,10 +300,6 @@ MyApplet.prototype = {
         }
     },
 
-//
-//override getDisplayLayout to declare that this applet is suitable for both horizontal and
-// vertical orientations
-//
     getDisplayLayout: function() {
         return Applet.DisplayLayout.BOTH;
     },
@@ -338,7 +330,9 @@ MyApplet.prototype = {
             this.buttons[i].destroy();
         }
 
-        if (this.display_type == "visual")
+        let isVertical = (this.orientation == St.Side.LEFT || this.orientation == St.Side.RIGHT);
+
+        if (this.display_type == "visual" && !isVertical)
             this.actor.set_style_class_name('workspace-graph');
         else
             this.actor.set_style_class_name('workspace-switcher');
@@ -347,7 +341,7 @@ MyApplet.prototype = {
 
         this.buttons = [];
         for (let i = 0; i < global.screen.n_workspaces; ++i) {
-            if (this.display_type == "visual")
+            if (this.display_type == "visual" && !isVertical)
                 this.buttons[i] = new WorkspaceGraph(i, this);
             else
                 this.buttons[i] = new SimpleButton(i, this);
@@ -357,7 +351,7 @@ MyApplet.prototype = {
         }
 
         this.signals.disconnectAllSignals();
-        if (this.display_type == "visual") {
+        if (this.display_type == "visual" && !isVertical) {
             // In visual mode, keep track of window events to represent them
             this.signals.connect(global.display, "notify::focus-window", this._onFocusChanged);
             this._onFocusChanged();

--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -534,7 +534,7 @@ IconApplet.prototype = {
     _init: function(orientation, panel_height, instance_id) {
         Applet.prototype._init.call(this, orientation, panel_height, instance_id);
 
-	this._applet_icon_box = new St.Bin(); // https://developer.gnome.org/st/stable/StBin.htm
+        this._applet_icon_box = new St.Bin(); // https://developer.gnome.org/st/stable/StBin.htm
 
         this._applet_icon_box.set_fill(true,true);
         this._applet_icon_box.set_alignment(St.Align.MIDDLE,St.Align.MIDDLE);
@@ -630,22 +630,22 @@ IconApplet.prototype = {
 
         switch (icon_type) {
             case St.IconType.FULLCOLOR:
-            this._applet_icon.set_icon_size(this._scaleMode ?
-                                            fullcolor_scaleup :
-                                            DEFAULT_ICON_HEIGHT);
-            this._applet_icon.set_style_class_name('applet-icon');
+                this._applet_icon.set_icon_size(this._scaleMode ?
+                                                fullcolor_scaleup :
+                                                DEFAULT_ICON_HEIGHT);
+                this._applet_icon.set_style_class_name('applet-icon');
             break;
             case St.IconType.SYMBOLIC:
-            this._applet_icon.set_icon_size(this._scaleMode ?
-                                            symb_scaleup :
-                                            -1);
-            this._applet_icon.set_style_class_name('system-status-icon');
+                this._applet_icon.set_icon_size(this._scaleMode ?
+                                                symb_scaleup :
+                                                -1);
+                this._applet_icon.set_style_class_name('system-status-icon');
             break;
             default:
-            this._applet_icon.set_icon_size(this._scaleMode ?
-                                            symb_scaleup :
-                                            -1);
-                                            this._applet_icon.set_style_class_name('system-status-icon');
+                this._applet_icon.set_icon_size(this._scaleMode ?
+                                                symb_scaleup :
+                                                -1);
+                                                this._applet_icon.set_style_class_name('system-status-icon');
         }
     },
 
@@ -687,8 +687,13 @@ TextApplet.prototype = {
                                             track_hover: true, 
                                             style_class: 'applet-label'});
         this._applet_label.clutter_text.ellipsize = Pango.EllipsizeMode.NONE;
-        this.actor.add(this._applet_label, { y_align: St.Align.MIDDLE, 
-                                             y_fill: false });
+
+        this._layoutBin = new St.Bin();
+        this.actor.add(this._layoutBin);
+        this._layoutBin.set_child(this._applet_label);
+
+        this.actor.add(this._layoutBin, { y_align: St.Align.MIDDLE, 
+                                          y_fill: false });
         this.actor.set_label_actor(this._applet_label);
     },
 

--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -152,7 +152,7 @@ Applet.prototype = {
                                         reactive: true,
                                         track_hover: true });
 
-        this.setOrientation_internal(orientation);
+        this.setOrientationInternal(orientation);
     
         this._applet_tooltip = new Tooltips.PanelItemTooltip(this, "", orientation);                                        
         this.actor.connect('button-press-event', Lang.bind(this, this._onButtonPressEvent));  
@@ -170,7 +170,7 @@ Applet.prototype = {
         this._panelLocation = null; 	// Backlink to the panel location our applet is in, set by Cinnamon.
         this._newPanelLocation = null; 	//  Used when moving an applet
         this._applet_enabled = true; 	// Whether the applet is enabled or not (if not it hides in the panel as if it wasn't there)
-	this._orientation = orientation;  // orientation of the panel the applet is on  St.Side.TOP BOTTOM LEFT RIGHT
+        this._orientation = orientation;  // orientation of the panel the applet is on  St.Side.TOP BOTTOM LEFT RIGHT
 
         this._panelHeight = panel_height ? panel_height : 25;
         this.instance_id = instance_id; // Needed by appletSettings
@@ -361,29 +361,22 @@ Applet.prototype = {
     },
 
     /**
-     * setOrientation_internal:
+     * setOrientationInternal:
      * @orientation (St.Side): the orientation
      *
      * Sets the orientation of the St.BoxLayout.
      *
      */
-    setOrientation_internal: function (orientation) {
+    setOrientationInternal: function (orientation) {
 
-        if (orientation == St.Side.LEFT || orientation == St.Side.RIGHT)
-        {
+        if (orientation == St.Side.LEFT || orientation == St.Side.RIGHT) {
             this.actor.add_style_class_name('vertical');
             this.actor.set_important(true);
-            this.actor.set_y_align(Clutter.ActorAlign.FILL);
-            this.actor.set_y_expand(true);
-            this.actor.set_x_align(Clutter.ActorAlign.CENTER);  // making this FILL also aligns to start
+            this.actor.set_vertical(true);
             this.actor.set_x_expand(true);
-        }
-        else {
+        } else {
             this.actor.remove_style_class_name('vertical');
-            this.actor.set_y_align(Clutter.ActorAlign.FILL);
-            this.actor.set_y_expand(true);
-            this.actor.set_x_align(Clutter.ActorAlign.CENTER);
-            this.actor.set_x_expand(false);
+            this.actor.set_vertical(false);
         }
     },
 
@@ -397,7 +390,7 @@ Applet.prototype = {
      */
     setOrientation: function (orientation) {
 
-        this.setOrientation_internal(orientation);
+        this.setOrientationInternal(orientation);
         this.on_orientation_changed(orientation);
         this.emit("orientation-changed", orientation);
         this.finalizeContextMenu();
@@ -654,14 +647,6 @@ IconApplet.prototype = {
                                             -1);
                                             this._applet_icon.set_style_class_name('system-status-icon');
         }
-//        if (this._orientation == St.Side.LEFT || this._orientation == St.Side.RIGHT)
-//        {
-//            let ph = this._panelHeight;   
-//            this.actor.set_clip(0, 0, ph, ph);  // ensure no visible bleeding of the allocation box 
-                                                  // beyond the panel,  e.g. on hover
-//        }
-
-
     },
 
     on_panel_height_changed: function() {
@@ -788,6 +773,21 @@ TextIconApplet.prototype = {
                 this._applet_icon.visible = enabled;
             }
         }
+    },
+
+    /**
+     * hide_applet_label:
+     * @hide (boolean): whether the applet label is hidden or not
+     *
+     * Sets whether the applets label is hidden or not. A convenience
+     * function to hide applet labels when an applet is placed in a vertical
+     * panel
+     */
+    hide_applet_label: function (hide) {
+        if (hide)
+            this._applet_label.hide();
+        else
+            this._applet_label.show();
     },
 
     /**

--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -756,7 +756,6 @@ TextIconApplet.prototype = {
      * Sets the text of the actor to @text
      */
     set_applet_label: function (text) {
-
         this._applet_label.set_text(text);
         if ((text && text != "") && this._applet_icon_box.child &&
             (this._orientation == St.Side.TOP || this._orientation == St.Side.BOTTOM)) {
@@ -800,6 +799,8 @@ TextIconApplet.prototype = {
             this._applet_label.show();
             this._layoutBin.show();
         }
+
+        this.set_applet_label(this._applet_label.get_text());
     },
 
     /**

--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -624,9 +624,9 @@ IconApplet.prototype = {
 
     _setStyle: function() {
 
-        let symb_scaleup 	= ((this._panelHeight / DEFAULT_PANEL_HEIGHT) * PANEL_SYMBOLIC_ICON_DEFAULT_HEIGHT) / global.ui_scale;
-        let fullcolor_scaleup 	= this._panelHeight * COLOR_ICON_HEIGHT_FACTOR / global.ui_scale;
-        let icon_type 		= this._applet_icon.get_icon_type();
+        let symb_scaleup = ((this._panelHeight / DEFAULT_PANEL_HEIGHT) * PANEL_SYMBOLIC_ICON_DEFAULT_HEIGHT) / global.ui_scale;
+        let fullcolor_scaleup = this._panelHeight * COLOR_ICON_HEIGHT_FACTOR / global.ui_scale;
+        let icon_type = this._applet_icon.get_icon_type();
 
         switch (icon_type) {
             case St.IconType.FULLCOLOR:
@@ -689,7 +689,6 @@ TextApplet.prototype = {
         this._applet_label.clutter_text.ellipsize = Pango.EllipsizeMode.NONE;
 
         this._layoutBin = new St.Bin();
-        this.actor.add(this._layoutBin);
         this._layoutBin.set_child(this._applet_label);
 
         this.actor.add(this._layoutBin, { y_align: St.Align.MIDDLE, 
@@ -741,8 +740,12 @@ TextIconApplet.prototype = {
                                             track_hover: true, 
                                             style_class: 'applet-label'});
         this._applet_label.clutter_text.ellipsize = Pango.EllipsizeMode.NONE;
-        this.actor.add(this._applet_label, { y_align: St.Align.MIDDLE, 
-                                             y_fill: false });
+
+        this._layoutBin = new St.Bin();
+        this._layoutBin.set_child(this._applet_label);
+
+        this.actor.add(this._layoutBin, { y_align: St.Align.MIDDLE, 
+                                          y_fill: false });
         this.actor.set_label_actor(this._applet_label);
     },
 
@@ -755,7 +758,8 @@ TextIconApplet.prototype = {
     set_applet_label: function (text) {
 
         this._applet_label.set_text(text);
-        if ((text && text != "") && this._applet_icon_box.child) {
+        if ((text && text != "") && this._applet_icon_box.child &&
+            (this._orientation == St.Side.TOP || this._orientation == St.Side.BOTTOM)) {
             this._applet_label.set_margin_left(6.0);
         }
         else {
@@ -789,10 +793,13 @@ TextIconApplet.prototype = {
      * panel
      */
     hide_applet_label: function (hide) {
-        if (hide)
+        if (hide) {
             this._applet_label.hide();
-        else
+            this._layoutBin.hide();
+        } else {
             this._applet_label.show();
+            this._layoutBin.show();
+        }
     },
 
     /**

--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -161,26 +161,26 @@ Applet.prototype = {
         this._applet_context_menu = new AppletContextMenu(this, orientation);
         this._menuManager.addMenu(this._applet_context_menu);     
 
-        this.actor._applet = this; 	// Backlink to get the applet from its actor 
-					//(handy when we want to know stuff about a particular applet within the panel)
+        this.actor._applet = this;  // Backlink to get the applet from its actor 
+                                    // (handy when we want to know stuff about a particular applet within the panel)
         this.actor._delegate = this;
-        this._order = 0; 		// Defined in gsettings, this is the order of the applet within a panel location. 
-			 		// This value is set by Cinnamon when loading/listening_to gsettings.
-        this._newOrder = null; 		//  Used when moving an applet
-        this._panelLocation = null; 	// Backlink to the panel location our applet is in, set by Cinnamon.
-        this._newPanelLocation = null; 	//  Used when moving an applet
-        this._applet_enabled = true; 	// Whether the applet is enabled or not (if not it hides in the panel as if it wasn't there)
+        this._order = 0;        // Defined in gsettings, this is the order of the applet within a panel location. 
+                                // This value is set by Cinnamon when loading/listening_to gsettings.
+        this._newOrder = null;      //  Used when moving an applet
+        this._panelLocation = null;     // Backlink to the panel location our applet is in, set by Cinnamon.
+        this._newPanelLocation = null;  //  Used when moving an applet
+        this._applet_enabled = true;    // Whether the applet is enabled or not (if not it hides in the panel as if it wasn't there)
         this._orientation = orientation;  // orientation of the panel the applet is on  St.Side.TOP BOTTOM LEFT RIGHT
 
         this._panelHeight = panel_height ? panel_height : 25;
         this.instance_id = instance_id; // Needed by appletSettings
-        this._uuid = null; 		// Defined in gsettings, set by Cinnamon.
-        this._hook = null; 		// Defined in metadata.json, set by appletManager
-        this._meta = null; 		// set by appletManager
+        this._uuid = null;      // Defined in gsettings, set by Cinnamon.
+        this._hook = null;      // Defined in metadata.json, set by appletManager
+        this._meta = null;      // set by appletManager
         this._dragging = false;                
         this._draggable = DND.makeDraggable(this.actor);
         this._draggable.connect('drag-begin', Lang.bind(this, this._onDragBegin));
-    	this._draggable.connect('drag-cancelled', Lang.bind(this, this._onDragCancelled));
+        this._draggable.connect('drag-cancelled', Lang.bind(this, this._onDragCancelled));
         this._draggable.connect('drag-end', Lang.bind(this, this._onDragEnd));        
 
         try {
@@ -254,9 +254,9 @@ Applet.prototype = {
                     this.on_applet_clicked(event);
                 }
             }
-            if (event.get_button()==3){            
+            if (event.get_button() == 3) {            
                 if (this._applet_context_menu._getMenuItems().length > 0) {
-                    this._applet_context_menu.toggle();			
+                    this._applet_context_menu.toggle();         
                 }
             }
         }
@@ -368,7 +368,6 @@ Applet.prototype = {
      *
      */
     setOrientationInternal: function (orientation) {
-
         if (orientation == St.Side.LEFT || orientation == St.Side.RIGHT) {
             this.actor.add_style_class_name('vertical');
             this.actor.set_important(true);
@@ -389,7 +388,6 @@ Applet.prototype = {
      * This function should only be called by appletManager
      */
     setOrientation: function (orientation) {
-
         this.setOrientationInternal(orientation);
         this.on_orientation_changed(orientation);
         this.emit("orientation-changed", orientation);
@@ -750,6 +748,23 @@ TextIconApplet.prototype = {
     },
 
     /**
+     * update_label_margin:
+     *
+     * Sets a margin between the icon and the label when it contains a non
+     * empty string. The margin is always set to zero in a vertical panel
+     */
+    update_label_margin: function () {
+        let text = this._applet_label.get_text()
+
+        if ((text && text != "") && this._applet_icon_box.child &&
+            (this._orientation == St.Side.TOP || this._orientation == St.Side.BOTTOM)) {
+            this._applet_label.set_margin_left(6.0);
+        } else {
+            this._applet_label.set_margin_left(0);
+        }
+    },
+
+    /**
      * set_applet_label:
      * @text (string): text to be displayed at the label
      * 
@@ -757,13 +772,7 @@ TextIconApplet.prototype = {
      */
     set_applet_label: function (text) {
         this._applet_label.set_text(text);
-        if ((text && text != "") && this._applet_icon_box.child &&
-            (this._orientation == St.Side.TOP || this._orientation == St.Side.BOTTOM)) {
-            this._applet_label.set_margin_left(6.0);
-        }
-        else {
-            this._applet_label.set_margin_left(0);
-        }
+        this.update_label_margin();
     },
 
     /**
@@ -800,7 +809,7 @@ TextIconApplet.prototype = {
             this._layoutBin.show();
         }
 
-        this.set_applet_label(this._applet_label.get_text());
+        this.update_label_margin();
     },
 
     /**


### PR DESCRIPTION
Fix the layout of applets on vertical panels. Currently in a vertical panel the container widget holding our applet actors does not properly fit to the full width of a vertical panel the way it does the height of a horizontal panel. This is really obvious in themes such as Mint-Y that color a filled box on applets when hovered. Applets are depending on this small box to clip the items it doesn't want the applet to show in vertical panels such as text labels. Because of that, fixing the layout of the applets also required adapting some of the individual applets to work properly when moving them between different panel orientations.

Since I went through a lot of the applets individually I also cleaned up some of the code formatting issues in those applets.

Some applets could use further, more involved, fixes. The visual style workspace switcher is currently not allowed in vertical panels because in many cases it leaves you with something unusable. There may be ways to get around it but would require some changes to how it's drawn. The calendar applet could probably be done better as well. It is currently hard coded to a single format in vertical panels because of limitations to what can fit.