### PR TITLE
avoid varying space between month and day

### DIFF
--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
@@ -89,7 +89,7 @@ MyApplet.prototype = {
             }
 
             // Track changes to clock settings
-            this._dateFormatFull = _("%A %B %e, %Y");
+            this._dateFormatFull = _("%A %B %-e, %Y");
 
             this.settings.bind("use-custom-format", "use_custom_format", this.on_settings_changed);
             this.settings.bind("custom-format", "custom_format", this.on_settings_changed);


### PR DESCRIPTION
Use of `%e` causes uneven spacing in the date display on the tool-tip and the applet itself on single-digit days, e.g.—

```
Sunday November  6, 2016
      ^        ^^  ^
```

Use of `%-e` ensures uniform spacing across the entire string, e.g.—
```
Sunday November 6, 2016
      ^        ^  ^
```