### PR TITLE
[3.4] window-list: Rearrange popup menu items

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -760,6 +760,26 @@ AppMenuButtonRightClickMenu.prototype = {
         let mw = this.metaWindow;
         let item;
         let length;
+        
+        // Applet preferences
+        let subMenu = new PopupMenu.PopupSubMenuMenuItem(_("Preferences"));
+        this.addMenuItem(subMenu);
+
+        item = new PopupMenu.PopupIconMenuItem(_("About..."), "dialog-question", St.IconType.SYMBOLIC);
+        item.connect('activate', Lang.bind(this._launcher._applet, this._launcher._applet.openAbout));
+        subMenu.menu.addMenuItem(item);
+
+        item = new PopupMenu.PopupIconMenuItem(_("Configure..."), "system-run", St.IconType.SYMBOLIC);
+        item.connect('activate', Lang.bind(this._launcher._applet, this._launcher._applet.configureApplet));
+        subMenu.menu.addMenuItem(item);
+
+        item = new PopupMenu.PopupIconMenuItem(_("Remove 'Window list'"), "edit-delete", St.IconType.SYMBOLIC);
+        item.connect('activate', Lang.bind(this, function() {
+            AppletManager._removeAppletFromPanel(this._launcher._applet._uuid, this._launcher._applet.instance_id);
+        }));
+        subMenu.menu.addMenuItem(item);
+        
+        this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
         // Move to monitor
         if ((length = Main.layoutManager.monitors.length) == 2) {
@@ -884,25 +904,6 @@ AppMenuButtonRightClickMenu.prototype = {
             mw.delete(global.get_current_time());
         });
         this.addMenuItem(item);
-
-        this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-
-        let subMenu = new PopupMenu.PopupSubMenuMenuItem(_("Preferences"));
-        this.addMenuItem(subMenu);
-
-        item = new PopupMenu.PopupIconMenuItem(_("About..."), "dialog-question", St.IconType.SYMBOLIC);
-        item.connect('activate', Lang.bind(this._launcher._applet, this._launcher._applet.openAbout));
-        subMenu.menu.addMenuItem(item);
-
-        item = new PopupMenu.PopupIconMenuItem(_("Configure..."), "system-run", St.IconType.SYMBOLIC);
-        item.connect('activate', Lang.bind(this._launcher._applet, this._launcher._applet.configureApplet));
-        subMenu.menu.addMenuItem(item);
-
-        item = new PopupMenu.PopupIconMenuItem(_("Remove 'Window list'"), "edit-delete", St.IconType.SYMBOLIC);
-        item.connect('activate', Lang.bind(this, function() {
-            AppletManager._removeAppletFromPanel(this._launcher._applet._uuid, this._launcher._applet.instance_id);
-        }));
-        subMenu.menu.addMenuItem(item);
     },
 
     _onToggled: function(actor, isOpening){


### PR DESCRIPTION
Window actions should be the nearest to where the cursor is.
Pushed preferences item to the top and reverted order in the top panel.
Adding the elements at the top reverts the order while keeping the same
code structure.
Fixes #5969

**EDIT**: Re-commited changes. Only moved preferences to the top.