### PR TITLE
cs_effects.py: disable effects on menus when window effects is disabled

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_effects.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_effects.py
@@ -256,7 +256,8 @@ class Module:
     def on_desktop_effects_enabled_changed(self, schema, key):
         active = schema.get_boolean(key)
 
-        if not active and schema.get_boolean("desktop-effects-on-dialogs"):
+        if not active:
             schema.set_boolean("desktop-effects-on-dialogs", False)
+            schema.set_boolean("desktop-effects-on-menus", False)
 
         self.update_effects(self.custom_switch, None)


### PR DESCRIPTION
Make sure it is disabled along with effects on dialog boxes when window
effects setting is disabled to ensure all effects are disabled.

Fixes #5936