### PR TITLE
SoundFileChooser: Fix showing incorrect names

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
@@ -911,9 +911,9 @@ class SoundFileChooser(SettingsWidget):
         dialog.destroy()
 
     def update_button_label(self, absolute_path):
-        f = Gio.File.new_for_path(absolute_path)
-
-        self.button_label.set_label(f.get_basename())
+        if absolute_path != "":
+            f = Gio.File.new_for_path(absolute_path)
+            self.button_label.set_label(f.get_basename())
 
     def on_setting_changed(self, *args):
         self.update_button_label(self.get_value())


### PR DESCRIPTION
It seems Gio.File.new_for_path() will always return a value, even when passing
an empty string as a path. To avoid having a directory name shown in the button,
first check if the string is empty and bypass setting the label if it is.