### PR TITLE
cs_effects: Disable menu animations when turning off window effects

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_effects.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_effects.py
@@ -66,7 +66,7 @@ class GSettingsTweenChooserButton(TweenChooserButton, CSGSettingsBackend):
         self.bind_prop = "tween"
         self.bind_dir = Gio.SettingsBindFlags.DEFAULT
         self.bind_object = self
-        
+
         if schema not in settings_objects.keys():
             settings_objects[schema] = Gio.Settings.new(schema)
         self.settings = settings_objects[schema]
@@ -80,7 +80,7 @@ class GSettingsEffectChooserButton(EffectChooserButton, CSGSettingsBackend):
         self.bind_prop = "effect"
         self.bind_dir = Gio.SettingsBindFlags.DEFAULT
         self.bind_object = self
-        
+
         if schema not in settings_objects.keys():
             settings_objects[schema] = Gio.Settings.new(schema)
         self.settings = settings_objects[schema]
@@ -258,5 +258,8 @@ class Module:
 
         if not active and schema.get_boolean("desktop-effects-on-dialogs"):
             schema.set_boolean("desktop-effects-on-dialogs", False)
+
+        if not active and schema.get_boolean("desktop-effects-on-menus"):
+            schema.set_boolean("desktop-effects-on-menus", False)
 
         self.update_effects(self.custom_switch, None)


### PR DESCRIPTION
When disabling window effects the menu effects setting is hidden. Make sure to
disable the menu effects when that happens.

Fixes https://github.com/linuxmint/Cinnamon/issues/5936