### PR TITLE
[Xlet settings] "entry" and "iconchooser" elements modifications.

### DIFF
--- a/docs/reference/cinnamon-tutorials/xlet-settings-ref.xml
+++ b/docs/reference/cinnamon-tutorials/xlet-settings-ref.xml
@@ -21,6 +21,7 @@
         <listitem><code>type</code>: should be <code>entry</code></listitem>
         <listitem><code>default</code>: default string value</listitem>
         <listitem><code>description</code>: String describing the setting</listitem>
+        <listitem><code>expand-width</code>:  (optional) true or false, or leave off entirely. Forces editable fields of <code>entry</code>'s elements to occupy the entire space available in a row</listitem>
       </itemizedlist>
 
       <para>A text entry field that stores a <code>string</code></para>
@@ -89,6 +90,7 @@
         <listitem><code>description</code>: String describing the setting</listitem>
         <listitem><code>default</code>: Default filename to use</listitem>
         <listitem><code>select-dir</code>:  (optional) true or false, or leave off entirely. Forces directory selection.</listitem>
+        <listitem><code>expand-width</code>:  (optional) true or false, or leave off entirely. Forces editable fields of <code>filechooser</code>'s elements to occupy the entire space available in a row</listitem>
       </itemizedlist>
 
       <para>Opens a file picker dialog to allow you to choose a filename.  If <code>select-dir</code> is <code>true</code>, it will only allow directories to be selected.  Stores as a <code>string</code>.</para>

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py
@@ -12,7 +12,8 @@ JSON_SETTINGS_PROPERTIES_MAP = {
     "height"        : "height",
     "tooltip"       : "tooltip",
     "possible"      : "possible",
-    "dependency"    : "dep_key"
+    "dependency"    : "dep_key",
+    "expand-width"  : "expand_width"
 }
 
 class JSONSettingsHandler(object):
@@ -21,7 +22,7 @@ class JSONSettingsHandler(object):
 
         self.resume_timeout = None
         self.notify_callback = notify_callback
-        
+
         self.filepath = filepath
         self.file_obj = Gio.File.new_for_path(self.filepath)
         self.file_monitor = self.file_obj.monitor_file(Gio.FileMonitorFlags.SEND_MOVED, None)
@@ -227,7 +228,7 @@ def json_settings_factory(subclass):
         def __init__(self, key, settings, properties):
             self.key = key
             self.settings = settings
-            
+
             kwargs = {}
             for prop in properties:
                 if prop in JSON_SETTINGS_PROPERTIES_MAP:

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
@@ -552,14 +552,14 @@ class Entry(SettingsWidget):
     bind_prop = "text"
     bind_dir = Gio.SettingsBindFlags.DEFAULT
 
-    def __init__(self, label, size_group=None, dep_key=None, tooltip=""):
+    def __init__(self, label, expand_width=False, size_group=None, dep_key=None, tooltip=""):
         super(Entry, self).__init__(dep_key=dep_key)
 
         self.label = Gtk.Label.new(label)
         self.content_widget = Gtk.Entry()
 
         self.pack_start(self.label, False, False, 0)
-        self.pack_end(self.content_widget, False, False, 0)
+        self.pack_end(self.content_widget, expand_width, expand_width, 0)
 
         self.set_tooltip_text(tooltip)
 
@@ -924,7 +924,7 @@ class IconChooser(SettingsWidget):
     bind_prop = "text"
     bind_dir = Gio.SettingsBindFlags.DEFAULT
 
-    def __init__(self, label, size_group=None, dep_key=None, tooltip=""):
+    def __init__(self, label, expand_width=False, size_group=None, dep_key=None, tooltip=""):
         super(IconChooser, self).__init__(dep_key=dep_key)
 
         valid, self.width, self.height = Gtk.icon_size_lookup(Gtk.IconSize.BUTTON)
@@ -938,11 +938,11 @@ class IconChooser(SettingsWidget):
         self.preview = Gtk.Image.new()
         self.image_button.set_image(self.preview)
 
-        self.content_widget.pack_start(self.bind_object, False, False, 2)
+        self.content_widget.pack_start(self.bind_object, expand_width, expand_width, 2)
         self.content_widget.pack_start(self.image_button, False, False, 5)
 
         self.pack_start(self.label, False, False, 0)
-        self.pack_end(self.content_widget, False, False, 0)
+        self.pack_end(self.content_widget, expand_width, expand_width, 0)
 
         self.image_button.connect("clicked", self.on_button_pressed)
         self.handler = self.bind_object.connect("changed", self.set_icon)


### PR DESCRIPTION
By default, "entry" and "iconchooser" editable fields are too small on xlet's setting windows. In addition, they don't expand their width when the window is resized. This makes those elements *uncomfortable to work with*.

This commit adds to the "entry" and "iconchooser" elements a new boolean option (optional) called "expand-width". When set to **true**, the editable fields for "entry" and "iconchooser" elements will occupy all available space in the row and at the same time will expand if the window is resized.

#### Comparisons

This is how "entry" and "iconchooser" elements looks like on current Cinnamon stable (3.0.7). Editable fields occupy all the available space and they expand on window resize.

![entrywidthonstable](https://cloud.githubusercontent.com/assets/3822556/19910860/8093c372-a06e-11e6-9f6c-33acb559afc9.png)

This is how those elements looks like on Cinnamon nightly with the new proposed option ("expand-width") set to **true** in the section called **Custom launcher 1** and with the same option omitted on the section called **Custom launcher 2**. The editable fields on section **Custom launcher 1** will expand when the window is resized.

![entrywidthnormal](https://cloud.githubusercontent.com/assets/3822556/19910859/8033316a-a06e-11e6-94d1-d4583788b338.png)

### Technicalities

I have chosen to add this new option instead of directly editing the python functions that creates the "entry" and "iconchooser" elements because I considerer it less intrusive and it doesn't affect existing elements using those functions (like the away message option on the Screensaver settings window).