### PR TITLE
correct applet context menu on panel orientation move

### DIFF
--- a/js/ui/boxpointer.js
+++ b/js/ui/boxpointer.js
@@ -146,6 +146,7 @@ BoxPointer.prototype = {
         // Need not trigger any other function. Menu position is
         // recalculated every time it is shown
         this._arrowSide = side;
+        this._userArrowSide = side;
     },
 
     _adjustAllocationForArrow: function(isWidth, alloc) {


### PR DESCRIPTION
Thanks @lestcape

Solves an issue where the applet context menu gets deformed when moving a panel between orientations.