### PR TITLE
Fix up keybind handling in menu applet

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1201,7 +1201,7 @@ MyApplet.prototype = {
     },
 
     _updateKeybinding: function() {
-        Main.keybindingManager.addHotKey("overlay-key", this.overlayKey, Lang.bind(this, function() {
+        Main.keybindingManager.addHotKey("overlay-key-" + this.instance_id, this.overlayKey, Lang.bind(this, function() {
             if (!Main.overview.visible && !Main.expo.visible)
                 this.menu.toggle_with_options(false);
         }));
@@ -1318,7 +1318,7 @@ MyApplet.prototype = {
     },
 
     on_applet_removed_from_panel: function () {
-        Main.keybindingManager.removeHotKey("overlay-key")
+        Main.keybindingManager.removeHotKey("overlay-key-" + this.instance_id)
     },
 
     _launch_editor: function() {

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1317,6 +1317,10 @@ MyApplet.prototype = {
         this.initial_load_done = true;
     },
 
+    on_applet_removed_from_panel: function () {
+        Main.keybindingManager.removeHotKey("overlay-key")
+    },
+
     _launch_editor: function() {
         Util.spawnCommandLine("cinnamon-menu-editor");
     },


### PR DESCRIPTION
We need to remove the keybind when the applet removed so it doesn't keep the menu alive, and make the keybinding name unique per-instance otherwise we have conflicts between instances' overlay-key setting.

This still needs additional work as multiple menu applets will share the default keybinding and it will activate one instance per keypress in sequence.
