### PR TITLE
cs_themes: Don't show duplicate themes

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
@@ -276,6 +276,12 @@ class Module:
         valid.sort(lambda a,b: cmp(a[0].lower(), b[0].lower()))
         res = []
         for i in valid:
+            for j in res:
+                if i[0] == j[0]:
+                    if i[1] == dirs[0]:
+                        continue
+                    else:
+                        res.remove(j)
             res.append((i[0], i[1]))
         return res
 
@@ -299,15 +305,21 @@ class Module:
                 try:
                     for line in list(open(path)):
                         if line.startswith("Directories="):
-                            valid.append(directory[0])
+                            valid.append(directory)
                             break
                 except Exception as e:
                     print (e)
 
-        valid.sort(lambda a,b: cmp(a.lower(), b.lower()))
+        valid.sort(lambda a,b: cmp(a[0].lower(), b[0].lower()))
         res = []
         for i in valid:
-            res.append(i)
+            for j in res:
+                if i[0] == j:
+                    if i[1] == dirs[0]:
+                        continue
+                    else:
+                        res.remove(j)
+            res.append(i[0])
         return res
 
     def _load_cursor_themes(self):
@@ -316,6 +328,12 @@ class Module:
         valid.sort(lambda a,b: cmp(a[0].lower(), b[0].lower()))
         res = []
         for i in valid:
+            for j in res:
+                if i[0] == j[0]:
+                    if i[1] == dirs[0]:
+                        continue
+                    else:
+                        res.remove(j)
             res.append((i[0], i[1]))
         return res
 
@@ -325,6 +343,12 @@ class Module:
         valid.sort(lambda a,b: cmp(a[0].lower(), b[0].lower()))
         res = []
         for i in valid:
+            for j in res:
+                if i[0] == j[0]:
+                    if i[1] == dirs[0]:
+                        continue
+                    else:
+                        res.remove(j)
             res.append((i[0], i[1]))
         return res
 
@@ -334,5 +358,11 @@ class Module:
         valid.sort(lambda a,b: cmp(a[0].lower(), b[0].lower()))
         res = []
         for i in valid:
+            for j in res:
+                if i[0] == j[0]:
+                    if i[1] == dirs[0]:
+                        continue
+                    else:
+                        res.remove(j)
             res.append((i[0], i[1]))
         return res


### PR DESCRIPTION
Currently when we have a theme of the same name in both the /usr and /home
directory both themes are shown in the theme chooser buttons. When choosing either
of the themes in the settings the one in /home will be given precedence. When
both exist, only show the one from the users home directory since that is the
one that will be applied regardless of which the user chooses.

Fixes https://github.com/linuxmint/Cinnamon/issues/5778