### PR TITLE
[workspace-switcher] Fix buttons' size

### DIFF
--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
@@ -185,13 +185,11 @@ SimpleButton.prototype = {
             this.actor.add_style_pseudo_class('outlined');
         }
 
-        if (applet._scaleMode) {
-            if (applet.orientation == St.Side.TOP || applet.orientation == St.Side.BOTTOM) {
-                this.actor.set_height(applet._panelHeight);
-            } else {
-                this.actor.set_height(0.6 * applet._panelHeight);  // factors are completely empirical
-                this.actor.set_width(0.9 * applet._panelHeight);
-            }
+        if (applet.orientation == St.Side.TOP || applet.orientation == St.Side.BOTTOM) {
+            this.actor.set_height(applet._panelHeight);
+        } else {
+            this.actor.set_height(0.6 * applet._panelHeight);  // factors are completely empirical
+            this.actor.set_width(0.9 * applet._panelHeight);
         }
 
         if (applet.orientation == St.Side.LEFT || applet.orientation == St.Side.RIGHT)


### PR DESCRIPTION
Workspace applet buttons didn't get proper height (or width in vertical mode), like any other button, if the auto-scale font setting was not enabled.

Here is a screenshot of the problem:
![screenshot from 2016-11-13 20-49-51](https://cloud.githubusercontent.com/assets/10391266/20248375/1ee7aeda-a9e3-11e6-8891-766c1611ae54.png) ![screenshot from 2016-11-15 21-07-48](https://cloud.githubusercontent.com/assets/10391266/20322018/d083f56e-ab77-11e6-94da-c4ea14c123a3.png)