### PR TITLE
xlet settings: Replace old binding function in settings.js with two n…

### DIFF
--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
@@ -89,8 +89,8 @@ MyApplet.prototype = {
             // Track changes to clock settings
             this._dateFormatFull = _("%A %B %e, %Y");
 
-            this.settings.bindProperty(Settings.BindingDirection.IN, "use-custom-format", "use_custom_format", this.on_settings_changed, null);
-            this.settings.bindProperty(Settings.BindingDirection.IN, "custom-format", "custom_format", this.on_settings_changed, null);        
+            this.settings.bind("use-custom-format", "use_custom_format", this.on_settings_changed);
+            this.settings.bind("custom-format", "custom_format", this.on_settings_changed);
 
             // Track changes to date&time settings
             this.datetime_settings = new Gio.Settings({ schema_id: "org.cinnamon.desktop.interface" });

--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/calendar.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/calendar.js
@@ -151,10 +151,9 @@ Calendar.prototype = {
         this._digitWidth = NaN;
         this.settings = settings;
 
-        this.settings.connect("changed::show-week-numbers", Lang.bind(this, this._onSettingsChange));
+        this.settings.bindWithObject(this, "show-week-numbers", "show_week_numbers", this._onSettingsChange);
         this.desktop_settings = new Gio.Settings({ schema_id: DESKTOP_SCHEMA });
         this.desktop_settings.connect("changed::" + FIRST_WEEKDAY_KEY, Lang.bind(this, this._onSettingsChange));
-        this.show_week_numbers = this.settings.getValue("show-week-numbers");
 
         // Find the ordering for month/year in the calendar heading
 
@@ -186,14 +185,7 @@ Calendar.prototype = {
     },
 
     _onSettingsChange: function(object, key, old_val, new_val) {
-        switch (key) {
-	    case SHOW_WEEKDATE_KEY:
-		this.show_week_numbers = new_val;
-		break;
-	    case FIRST_WEEKDAY_KEY:
-		this._weekStart = Cinnamon.util_get_week_start();
-		break;
-	}
+        if (key == FIRST_WEEKDAY_KEY) this._weekStart = Cinnamon.util_get_week_start();
         this._buildHeader();
         this._update(false);
     },

--- a/files/usr/share/cinnamon/applets/expo@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/expo@cinnamon.org/applet.js
@@ -20,10 +20,7 @@ MyApplet.prototype = {
 
             this.settings = new Settings.AppletSettings(this, metadata["uuid"], this.instance_id);
 
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                                       "activate-on-hover",
-                                       "_hover_activates",
-                                       function () {});
+            this.settings.bind("activate-on-hover", "_hover_activates");
 
             this.actor.connect('enter-event', Lang.bind(this, this._onEntered));
         }

--- a/files/usr/share/cinnamon/applets/keyboard@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/keyboard@cinnamon.org/applet.js
@@ -59,16 +59,8 @@ MyApplet.prototype = {
 
             this.settings = new Settings.AppletSettings(this, metadata["uuid"], this.instance_id);
 
-            this.settings.bindProperty(Settings.BindingDirection.BIDIRECTIONAL,
-                                       "use-letters",
-                                       "_showLetters",
-                                       this._syncConfig,
-                                       null);
-            this.settings.bindProperty(Settings.BindingDirection.BIDIRECTIONAL,
-                                       "use-uppercase",
-                                       "_useUpperCase",
-                                       this._syncConfig,
-                                       null);
+            this.settings.bindProperty("use-letters", "_showLetters", this._syncConfig);
+            this.settings.bindProperty("use-uppercase", "_useUpperCase", this._syncConfig);
 
             this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
             this.menu.addAction(_("Show Keyboard Layout"), Lang.bind(this, function() {

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1106,26 +1106,26 @@ MyApplet.prototype = {
 
         this.settings = new Settings.AppletSettings(this, "menu@cinnamon.org", instance_id);
 
-        this.settings.bindProperty(Settings.BindingDirection.IN, "show-places", "showPlaces", this._refreshBelowApps, null);
+        this.settings.bind("show-places", "showPlaces", this._refreshBelowApps);
 
         this._appletEnterEventId = 0;
         this._appletLeaveEventId = 0;
         this._appletHoverDelayId = 0;
 
-        this.settings.bindProperty(Settings.BindingDirection.IN, "hover-delay", "hover_delay_ms", this._updateActivateOnHover, null);
-        this.settings.bindProperty(Settings.BindingDirection.IN, "activate-on-hover", "activateOnHover", this._updateActivateOnHover, null);
+        this.settings.bind("hover-delay", "hover_delay_ms", this._updateActivateOnHover);
+        this.settings.bind("activate-on-hover", "activateOnHover", this._updateActivateOnHover);
         this._updateActivateOnHover();
 
         this.menu.actor.add_style_class_name('menu-background');
         this.menu.connect('open-state-changed', Lang.bind(this, this._onOpenStateChanged));
 
-        this.settings.bindProperty(Settings.BindingDirection.IN, "menu-icon-custom", "menuIconCustom", this._updateIconAndLabel, null);
-        this.settings.bindProperty(Settings.BindingDirection.IN, "menu-icon", "menuIcon", this._updateIconAndLabel, null);
-        this.settings.bindProperty(Settings.BindingDirection.IN, "menu-label", "menuLabel", this._updateIconAndLabel, null);
-        this.settings.bindProperty(Settings.BindingDirection.IN, "overlay-key", "overlayKey", this._updateKeybinding, null);
-        this.settings.bindProperty(Settings.BindingDirection.IN, "show-category-icons", "showCategoryIcons", this._refreshAll, null);
-        this.settings.bindProperty(Settings.BindingDirection.IN, "show-application-icons", "showApplicationIcons", this._refreshAll, null);
-        this.settings.bindProperty(Settings.BindingDirection.IN, "favbox-show", "favBoxShow", this._favboxtoggle, null);
+        this.settings.bind("menu-icon-custom", "menuIconCustom", this._updateIconAndLabel);
+        this.settings.bind("menu-icon", "menuIcon", this._updateIconAndLabel);
+        this.settings.bind("menu-label", "menuLabel", this._updateIconAndLabel);
+        this.settings.bind("overlay-key", "overlayKey", this._updateKeybinding);
+        this.settings.bind("show-category-icons", "showCategoryIcons", this._refreshAll);
+        this.settings.bind("show-application-icons", "showApplicationIcons", this._refreshAll);
+        this.settings.bind("favbox-show", "favBoxShow", this._favboxtoggle);
 
         this._updateKeybinding();
 
@@ -1171,7 +1171,7 @@ MyApplet.prototype = {
         this._pathCompleter = new Gio.FilenameCompleter();
         this._pathCompleter.set_dirs_only(false);
         this.lastAcResults = new Array();
-        this.settings.bindProperty(Settings.BindingDirection.IN, "search-filesystem", "searchFilesystem", null, null);
+        this.settings.bind("search-filesystem", "searchFilesystem");
         this.refreshing = false; // used as a flag to know if we're currently refreshing (so we don't do it more than once concurrently)
 
         // We shouldn't need to call refreshAll() here... since we get a "icon-theme-changed" signal when CSD starts.
@@ -2260,7 +2260,7 @@ MyApplet.prototype = {
 
         this._updateVFade();
 
-        this.settings.bindProperty(Settings.BindingDirection.IN, "enable-autoscroll", "autoscroll_enabled", this._update_autoscroll, null);
+        this.settings.bind("enable-autoscroll", "autoscroll_enabled", this._update_autoscroll);
         this._update_autoscroll();
 
         let vscroll = this.applicationsScrollBox.get_vscroll_bar();

--- a/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
@@ -24,8 +24,8 @@ MyApplet.prototype = {
 
         // Settings
         this.settings = new Settings.AppletSettings(this, metadata.uuid, instanceId);
-        this.settings.bindProperty(Settings.BindingDirection.IN, "ignoreTransientNotifications", "ignoreTransientNotifications", null, null);
-        this.settings.bindProperty(Settings.BindingDirection.IN, "showEmptyTray", "showEmptyTray", this._show_hide_tray, null);
+        this.settings.bind("ignoreTransientNotifications", "ignoreTransientNotifications");
+        this.settings.bind("showEmptyTray", "showEmptyTray", this._show_hide_tray);
 
         // Layout
         this._orientation = orientation;

--- a/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
@@ -320,14 +320,8 @@ MyApplet.prototype = {
         }
 
         this.settings = new Settings.AppletSettings(this, metadata.uuid, instance_id);
-        this.settings.bindProperty(Settings.BindingDirection.BIDIRECTIONAL,
-                                   "launcherList",
-                                   "launcherList",
-                                   this._onSettingsChanged, null);
-        this.settings.bindProperty(Settings.BindingDirection.IN,
-                                   "allow-dragging",
-                                   "allowDragging",
-                                   this._updateLauncherDrag, null);
+        this.settings.bind("launcherList", "launcherList", this._onSettingsChanged);
+        this.settings.bind("allow-dragging", "allowDragging", this._updateLauncherDrag);
 
         this.uuid = metadata.uuid;
 

--- a/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
@@ -287,7 +287,7 @@ MyApplet.prototype = {
 
             this._proxy.connect("g-properties-changed", Lang.bind(this, this._devicesChanged));
             global.settings.connect('changed::device-aliases', Lang.bind(this, this._on_device_aliases_changed));
-            this.settings.bindProperty(Settings.BindingDirection.IN, "labelinfo", "labelinfo", Lang.bind(this, this._devicesChanged), null);
+            this.settings.bind("labelinfo", "labelinfo", this._devicesChanged);
 
             this._devicesChanged();
         }));

--- a/files/usr/share/cinnamon/applets/scale@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/scale@cinnamon.org/applet.js
@@ -20,10 +20,7 @@ MyApplet.prototype = {
 
             this.settings = new Settings.AppletSettings(this, metadata["uuid"], this.instance_id);
 
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                                       "activate-on-hover",
-                                       "_hover_activates",
-                                       function () {});
+            this.settings.bind("activate-on-hover", "_hover_activates");
 
             this.actor.connect('enter-event', Lang.bind(this, this._onEntered));
         }

--- a/files/usr/share/cinnamon/applets/settings-example@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/settings-example@cinnamon.org/applet.js
@@ -26,51 +26,19 @@ MyApplet.prototype = {
 
         /* Now we'll proceed with setting up individual setting bindings. */
 
-        this.settings.bindProperty(Settings.BindingDirection.IN,   // The binding direction - IN means we only listen for changes from this applet
-                                 "icon-name",                               // The setting key, from the setting schema file
-                                 "icon_name",                               // The property to bind the setting to - in this case it will initialize this.icon_name to the setting value
-                                 this.on_settings_changed,                  // The method to call when this.icon_name has changed, so you can update your applet
-                                 null);                                     // Any extra information you want to pass to the callback (optional - pass null or just leave out this last argument)
-        this.settings.bindProperty(Settings.BindingDirection.IN,
-                                 "color",
-                                 "bg_color",
-                                 this.on_settings_changed,
-                                 null);
-        this.settings.bindProperty(Settings.BindingDirection.IN,
-                                 "spinner-number",
-                                 "spinner_number",
-                                 this.on_settings_changed,
-                                 null);
-        this.settings.bindProperty(Settings.BindingDirection.IN,
-                                 "combo-selection",
-                                 "combo_choice",
-                                 this.on_settings_changed,
-                                 null);
-        this.settings.bindProperty(Settings.BindingDirection.BIDIRECTIONAL, // BIDIRECTIONAL means the applet will listen
-                                 "scale-demo",                                  // for changes to the stored setting, AND the
-                                 "scale_val",                                   // settings daemon will listen for changes made
-                                 this.on_settings_changed,                      // to this.scale_val by the APPLET
-                                 null);
-        this.settings.bindProperty(Settings.BindingDirection.IN,
-                                  "use-custom-label",
-                                  "use_custom",
-                                  this.on_settings_changed,
-                                  null);
-        this.settings.bindProperty(Settings.BindingDirection.IN,
-                                 "custom-label",
-                                 "custom_label",
-                                 this.on_settings_changed,
-                                 null);
-        this.settings.bindProperty(Settings.BindingDirection.IN,
-                                 "tween-function",
-                                 "tween_function",
-                                 this.on_settings_changed,
-                                 null);
-        this.settings.bindProperty(Settings.BindingDirection.IN,
-                                 "keybinding-test",
-                                 "keybinding",
-                                 this.on_keybinding_changed,
-                                 null);
+        this.settings.bind("icon-name",                // The setting key, from the setting schema file
+                           "icon_name",                // The property to bind the setting to - in this case it will initialize this.icon_name to the setting value
+                           this.on_settings_changed,   // The method to call when this.icon_name has changed, so you can update your applet
+                           null);                      // Any extra information you want to pass to the callback (optional - pass null or just leave out this last argument)
+
+        this.settings.bind("scale-demo", "scale_val", this.on_settings_changed);
+        this.settings.bind("color", "bg_color", this.on_settings_changed);
+        this.settings.bind("spinner-number", "spinner_number", this.on_settings_changed);
+        this.settings.bind("combo-selection", "combo_choice", this.on_settings_changed);
+        this.settings.bind("use-custom-label",  "use_custom", this.on_settings_changed);
+        this.settings.bind("custom-label", "custom_label", this.on_settings_changed);
+        this.settings.bind("tween-function", "tween_function", this.on_settings_changed);
+        this.settings.bind("keybinding-test", "keybinding", this.on_keybinding_changed);
 
         this.settings.connect("changed::signal-test", Lang.bind(this, this.on_signal_test_fired));
 

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -875,26 +875,26 @@ MyApplet.prototype = {
             this.metadata = metadata;
             this.orientation = orientation;
             this.settings = new Settings.AppletSettings(this, metadata.uuid, instanceId);
-            this.settings.bindProperty(Settings.BindingDirection.IN, "showtrack", "showtrack", this.on_settings_changed, null);
-            this.settings.bindProperty(Settings.BindingDirection.IN, "middleClickAction", "middleClickAction");
-            this.settings.bindProperty(Settings.BindingDirection.IN, "showalbum", "showalbum", this.on_settings_changed, null);
-            this.settings.bindProperty(Settings.BindingDirection.IN, "truncatetext", "truncatetext", this.on_settings_changed, null);
-            this.settings.bindProperty(Settings.BindingDirection.IN, "hideSystray", "hideSystray", function() {
+            this.settings.bind("showtrack", "showtrack", this.on_settings_changed);
+            this.settings.bind("middleClickAction", "middleClickAction");
+            this.settings.bind("showalbum", "showalbum", this.on_settings_changed);
+            this.settings.bind("truncatetext", "truncatetext", this.on_settings_changed);
+            this.settings.bind("hideSystray", "hideSystray", function() {
                 if (this.hideSystray) this.registerSystrayIcons();
                 else this.unregisterSystrayIcons();
             });
 
-            this.settings.bindProperty(Settings.BindingDirection.IN, "playerControl", "playerControl", this.on_settings_changed);
-            this.settings.bindProperty(Settings.BindingDirection.IN, "extendedPlayerControl", "extendedPlayerControl", function(){
+            this.settings.bind("playerControl", "playerControl", this.on_settings_changed);
+            this.settings.bind("extendedPlayerControl", "extendedPlayerControl", function(){
                 for(let i in this._players)
                     this._players[i].onSettingsChanged();
             });
-            this.settings.bindProperty(Settings.BindingDirection.IN, "positionLabelType", "positionLabelType", function(){
+            this.settings.bind("positionLabelType", "positionLabelType", function(){
                 for(let i in this._players)
                     this._players[i].onSettingsChanged();
             });
 
-            this.settings.bindProperty(Settings.BindingDirection.OUT, "_knownPlayers", "_knownPlayers");
+            this.settings.bind("_knownPlayers", "_knownPlayers");
             if (this.hideSystray) this.registerSystrayIcons();
 
             this.menuManager = new PopupMenu.PopupMenuManager(this);

--- a/files/usr/share/cinnamon/applets/spacer@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/spacer@cinnamon.org/applet.js
@@ -17,11 +17,7 @@ MyApplet.prototype = {
 
         this.settings = new Settings.AppletSettings(this, "spacer@cinnamon.org", this.instance_id);
 
-        this.settings.bindProperty(Settings.BindingDirection.IN,  // Setting type
-                                     "width",             // The setting key
-                                     "width",             // The property to manage (this.width)
-                                     this.width_changed,  // Callback when value changes
-                                     null);               // Optional callback data
+        this.settings.bind("width", "width", this.width_changed);
 
         this.orientation = orientation;
 

--- a/files/usr/share/cinnamon/applets/user@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/user@cinnamon.org/applet.js
@@ -42,7 +42,7 @@ MyApplet.prototype = {
 
             this._userIcon = new St.Bin({ style_class: 'user-icon'});
             
-            this.settings.bindProperty(Settings.BindingDirection.IN, "display-name", "disp_name", this._updateLabel, null);
+            this.settings.bind("display-name", "disp_name", this._updateLabel);
 
             userBox.connect('button-press-event', Lang.bind(this, function() {
                 this.menu.toggle();

--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -949,32 +949,12 @@ MyApplet.prototype = {
 
         this.settings = new Settings.AppletSettings(this, "window-list@cinnamon.org", this.instance_id);
 
-        this.settings.bindProperty(Settings.BindingDirection.IN,
-                "enable-alerts",
-                "enableAlerts",
-                this._updateAttentionGrabber,
-                null);
-        this.settings.bindProperty(Settings.BindingDirection.IN,
-                "enable-scrolling",
-                "scrollable",
-                this._onEnableScrollChanged,
-                null);
-        this.settings.bindProperty(Settings.BindingDirection.IN,
-                "reverse-scrolling",
-                "reverseScroll",
-                null, null);
-        this.settings.bindProperty(Settings.BindingDirection.IN,
-                "middle-click-close",
-                "middleClickClose",
-                null, null);
-        this.settings.bindProperty(Settings.BindingDirection.IN,
-                "buttons-use-entire-space",
-                "buttonsUseEntireSpace",
-                this._refreshItems, null);
-        this.settings.bindProperty(Settings.BindingDirection.IN,
-                "window-preview",
-                "usePreview",
-                this._onPreviewChanged, null);
+        this.settings.bind("enable-alerts", "enableAlerts", this._updateAttentionGrabber);
+        this.settings.bind("enable-scrolling", "scrollable", this._onEnableScrollChanged);
+        this.settings.bind("reverse-scrolling", "reverseScroll");
+        this.settings.bind("middle-click-close", "middleClickClose");
+        this.settings.bind("buttons-use-entire-space", "buttonsUseEntireSpace", this._refreshItems);
+        this.settings.bind("window-preview", "usePreview", this._onPreviewChanged);
 
         this.signals = new SignalManager.SignalManager(this);
 

--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
@@ -234,7 +234,7 @@ MyApplet.prototype = {
             this.manager_container.show();
 
             this.settings = new Settings.AppletSettings(this, metadata.uuid, instance_id);
-            this.settings.bindProperty(Settings.BindingDirection.IN, "display_type", "display_type", Lang.bind(this, this._createButtons), null);
+            this.settings.bind("display_type", "display_type", this._createButtons);
 
             this.actor.connect('scroll-event', this.hook.bind(this));
 

--- a/files/usr/share/cinnamon/desklets/clock@cinnamon.org/desklet.js
+++ b/files/usr/share/cinnamon/desklets/clock@cinnamon.org/desklet.js
@@ -23,14 +23,10 @@ MyDesklet.prototype = {
         this.clock = new CinnamonDesktop.WallClock();
 
         this.settings = new Settings.DeskletSettings(this, this.metadata["uuid"], desklet_id);
-
-        this.settings.bindProperty(Settings.BindingDirection.IN, "date-format", "format", function() {}, null);
-
-        this.settings.bindProperty(Settings.BindingDirection.IN, "font-size", "size", this._onSettingsChanged, null);
-        
-        this.settings.bindProperty(Settings.BindingDirection.IN, "text-color", "color", this._onSettingsChanged, null);
-        
-        this.settings.bindProperty(Settings.BindingDirection.IN, "use-custom-format", "use_custom_format", this._onSettingsChanged, null);
+        this.settings.bind("date-format", "format");
+        this.settings.bind("font-size", "size", this._onSettingsChanged);
+        this.settings.bind("text-color", "color", this._onSettingsChanged);
+        this.settings.bind("use-custom-format", "use_custom_format", this._onSettingsChanged);
         
         this._menu.addSettingsAction(_("Date and Time Settings"), "calendar")
 

--- a/files/usr/share/cinnamon/desklets/photoframe@cinnamon.org/desklet.js
+++ b/files/usr/share/cinnamon/desklets/photoframe@cinnamon.org/desklet.js
@@ -25,48 +25,13 @@ MyDesklet.prototype = {
 
         try {
             this.settings = new Settings.DeskletSettings(this, this.metadata["uuid"], this.instance_id);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                                     "directory",
-                                     "dir",
-                                     this.on_setting_changed,
-                                     null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                                      "shuffle",
-                                      "shuffle",
-                                      this.on_setting_changed,
-                                      null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                                     "delay",
-                                     "delay",
-                                     this.on_setting_changed,
-                                     null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                                     "height",
-                                     "height",
-                                     this.on_setting_changed,
-                                     null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                                     "width",
-                                     "width",
-                                     this.on_setting_changed,
-                                     null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                                     "fade-delay",
-                                     "fade_delay",
-                                     this.on_setting_changed,
-                                     null);
-
-            this.settings.bindProperty(Settings.BindingDirection.IN,
-                                     "effect",
-                                     "effect",
-                                     this.on_setting_changed,
-                                     null);
+            this.settings.bind("directory", "dir", this.on_setting_changed);
+            this.settings.bind("shuffle",  "shuffle", this.on_setting_changed);
+            this.settings.bind("delay", "delay", this.on_setting_changed);
+            this.settings.bind("height", "height", this.on_setting_changed);
+            this.settings.bind("width", "width", this.on_setting_changed);
+            this.settings.bind("fade-delay", "fade_delay", this.on_setting_changed);
+            this.settings.bind("effect", "effect", this.on_setting_changed);
         } catch (e) {
             global.logError(e);
         }


### PR DESCRIPTION
…ew ones and allow multiple bindings on the same key (take 2)

The primary reason for this is that the binding direction is no longer meaningful internally due to the use of javascript properties rather than using a watch function. In addition, there are many instances where it is preferable to bind a key to a different object than the rest, and even to multiple objects.

In its place are two new functions:
* 'bind' works basically the same as 'bindProperty' did, but without the need to pass a binding direction as the first argument.
* 'bindWithObject' works identically to 'bind' but allows the caller to specify the object to which the property will be bound.

Three new functions were also added to unbind keys:
* 'unbind' removes a binding on the bind object passed to the settings object on initialization.
* 'unbindWithObject' removes a binding to a specific object (usually when bound using 'bindWithObject'.
* 'unbindAll' removes all bindings on a single key.

'bindProperty' and 'unbindProperty' are now considered deprecated. They still work as wrappers around 'bind' and 'unbind' respectively, but it is recommended that 'bind', 'bindWithObject', 'unbind', 'unbindWithObject', and 'unbindAll' be used in newer code.

The system applets and desklets were updated to reflect these changes.