### PR TITLE
Fix menu item order in window list

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -761,8 +761,6 @@ AppMenuButtonRightClickMenu.prototype = {
     },
 
     _populateMenu: function() {
-        this.box.pack_start = this.orientation == St.Side.TOP;
-
         let mw = this.metaWindow;
         let item;
         let length;


### PR DESCRIPTION
This fixes a problem, when the menu orientation is not St.Side.TOP.
the menu box layout was is reverse order.
