### PR TITLE
[menu-applet] AllApps category becomes unselected, when Cinnamon rest…

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -2036,6 +2036,11 @@ MyApplet.prototype = {
 
         this._recalc_height();
         this._resizeApplicationsBox();
+
+        this._setCategoriesButtonActive(true);
+        this._select_category(null, this._allAppsCategoryButton);
+        this._allAppsCategoryButton.actor.style_class = "menu-category-button-selected";
+        this._activeContainer = null;
     },
 
     _refreshRecent : function() {
@@ -2129,6 +2134,11 @@ MyApplet.prototype = {
 
         this._recalc_height();
         this._resizeApplicationsBox();
+
+        this._setCategoriesButtonActive(true);
+        this._select_category(null, this._allAppsCategoryButton);
+        this._allAppsCategoryButton.actor.style_class = "menu-category-button-selected";
+        this._activeContainer = null;
     },
 
     _refreshApps : function() {


### PR DESCRIPTION
…arts

Fixes https://github.com/linuxmint/Cinnamon/issues/5872

Actually it suffices to set the AllApps category button as activated after refreshRecent, but just in case I also added it in refreshPlaces.