### PR TITLE
[cinnamon-json-makepot] Added support for "title" key

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-json-makepot/cinnamon-json-makepot.py
+++ b/files/usr/share/cinnamon/cinnamon-json-makepot/cinnamon-json-makepot.py
@@ -217,7 +217,7 @@ class Main:
 
     def extract_strings(self, data, parent=""):
         for key in data.keys():
-            if key in ("description", "tooltip", "units"):
+            if key in ("description", "tooltip", "units", "title"):
                 comment = "%s->settings-schema.json->%s->%s" % (self.current_parent_dir, parent, key)
                 self.save_entry(data[key], comment)
             elif key in "options":


### PR DESCRIPTION
With the redesign of the xlets settings system, there is a new UI element called "page". These elements have a key called "title" that needs to be translated.

This commit adds the ability to the `cinnamon-json-makepot` command to extract from the settings-schema.json file those keys when said command is used to create a .pot file.