### PR TITLE
write-applet.xml: fix incorrect example code

### DIFF
--- a/docs/reference/cinnamon-tutorials/write-applet.xml
+++ b/docs/reference/cinnamon-tutorials/write-applet.xml
@@ -106,7 +106,7 @@
             },
 
             on_applet_clicked: function() {
-                Util.spawn('xkill');
+                Util.spawn(['xkill']);
             }
         };
 
@@ -199,7 +199,7 @@
             },
 
             on_applet_clicked: function() {
-                Util.spawn('xkill');
+                Util.spawn(['xkill']);
             }
         };
       </programlisting>
@@ -264,7 +264,7 @@
     <informalexample>
       <programlisting>
         on_applet_clicked: function() {
-            Util.spawn('xkill');
+            Util.spawn(['xkill']);
         }
       </programlisting>
     </informalexample>


### PR DESCRIPTION
The argv parameter of the spawn function in utils.js needs to be an array of strings.