### PR TITLE
appletManager.js: fix max instance check when pasting applet config

### DIFF
--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -613,7 +613,7 @@ function pasteAppletConfiguration(panelId) {
     clipboard.forEach(function(x) {
         let uuid = x.uuid
         let max = Extension.get_max_instances(uuid, Extension.Type.APPLET);
-        if (max == -1 || raw.filter(a => a.split(":")[2] == uuid).length < max) {
+        if (max == -1 || raw.filter(a => a.split(":")[3] == uuid).length < max) {
             raw.push("panel" + panelId + ":" + x.location_label + ":" + x.order + ":" + uuid + ":" + nextId);
             nextId ++;
         } else {


### PR DESCRIPTION
The element at index 2 is the applets order on the panel, the uuid is
at index 3.