### PR TITLE
[WIP] add swarm-symbolic.svg

### DIFF
--- a/data/icons/Makefile.am
+++ b/data/icons/Makefile.am
@@ -16,6 +16,7 @@ public_icons = \
     hicolor_actions_scalable_num-lock-symbolic.svg \
     hicolor_actions_scalable_num-lock-off-symbolic.svg \
 	hicolor_apps_scalable_cinnamon-panel-launcher.svg \
+	hicolor_apps_symbolic_swarm-symbolic.svg \
 	hicolor_categories_16x16_cs-desklets.svg \
 	hicolor_categories_16x16_cs-backgrounds.svg \
 	hicolor_categories_scalable_cs-applets.svg \

--- a/data/icons/hicolor_apps_symbolic_swarm-symbolic.svg
+++ b/data/icons/hicolor_apps_symbolic_swarm-symbolic.svg
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 16 16"
+   fill-rule="evenodd"
+   clip-rule="evenodd"
+   stroke-linejoin="round"
+   stroke-miterlimit="1.414"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="swarm-symbolic.svg">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="719"
+     id="namedview10"
+     showgrid="false"
+     inkscape:zoom="16"
+     inkscape:cx="3.7577897"
+     inkscape:cy="9.8698235"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     fill-rule="nonzero"
+     id="g4"
+     style="fill:#bebebe;fill-opacity:1;stroke:none;stroke-opacity:1">
+    <path
+       d="M6.6 12.822c-.397-.896-.614-1.866-.638-2.84-.642.993-1.127 1.992-1.45 2.737-.016.035-.253.622-.322.804-.086.226.03.488.256.575.182.07.776.286.813.298.762.256 1.816.56 2.97.748-.683-.66-1.24-1.452-1.63-2.324zM8.14 5.59C5.885.983.875 1.148.085 3.207c-.607 1.582 2.048 5.35 8.16 2.63l.002-.003c-.02-.038-.092-.2-.107-.242zM9.2 5.275C7.95 2.178 10.135.4 11.337.862c.893.343 1.375 3.012-2.076 4.55H9.26c-.008-.023-.05-.115-.06-.137zM15.607 8.785C15.084 7.61 14.125 6.77 13.01 6.37c-.112-.042-.227-.06-.34-.06-.58 0-1.138.482-1.19 1.084-.09 1.004.11 2.026.55 3.01.43.973 1.044 1.794 1.833 2.397.205.16.456.233.707.233.452 0 .903-.24 1.082-.67.46-1.104.482-2.393-.045-3.578z"
+       id="path6"
+       style="fill:#bebebe;fill-opacity:1;stroke:none;stroke-opacity:1" />
+    <path
+       d="M12.987 13.946c-.965-.74-1.73-1.733-2.274-2.954-.552-1.24-.777-2.492-.67-3.724.03-.343.13-.674.292-.976l-.092.023c-.508.127-1 .348-1.437.635-.633.417-1.192 1.034-1.432 1.764-.065.197-.114.413-.13.62-.077.986.084 2.006.514 2.973.417.936 1.04 1.716 1.79 2.31.456.365 1.28.594 1.954.594.633 0 1.257-.188 1.818-.473.175-.09.56-.33.586-.348-.334-.087-.648-.237-.92-.444z"
+       id="path8"
+       style="fill:#bebebe;fill-opacity:1;stroke:none;stroke-opacity:1" />
+  </g>
+</svg>


### PR DESCRIPTION
This icon is from Entypo pictograms by Daniel Bruce — www.entypo.com, which is under CC BY-SA 4.0

The color was changed to #bebebe.

EDIT: 
I replaced the swarm.svg icon by Daniel Bruce with an icon by Dan Leech from https://github.com/danleech/simple-icons
The LICENSE.md file in Dan Leech repo says CC0 1.0 Universal.