### PR TITLE
[Xlet settings] Added support for "button" to extensions settings windows.

### DIFF
--- a/docs/reference/cinnamon-tutorials/xlet-settings-ref.xml
+++ b/docs/reference/cinnamon-tutorials/xlet-settings-ref.xml
@@ -201,7 +201,9 @@
         <listitem><code>callback</code>: string of callback method name (no "this", just "myFunc")</listitem>
       </itemizedlist>
 
-      <para>A <emphasis>non-setting</emphasis> widget, this provides a button, which, when clicked, activates the <code>callback</code> method in your applet. Note: the callback value should be a string of the method name only.  For instance, to call <code>this.myCallback()</code>, you would put <code>myCallback</code> for the callback value.</para>
+      <para>A <emphasis>non-setting</emphasis> widget, this provides a button, which, when clicked, activates the <code>callback</code> method in your applet/desklet. Note: the callback value should be a string of the method name only.  For instance, to call <code>this.myCallback()</code>, you would put <code>myCallback</code> for the callback value.</para>
+
+      <para>Special case: for a <code>button</code> element to work on an extension setting window, an object containing all needed callback functions needs to be created and then returned by the <code>enable()</code> function.</para>
     </sect3>
     <sect3>
       <title>Additional Setting Options</title>

--- a/js/ui/cinnamonDBus.js
+++ b/js/ui/cinnamonDBus.js
@@ -167,10 +167,10 @@ CinnamonDBus.prototype = {
      * indicating whether the operation was successful or not.
      *
      */
-    ScreenshotArea: function (include_cursor, x, y, width, height, flash, filename) {
+    ScreenshotArea: function(include_cursor, x, y, width, height, flash, filename) {
         let screenshot = new Cinnamon.Screenshot();
-        screenshot.screenshot_area (include_cursor, x, y, width, 200, filename,
-                                Lang.bind(this, this._onScreenshotComplete, flash));
+        screenshot.screenshot_area(include_cursor, x, y, width, 200, filename,
+            Lang.bind(this, this._onScreenshotComplete, flash));
     },
 
     /**
@@ -185,11 +185,10 @@ CinnamonDBus.prototype = {
      * indicating whether the operation was successful or not.
      *
      */
-    ScreenshotWindow: function (include_frame, include_cursor, flash, filename) {
+    ScreenshotWindow: function(include_frame, include_cursor, flash, filename) {
         let screenshot = new Cinnamon.Screenshot();
-        screenshot.screenshot_window (include_frame, include_cursor, filename,
-                                      Lang.bind(this, this._onScreenshotComplete,
-                                                flash, invocation));
+        screenshot.screenshot_window(include_frame, include_cursor, filename,
+            Lang.bind(this, this._onScreenshotComplete, flash));
     },
 
     /**
@@ -203,11 +202,10 @@ CinnamonDBus.prototype = {
      * indicating whether the operation was successful or not.
      *
      */
-    Screenshot: function (include_cursor, flash, filename) {
+    Screenshot: function(include_cursor, flash, filename) {
         let screenshot = new Cinnamon.Screenshot();
         screenshot.screenshot(include_cursor, filename,
-                          Lang.bind(this, this._onScreenshotComplete,
-                                    flash, invocation));
+            Lang.bind(this, this._onScreenshotComplete, flash));
     },
 
     ShowOSD: function(params) {
@@ -227,7 +225,12 @@ CinnamonDBus.prototype = {
     },
 
     FlashArea: function(x, y, width, height) {
-        let flashspot = new Flashspot.Flashspot({ x : x, y : y, width: width, height: height});
+        let flashspot = new Flashspot.Flashspot({
+            x: x,
+            y: y,
+            width: width,
+            height: height
+        });
         flashspot.fire();
     },
 
@@ -255,18 +258,22 @@ CinnamonDBus.prototype = {
 
     _getXletObject: function(uuid, instance_id) {
         var obj = null;
-        
+
         obj = AppletManager.get_object_for_uuid(uuid, instance_id);
-        
+
         if (!obj) {
             obj = DeskletManager.get_object_for_uuid(uuid, instance_id);
         }
 
-        return obj
+        if (!obj) {
+            obj = ExtensionSystem.get_object_for_uuid(uuid);
+        }
+
+        return obj;
     },
 
     EmitXletAddedComplete: function(success, uuid, name) {
-        this._dbusImpl.emit_signal('XletAddedComplete', GLib.Variant.new('(bs)', [success,uuid]));
+        this._dbusImpl.emit_signal('XletAddedComplete', GLib.Variant.new('(bs)', [success, uuid]));
     },
 
     GetRunningXletUUIDs: function(type) {
@@ -360,11 +367,9 @@ CinnamonDBus.prototype = {
         if (!Main.expo.animationInProgress)
             Main.expo.toggle();
     },
-    
-    PushSubprocessResult: function(process_id, result)
-    {
-        if (Util.subprocess_callbacks[process_id])
-        {
+
+    PushSubprocessResult: function(process_id, result) {
+        if (Util.subprocess_callbacks[process_id]) {
             Util.subprocess_callbacks[process_id](result);
         }
     },

--- a/js/ui/extensionSystem.js
+++ b/js/ui/extensionSystem.js
@@ -10,6 +10,8 @@ var extensionMeta;
 const runningExtensions = {};
 // Arrays of uuids
 var enabledExtensions;
+// Maps extension.uuid -> extension objects
+const extensionObj = [];
 
 const ENABLED_EXTENSIONS_KEY = 'enabled-extensions';
 
@@ -34,11 +36,14 @@ function prepareExtensionUnload(extension) {
         extension.logError('Failed to evaluate \'disable\' function on extension: ' + extension.uuid, e);
     }
     delete runningExtensions[extension.uuid];
+
+    if (extensionObj[extension.uuid])
+        delete extensionObj[extension.uuid];
 }
 
 // Callback for extension.js
 function finishExtensionLoad(extension) {
-    if(!extension.lockRole(extension.module)) {
+    if (!extension.lockRole(extension.module)) {
         return false;
     }
 
@@ -48,26 +53,45 @@ function finishExtensionLoad(extension) {
         extension.logError('Failed to evaluate \'init\' function on extension: ' + extension.uuid, e);
         return false;
     }
+
+    let extensionCallbacks;
     try {
-        extension.module.enable();
+        extensionCallbacks = extension.module.enable();
     } catch (e) {
         extension.logError('Failed to evaluate \'enable\' function on extension: ' + extension.uuid, e);
         return false;
     }
 
     runningExtensions[extension.uuid] = true;
+
+    // extensionCallbacks is an object returned by the enable() function defined in extension.js.
+    // The extensionCallbacks object should contain functions that can be used by the "callback" key
+    // of "button" elements defined in the extension's settings file (settings-schema.json).
+    if (extensionCallbacks) {
+        extensionObj[extension.uuid] = extensionCallbacks;
+        extensionCallbacks._uuid = extension.uuid;
+    }
+
     return true;
+}
+
+function get_object_for_uuid(uuid) {
+    for (let thisExtensionUUID in extensionObj) {
+        if (extensionObj[thisExtensionUUID]._uuid == uuid)
+            return extensionObj[thisExtensionUUID];
+        return null;
+    }
 }
 
 function onEnabledExtensionsChanged() {
     enabledExtensions = global.settings.get_strv(ENABLED_EXTENSIONS_KEY);
 
-    for(let uuid in Extension.Type.EXTENSION.maps.objects) {
-        if(enabledExtensions.indexOf(uuid) == -1)
+    for (let uuid in Extension.Type.EXTENSION.maps.objects) {
+        if (enabledExtensions.indexOf(uuid) == -1)
             Extension.unloadExtension(uuid, Extension.Type.EXTENSION);
     }
-    
-    for(let i=0; i<enabledExtensions.length; i++) {
+
+    for (let i = 0; i < enabledExtensions.length; i++) {
         Extension.loadExtension(enabledExtensions[i], Extension.Type.EXTENSION);
     }
 }
@@ -76,9 +100,9 @@ function init() {
     extensions = Extension.Type.EXTENSION.maps.importObjects;
     extensionMeta = Extension.Type.EXTENSION.maps.meta;
     ExtensionState = Extension.State;
-    
+
     global.settings.connect('changed::' + ENABLED_EXTENSIONS_KEY, onEnabledExtensionsChanged);
-    
+
     enabledExtensions = global.settings.get_strv(ENABLED_EXTENSIONS_KEY);
     for (let i = 0; i < enabledExtensions.length; i++) {
         Extension.loadExtension(enabledExtensions[i], Extension.Type.EXTENSION);


### PR DESCRIPTION
By default, "button" elements aren't functional when used inside the settings windows for extensions. There isn't a mechanism to store the callback declared in the "callback" keys of said elements.

This commit adds to the extensions system a mechanism similar to what applets and desklets managers uses. It stores an object containing one or more functions (defined by the extension creator) returned by the `enable()` function defined in extension.js. These functions can then be called from "button" elements defined in the extension's settings file (settings-schema.json).

Corrected some minor indentation/white space inconsistencies and removed a couple of undeclared/unused arguments.

This commit closes linuxmint/Cinnamon#5842

### Usage

Given the following "button" elements...

```json
"button_id_001": {
    "type": "button",
    "description": "Execute callbackFunction001",
    "callback": "callbackFunction001"
},
"button_id_002": {
    "type": "button",
    "description": "Execute callbackFunction002",
    "callback": "callbackFunction002"
}
```

...the callback function will have to be defined like this...

```javascript
/**
 * Main extension code
 */
const MyCallbacks = {
    callbackFunction001: function() {
        // body...
    },
    callbackFunction002: function() {
        // body...
    }
};

function enable() {
    /**
     * Main extension code
     */
    return MyCallbacks;
}
/**
 * Main extension code
 */
```

### Technicalities

- I first considered to expose the entire extension module, so it would be easy to access any function defined in the extension.js file from a "button" element's callback. But that might have been an exaggeration and even insecure(?). So I opted to implement a mechanism similar to what the applets/desklets managers use.
- File cinnamonDBus.js:
    - I removed what seems to have been two undeclared/unused arguments from the **ScreenshotWindow** and **Screenshot** functions. I couldn't find any call to these two functions to evaluate if those arguments aren't really needed (maybe I have to add them to the function declaration to be correctly passed(?)). **I will need confirmation on this.**

