### PR TITLE
inhibit-applet: Fix an oversized menu item

### DIFF
--- a/files/usr/share/cinnamon/applets/inhibit@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/inhibit@cinnamon.org/applet.js
@@ -83,10 +83,10 @@ InhibitSwitch.prototype = {
         if (current_state >= INHIBIT_SLEEP_FLAG && !this.sessionCookie) {
             this.tooltip.set_text(_("Power management is already inhibited by another program"));
             this._applet.set_applet_tooltip(_("Power management: inhibited by another program"));
-            this._statusIcon.show();
+            this._statusIcon.set_opacity(255);
         } else {
             this.tooltip.set_text("");
-            this._statusIcon.hide();
+            this._statusIcon.set_opacity(0);
         }
     },
 


### PR DESCRIPTION
On initial show the first menu item is overly large. This seem to be caused by
the way we show and hide _statusIcon object. Switching from using show/hide to
hiding the icon by using it's opacity fixes the issue.

Fixes https://github.com/linuxmint/Cinnamon/issues/5810