### PR TITLE
cinnamon-json-makepot: Added support to scan for JS files inside sub-dirs.

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-json-makepot/cinnamon-json-makepot.py
+++ b/files/usr/share/cinnamon/cinnamon-json-makepot/cinnamon-json-makepot.py
@@ -126,7 +126,12 @@ class Main:
                 quit()
             print " "
             print "Running xgettext on JavaScript files..."
-            os.system("xgettext --language=C --keyword=_ --output=%s *.js" % (self.potname))
+
+            tmp = tempfile.NamedTemporaryFile(prefix="cinnamon-json-makepot-")
+            try:
+                os.system('find . -iname "*.js" > %s' % tmp.name)
+            finally:
+                os.system("xgettext --language=C --keyword=_ --output=%s --files-from=%s" % (self.potname, tmp.name))
 
         self.current_parent_dir = ""
 


### PR DESCRIPTION
Currently the `cinnamon-json-makepot` command, when run with the `--js` argument, it scans only the JavaScript files that are in the root folder of an xlet. In an xlet with "multiversion" enabled, all JavaScript files inside sub-directories will be ignored and the resultant .pot file will be incomplete.

This commit adds the ability to scan all JavaScript files inside an xlet folder by saving a list with all JavaScript files found into a temporary file. Then that file is used to pass the *--files-from* argument to `xgettext`.

## Technicalities

- **settings-schema.json** files found inside sub-folders are already *taken care of*. The *problem* is only with JS files inside sub-folders.
- ~~I'm *worried about* the *universality* of the `find` command and the **/tmp** folder. I don't know if that command and that folder are *guaranteed* to be fount in all Linux distributions~~. Still using the `find` command, but switched to use the **tempfile** Python module.