### PR TITLE
Fix gi import version warning

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-menu-editor/cme/MainWindow.py
+++ b/files/usr/share/cinnamon/cinnamon-menu-editor/cme/MainWindow.py
@@ -17,6 +17,9 @@
 #   License along with this library; if not, write to the Free Software
 #   Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA
 
+import gi
+gi.require_version('Gtk', '3.0')
+gi.require_version('CMenu', '3.0')
 from gi.repository import Gtk, GObject, Gio, GdkPixbuf, Gdk, CMenu, GLib
 import cgi
 import os


### PR DESCRIPTION
Fixes

```
$ python2 /usr/bin/cinnamon-menu-editor
/usr/share/cinnamon/cinnamon-menu-editor/cme/MainWindow.py:20: PyGIWarning: Gtk was imported without specifying a version first. Use gi.require_version('Gtk', '3.0') before import to ensure that the right version gets loaded.
  from gi.repository import Gtk, GObject, Gio, GdkPixbuf, Gdk, CMenu, GLib
/usr/share/cinnamon/cinnamon-menu-editor/cme/MainWindow.py:20: PyGIWarning: CMenu was imported without specifying a version first. Use gi.require_version('CMenu', '3.0') before import to ensure that the right version gets loaded.
  from gi.repository import Gtk, GObject, Gio, GdkPixbuf, Gdk, CMenu, GLib
```