### PR TITLE
[bugfix] ensure applets that override on_panel_height_changed  scale OK

### DIFF
--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -444,9 +444,18 @@ Applet.prototype = {
             this._panelHeight = panel_height;
         }
         this._scaleMode = AppletManager.enabledAppletDefinitions.idMap[this.instance_id].panel.scaleMode;
-        this.on_panel_height_changed();
+        this.on_panel_height_changed_internal();
     },
     
+    /**
+     * on_panel_height_changed_internal:
+     *
+     * This function is called when the panel containing the applet changes height
+     */
+    on_panel_height_changed_internal: function() {
+        this.on_panel_height_changed();
+    },
+
     /**
      * on_panel_height_changed:
      * 
@@ -665,10 +674,10 @@ IconApplet.prototype = {
         }
     },
 
-    on_panel_height_changed: function() {
-        this._scaleMode = AppletManager.enabledAppletDefinitions.idMap[this.instance_id].panel.scaleMode;
+    on_panel_height_changed_internal: function() {
         if (this._applet_icon)
             this._setStyle();
+        this.on_panel_height_changed();
     }
 };
 


### PR DESCRIPTION
The logic in the common applet code has been changed so that the scaling
is not overridden by the local function.
The applet will end up doing the central function and then its local one,
if it has one. The central function has the common scaling code, this
way it doesn't get skipped inadvertently.

This also corrects related errors associated with turning scale mode on and off.

One more associated change to the window-list applet in a vertical panel will be needed
but as there are changes queued up for that I think it's best done subsequently
fixes #5700
