### PR TITLE
[window-list applet] using icons on context menu

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -826,7 +826,7 @@ AppMenuButtonRightClickMenu.prototype = {
         this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
         // Close all/others
-        item = new PopupMenu.PopupMenuItem(_("Close all"));
+        item = new PopupMenu.PopupIconMenuItem(_("Close all"), "application-exit", St.IconType.SYMBOLIC);
         item.connect('activate', Lang.bind(this, function() {
             for (let window of this._windows)
                 if (window.actor.visible &&
@@ -835,7 +835,7 @@ AppMenuButtonRightClickMenu.prototype = {
         }));
         this.addMenuItem(item);
 
-        item = new PopupMenu.PopupMenuItem(_("Close others"));
+        item = new PopupMenu.PopupIconMenuItem(_("Close others"), "window-close", St.IconType.SYMBOLIC);
         item.connect('activate', Lang.bind(this, function() {
             for (let window of this._windows)
                 if (window.actor.visible &&
@@ -857,12 +857,12 @@ AppMenuButtonRightClickMenu.prototype = {
         }
 
         if (mw.minimized) {
-            item = new PopupMenu.PopupMenuItem(_("Restore"));
+            item = new PopupMenu.PopupIconMenuItem(_("Restore"), "view-sort-descending", St.IconType.SYMBOLIC);
             item.connect('activate', function() {
                 Main.activateWindow(mw, global.get_current_time());
             });
         } else {
-            item = new PopupMenu.PopupMenuItem(_("Minimize"));
+            item = new PopupMenu.PopupIconMenuItem(_("Minimize"), "view-sort-ascending", St.IconType.SYMBOLIC);
             item.connect('activate', function() {
                 mw.minimize(global.get_current_time());
             });
@@ -870,19 +870,19 @@ AppMenuButtonRightClickMenu.prototype = {
         this.addMenuItem(item);
 
         if (mw.get_maximized()) {
-            item = new PopupMenu.PopupMenuItem(_("Unmaximize"));
+            item = new PopupMenu.PopupIconMenuItem(_("Unmaximize"), "view-restore", St.IconType.SYMBOLIC);
             item.connect('activate', function() {
                 mw.unmaximize(Meta.MaximizeFlags.HORIZONTAL | Meta.MaximizeFlags.VERTICAL);
             });
         } else {
-            item = new PopupMenu.PopupMenuItem(_("Maximize"));
+            item = new PopupMenu.PopupIconMenuItem(_("Maximize"), "view-fullscreen", St.IconType.SYMBOLIC);
             item.connect('activate', function() {
                 mw.maximize(Meta.MaximizeFlags.HORIZONTAL | Meta.MaximizeFlags.VERTICAL);
             });
         }
         this.addMenuItem(item);
 
-        item = new PopupMenu.PopupMenuItem(_("Close"));
+        item = new PopupMenu.PopupIconMenuItem(_("Close"), "edit-delete", St.IconType.SYMBOLIC);
         item.connect('activate', function() {
             mw.delete(global.get_current_time());
         });


### PR DESCRIPTION
The following pictures are saying pretty much everything about this commit:
![bildschirmfoto vom 2016-10-02 17-46-03](https://cloud.githubusercontent.com/assets/8415124/19021804/b6ebc5e4-88c9-11e6-91de-375c02281258.png)
![bildschirmfoto vom 2016-10-02 17-46-26](https://cloud.githubusercontent.com/assets/8415124/19021805/b8b64a02-88c9-11e6-994f-8411d69f580e.png)

I saw this here https://cinnamon-spices.linuxmint.com/applets/view/261 and liked it.
Maybe you can use/create different icons.

This is especially helpful if you take a close look at the first picture.
In German the words "Restore" and "Unmaximize" are translated with the same word "Wiederherstellen".
Without the icons you can't tell the difference.
Before I saw this applet with icons, I wasn't even aware, that there was a difference xD