### PR TITLE
added PopupSwitchIconMenuItem and used it in sound-applet

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -976,8 +976,8 @@ MyApplet.prototype = {
 
             this.actor.connect('scroll-event', Lang.bind(this, this._onScrollEvent));
 
-            this.mute_out_switch = new PopupMenu.PopupSwitchMenuItem(_("Mute output"), false);
-            this.mute_in_switch = new PopupMenu.PopupSwitchMenuItem(_("Mute input"), false);
+            this.mute_out_switch = new PopupMenu.PopupSwitchIconMenuItem(_("Mute output"), false, "audio-volume-muted", St.IconType.SYMBOLIC);
+            this.mute_in_switch = new PopupMenu.PopupSwitchIconMenuItem(_("Mute input"), false, "microphone-sensitivity-none", St.IconType.SYMBOLIC);
             this._applet_context_menu.addMenuItem(this.mute_out_switch);
             this._applet_context_menu.addMenuItem(this.mute_in_switch);
 
@@ -992,6 +992,7 @@ MyApplet.prototype = {
 
             this._inputSection = new PopupMenu.PopupMenuSection;
             this._inputVolumeSection = new VolumeSlider(this, null, _("Microphone"), null);
+            this._inputVolumeSection.connect("values-changed", Lang.bind(this, this._inputValuesChanged));
             this._selectInputDeviceItem = new PopupMenu.PopupSubMenuMenuItem(_("Input device"));
             this._inputSection.addMenuItem(this._inputVolumeSection);
             this._inputSection.addMenuItem(this._selectInputDeviceItem);
@@ -1353,7 +1354,12 @@ MyApplet.prototype = {
 
     _outputValuesChanged: function(actor, iconName, percentage) {
         this.setIcon(iconName, "output");
+        this.mute_out_switch.setIconSymbolicName(iconName);
         this.set_applet_tooltip(_("Volume") + ": " + percentage);
+    },
+
+    _inputValuesChanged: function(actor, iconName) {
+        this.mute_in_switch.setIconSymbolicName(iconName);
     },
 
     _onControlStateChanged: function() {

--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -883,6 +883,95 @@ PopupSwitchMenuItem.prototype = {
     }
 };
 
+function PopupSwitchIconMenuItem() {
+    this._init.apply(this, arguments);
+}
+
+PopupSwitchIconMenuItem.prototype = {
+    __proto__: PopupBaseMenuItem.prototype,
+
+    /**
+     * _init:
+     * @text (string): text to display in the label
+     * @active: boolean to set switch on or off
+     * @iconName (string): name of the icon used
+     * @iconType (St.IconType): the type of icon (usually #St.IconType.SYMBOLIC
+     * or #St.IconType.FULLCOLOR)
+     * @params (JSON): parameters to pass to %PopupMenu.PopupBaseMenuItem._init
+     */
+    _init: function(text, active, iconName, iconType, params) {
+        PopupBaseMenuItem.prototype._init.call(this, params);
+
+        this.label = new St.Label({ text: text });
+        this._statusLabel = new St.Label({ text: '', style_class: 'popup-inactive-menu-item' });
+
+        this._icon = new St.Icon({ style_class: 'popup-menu-icon',
+            icon_name: iconName,
+            icon_type: iconType});
+
+        this._switch = new Switch(active);
+
+        this.addActor(this._icon, {span: 0});
+        this.addActor(this.label);
+        this.addActor(this._statusLabel);
+
+        this._statusBin = new St.Bin({ x_align: St.Align.END });
+        this.addActor(this._statusBin, { expand: true, span: -1, align: St.Align.END });
+        this._statusBin.child = this._switch.actor;
+    },
+
+    /**
+     * setIconSymbolicName:
+     * @iconName (string): name of the icon
+     *
+     * Changes the icon to a symbolic icon with name @iconName.
+     */
+    setIconSymbolicName: function (iconName) {
+        this._icon.set_icon_name(iconName);
+        this._icon.set_icon_type(St.IconType.SYMBOLIC);
+    },
+
+    /**
+     * setIconName:
+     * @iconName (string): name of the icon
+     *
+     * Changes the icon to a full color icon with name @iconName.
+     */
+    setIconName: function (iconName) {
+        this._icon.set_icon_name(iconName);
+        this._icon.set_icon_type(St.IconType.FULLCOLOR);
+    },
+
+    setStatus: function(text) {
+        if (text != null) {
+            this._statusLabel.set_text(text);
+        } else {
+            this._statusLabel.set_text('');
+        }
+    },
+
+    activate: function(event) {
+        if (this._switch.actor.mapped) {
+            this.toggle();
+        }
+
+        PopupBaseMenuItem.prototype.activate.call(this, event, true);
+    },
+
+    toggle: function() {
+        this._switch.toggle();
+        this.emit('toggled', this._switch.state);
+    },
+
+    get state() {
+        return this._switch.state;
+    },
+
+    setToggleState: function(state) {
+        this._switch.setToggleState(state);
+    }
+};
+
 /**
  * #PopupIconMenuItem:
  * @short_description: A menu item with an icon and a text.


### PR DESCRIPTION
The new PopupSwitchIconMenuItem is the same as PopupSwitchMenuItem, but allows icons to the left of the label.
(comparable with PopupMenuItem and PopupIconMenuItem)

It is used in the contextMenu of the sound-applet, to show icons for mute switches.
This commit is a response to the feature-request https://github.com/linuxmint/Cinnamon/issues/4940,
but it only implements the requested icons. It is missing the requested alignment of the text of 'Applications' and 'Output devices'.

![bildschirmfoto vom 2016-10-21 02-04-45](https://cloud.githubusercontent.com/assets/8415124/19582187/dfb70c32-9732-11e6-9fec-d971defd56f1.png)

The new icons in the contextMenu are changing, when the input/output values are changed.