### PR TITLE
popupMenu: Mark the new 'menu' style class as important

### DIFF
--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -2135,7 +2135,8 @@ PopupMenu.prototype = {
         this.animating = false;
         this._slidePosition = -1;
 
-        this.actor = new St.Bin({ style_class: 'menu' });
+        this.actor = new St.Bin({ style_class: 'menu',
+                                  important: true });
         this.actor._delegate = this;
         this.actor.connect('key-press-event', Lang.bind(this, this._onKeyPressEvent));
 


### PR DESCRIPTION
We need this so theming from the default theme is used in themes that don't yet
support the new style class for menus.