### PR TITLE
panel-launchers: close the menu before destroying when removing launcher

### DIFF
--- a/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
@@ -95,6 +95,7 @@ PanelAppLauncherMenu.prototype = {
     },
 
     _onRemoveActivate: function(item, event) {
+        this.close();
         this._launcher.launchersBox.removeLauncher(this._launcher, this._launcher.isCustom());
         this._launcher.actor.destroy();
     },


### PR DESCRIPTION
There may be a better/more correct fix for this. I'm not sure if this was introduced with the popupMenu.js changes or if it has existed for a while unnoticed.

If we destroy the menu while it is open then a callback set by pushModal removes
the grab when it recieves the actor's destroy signal. Shortly after, we attempt to
remove it again in popupMenu.js via the menu state change signal and fail. Closing
the menu before destroying the actor avoids this issue.

Fixes #5968