### PR TITLE
cinnamon-global.c: fix a gi warning

### DIFF
--- a/src/cinnamon-global.c
+++ b/src/cinnamon-global.c
@@ -1096,7 +1096,7 @@ _cinnamon_global_set_plugin (CinnamonGlobal *global,
  * @global: A #CinnamonGlobal
  * @meminfo: (out caller-allocates): Output location for memory information
  *
- * Return value: (transfer none): a generic pointer to the GjsContext
+ * Get Cinnamon memory usage information.
  */
 void
 cinnamon_global_get_memory_info (CinnamonGlobal *global, CinnamonJSMemoryInfo *meminfo)


### PR DESCRIPTION
This function has no return, so I've removed the return annotation and added
a symbol description instead.

Fixes:
Warning: Cinnamon: cinnamon_global_get_memory_info: invalid return annotation