### PR TITLE
messageTray: Fix the placement of notifications

### DIFF
--- a/js/ui/messageTray.js
+++ b/js/ui/messageTray.js
@@ -870,10 +870,10 @@ Notification.prototype = {
 
         let [titleMinW, titleNatW] = this._titleLabel.get_preferred_width(-1);
         let [titleMinH, titleNatH] = this._titleLabel.get_preferred_height(availWidth);
-        
+
         let [timeMinW, timeNatW] = this._timeLabel.get_preferred_width(-1);
         let [timeMinH, timeNatH] = this._timeLabel.get_preferred_height(availWidth);
-        
+
         let [bannerMinW, bannerNatW] = this._bannerLabel.get_preferred_width(availWidth);
 
         let titleBox = new Clutter.ActorBox();
@@ -908,7 +908,7 @@ Notification.prototype = {
         this._titleFitsInBannerMode = (titleNatW <= availWidth);
 
         let bannerFits = true;
-        
+
         if (titleBoxW + this._spacing > availWidth) {
             this._bannerLabel.opacity = 0;
             bannerFits = false;
@@ -1432,7 +1432,7 @@ MessageTray.prototype = {
         this._notificationQueue = [];
         this._notification = null;
         this._notificationClickedId = 0;
-        
+
         this._pointerBarrier = 0;
 
         this._focusGrabber = new FocusGrabber();
@@ -1455,7 +1455,7 @@ MessageTray.prototype = {
         this._notificationExpandedId = 0;
         this._notificationRemoved = false;
         this._reNotifyAfterHideNotification = null;
-        
+
         this._sources = [];
         Main.layoutManager.addChrome(this._notificationBin);
 
@@ -1519,7 +1519,7 @@ MessageTray.prototype = {
         let index = this._getSourceIndex(source);
         if (index == -1)
             return;
-            
+
         this._sources.splice(index, 1);
 
         let needUpdate = false;
@@ -1682,17 +1682,21 @@ MessageTray.prototype = {
         this._notificationClickedId = this._notification.connect('done-displaying',
                                                                  Lang.bind(this, this._escapeTray));
         this._notificationBin.child = this._notification.actor;
-        this._notificationBin.opacity = 0;        
+        this._notificationBin.opacity = 0;
 
         let monitor = Main.layoutManager.primaryMonitor;
-        let panel = Main.panelManager.getPanel(0, 0); // We only want the top panel in monitor 0
-        let height = 5;
-        if (panel)
-            height += panel.actor.get_height();
-        this._notificationBin.y = monitor.y + height * 2; // Notifications appear from here (for the animation)
+        let topPanel = Main.panelManager.getPanel(0, 0);
+        let rightPanel = Main.panelManager.getPanel(0, 3);
+        let topGap = 5;
+        let rightGap = 0;
+        if (topPanel)
+            topGap += topPanel.actor.get_height();
+        if (rightPanel)
+            rightGap += rightPanel.actor.get_width();
+        this._notificationBin.y = monitor.y + topGap * 2; // Notifications appear from here (for the animation)
 
-        let margin = this._notification._table.get_theme_node().get_length('margin-from-right-edge-of-screen');                
-        this._notificationBin.x = monitor.x + monitor.width - this._notification._table.width - margin;
+        let margin = this._notification._table.get_theme_node().get_length('margin-from-right-edge-of-screen');
+        this._notificationBin.x = monitor.x + monitor.width - this._notification._table.width - margin - rightGap;
         Main.soundManager.play('notification');
         this._notificationBin.show();
 
@@ -1742,7 +1746,7 @@ MessageTray.prototype = {
         if (panel)
             height += panel.actor.get_height();
 
-        if (!this._notification.expanded)        	 
+        if (!this._notification.expanded)
             tweenParams.y = monitor.y + height;
 
         this._tween(this._notificationBin, '_notificationState', State.SHOWN, tweenParams);
@@ -1836,11 +1840,11 @@ MessageTray.prototype = {
         let expandedY = this._notification.actor.height - this._notificationBin.height;
         // Don't animate the notification to its new position if it has shrunk:
         // there will be a very visible "gap" that breaks the illusion.
-        
+
         // This isn't really working at the moment, but it was just crashing before
         // if it encountered a critical notification.  expandedY is always 0.  For now
         // just make sure it's not covering the top panel if there is one.
-        
+
         let monitor = Main.layoutManager.primaryMonitor;
         let panel = Main.panelManager.getPanel(0, 0); // We only want the top panel in monitor 0
         let height = 5;


### PR DESCRIPTION
Now that we allow vertical panels we need to take them into account when
placing notifications to avoid them overlapping the panel.