### PR TITLE
Do not make unnecessary iteration on popup menu close function

### DIFF
--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -2325,10 +2325,7 @@ PopupMenu.prototype = {
         this.isOpen = false;
         global.menuStackLength -= 1;
 
-        for (let i in Main.panelManager.panels) {
-            if (Main.panelManager.panels[i])
-                Main.panelManager.updatePanelsVisibility();
-        }
+        Main.panelManager.updatePanelsVisibility();
 
         if (this._activeMenuItem)
             this._activeMenuItem.setActive(false);


### PR DESCRIPTION
Please see the iteration happen inside updatePanelsVisibility. This fix: https://github.com/linuxmint/Cinnamon/issues/6023