### PR TITLE
[menu-applet] hide recent files, which are no longer available 

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -2092,6 +2092,10 @@ MyApplet.prototype = {
                             if (fileIndex !== -1)
                                 selectedAppUri = selectedAppUri.substr(fileIndex + 7);
                             this.selectedAppDescription.set_text(selectedAppUri);
+
+                            let file = Gio.file_new_for_uri(button.file.uriDecoded);
+                            if (!file.query_exists(null))
+                                this.selectedAppTitle.set_text(_("This file is no longer available"));
                             }));
                     button.actor.connect('leave-event', Lang.bind(this, function() {
                             button.actor.style_class = "menu-application-button";
@@ -2099,9 +2103,12 @@ MyApplet.prototype = {
                             this.selectedAppTitle.set_text("");
                             this.selectedAppDescription.set_text("");
                             }));
-                    this._recentButtons.push(button);
-                    this.applicationsBox.add_actor(button.actor);
-                    this.applicationsBox.add_actor(button.menu.actor);
+                    let file = Gio.file_new_for_uri(button.file.uriDecoded);
+                    if (file.query_exists(null)) {
+                        this._recentButtons.push(button);
+                        this.applicationsBox.add_actor(button.actor);
+                        this.applicationsBox.add_actor(button.menu.actor);
+                    }
                 }
 
                 let button = new RecentClearButton(this);


### PR DESCRIPTION
Recent files, which are no longer available, will be hidden in the recent files category after next call of refreshRecent.
If the file is available again, because it was on a CD or USB, it will appear again.
If a file is no longer available, but the recent files are not refreshed yet, the description of the file shows a warning "**This file is no longer available**".