### PR TITLE
appletManager.js: fix removeAppletFromPanels

### DIFF
--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -593,9 +593,9 @@ function updateAppletsOnPanel (panel) {
  * Unloads all applets on the panel
  */
 function unloadAppletsOnPanel (panel) {
-    enabledAppletDefinitions.idMap
-        .filter(x => x.panel == panel)
-        .forEach(removeAppletFromPanels);
+    let panelApplets = enabledAppletDefinitions.idMap.filter(x => x.panel == panel);
+    for (let i in panelApplets)
+        removeAppletFromPanels(panelApplets[i], false);
 }
 
 function copyAppletConfiguration(panelId) {


### PR DESCRIPTION
The function signature of removeAppletFromPanels has been changed and the
second parameter is not the element index. Since forEach invokes the
callback with the element index as the second parameter, we can't use that
anymore.