### PR TITLE
cs_screensaver.py: expose new cinnamon screensaver settings + bugfix

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
@@ -162,17 +162,18 @@ class MainWindow:
 
         # Resize vertically depending on the height requested by the module
         use_height = WIN_HEIGHT
+        total_height = n.height + self.bar_heights + WIN_H_PADDING
         if not sidePage.size:
             # No height requested, resize vertically if the module is taller than the window
-            if n.height > WIN_HEIGHT:
-                use_height = n.height + self.bar_heights + WIN_H_PADDING
+            if total_height > WIN_HEIGHT:
+                use_height = total_height
             #self.window.resize(use_width, n.height + self.bar_heights + WIN_H_PADDING)
         elif sidePage.size > 0:
             # Height hardcoded by the module
             use_height = sidePage.size + self.bar_heights + WIN_H_PADDING
         elif sidePage.size == -1:
             # Module requested the window to fit it (i.e. shrink the window if necessary)
-            use_height = n.height + self.bar_heights + WIN_H_PADDING
+            use_height = total_height
 
         self.window.resize(use_width, use_height)
 

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_screensaver.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_screensaver.py
@@ -104,6 +104,10 @@ class Module:
 
         size_group = Gtk.SizeGroup.new(Gtk.SizeGroupMode.HORIZONTAL)
 
+        widget = GSettingsSwitch(_("Always show clock"), schema, "show-clock")
+        widget.set_tooltip_text(_("Show the clock on the wallpaper instead of just the unlock screen"))
+        settings.add_row(widget)
+
         widget = GSettingsSwitch(_("Use a custom date and time format"), schema, "use-custom-format")
         settings.add_row(widget)
 
@@ -126,12 +130,26 @@ class Module:
         widget.set_tooltip_text(_("This is the default message displayed on your lock screen"))
         settings.add_row(widget)
 
-        settings.add_row(GSettingsFontButton(_("Font"), "org.cinnamon.desktop.screensaver", "font-message"))
+        settings.add_row(GSettingsFontButton(_("Away message font"), "org.cinnamon.desktop.screensaver", "font-message"))
 
         widget = GSettingsSwitch(_("Ask for a custom message when locking the screen from the menu"), schema, "ask-for-away-message")
         widget.set_tooltip_text(_("This option allows you to type a message each time you lock the screen from the menu"))
         settings.add_row(widget)
 
+        settings = page.add_section(_("General"))
+
+        widget = GSettingsSwitch(_("Use flags to indicate keyboard layout"), schema, "show-flags")
+        widget.set_tooltip_text(_("Show a flag to indicate the active keyboard layout. If disabled, a two-letter abbreviation is shown instead."))
+        settings.add_row(widget)
+
+        widget = GSettingsSwitch(_("Show keyboard layout in upper case letters"), schema, "upper-case-kbd-layout")
+        widget.set_tooltip_text(_("Always use upper case letters to indicate active keyboard layout"))
+        settings.add_row(widget)
+
+        widget = GSettingsSwitch(_("Show album art"), schema, "show-album-art")
+        widget.set_tooltip_text(_("Show album art on the unlock screen, if available, while media is playing"))
+        settings.add_row(widget)
+		
 class ScreensaverBox(Gtk.Box):
     def __init__(self, title):
         Gtk.Box.__init__(self)


### PR DESCRIPTION
I have renamed the "Date" page to "Customize" and added the new lock screen settings there. I think the away message stuff should probably be in customize too, but the whole reason I added the new stuff on the "Customize" page is to avoid having one page be too long and require scrolling by default. Let me know what you all think of the wording, layout, etc.... 

By the way I recommend we also merge #5342 as it is still compatible with the rewritten screensaver.

preview:
![screenshot-window-2016-10-14-132327](https://cloud.githubusercontent.com/assets/11601860/19401748/ddfb65d0-9211-11e6-9060-620d3a8f6551.png)
