### PR TITLE
[sound-applet] remove show percentage label for slider option

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/settings-schema.json
@@ -15,11 +15,6 @@
         "dependency": "playerControl",
         "indent": true
     },
-    "showSliderPercentage": {
-        "type": "switch",
-        "default": false,
-        "description": "Show percentage value of the slider"
-    },
     "_knownPlayers": {
         "type": "generic",
         "default": ["banshee", "vlc"]


### PR DESCRIPTION
Remove the option to show the percentage value besides slider, which was introduced in https://github.com/linuxmint/Cinnamon/pull/5854

If implementing something like that, it should be made consistent and globaly. Means the other applets, which use slider, e.g. brightness slider, should have this option too. It's not very clever to add this option individually for each applet. If it's done, it should be one switch, which turns on/off this option for every applet, and not having many switches for each applet on it's own.
Also this option has no significant additional benefit. A siginificant additional may (or may not?!) be, if the sound-applet gets the feature to turn the volume to more than 100%. So considering this maybe in the future and removing it for now, because of the first said reasons.