### PR TITLE
[applet.js] Re added ability to display a separator on applets context menus.

### DIFF
--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -492,6 +492,10 @@ Applet.prototype = {
             this.context_menu_separator = new PopupMenu.PopupSeparatorMenuItem();
         }
 
+        if (this._applet_context_menu._getMenuItems().length > 0) {
+            this._applet_context_menu.addMenuItem(this.context_menu_separator);
+        }
+
         if (items.indexOf(this.context_menu_item_about) == -1) {
             this._applet_context_menu.addMenuItem(this.context_menu_item_about);
         }


### PR DESCRIPTION
In Cinnamon version 3.0.7, when new menu items are added to the context menu of an applet/desklet, a separator automatically appears, dividing the default menu items (**About**, **Configure...** and **Remove...**) from the just added menu items. In Cinnamon version 3.2.x, the same behavior was observed until [this commit](https://git.io/v6rI7) removed it.

This commit brings back that behavior to the context menu for applets