### PR TITLE
[Menu applet] Added keyboard navigation for context menus.

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -265,7 +265,17 @@ GenericApplicationButton.prototype = {
     },
 
     _subMenuOpenStateChanged: function() {
-        if (this.menu.isOpen) this.appsMenuButton._scrollToButton(this.menu);
+        if (this.menu.isOpen) {
+            this.appsMenuButton._activeContextMenuParent = this;
+            this.appsMenuButton._scrollToButton(this.menu);
+        } else {
+            this.appsMenuButton._activeContextMenuItem = null;
+            this.appsMenuButton._activeContextMenuParent = null;
+        }
+    },
+
+    get _contextIsOpen() {
+        return this.menu.isOpen;
     }
 }
 
@@ -698,7 +708,17 @@ RecentButton.prototype = {
     },
 
     _subMenuOpenStateChanged: function() {
-        if (this.menu.isOpen) this.appsMenuButton._scrollToButton(this.menu);
+        if (this.menu.isOpen) {
+            this.appsMenuButton._activeContextMenuParent = this;
+            this.appsMenuButton._scrollToButton(this.menu);
+        } else {
+            this.appsMenuButton._activeContextMenuItem = null;
+            this.appsMenuButton._activeContextMenuParent = null;
+        }
+    },
+
+    get _contextIsOpen() {
+        return this.menu.isOpen;
     }
 };
 
@@ -1176,6 +1196,8 @@ MyApplet.prototype = {
         this.RecentManager = new DocInfo.DocManager();
         this.privacy_settings = new Gio.Settings( {schema_id: PRIVACY_SCHEMA} );
         this.noRecentDocuments = true;
+        this._activeContextMenuParent = null;
+        this._activeContextMenuItem = null;
         this._display();
         appsys.connect('installed-changed', Lang.bind(this, this.onAppSysChanged));
         AppFavorites.getAppFavorites().connect('changed', Lang.bind(this, this._refreshFavs));
@@ -1450,16 +1472,75 @@ MyApplet.prototype = {
             this._applet_icon_box.show();
         }
 
-	    if (this.orientation == St.Side.LEFT || this.orientation == St.Side.RIGHT)  // no menu label if in a vertical panel
-	    {
+        if (this.orientation == St.Side.LEFT || this.orientation == St.Side.RIGHT)  // no menu label if in a vertical panel
+        {
             this.set_applet_label("");
-	    }
+        }
         else {
             if (this.menuLabel != "")
                 this.set_applet_label(_(this.menuLabel));
             else
                 this.set_applet_label("");
         }
+    },
+
+    _navigateContextMenu: function(actor, symbol, ctrlKey) {
+        if (symbol === Clutter.KEY_Menu || symbol === Clutter.Escape ||
+            (ctrlKey && (symbol === Clutter.KEY_Return || symbol === Clutter.KP_Enter))) {
+            actor.activateContextMenus();
+            return true;
+        }
+
+        let goUp = symbol === Clutter.KEY_Up;
+        let nextActive = null;
+        let menuItems = actor.menu._getMenuItems(); // The context menu items
+
+        // The first context menu item of a RecentButton is used just as a label.
+        // So remove it from the iteration.
+        if (actor instanceof RecentButton)
+            menuItems.shift();
+
+        let menuItemsLength = menuItems.length;
+
+        switch (symbol) {
+            case Clutter.KEY_Page_Up:
+                this._activeContextMenuItem = menuItems[0];
+                this._activeContextMenuItem.setActive(true);
+                return true;
+            case Clutter.KEY_Page_Down:
+                this._activeContextMenuItem = menuItems[menuItemsLength - 1];
+                this._activeContextMenuItem.setActive(true);
+                return true;
+        }
+
+        if (!this._activeContextMenuItem) {
+            if (symbol === Clutter.KEY_Return || symbol === Clutter.KP_Enter) {
+                actor.activate();
+            } else {
+                this._activeContextMenuItem = menuItems[goUp ? menuItemsLength - 1 : 0];
+                this._activeContextMenuItem.setActive(true);
+            }
+            return true;
+        } else if (this._activeContextMenuItem &&
+            (symbol === Clutter.KEY_Return || symbol === Clutter.KP_Enter)) {
+            this._activeContextMenuItem.activate();
+            this._activeContextMenuItem = null;
+            return true;
+        }
+
+        let i = 0;
+        for (; i < menuItemsLength; i++) {
+            if (menuItems[i] === this._activeContextMenuItem) {
+                nextActive = goUp ? (menuItems[i - 1] || null) : (menuItems[i + 1] || null);
+                break;
+            }
+        }
+
+        if (!nextActive)
+            nextActive = goUp ? menuItems[menuItemsLength - 1] : menuItems[0];
+
+        nextActive.setActive(true);
+        this._activeContextMenuItem = nextActive;
     },
 
     _onMenuKeyPress: function(actor, event) {
@@ -1484,6 +1565,34 @@ MyApplet.prototype = {
         index = this._selectedItemIndex;
 
         let ctrlKey = modifierState & Clutter.ModifierType.CONTROL_MASK;
+
+        // If a context menu is open, hijack keyboard navigation and concentrate on the context menu.
+        if (this._activeContextMenuParent && this._activeContextMenuParent._contextIsOpen &&
+            this._activeContainer === this.applicationsBox &&
+            (this._activeContextMenuParent instanceof ApplicationButton ||
+                this._activeContextMenuParent instanceof RecentButton)) {
+            let continueNavigation = false;
+            switch (symbol) {
+                case Clutter.KEY_Up:
+                case Clutter.KEY_Down:
+                case Clutter.KEY_Return:
+                case Clutter.KP_Enter:
+                case Clutter.KEY_Menu:
+                case Clutter.KEY_Page_Up:
+                case Clutter.KEY_Page_Down:
+                case Clutter.Escape:
+                    this._navigateContextMenu(this._activeContextMenuParent, symbol, ctrlKey);
+                    break;
+                case Clutter.KEY_Right:
+                case Clutter.KEY_Left:
+                case Clutter.Tab:
+                case Clutter.ISO_Left_Tab:
+                    continueNavigation = true;
+                    break;
+            }
+            if (!continueNavigation)
+                return true;
+        }
 
         let navigationKey = true;
         let whichWay = "none";


### PR DESCRIPTION
The latest changes to the menu applet added the possibility to open the context menu for menu items with the keyboard, but the context wasn't navigable. This pull request adds the ability to navigate the context menus with the keyboard.

#### Usage

- The **Arrow Up/Down** and **PageUp/PageDown** keys will navigate through the menu items of an open context menu.
- If the **Arrow Left/Right** or **Tab** keys are pressed, it will continue navigation outside the applications box.
- If the **Escape** key is pressed while a context menu is open, first it will close the opened context menu and if it's pressed again it will close the applet menu.
