### PR TITLE
[menu-applet] deactivate TAB-key in menu, because of weird behavior

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1590,6 +1590,8 @@ MyApplet.prototype = {
             }
             return false;
 
+        } else if (symbol == Clutter.Tab) {
+            return true;
         } else {
             return false;
         }


### PR DESCRIPTION
I think this commit solves some weird behavior in the menu, when the TAB key is pressed.
See: https://github.com/linuxmint/Cinnamon/issues/5719 and https://github.com/linuxmint/Cinnamon/issues/5333