### PR TITLE
[Xlet settings] Added option to "colorchooser" elements to enable alpha.

### DIFF
--- a/docs/reference/cinnamon-tutorials/xlet-settings-ref.xml
+++ b/docs/reference/cinnamon-tutorials/xlet-settings-ref.xml
@@ -44,6 +44,7 @@
         <listitem><code>type</code>: should be <code>colorchooser</code></listitem>
         <listitem><code>default</code>: default color string - can be <code>"red"</code> or <code>"rgba(x,x,x,x)"</code>, etc...</listitem>
         <listitem><code>description</code>: String describing the setting</listitem>
+        <listitem><code>enable-alpha</code>:  (optional) true or false, or leave off entirely. Enables the <code>colorchooser</code> to select a color with alpha</listitem>
       </itemizedlist>
 
       <para>A Color button that lets you choose a RGBA color code as a <code>string</code></para>

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py
@@ -12,7 +12,8 @@ JSON_SETTINGS_PROPERTIES_MAP = {
     "height"        : "height",
     "tooltip"       : "tooltip",
     "possible"      : "possible",
-    "dependency"    : "dep_key"
+    "dependency"    : "dep_key",
+    "enable-alpha"  : "enable_alpha",
 }
 
 class JSONSettingsHandler(object):
@@ -21,7 +22,7 @@ class JSONSettingsHandler(object):
 
         self.resume_timeout = None
         self.notify_callback = notify_callback
-        
+
         self.filepath = filepath
         self.file_obj = Gio.File.new_for_path(self.filepath)
         self.file_monitor = self.file_obj.monitor_file(Gio.FileMonitorFlags.SEND_MOVED, None)
@@ -227,7 +228,7 @@ def json_settings_factory(subclass):
         def __init__(self, key, settings, properties):
             self.key = key
             self.settings = settings
-            
+
             kwargs = {}
             for prop in properties:
                 if prop in JSON_SETTINGS_PROPERTIES_MAP:

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
@@ -769,7 +769,7 @@ class ComboBox(SettingsWidget):
 class ColorChooser(SettingsWidget):
     bind_dir = None
 
-    def __init__(self, label, legacy_string=False, size_group=None, dep_key=None, tooltip=""):
+    def __init__(self, label, enable_alpha=False, legacy_string=False, size_group=None, dep_key=None, tooltip=""):
         super(ColorChooser, self).__init__(dep_key=dep_key)
         # note: Gdk.Color is deprecated in favor of Gdk.RGBA, but as the hex format is still used
         # in some places (most notably the desktop background handling in cinnamon-desktop) we
@@ -778,6 +778,7 @@ class ColorChooser(SettingsWidget):
 
         self.label = Gtk.Label(label)
         self.content_widget = Gtk.ColorButton()
+        self.content_widget.set_use_alpha(enable_alpha)
         self.pack_start(self.label, False, False, 0)
         self.pack_end(self.content_widget, False, False, 0)
 


### PR DESCRIPTION
By default, "colorchooser" elements can't choose a color with alpha (transparency). Contrary to what it occurs in the current stable Cinnamon version 3.0.7, where all "colorchooser" elements from xlet's settings windows are able to select a color with alpha.

This commit adds to the "colorchooser" elements a new boolean option (optional) called "enable-alpha". When set to **true**, "colorchooser" elements will be able to select a color with alpha. When set to **false** or ignored, "colorchooser" elements will not be able to select a color with alpha.

This commit closes linuxmint/Cinnamon#5647

### Technicalities

I first considered to enable alpha for color choosers globally by directly modifying the **ColorChooser** function (located in [this file](https://github.com/linuxmint/Cinnamon/blob/master/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py#770)). But I didn't know if that would *break* something that uses a color chooser and it doesn't support a color with alpha. So, instead, I have chosen to add this new option, because I considerer it less intrusive and it doesn't affect existing elements using those functions (like the color choosers on the Backgrounds settings window). **If someone can confirm that enabling alpha for color choosers globally wouldn't *break* anything, I could *convert* this pull request or create a new one for that purpose.**