### PR TITLE
applets: Change how applets set the type of panel they are allowed in

### DIFF
--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
@@ -42,6 +42,8 @@ MyApplet.prototype = {
 
     _init: function(orientation, panel_height, instance_id) {        
         Applet.TextApplet.prototype._init.call(this, orientation, panel_height, instance_id);
+
+        this.setAllowedLayout(Applet.AllowedLayout.BOTH);
         
         try {    
 
@@ -225,13 +227,6 @@ MyApplet.prototype = {
                 // signal will fire
             }
         }));
-    },
-//
-//override getDisplayLayout to declare that this applet is suitable for both horizontal and
-// vertical orientations
-//
-    getDisplayLayout: function() {
-        return Applet.DisplayLayout.BOTH;
     },
 
     on_orientation_changed: function (orientation) {

--- a/files/usr/share/cinnamon/applets/keyboard@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/keyboard@cinnamon.org/applet.js
@@ -44,6 +44,8 @@ MyApplet.prototype = {
 
     _init: function(metadata, orientation, panel_height, instance_id) {        
         Applet.TextIconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
+
+        this.setAllowedLayout(Applet.AllowedLayout.BOTH);
         
         try {
             this.metadata = metadata;
@@ -97,13 +99,6 @@ MyApplet.prototype = {
     
     on_applet_clicked: function(event) {
         this.menu.toggle();        
-    },
-//
-//override getDisplayLayout to declare that this applet is suitable for both horizontal and
-// vertical orientations
-//
-    getDisplayLayout: function() {
-        return Applet.DisplayLayout.BOTH;
     },
 
     _syncConfig: function() {

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1094,6 +1094,9 @@ MyApplet.prototype = {
 
     _init: function(orientation, panel_height, instance_id) {
         Applet.TextIconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
+
+        this.setAllowedLayout(Applet.AllowedLayout.BOTH);
+
         this.initial_load_done = false;
 
         this.set_applet_tooltip(_("Menu"));
@@ -1296,10 +1299,6 @@ MyApplet.prototype = {
         if (this.initial_load_done)
             this._refreshAll();
         this._updateIconAndLabel();
-    },
-
-    getDisplayLayout: function() {
-        return Applet.DisplayLayout.BOTH;
     },
 
     on_applet_added_to_panel: function () {

--- a/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
@@ -22,6 +22,8 @@ MyApplet.prototype = {
     _init: function(metadata, orientation, panel_height, instanceId) {
         Applet.TextIconApplet.prototype._init.call(this, orientation, panel_height, instanceId);
 
+        this.setAllowedLayout(Applet.AllowedLayout.BOTH);
+
         // Settings
         this.settings = new Settings.AppletSettings(this, metadata.uuid, instanceId);
         this.settings.bindProperty(Settings.BindingDirection.IN, "ignoreTransientNotifications", "ignoreTransientNotifications", null, null);
@@ -243,10 +245,6 @@ MyApplet.prototype = {
         this.menu = new Applet.AppletPopupMenu(this, orientation);
         this.menuManager.addMenu(this.menu);
         this._display();
-    },
-
-    getDisplayLayout: function() {
-        return Applet.DisplayLayout.BOTH;
     },
 
     on_applet_clicked: function(event) {

--- a/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
@@ -308,6 +308,8 @@ MyApplet.prototype = {
         Applet.Applet.prototype._init.call(this, orientation, panel_height, instance_id);
         this.actor.set_track_hover(false);
 
+        this.setAllowedLayout(Applet.AllowedLayout.BOTH);
+
         this.orientation = orientation;
         this._dragPlaceholder = null;
         this._dragPlaceholderPos = -1;
@@ -438,13 +440,6 @@ MyApplet.prototype = {
             this._set_vertical_style();
         }
         this.reload();
-    },
-//
-// override getDisplayLayout to declare that this applet is suitable for both horizontal and
-// vertical orientations
-//
-    getDisplayLayout: function() {
-        return Applet.DisplayLayout.BOTH;
     },
 
 //

--- a/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
@@ -248,6 +248,8 @@ MyApplet.prototype = {
     _init: function(metadata, orientation, panel_height, instanceId) {
         Applet.TextIconApplet.prototype._init.call(this, orientation, panel_height, instanceId);
 
+        this.setAllowedLayout(Applet.AllowedLayout.BOTH);
+
         this.metadata = metadata;
         this.orientation = orientation;
 
@@ -558,10 +560,6 @@ MyApplet.prototype = {
     on_orientation_changed: function(orientation) {
         this.orientation = orientation;
         this.update_label_visible();
-    },
-
-    getDisplayLayout: function() {
-        return Applet.DisplayLayout.BOTH;
     }
 };
 

--- a/files/usr/share/cinnamon/applets/separator@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/separator@cinnamon.org/applet.js
@@ -11,13 +11,11 @@ MyApplet.prototype = {
 
     _init: function(orientation, panel_height, instance_id) {
         Applet.Applet.prototype._init.call(this, orientation, panel_height, instance_id);
-        this.actor.style_class = 'applet-separator'; 
+        this.actor.style_class = 'applet-separator';
+
+        this.setAllowedLayout(Applet.AllowedLayout.BOTH);
 
         this.on_orientation_changed(orientation);
-    },
-
-    getDisplayLayout: function() {
-        return Applet.DisplayLayout.BOTH;
     },
 
     on_panel_height_changed: function() {

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -871,6 +871,8 @@ MyApplet.prototype = {
     _init: function(metadata, orientation, panel_height, instanceId) {
         Applet.TextIconApplet.prototype._init.call(this, orientation, panel_height, instanceId);
 
+        this.setAllowedLayout(Applet.AllowedLayout.BOTH);
+
         try {
             this.metadata = metadata;
             this.orientation = orientation;
@@ -1503,10 +1505,6 @@ MyApplet.prototype = {
     on_orientation_changed: function(orientation) {
         this.orientation = orientation;
         this.updateLabelVisible();
-    },
-
-    getDisplayLayout: function() {
-        return Applet.DisplayLayout.BOTH;
     }
 };
 

--- a/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
@@ -52,6 +52,8 @@ MyApplet.prototype = {
     _init: function(orientation, panel_height, instance_id) {
         Applet.Applet.prototype._init.call(this, orientation, panel_height, instance_id);
 
+        this.setAllowedLayout(Applet.AllowedLayout.BOTH);
+
         this.actor.remove_style_class_name("applet-box");
         this.actor.style="spacing: 5px;";
 
@@ -178,14 +180,6 @@ MyApplet.prototype = {
     },
 
     on_applet_clicked: function(event) {
-    },
-
-//
-//override getDisplayLayout to declare that this applet is suitable for both horizontal and
-// vertical orientations
-//
-    getDisplayLayout: function() {
-        return Applet.DisplayLayout.BOTH;
     },
 
     on_orientation_changed: function(neworientation) {

--- a/files/usr/share/cinnamon/applets/user@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/user@cinnamon.org/applet.js
@@ -24,6 +24,8 @@ MyApplet.prototype = {
 
     _init: function(orientation, panel_height, instance_id) {
         Applet.TextIconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
+
+        this.setAllowedLayout(Applet.AllowedLayout.BOTH);
         
         try {
             this._session = new GnomeSession.SessionManager();
@@ -193,13 +195,6 @@ MyApplet.prototype = {
             this.hide_applet_label(true);
         else
             this.hide_applet_label(false);
-    },
-//
-//override getDisplayLayout to declare that this applet is suitable for both horizontal and
-// vertical orientations
-//
-    getDisplayLayout: function() {
-        return Applet.DisplayLayout.BOTH;
     },
 };
 

--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -920,6 +920,8 @@ MyApplet.prototype = {
     _init: function(orientation, panel_height, instance_id) {
         Applet.Applet.prototype._init.call(this, orientation, panel_height, instance_id);
 
+        this.setAllowedLayout(Applet.AllowedLayout.BOTH);
+
         this.actor.set_track_hover(false);
         this.actor.set_style_class_name("window-list-box");
         this.orientation = orientation;
@@ -1017,13 +1019,6 @@ MyApplet.prototype = {
 
     on_panel_height_changed: function() {
         this._refreshAllItems();
-    },
-    //
-    // override getDisplayLayout to declare that this applet is suitable for both horizontal and
-    // vertical orientations
-    //
-    getDisplayLayout: function() {
-        return Applet.DisplayLayout.BOTH;
     },
 
     on_orientation_changed: function(orientation) {

--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
@@ -212,6 +212,8 @@ MyApplet.prototype = {
     _init: function(metadata, orientation, panel_height, instance_id) {
         Applet.Applet.prototype._init.call(this, orientation, panel_height, instance_id);
 
+        this.setAllowedLayout(Applet.AllowedLayout.BOTH);
+
         try {
             this.orientation = orientation;
             this.panel_height = panel_height;
@@ -298,10 +300,6 @@ MyApplet.prototype = {
         for (let i = 0; i < this.buttons.length; ++i) {
             this.buttons[i].reactive = reactive;
         }
-    },
-
-    getDisplayLayout: function() {
-        return Applet.DisplayLayout.BOTH;
     },
 
     on_orientation_changed: function(neworientation) {

--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -23,7 +23,7 @@ const DEFAULT_PANEL_HEIGHT = 25;
 const DEFAULT_ICON_HEIGHT = 22;
 const FALLBACK_ICON_HEIGHT = 22;
 
-const DisplayLayout = {  // the panel layout that an applet is suitable for
+const AllowedLayout = {  // the panel layout that an applet is suitable for
     VERTICAL: 'vertical',
     HORIZONTAL: 'horizontal',
     BOTH: 'both'
@@ -131,6 +131,9 @@ AppletPopupMenu.prototype = {
  * @_menuManager (PopupMenu.PopupMenuManager): The menu manager of the applet
  * @_applet_context_menu (Applet.AppletContextMenu): The context menu of the applet
  * @_applet_tooltip_text (string): Text of the tooltip
+ * @_allowedLayout (Applet.AllowedLayout): The allowed layout of the applet. This
+ * determines the type of panel an applet is allowed in. By default this is set
+ * to Applet.AllowedLayout.HORIZONTAL
  * 
  * Base applet class that other applets can inherit
  */
@@ -152,6 +155,7 @@ Applet.prototype = {
                                         reactive: true,
                                         track_hover: true });
 
+        this._allowedLayout = AllowedLayout.HORIZONTAL;
         this.setOrientationInternal(orientation);
     
         this._applet_tooltip = new Tooltips.PanelItemTooltip(this, "", orientation);                                        
@@ -395,12 +399,26 @@ Applet.prototype = {
     },
 
     /**
-     * #getDisplayLayout
-     * @short_description: returns the default type of panel that an applet is suitable for.
-     *                     intended to be overridden in individual applets
+     * setAllowedLayout:
+     * @layout (AllowedLayout): the allowed layout
+     *
+     * Sets the layout allowed by the applet. Possible values are
+     * AllowedLayout.HORIZONTAL, AllowedLayout.VERTICAL, and
+     * AllowedLayout.BOTH.
      */
-    getDisplayLayout: function() {
-        return DisplayLayout.HORIZONTAL;
+    setAllowedLayout: function (layout) {
+        this._allowedLayout = layout;
+    },
+
+    /**
+     * getAllowedLayout:
+     *
+     * Retrieves the type of layout an applet is allowed to have.
+     *
+     * Returns (Applet.AllowedLayout): The allowed layout of the applet
+     */
+    getAllowedLayout: function() {
+        return this._allowedLayout;
     },
 
     /**

--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -338,39 +338,33 @@ function addAppletToPanels(extension, appletDefinition) {
 }
 
 function removeAppletFromInappropriatePanel (extension, applet, appletDefinition) {
-//
-//  We want to ensure that applets placed in a panel can be shown correctly
-//  - particularly because wide applets will not fit in a vertical panel unless
-//  they have logic to manage this explicitly
-//  If the applet is of type Icon Applet (and not a text icon applet) then should be fine otherwise
-//  we look to see if it has declared itself suitable via a getDisplayLayout call
-//
-//  If the applet turns out to be unsuitable then remove it.  The applet will show with a red
-//  indicator in the applet list
-//
-        if (applet instanceof Applet.IconApplet && !(applet instanceof Applet.TextIconApplet)) {
-            ;
-        }
-        else {
-            let displaylayout = applet.getDisplayLayout();
+    //  We want to ensure that applets placed in a panel can be shown correctly
+    //  - particularly because wide applets will not fit in a vertical panel unless
+    //  they have logic to manage this explicitly
+    //  If the applet is of type Icon Applet (and not a text icon applet) then should be fine otherwise
+    //  we look to see if it has declared itself suitable via a getAllowedLayout call
+    //
+    //  If the applet turns out to be unsuitable then remove it.  The applet will show with a red
+    //  indicator in the applet list
+    if (applet instanceof Applet.IconApplet && !(applet instanceof Applet.TextIconApplet)) {
+        ;
+    } else {
+        let allowedLayout = applet.getAllowedLayout();
 
-            if ((appletDefinition.orientation == St.Side.LEFT || appletDefinition.orientation == St.Side.RIGHT)
-                &&
-                displaylayout == Applet.DisplayLayout.HORIZONTAL) {
-                    global.logError("applet "+appletDefinition.uuid+" not suitable for panel orientation "+appletDefinition.orientation);
-                    removeAppletFromPanels(extension._loadedDefinitions[appletDefinition.applet_id]);
-                    let dialog = new ModalDialog.NotifyDialog(_("This applet is not suitable for vertical panels") + "\n\n");
-                    dialog.open();
-            }
-            else if ((appletDefinition.orientation == St.Side.TOP || appletDefinition.orientation == St.Side.BOTTOM)
-                &&
-                displaylayout == Applet.DisplayLayout.VERTICAL) {
-                    global.logError("applet "+appletDefinition.uuid+" not suitable for panel orientation "+appletDefinition.orientation);
-                    removeAppletFromPanels(extension._loadedDefinitions[appletDefinition.applet_id]);
-                    let dialog = new ModalDialog.NotifyDialog(_("This applet is not suitable for horizontal panels") + "\n\n");
-                    dialog.open();
-            }
+        if ((appletDefinition.orientation == St.Side.LEFT || appletDefinition.orientation == St.Side.RIGHT) &&
+             allowedLayout == Applet.AllowedLayout.HORIZONTAL) {
+            global.logError("applet " + appletDefinition.uuid + " not suitable for panel orientation " + appletDefinition.orientation);
+            removeAppletFromPanels(extension._loadedDefinitions[appletDefinition.applet_id]);
+            let dialog = new ModalDialog.NotifyDialog(_("This applet is not suitable for vertical panels") + "\n\n");
+            dialog.open();
+        } else if ((appletDefinition.orientation == St.Side.TOP || appletDefinition.orientation == St.Side.BOTTOM) &&
+                    allowedLayout == Applet.AllowedLayout.VERTICAL) {
+                global.logError("applet " + appletDefinition.uuid + " not suitable for panel orientation " + appletDefinition.orientation);
+                removeAppletFromPanels(extension._loadedDefinitions[appletDefinition.applet_id]);
+                let dialog = new ModalDialog.NotifyDialog(_("This applet is not suitable for horizontal panels") + "\n\n");
+                dialog.open();
         }
+    }
 }
 
 

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -1781,27 +1781,23 @@ PanelZoneDNDHandler.prototype = {
 
         if (!(source instanceof Applet.Applet)) return false;
 
-//
-//  We want to ensure that applets placed in a panel can be shown correctly
-//  If the applet is of type Icon Applet then should be fine
-//  otherwise we look to see if it has declared itself suitable
-//
+        //  We want to ensure that applets placed in a panel can be shown correctly
+        //  If the applet is of type Icon Applet then should be fine
+        //  otherwise we look to see if it has declared itself suitable
         if (source instanceof Applet.IconApplet) {
             ;
         }
         else {
-            let displaylayout = source.getDisplayLayout();
+            let allowedLayout = source.getAllowedLayout();
             let panelstyle = this._panelZone.get_parent().get_style_class_name();
 
-            if ((panelstyle.contains("panel-left") || panelstyle.contains("panel-right"))
-                &&
-                displaylayout == Applet.DisplayLayout.HORIZONTAL) {
+            if ((panelstyle.contains("panel-left") || panelstyle.contains("panel-right")) &&
+                 allowedLayout == Applet.AllowedLayout.HORIZONTAL) {
                     global.log("applet not suitable for panel");
                     return false;
             }
-            else if ((panelstyle.contains("panel-top") || panelstyle.contains("panel-bottom"))
-                &&
-                displaylayout == Applet.DisplayLayout.VERTICAL) {
+            else if ((panelstyle.contains("panel-top") || panelstyle.contains("panel-bottom")) &&
+                      allowedLayout == Applet.AllowedLayout.VERTICAL) {
                     global.log("applet not suitable for panel");
                     return false;
             }


### PR DESCRIPTION
Currently an applet has to override getDisplayLayout() to allow itself in a
vertical panel which doesn't really make sense. An applet should be setting the
type of allowed layout it can have. Add an _allowedLayout variable to the base
applet class that is set by default to AllowLayout.HORIZONTAL. Then add two
functions that allow getting and setting that variable. Now to allow an
applet in non-horizontal panels an applet should call setAllowedLayout with the
appropriate value.