### PR TITLE
cinnamon-settings: Fix a couple of ugly buttons

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
@@ -159,10 +159,12 @@ class Module:
                 settings.add_row(widget)
 
             if os.path.exists("/usr/bin/upload-system-info"):
+                widget = SettingsWidget()
                 button = Gtk.Button(_("Upload system information"))
                 button.set_tooltip_text(_("No personal information included"))
                 button.connect("clicked", self.on_button_clicked)
-                page.pack_start(button, False, False, 0)
+                widget.pack_start(button, True, True, 0)
+                settings.add_row(widget)
 
     def on_button_clicked(self, button):
         subprocess.Popen(["upload-system-info"])

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_screensaver.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_screensaver.py
@@ -121,15 +121,17 @@ class Module:
         widget = GSettingsEntry(_("Date Format: "), schema, "date-format", size_group=size_group)
         settings.add_reveal_row(widget, schema, "use-custom-format")
 
+        widget = SettingsWidget()
+        button = Gtk.Button(_("Show information on date format syntax"))
+        button.connect("clicked", self.on_show_custom_format_info_button_clicked)
+        widget.pack_start(button, True, True, 0)
+        settings.add_reveal_row(widget, schema, "use-custom-format")
+
         widget = GSettingsFontButton(_("Time Font"), "org.cinnamon.desktop.screensaver", "font-time", size_group=size_group)
         settings.add_row(widget)
 
         widget = GSettingsFontButton(_("Date Font"), "org.cinnamon.desktop.screensaver", "font-date", size_group=size_group)
         settings.add_row(widget)
-
-        button = Gtk.Button(_("Show information on date format syntax"))
-        button.connect("clicked", self.on_show_custom_format_info_button_clicked)
-        page.pack_start(button, False, False, 0)
 
         settings = page.add_section(_("Away message"))
 


### PR DESCRIPTION
A couple of buttons were added to the settings outside of list boxes. Move them
into the list boxes so they don't completely break the layout we created.