### PR TITLE
panel.js: don't try to hide the panel if it's destroyed

### DIFF
--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -3458,6 +3458,7 @@ Panel.prototype = {
      * @force.
      */
     _hidePanel: function(force) {
+        if (this._destroyed) return;
         this._showHideTimer = 0;
 
         if ((this._shouldShow && !force) || global.menuStackLength > 0) return;


### PR DESCRIPTION
This prevents an error when you remove a panel that has auto hide
enabled.

Cjs-WARNING **: JS ERROR: TypeError: this.monitor is null
Panel.prototype._hidePanel@/usr/share/cinnamon/js/ui/panel.js:3535