### PR TITLE
add vertical style class to workspace switcher in a vertical panel

### DIFF
--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
@@ -191,6 +191,7 @@ SimpleButton.prototype = {
             } else {
                 this.actor.set_height(0.6 * applet._panelHeight);  // factors are completely empirical
                 this.actor.set_width(0.9 * applet._panelHeight);
+                this.actor.add_style_class_name('vertical');
             }
         }
         let label = new St.Label({ text: (index + 1).toString() });


### PR DESCRIPTION
Straightforward change to add a vertical style class when in a vertical panel.
No code is needed to remove it on a move to a horizontal panel,  as buttons are rebuilt from scratch
when panels are moved between orientations.
Linked to a change to improve appearance of this applet in vertical panels in Mint-X themes