### PR TITLE
Fix grammar mistakes in source files

### DIFF
--- a/docs/reference/cinnamon-tutorials/importer.xml
+++ b/docs/reference/cinnamon-tutorials/importer.xml
@@ -1,9 +1,9 @@
 <chapter id="importer">
   <title>The Importer</title>
-  <para>To access code of other JavaScript files, cjs has got the <code>imports</code> object.</para>
+  <para>To access code of other JavaScript files, cjs has the <code>imports</code> object.</para>
 
   <para>
-    In cjs in combination of Cinnamon you can use following statements to import statements:
+    In cjs in combination with Cinnamon you can use following statements to import statements:
 
     <informalexample>
       <programlisting>
@@ -26,7 +26,7 @@
     </para>
 
     <para>
-      To clearify, an example:
+      To clarify, an example:
       <informalexample>
         <programlisting>
           //Direct access to file a.js
@@ -60,7 +60,7 @@
 
     <para>
       In every case, you can include cjs core modules.
-      Those provides you useful functions or (less often) bindings to C libraries.
+      Those provide you useful functions or (less often) bindings to C libraries.
     </para>
 
     <para>
@@ -83,11 +83,11 @@
   <sect2>
     <title><code>imports.gi.*</code></title>
 
-    <para>As Cinnamon uses C libraries like Clutter, Muffin and more, there is a little problem: How can be those libraries used in cjs?</para>
+    <para>As Cinnamon uses C libraries like Clutter, Muffin and more, there is a little problem: How can those libraries be used in cjs?</para>
 
     <para>
       For this, there is <ulink role="online-location" url="https://wiki.gnome.org/Projects/GObjectIntrospection">GObject Introspection</ulink>.
-      For short, it allows you to use C libraries in cjs, Python and other languages.
+      In short, it allows you to use C libraries in cjs, Python and other languages.
     </para>
 
     <para>
@@ -124,7 +124,7 @@
   <sect2>
     <title><code>imports.misc.*</code></title>
 
-    <para>Those imports under <code>imports.misc.*</code> are belonging to Cinnamon, but aren't tied to it that much like <code>imports.ui.*</code>.</para>
+    <para>Those imports under <code>imports.misc.*</code> belong to Cinnamon, but aren't tied to it as much as <code>imports.ui.*</code>.</para>
 
     <para>
       <informalexample>
@@ -143,7 +143,7 @@
 
     <para>
       When you want to split a big xlet code into smaller files, you'll need to import them.
-      A simple way is using <code>imports.xlet</code>, wher <code>xlet</code> is your xlet type
+      A simple way is using <code>imports.xlet</code>, where <code>xlet</code> is your xlet type
       (<code>applet</code>, <code>desklet</code>, <code>extension</code>, <code>search_provider</code>)
       <informalexample>
         <programlisting>
@@ -195,7 +195,7 @@
     </para>
 
     <para>
-      There is no harm renaming <code>__init__.js</code> to something other (like <code>util.js</code>) and using <code>imports.xlet.util.*</code>.
+      There is no harm renaming <code>__init__.js</code> to something else (like <code>util.js</code>) and using <code>imports.xlet.util.*</code>.
     </para>
   </sect2>
 </chapter>

--- a/docs/reference/cinnamon-tutorials/using-documentation.xml
+++ b/docs/reference/cinnamon-tutorials/using-documentation.xml
@@ -4,9 +4,9 @@
     <title>Overview</title>
     <para>The documentation of Cinnamon is separated into 4 different parts (5 if you count muffin). What you are currently reading is the tutorials, which includes the general top-level overviews and tutorials you will need for Cinnamon. This is named "Cinnamon Tutorials".</para>
 
-    <para>The second part of the Javascript reference, which describes the Javascript part of Cinnamon. This is named the "Cinnamon Javascript Reference Manual". This is a technical reference for the individual functions and objects available in Cinnamon. Note that this documentation is aimed at both applet/extension developers and Cinnamon developers themselves. So depending on who you are, some of the information might be entirely irrelevant.</para>
+    <para>The second part is the Javascript reference, which describes the Javascript part of Cinnamon. This is named the "Cinnamon Javascript Reference Manual". This is a technical reference for the individual functions and objects available in Cinnamon. Note that this documentation is aimed at both applet/extension developers and Cinnamon developers themselves. So depending on who you are, some of the information might be entirely irrelevant.</para>
 
-    <para>The second part of the documentation is for the C part of Cinnamon, which is simply referred to as the "Cinnamon Reference Manual".</para>
+    <para>The third part of the documentation is for the C part of Cinnamon, which is simply referred to as the "Cinnamon Reference Manual".</para>
 
     <para>The last part is the documentation for Shell toolkit, or St. This is the graphical toolkit used to draw widgets on the screen (similar to Gtk).</para>
 
@@ -47,15 +47,15 @@
     <title>C documentation</title>
     <para>The items described here are common to all C modules imported, not just those relating to Cinnamon.</para>
 
-    <para>Reading the documentation of C modules is tricky, since they are written for C, and we are in Javascript. In particular, C has no concept of objects, while Javascript does. Thus the naming convention of many things are different when used in Cinnamon, and the documentation is not directly applicable. The following sections will describe how to translate C into Javascript.</para>
+    <para>Reading the documentation of C modules is tricky, since they are written for C, and we are in Javascript. In particular, C has no concept of objects, while Javascript does. Thus the naming conventions of many things are different when used in Cinnamon, and the documentation is not directly applicable. The following sections will describe how to translate C into Javascript.</para>
 
-    <para>Note that most of these apply to Python and other non-C language.</para>
+    <para>Note that most of these apply to Python and other non-C languages.</para>
 
     <sect3>
       <title>Objects</title>
       <para>C has no concept of objects, but GObject allows C code to create things that look like objects. For example, <code>St.Bin</code> is something that looks like an object, and acts like an object in Javascript. If you want to look up the documentation of <code>St.Bin</code>, you search for <code>StBin</code> (without the ".") and the documentation will come up.</para>
 
-      <para>The removal of the "." is since, in Javascript, we first import the whole St, and then take the "<code>Bin</code>" object from St. This concept is non-existent in C. In C, it is simply StBin.</para>
+      <para>The "." is removed since, in Javascript, we first import the whole St, and then take the "<code>Bin</code>" object from St. This concept is non-existent in C. In C, it is simply StBin.</para>
 
       <para>A notable exception is with <code>Gio</code> and <code>GLib</code> objects, in which the <code>G</code> prefix is used in C for both while <code>Gio</code> and <code>GLib</code> is used in Javascript. For example, the C object is <code>GSettings</code> while the Javascript object is <code>Gio.Settings</code>.</para>
 
@@ -76,7 +76,7 @@
 
     <sect3>
       <title>Properties</title>
-      <para>GObjects have properties. These can generally accessed directly. For example, if <code>actor</code> is an <code>StBin</code> and you want to access the <code>x-fill</code> property, you can use <code>actor.x_fill</code>. Note that we translate <code>-</code> to <code>_</code>.</para>
+      <para>GObjects have properties. These can generally be accessed directly. For example, if <code>actor</code> is an <code>StBin</code> and you want to access the <code>x-fill</code> property, you can use <code>actor.x_fill</code>. Note that we translate <code>-</code> to <code>_</code>.</para>
 
       <para>Sometimes, for some absurd reason, the properties cannot be accessed directly. In this case, there is still hope. You can access the property via <code>actor.get_property("x-fill")</code> and <code>actor.set_property("x-fill", false)</code>.</para>
     </sect3>

--- a/docs/reference/cinnamon-tutorials/write-applet.xml
+++ b/docs/reference/cinnamon-tutorials/write-applet.xml
@@ -34,7 +34,7 @@
       </listitem>
     </itemizedlist>
     <para>
-      Applets go in <code>~/.local/share/cinnamon/applets</code> (or in <code>/usr/share/cinnamon/applets</code> if you want them installed system-wide). So let’s go there and let’s create the files and folders necessary to any Cinnamon applet.
+      Applets go in <code>~/.local/share/cinnamon/applets</code> (or in <code>/usr/share/cinnamon/applets</code> if you want them installed system-wide). So let’s go there and let’s create the files and folders necessary for any Cinnamon applet.
     </para>
 
     <screen>
@@ -116,7 +116,7 @@
       </programlisting>
     </informalexample>
     <para>
-      Now we'll go through the code one by one, starting from the bottom.
+      Now we'll go through the code line by line, starting from the bottom.
     </para>
 
     <informalexample>
@@ -127,11 +127,11 @@
       </programlisting>
     </informalexample>
     <para>
-      The <code>main</code> function is the only thing Cinnamon understand. To load an applet, Cinnamon calls the <code>main</code> function in the applet's code, and expects to get an Applet object, which it will add to the panel. So here we instantiate an <code>MyApplet</code> object (whose details are defined above), and returns it.
+      The <code>main</code> function is the only thing Cinnamon understands. To load an applet, Cinnamon calls the <code>main</code> function in the applet's code, and expects to get an Applet object, which it will add to the panel. So here we instantiate a <code>MyApplet</code> object (whose details are defined above), and return it.
     </para>
 
     <para>
-      You will notice that there are a lot of parameters floating around. <code>metadata</code> contains, basically the information inside <code>metadata.json</code> plus some more. This is not very helpful in general, but can sometimes provide some useful information.
+      You will notice that there are a lot of parameters floating around. <code>metadata</code> contains, basically, the information inside <code>metadata.json</code> plus some more. This is not very helpful in general, but can sometimes provide some useful information.
     </para>
 
     <para>
@@ -147,7 +147,7 @@
     </para>
 
     <para>
-      If that sounds like a lot of things to take care of, you should be relieved that the applet API handles all that for you! All you have to do is to pass it to the applet API. Here we are passing these information to the constructor, and the constructor will later pass it to the applet API.
+      If that sounds like a lot of things to take care of, you should be relieved that the applet API handles all that for you! All you have to do is to pass it to the applet API. Here we are passing this information to the constructor, and the constructor will later pass it to the applet API.
     </para>
 
     <para>
@@ -180,7 +180,7 @@
     </para>
 
     <para>
-      Also note that we pass all those <code>orientation</code> etc. information down the chain until it ultimately reaches the applet API.
+      Also note that we pass all the <code>orientation</code> etc. information down the chain until it ultimately reaches the applet API.
     </para>
 
     <para>
@@ -227,7 +227,7 @@
     </para>
 
     <para>
-      Next, in our <code>_init</code> function, we call the <link linkend="cinnamon-js-ui-Applet-IconApplet-_init"><code>_init</code></link> function of <code>Applet.IconApplet</code>. Here we pass on all those information about <code>orientation</code> etc to this <code>_init</code> function, and this function will help us sort out all the mess required to make the applet display properly.
+      Next, in our <code>_init</code> function, we call the <link linkend="cinnamon-js-ui-Applet-IconApplet-_init"><code>_init</code></link> function of <code>Applet.IconApplet</code>. Here we pass on all the information about <code>orientation</code> etc. to this <code>_init</code> function, and this function will help us sort out all the mess required to make the applet display properly.
     </para>
 
     <para>

--- a/docs/reference/cinnamon-tutorials/xlet-versioning.xml
+++ b/docs/reference/cinnamon-tutorials/xlet-versioning.xml
@@ -16,7 +16,7 @@
   </para>
 
   <para>
-    Here extension versioning comes to the rescue. Since Cinnamon 2.6, it is possible to ship different versions of your extension for different versions of Cinnamon. Here "extension" will refer to all extensions, applets and desklets.
+    Here extension versioning comes to the rescue. As of Cinnamon 2.6, it is possible to ship different versions of your extension for different versions of Cinnamon. Here "extension" will refer to all extensions, applets and desklets.
   </para>
 
   <para> To enable extension versioning, extensions have to add the line</para>
@@ -34,10 +34,10 @@
   </para>
 
   <para>
-    If no suitable directory is found, then the contents in <code>extension@uuid/</code> will be loaded. Note that Cinnamon versions prior to 2.6 will not understand this directory magic, and will always try to load the contents in <code>extension@uuid/</code>. Hence it is suggested that extension maintainers put the version for 2.4 in <code>extension@uuid</code>, and create new directories if changes <emphasis>specific to newer cinnamon versions</emphasis> are made. Don't make a new directory whenever a Cinnamon version is out since it is just a waste of space (and maintenance effort).
+    If no suitable directory is found, then the contents in <code>extension@uuid/</code> will be loaded. Note that Cinnamon versions prior to 2.6 will not understand this directory magic, and will always try to load the contents in <code>extension@uuid/</code>. Hence it is suggested that extension maintainers put the version for 2.4 in <code>extension@uuid</code>, and create new directories if changes <emphasis>specific to newer Cinnamon versions</emphasis> are made. Don't make a new directory whenever a Cinnamon version is out since it is just a waste of space (and maintenance effort).
   </para>
 
   <para>
-   Note that this also allows you to support future versions of Cinnamon. For example, if you see a cool feature in the development branch of Cinnamon, you can modify your code and put it in the 2.6 folder (assuming the current version is 2.4). Then once the user upgrades their cinnamon version, the new code will be used instead. This also allows extensions to be smoothly upgraded between versions.
+   Note that this also allows you to support future versions of Cinnamon. For example, if you see a cool feature in the development branch of Cinnamon, you can modify your code and put it in the 2.6 folder (assuming the current version is 2.4). Then once the user upgrades their Cinnamon version, the new code will be used instead. This also allows extensions to be smoothly upgraded between versions.
  </para>
 </chapter>


### PR DESCRIPTION
These are the same changes as in this pull request:
https://github.com/linuxmint/linuxmint.github.io/pull/9

except made to the *.xml files.  Thanks!