### PR TITLE
[menu-applet] clear recent list applet with ENTER-key

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -756,10 +756,14 @@ RecentClearButton.prototype = {
 
     _onButtonReleaseEvent: function (actor, event) {
         if (event.get_button()==1){
-            this.appsMenuButton.menu.close();
-            let GtkRecent = new Gtk.RecentManager();
-            GtkRecent.purge_items();
+            this.activate(event);
         }
+    },
+
+    activate: function(event) {
+        this.appsMenuButton.menu.close();
+        let GtkRecent = new Gtk.RecentManager();
+        GtkRecent.purge_items();
     }
 };
 


### PR DESCRIPTION
When pressing the ENTER/RETURN-key on the RecentClearButton nothing happened.
Now it clears the recent list, when you hit ENTER.