### PR TITLE
panel.js: add dialog to launch settings when the last panel is removed

### DIFF
--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -820,6 +820,14 @@ PanelManager.prototype = {
         this._setMainPanel();
         this._checkCanAdd();
         this._updateAllPointerBarriers();
+
+        // If the user removed the last panel, pop up a dialog to ask if they want to open panel settings
+        if (panelProperties.length == 0) {
+            let lastPanelRemovedDialog = new ModalDialog.ConfirmDialog(
+                _("You don't have any panels added.\nDo you want to open panel settings?"),
+                Lang.bind(this, function() { Util.spawnCommandLine("cinnamon-settings panel"); }));
+            lastPanelRemovedDialog.open();
+        }
     },
 
     /**


### PR DESCRIPTION
If the user removes the last remaining panel, pop up a dialog asking if they
want to launch panel settings. This can help prevent situations where the
desktop isn't usable for users that don't know how to get to panel settings
other than through the panel/menu applet.