### PR TITLE
Remove the 20 recent files limit

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -29,7 +29,6 @@ const ICON_SIZE = 16;
 const MAX_FAV_ICON_SIZE = 32;
 const CATEGORY_ICON_SIZE = 22;
 const APPLICATION_ICON_SIZE = 22;
-const MAX_RECENT_FILES = 20;
 
 const INITIAL_BUTTON_LOAD = 30;
 const MAX_BUTTON_WIDTH = "max-width: 20em;";
@@ -2206,7 +2205,7 @@ MyApplet.prototype = {
             this._categoryButtons.push(this.recentButton);
 
             if (this.RecentManager._infosByTimestamp.length > 0) {
-                for (let id = 0; id < MAX_RECENT_FILES && id < this.RecentManager._infosByTimestamp.length; id++) {
+                for (let id = 0; id < this.RecentManager._infosByTimestamp.length; id++) {
                     let button = new RecentButton(this, this.RecentManager._infosByTimestamp[id], this.showApplicationIcons);
                     this._addEnterEvent(button, Lang.bind(this, function() {
                             this._clearPrevSelection(button.actor);

--- a/js/misc/docInfo.js
+++ b/js/misc/docInfo.js
@@ -11,7 +11,6 @@ const GLib = imports.gi.GLib;
 const Main = imports.ui.main;
 
 const THUMBNAIL_ICON_MARGIN = 2;
-const MAX_RECENT_FILES = 20;
 
 function DocInfo(recentInfo) {
     this._init(recentInfo);
@@ -141,7 +140,7 @@ DocManager.prototype = {
         let docs = this._docSystem.get_all();
         this._infosByTimestamp = [];
         this._infosByUri = {};
-        for (let i = 0; i < docs.length && i < MAX_RECENT_FILES; i++) {
+        for (let i = 0; i < docs.length; i++) {
             let recentInfo = docs[i];
             let docInfo = new DocInfo(recentInfo);
             this._infosByTimestamp.push(docInfo);


### PR DESCRIPTION
There used to be a reason to limit the number of files before d5ff93e034d46aedf2c7f29252f19db9608bd194 removed costly computational steps. Now it works fine without this limit.

fixes #5928