### PR TITLE
[menu-applet] a more intuitive way of keyboard-navigation in menu

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1465,26 +1465,32 @@ MyApplet.prototype = {
         index = this._selectedItemIndex;
 
         if (this._activeContainer === null && symbol == Clutter.KEY_Up) {
-            this._activeContainer = this.applicationsBox;
-            item_actor = this.appBoxIter.getLastVisible();
-            index = this.appBoxIter.getAbsoluteIndexOfChild(item_actor);
-            this._scrollToButton(item_actor._delegate);
+            this._activeContainer = this.categoriesBox;
+            item_actor = this.catBoxIter.getLastVisible();
+            index = this.catBoxIter.getAbsoluteIndexOfChild(item_actor);
         } else if (this._activeContainer === null && symbol == Clutter.KEY_Down) {
+            this._activeContainer = this.categoriesBox;
+            item_actor = this.catBoxIter.getFirstVisible();
+            item_actor = this._activeContainer._vis_iter.getNextVisible(item_actor);
+            index = this.catBoxIter.getAbsoluteIndexOfChild(item_actor);
+        } else if (this._activeContainer === null && symbol == Clutter.KEY_Left && this.favBoxShow) {
+            this._activeContainer = this.favoritesBox;
+            item_actor = this.favBoxIter.getFirstVisible();
+            index = this.favBoxIter.getAbsoluteIndexOfChild(item_actor);
+        } else if (this._activeContainer === null && symbol == Clutter.KEY_Right) {
             this._activeContainer = this.applicationsBox;
             item_actor = this.appBoxIter.getFirstVisible();
             index = this.appBoxIter.getAbsoluteIndexOfChild(item_actor);
             this._scrollToButton(item_actor._delegate);
-        } else if (this._activeContainer === null && symbol == Clutter.KEY_Left && this.favBoxShow ) {
-            this._activeContainer = this.favoritesBox;
-            item_actor = this.favBoxIter.getFirstVisible();
-            index = this.favBoxIter.getAbsoluteIndexOfChild(item_actor);
         } else if (symbol == Clutter.KEY_Up) {
             if (this._activeContainer != this.categoriesBox) {
                 this._previousSelectedActor = this._activeContainer.get_child_at_index(index);
                 item_actor = this._activeContainer._vis_iter.getPrevVisible(this._previousSelectedActor);
-                this._previousVisibleIndex = this._activeContainer._vis_iter.getVisibleIndex(item_actor);
+                if (this._activeContainer === this.applicationsBox) {
+                    this._previousVisibleIndex = this._activeContainer._vis_iter.getVisibleIndex(item_actor);
+                    this._scrollToButton(item_actor._delegate);
+                }
                 index = this._activeContainer._vis_iter.getAbsoluteIndexOfChild(item_actor);
-                this._scrollToButton(item_actor._delegate);
             } else {
                 this._previousTreeSelectedActor = this.categoriesBox.get_child_at_index(index);
                 this._previousTreeSelectedActor._delegate.isHovered = false;
@@ -1495,10 +1501,11 @@ MyApplet.prototype = {
             if (this._activeContainer != this.categoriesBox) {
                 this._previousSelectedActor = this._activeContainer.get_child_at_index(index);
                 item_actor = this._activeContainer._vis_iter.getNextVisible(this._previousSelectedActor);
-
-                this._previousVisibleIndex = this._activeContainer._vis_iter.getVisibleIndex(item_actor);
+                if (this._activeContainer === this.applicationsBox) {
+                    this._previousVisibleIndex = this._activeContainer._vis_iter.getVisibleIndex(item_actor);
+                    this._scrollToButton(item_actor._delegate);
+                }
                 index = this._activeContainer._vis_iter.getAbsoluteIndexOfChild(item_actor);
-                this._scrollToButton(item_actor._delegate);
             } else {
                 this._previousTreeSelectedActor = this.categoriesBox.get_child_at_index(index);
                 this._previousTreeSelectedActor._delegate.isHovered = false;


### PR DESCRIPTION
When opening the menu you can see, that the "All Applications" button is highlighted:
![bildschirmfoto vom 2016-10-02 22-02-13](https://cloud.githubusercontent.com/assets/8415124/19023333/b19407c8-88ec-11e6-9188-e3a42a03858f.png)

Imagine the following two scenarios:
1. You would expect to get the next category by pressing the  down key on your keyboard, because the first category is already highligted. Wrong.
Instead you get the first application in the "All Applications" category.
2. You press the right key on your keyboard and expect to get the first application in the "All Applications" category. Wrong again. You get the first category "All Applications", which is already highlighted.

I think the suggested way is more intuitive, due to the fact, that the "All Applications" button is highlighted, when you open the menu.

The only thing I wasn't sure about was what the `this._scrollToButton(item_actor._delegate);` function is doing. Maybe somebody, who does know what the function is doing, could check that.

