### PR TITLE
[sound-applet] removed ancient code for timeLabel

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/settings-schema.json
@@ -15,17 +15,6 @@
         "dependency": "playerControl",
         "indent": true
     },
-    "positionLabelType": {
-        "type": "combobox",
-        "default": "length",
-        "description": "Position label",
-        "options": {
-            "Song length": "length",
-            "Countdown": "countdown"
-        },
-        "dependency": "playerControl",
-        "indent": true
-    },
     "showSliderPercentage": {
         "type": "switch",
         "default": false,


### PR DESCRIPTION
The feature to show the timer/minutes in the sound-applet, was removed a long long time ago.
This removes remained code of this feature, which also includes the remained option "countdown/song lenght" in the settings of the applet.