### PR TITLE
menu-applet: Make the 'menu-background' style class work again

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1150,7 +1150,7 @@ MyApplet.prototype = {
         this.settings.bind("activate-on-hover", "activateOnHover", this._updateActivateOnHover);
         this._updateActivateOnHover();
 
-        this.menu.actor.add_style_class_name('menu-background');
+        this.menu.actor.connect('style-changed', Lang.bind(this, this._addCustomStyle));
         this.menu.connect('open-state-changed', Lang.bind(this, this._onOpenStateChanged));
 
         this.settings.bind("menu-icon-custom", "menuIconCustom", this._updateIconAndLabel);
@@ -1235,6 +1235,10 @@ MyApplet.prototype = {
             this.refreshing = true;
             Mainloop.timeout_add_seconds(1, Lang.bind(this, this._refreshAll));
         }
+    },
+
+    _addCustomStyle: function() {
+        this.menu.actor.add_style_class_name('menu-background');
     },
 
     onAppSysChanged: function() {


### PR DESCRIPTION
The new popupMenu implementation allows theming the menus based on orientation.
This overwrites the menu-background style class added by the menu applet. To
get around this connect to the actors 'style-changed' signal so that anytime
popupMenu.js changes the style class we ensure the applets custom style class
gets re-added.

Fixes https://github.com/linuxmint/Cinnamon/issues/5934