### PR TITLE
cinnamon-desktop-editor: Fixed panel launcher add/edit dialogs breakage.

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-desktop-editor/cinnamon-desktop-editor.py
+++ b/files/usr/share/cinnamon/cinnamon-desktop-editor/cinnamon-desktop-editor.py
@@ -475,7 +475,7 @@ class Main:
 
     def panel_launcher_cb(self, success, dest_path):
         if success:
-            settings = JSonSettingsWidgets.JSonSettingsHandler(self.json_path)
+            settings = JsonSettingsWidgets.JSONSettingsHandler(self.json_path)
 
             launchers = settings.get_value("launcherList")
             if self.desktop_file is None:


### PR DESCRIPTION
Currently, when pressing the **Ok** button of a dialog that adds a new panel launcher or edits an existent one, the changes will not be saved and the dialog will not close. This commit fixes that.

Fixes: linuxmint/Cinnamon#6016