### PR TITLE
cs_backgrounds.py: fix thumb generation on LMDE2

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_backgrounds.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_backgrounds.py
@@ -601,10 +601,11 @@ class PixCache(object):
 
     # Convert RGBA PIL Image to Pixbuf
     def _image_to_pixbuf(self, img):
+        [w, h] = img.size
         return GdkPixbuf.Pixbuf.new_from_bytes(GLib.Bytes.new(img.tobytes()),
                                                GdkPixbuf.Colorspace.RGB,
-                                               True, 8, img.width, img.height,
-                                               img.width * 4)
+                                               True, 8, w, h,
+                                               w * 4)
 
 PIX_CACHE = PixCache()
 


### PR DESCRIPTION
The PIL version in LMDE2 doesn't seem to support width and height properties
for Image objects, so use Image.size instead.

Fixes #5986 