### PR TITLE
[menu-applet] decodeUriComponent in app description

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1796,7 +1796,12 @@ MyApplet.prototype = {
                         this._clearPrevSelection(button.actor);
                         button.actor.style_class = "menu-application-button-selected";
                         this.selectedAppTitle.set_text("");
-                        this.selectedAppDescription.set_text(button.place.id.slice(16).replace(/%20/g, ' '));
+                        let selectedAppId = button.place.idDecoded;
+                        selectedAppId = selectedAppId.substr(selectedAppId.indexOf(':') + 1);
+                        let fileIndex = selectedAppId.indexOf('file:///');
+                        if (fileIndex !== -1)
+                            selectedAppId = selectedAppId.substr(fileIndex + 7);
+                        this.selectedAppDescription.set_text(selectedAppId);
                         }));
                 button.actor.connect('leave-event', Lang.bind(this, function() {
                             this._previousSelectedActor = button.actor;
@@ -1863,7 +1868,11 @@ MyApplet.prototype = {
                             this._clearPrevSelection(button.actor);
                             button.actor.style_class = "menu-application-button-selected";
                             this.selectedAppTitle.set_text("");
-                            this.selectedAppDescription.set_text(button.file.uri.slice(7).replace(/%20/g, ' '));
+                            let selectedAppUri = button.file.uriDecoded;
+                            let fileIndex = selectedAppUri.indexOf("file:///");
+                            if (fileIndex !== -1)
+                                selectedAppUri = selectedAppUri.substr(fileIndex + 7);
+                            this.selectedAppDescription.set_text(selectedAppUri);
                             }));
                     button.actor.connect('leave-event', Lang.bind(this, function() {
                             button.actor.style_class = "menu-application-button";

--- a/js/misc/docInfo.js
+++ b/js/misc/docInfo.js
@@ -27,6 +27,7 @@ DocInfo.prototype = {
         this.name = recentInfo.get_display_name();
         this._lowerName = this.name.toLowerCase();
         this.uri = recentInfo.get_uri();
+        this.uriDecoded = decodeURIComponent(this.uri);
         this.mimeType = recentInfo.get_mime_type();
         //this.mtime = this._fetch_mtime(); // Expensive
     },

--- a/js/ui/placesManager.js
+++ b/js/ui/placesManager.js
@@ -29,6 +29,7 @@ function PlaceInfo(id, name, iconFactory, launch) {
 PlaceInfo.prototype = {
     _init: function(id, name, iconFactory, launch) {
         this.id = id;
+        this.idDecoded = decodeURIComponent(this.id);
         this.name = name;
         this._lowerName = name.toLowerCase();
         this.iconFactory = iconFactory;
@@ -84,6 +85,7 @@ PlaceDeviceInfo.prototype = {
         this.name = mount.get_name();
         this._lowerName = this.name.toLowerCase();
         this.id = 'mount:' + mount.get_root().get_uri();
+        this.idDecoded = decodeURIComponent(this.id);
     },
 
     iconFactory: function(size) {


### PR DESCRIPTION
The app description doesn't handle some characters (e.g. german umlaute ö ü ä) properly.
Fixes https://github.com/linuxmint/Cinnamon/issues/5595

Edit: fixes https://github.com/linuxmint/Cinnamon/issues/3620 and fixes https://github.com/linuxmint/Cinnamon/issues/3250