### PR TITLE
[menu-applet] hiding favorites box leaves an empty box in the menu, t…

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1396,9 +1396,9 @@ MyApplet.prototype = {
 
     _favboxtoggle: function() {
         if (!this.favBoxShow) {
-            this.leftPane.remove_actor(this.leftBox);
+            this.leftPane.hide();
         }else{
-            this.leftPane.add_actor(this.leftBox, { y_align: St.Align.END, y_fill: false });
+            this.leftPane.show();
         }
     },
 


### PR DESCRIPTION
…his should fix this

In the image below you can see the empty box, where the favorites box and the shutdown buttons supposed to be:
![hidefavbox_bug](https://cloud.githubusercontent.com/assets/8415124/19009214/b596ebaa-8771-11e6-9ce6-d5441ce7ea91.png)
