### PR TITLE
Change popup-sub-menu style class to popup-submenu for consistency

### DIFF
--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -2610,7 +2610,7 @@ PopupSubMenu.prototype = {
 
         this._arrow = sourceArrow;
 
-        this.actor = new St.ScrollView({ style_class: 'popup-sub-menu',
+        this.actor = new St.ScrollView({ style_class: 'popup-submenu',
                                          hscrollbar_policy: Gtk.PolicyType.NEVER,
                                          vscrollbar_policy: Gtk.PolicyType.NEVER });
 


### PR DESCRIPTION
Fixes #5956
Requires: linuxmint/cinnamon-themes#45
Requires: linuxmint/mint-y-theme#49