### PR TITLE
[Hot Corners] Added hover delay functionality.

### DIFF
--- a/data/org.cinnamon.gschema.xml.in
+++ b/data/org.cinnamon.gschema.xml.in
@@ -359,7 +359,7 @@
     </key>
 
     <key name="overview-corner" type="as">
-      <default>['expo:false:false', 'scale:false:false', 'scale:false:false', 'desktop:false:false']</default>
+      <default>['expo:false:false:0', 'scale:false:false:0', 'scale:false:false:0', 'desktop:false:false:0']</default>
       <_summary>Properties of overview corners</_summary>
       <_description>Properties of overview corners, in the form functionality:hover:icon. The order in which properties are displayed is top left, top right, bottom left, bottom right.</_description>
     </key>


### PR DESCRIPTION
This pull request adds the ability to set a hover delay to activate hot corners. Its main purpose is to 
avoid accidental hot corners activation. I also added tooltips to the hot corners icons that reflect their current action, as suggested by @anandrkris.

The new Hot Corners settings window would look like this:

![hotcornershoverdelayimplemented2](https://cloud.githubusercontent.com/assets/3822556/19623063/73cd232a-9891-11e6-8504-51f4bec855cb.png)

### Some technicalities
- File js/ui/hotCorner.js 
    - This PR also fixes some minor white-space *inconsistencies* on this file (some missing spaces and some extra tabs). But, as I use a code formatter plugin, it also expanded some objects. Let me know if I should revert back those objects expansions.
- File files/usr/share/cinnamon/cinnamon-settings/modules/cs_hotcorner.py
    - Here I had to add a timer to the **on_widget_changed** function to avoid repeated triggering from the new **SpinButton** elements. I tried to add that timer to a new callback for the **SpinButton** elements, but I wasn't able to pass the correct arguments to the **on_widget_changed** function. Any advice will be welcome.
    - <del>I used a **Gtk.Grid** instead of a **Gtk.HBox** because of its deprecation.</del> Switched to a **Gtk.Box** as suggested by @collinss.
- <del>This PR also adds a new string that needs to be translated. I will need advice on how to proceed with this as well.</del>