### PR TITLE
[3.4] Support hide the windows titlebar

### DIFF
--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -410,6 +410,7 @@ WindowManager.prototype = {
         this._tiling = [];
         this._mapping = [];
         this._destroying = [];
+        this._hide_titlebar_when_maximized = false;
 
         this.effects = {
             map: new WindowEffects.Map(this),
@@ -485,6 +486,17 @@ WindowManager.prototype = {
         global.screen.connect ("show-workspace-osd", Lang.bind (this, this.showWorkspaceOSD));
 
         this.settings = new Gio.Settings({schema_id: "org.cinnamon.muffin"});
+    },
+
+    hideTitlebarWhenMaximized: function(hide) {
+        if(this._hide_titlebar_when_maximized != hide) {
+            this._hide_titlebar_when_maximized = hide;
+            let windows = global.get_window_actors();
+            for (let i = 0; i < windows.length; i++) {
+                let window = windows[i];
+                window.meta_window.set_hide_titlebar_when_maximized(this._hide_titlebar_when_maximized);
+            }
+        }
     },
 
     blockAnimations: function() {
@@ -688,6 +700,7 @@ WindowManager.prototype = {
             Main.soundManager.play('map');
         }
         this._startWindowEffect(cinnamonwm, "map", actor);
+        actor.meta_window.set_hide_titlebar_when_maximized(this._hide_titlebar_when_maximized);
     },
 
     _destroyWindow : function(cinnamonwm, actor) {


### PR DESCRIPTION
This pull add the ability to hide all muffin window titlebars when the windows is maximized, alerting muffin to do this task for all windows if they are not client-side decorated.

In the muffin pull (https://github.com/linuxmint/muffin/pull/272), was added the possiblility to hide an individual window titlebar in any moment and also it's possible alert muffin to hide a window titlebar when a window is maximized. Both actions do nothing is the window it's client-side decorated.

You can select, not use this code and decide call the new muffin functions directly from a mufin meta window.
```
meta_window.set_hide_titlebar_when_maximized(boolean);
meta_window.set_hide_titlebar(boolean);
```

You also can know if a windows titlebar is currently effective hide for an specific window:
```
meta_window.is_titlebar_hide(); //Return boolean
```

This pull depend of the pull request on muffin side and only provide a convenient function to hide all windows titlebars when maximized at once, calling just one function.

So enable undecorate windows on maximized, will be easy as do in your cjs code:
```
Main.wm.hideTitlebarWhenMaximized(true);
```
And for revert this:
```
Main.wm.hideTitlebarWhenMaximized(false);
```