### PR TITLE
[menu-applet] create favBox, even if it's not shown at Cinnamon restart

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -2226,8 +2226,8 @@ MyApplet.prototype = {
         this._session = new GnomeSession.SessionManager();
         this._screenSaverProxy = new ScreenSaver.ScreenSaverProxy();
 
-        if (this.favBoxShow)
         this.leftPane.add_actor(this.leftBox, { y_align: St.Align.END, y_fill: false });
+        this._favboxtoggle();
 
         let rightPane = new St.BoxLayout({ vertical: true });
 


### PR DESCRIPTION
When the favortiesBox was turned off and you restarted Cinnamon, you couldn't get the favoritesBox to show again, i.e. the checkbox favBoxShow didn't worked, because the favoritesBox was never created at the first place.