### PR TITLE
menu-applet: Add a setting for the new menu animations

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1140,6 +1140,7 @@ MyApplet.prototype = {
         this.settings.bind("show-category-icons", "showCategoryIcons", this._refreshAll);
         this.settings.bind("show-application-icons", "showApplicationIcons", this._refreshAll);
         this.settings.bind("favbox-show", "favBoxShow", this._favboxtoggle);
+        this.settings.bind("enable-animation", "enableAnimation", null);
 
         this._updateKeybinding();
 
@@ -1203,7 +1204,7 @@ MyApplet.prototype = {
     _updateKeybinding: function() {
         Main.keybindingManager.addHotKey("overlay-key", this.overlayKey, Lang.bind(this, function() {
             if (!Main.overview.visible && !Main.expo.visible)
-                this.menu.toggle_with_options(false);
+                this.menu.toggle_with_options(this.enableAnimation);
         }));
     },
 
@@ -1241,7 +1242,7 @@ MyApplet.prototype = {
 
     openMenu: function() {
         if (!this._applet_context_menu.isOpen) {
-            this.menu.open(false);
+            this.menu.open(this.enableAnimation);
         }
     },
 
@@ -1322,7 +1323,7 @@ MyApplet.prototype = {
     },
 
     on_applet_clicked: function(event) {
-        this.menu.toggle_with_options(false);
+        this.menu.toggle_with_options(this.enableAnimation);
     },
 
     _onSourceKeyPress: function(actor, event) {
@@ -1416,7 +1417,7 @@ MyApplet.prototype = {
     _favboxtoggle: function() {
         if (!this.favBoxShow) {
             this.leftPane.hide();
-        }else{
+        } else {
             this.leftPane.show();
         }
     },

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/settings-schema.json
@@ -20,7 +20,7 @@
         "panel-behave" : {
             "type" : "section",
             "title" : "Behavior",
-            "keys" : ["overlay-key", "activate-on-hover", "hover-delay"]
+            "keys" : ["overlay-key", "activate-on-hover", "hover-delay", "enable-animation"]
         },
         "menu-layout" : {
             "type" : "section",
@@ -110,6 +110,12 @@
     "dependency" : "activate-on-hover",
     "description" : "Menu hover delay",
     "tooltip" : "Delay before the menu opens when hovered"
+ },
+ "enable-animation" : {
+    "type": "switch",
+    "default": false,
+    "description": "Use menu animations",
+    "tooltip": "Allow the menu to animate on open and close"
  },
   "menu-editor-button" : {
     "type" : "button",


### PR DESCRIPTION
Allow the new menu animations to be enabled on the main Cinnamon menu. In the
past there were complaints about the menu being too slow open and the new
animation may add to that perception. Set it off by default but allow users
to enable it.