### PR TITLE
cinnamon-settings: Do a better job of handling long labels

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/ChooserButtonWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/ChooserButtonWidgets.py
@@ -28,6 +28,7 @@ ANIMATION_FRAME_RATE = 20
 class BaseChooserButton(Gtk.Button):
     def __init__ (self, has_button_label=False):
         super(BaseChooserButton, self).__init__()
+        self.set_valign(Gtk.Align.CENTER)
         self.menu = Gtk.Menu()
         self.button_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=2)
         self.button_image = Gtk.Image()

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
@@ -467,6 +467,18 @@ class SettingsWidget(Gtk.Box):
             settings_objects[schema] = Gio.Settings.new(schema)
             return settings_objects[schema]
 
+class SettingsLabel(Gtk.Label):
+    def __init__(self, text=None):
+        Gtk.Label.__init__(self)
+        if text:
+            self.set_label(text)
+
+        self.set_alignment(0.0, 0.5)
+        self.set_line_wrap(True)
+
+    def set_label_text(self, text):
+        self.set_label(text)
+
 class IndentedHBox(Gtk.HBox):
     def __init__(self):
         super(IndentedHBox, self).__init__()
@@ -487,7 +499,7 @@ class Switch(SettingsWidget):
         super(Switch, self).__init__(dep_key=dep_key)
 
         self.content_widget = Gtk.Switch()
-        self.label = Gtk.Label(label)
+        self.label = SettingsLabel(label)
         self.pack_start(self.label, False, False, 0)
         self.pack_end(self.content_widget, False, False, 0)
 
@@ -507,7 +519,7 @@ class SpinButton(SettingsWidget):
 
         if units:
             label += " (%s)" % units
-        self.label = Gtk.Label.new(label)
+        self.label = SettingsLabel(label)
         self.content_widget = Gtk.SpinButton()
 
         self.pack_start(self.label, False, False, 0)
@@ -555,8 +567,9 @@ class Entry(SettingsWidget):
     def __init__(self, label, expand_width=False, size_group=None, dep_key=None, tooltip=""):
         super(Entry, self).__init__(dep_key=dep_key)
 
-        self.label = Gtk.Label.new(label)
+        self.label = SettingsLabel(label)
         self.content_widget = Gtk.Entry()
+        self.content_widget.set_valign(Gtk.Align.CENTER)
 
         self.pack_start(self.label, False, False, 0)
         self.pack_end(self.content_widget, expand_width, expand_width, 0)
@@ -601,9 +614,10 @@ class FontButton(SettingsWidget):
     def __init__(self, label, size_group=None, dep_key=None, tooltip=""):
         super(FontButton, self).__init__(dep_key=dep_key)
 
-        self.label = Gtk.Label.new(label)
+        self.label = SettingsLabel(label)
 
         self.content_widget = Gtk.FontButton()
+        self.content_widget.set_valign(Gtk.Align.CENTER)
 
         self.pack_start(self.label, False, False, 0)
         self.pack_end(self.content_widget, False, False, 0)
@@ -720,7 +734,7 @@ class ComboBox(SettingsWidget):
         self.valtype = valtype
         self.option_map = {}
 
-        self.label = Gtk.Label.new(label)
+        self.label = SettingsLabel(label)
 
         selected = None
 
@@ -731,6 +745,7 @@ class ComboBox(SettingsWidget):
 
         self.pack_start(self.label, False, False, 0)
         self.pack_end(self.content_widget, False, False, 0)
+        self.content_widget.set_valign(Gtk.Align.CENTER)
 
         self.set_options(options)
 
@@ -776,7 +791,7 @@ class ColorChooser(SettingsWidget):
         # still support it for now by adding the legacy_string argument
         self.legacy_string = legacy_string
 
-        self.label = Gtk.Label(label)
+        self.label = SettingsLabel(label)
         self.content_widget = Gtk.ColorButton()
         self.content_widget.set_use_alpha(True)
         self.pack_start(self.label, False, False, 0)
@@ -813,7 +828,7 @@ class FileChooser(SettingsWidget):
         else:
             action = Gtk.FileChooserAction.OPEN
 
-        self.label = Gtk.Label(label)
+        self.label = SettingsLabel(label)
         self.content_widget = Gtk.FileChooserButton(action=action)
         self.pack_start(self.label, False, False, 0)
         self.pack_end(self.content_widget, False, False, 0)
@@ -838,7 +853,7 @@ class SoundFileChooser(SettingsWidget):
     def __init__(self, label, size_group=None, dep_key=None, tooltip=""):
         super(SoundFileChooser, self).__init__(dep_key=dep_key)
 
-        self.label = Gtk.Label(label)
+        self.label = SettingsLabel(label)
         self.content_widget = Gtk.Box()
 
         c = self.content_widget.get_style_context()
@@ -930,7 +945,7 @@ class IconChooser(SettingsWidget):
 
         valid, self.width, self.height = Gtk.icon_size_lookup(Gtk.IconSize.BUTTON)
 
-        self.label = Gtk.Label.new(label)
+        self.label = SettingsLabel(label)
 
         self.content_widget = Gtk.Box()
         self.bind_object = Gtk.Entry()
@@ -1007,7 +1022,7 @@ class TweenChooser(SettingsWidget):
     def __init__(self, label, size_group=None, dep_key=None, tooltip=""):
         super(TweenChooser, self).__init__(dep_key=dep_key)
 
-        self.label = Gtk.Label.new(label)
+        self.label = SettingsLabel(label)
 
         self.content_widget = TweenChooserButton()
 
@@ -1026,7 +1041,7 @@ class EffectChooser(SettingsWidget):
     def __init__(self, label, possible=None, size_group=None, dep_key=None, tooltip=""):
         super(EffectChooser, self).__init__(dep_key=dep_key)
 
-        self.label = Gtk.Label.new(label)
+        self.label = SettingsLabel(label)
 
         self.content_widget = EffectChooserButton(possible)
 
@@ -1044,7 +1059,7 @@ class DateChooser(SettingsWidget):
     def __init__(self, label, size_group=None, dep_key=None, tooltip=""):
         super(DateChooser, self).__init__(dep_key=dep_key)
 
-        self.label = Gtk.Label.new(label)
+        self.label = SettingsLabel(label)
 
         self.content_widget = DateChooserButton()
 
@@ -1075,12 +1090,13 @@ class Keybinding(SettingsWidget):
 
         self.num_bind = num_bind
 
-        self.label = Gtk.Label(label)
+        self.label = SettingsLabel(label)
 
         self.buttons = []
         self.teach_button = None
 
         self.content_widget = Gtk.Frame(shadow_type=Gtk.ShadowType.IN)
+        self.content_widget.set_valign(Gtk.Align.CENTER)
         box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         self.content_widget.add(box)
 

--- a/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.ui
+++ b/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.ui
@@ -172,6 +172,7 @@
                 <property name="can_focus">True</property>
                 <property name="hexpand">True</property>
                 <property name="vexpand">True</property>
+                <property name="hscrollbar_policy">never</property>
                 <child>
                   <object class="GtkViewport" id="viewport1">
                     <property name="visible">True</property>

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_default.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_default.py
@@ -192,6 +192,8 @@ class MnemonicLabel(Gtk.Label):
         super(MnemonicLabel, self).__init__(label = "")
         self.set_text_with_mnemonic(text)
         self.set_mnemonic_widget(widget)
+        self.set_alignment(0.0, 0.5)
+        self.set_line_wrap(True)
 
 class DefaultAppChooserButton(Gtk.AppChooserButton):
     def __init__(self, content_type, gen_content_type):
@@ -275,6 +277,8 @@ class CustomAppChooserButton(Gtk.AppChooserButton):
         super(CustomAppChooserButton, self).__init__(content_type=content_type)
         self.media_settings = media_settings
         content_type = self.get_content_type()
+
+        self.set_valign(Gtk.Align.CENTER)
 
         #fetch preferences for this content type
         (pref_start_app, pref_ignore, pref_open_folder) = self.getPreferences()

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_effects.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_effects.py
@@ -197,10 +197,11 @@ class Module:
     def make_effect_group(self, group_label, key, effects=None):
         tmin, tmax, tstep, tdefault = (0, 2000, 50, 200)
 
-        row =SettingsWidget()
+        row = SettingsWidget()
         row.set_spacing(5)
 
-        label = Gtk.Label()
+        label = SettingsLabel()
+        label.set_margin_right(5)
         label.set_markup(group_label)
         label.props.xalign = 0.0
         row.pack_start(label, False, False, 0)

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_panel.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_panel.py
@@ -396,9 +396,9 @@ class PanelSwitch(PanelWidget):
         self.key = key
 
         self.content_widget = Gtk.Switch()
-        self.label1 = Gtk.Label(label1)
+        self.label1 = SettingsLabel(label1)
         self.label1.set_no_show_all(True)
-        self.label2 = Gtk.Label(label2)
+        self.label2 = SettingsLabel(label2)
         self.label2.set_no_show_all(True)
 
         self.pack_start(self.label1, False, False, 0)

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_privacy.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_privacy.py
@@ -37,7 +37,7 @@ class Module:
             settings.add_row(self.indefinite_switch)
 
             widget = SettingsWidget()
-            label = Gtk.Label(_("Number of days to remember old files"))
+            label = SettingsLabel(_("Number of days to remember old files"))
             widget.pack_start(label, False, False, 0)
             self.spinner = Gtk.SpinButton.new_with_range(1.0, 365.0, 1.0)
             self.spinner.set_digits(0)

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_windows.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_windows.py
@@ -143,11 +143,13 @@ class TitleBarButtonsOrderSelector(SettingsBox):
         left_box.set_border_width(5)
         left_box.set_margin_left(20)
         left_box.set_margin_right(20)
+        left_box.set_spacing(5)
 
         right_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         right_box.set_border_width(5)
         right_box.set_margin_left(20)
         right_box.set_margin_right(20)
+        right_box.set_spacing(5)
 
         try:
             left_items, right_items = self.value.split(":")
@@ -163,16 +165,22 @@ class TitleBarButtonsOrderSelector(SettingsBox):
             right_items = []
 
         left_label = Gtk.Label.new(_("Left side title bar buttons"))
+        left_label.set_alignment(0.0, 0.5)
+        left_label.set_line_wrap(True)
         left_box.pack_start(left_label, False, False, 0)
         left_grid = Gtk.Grid()
         left_grid.set_column_spacing(4)
         left_box.pack_end(left_grid, False, False, 0)
+        left_grid.set_valign(Gtk.Align.CENTER)
 
         right_label = Gtk.Label.new(_("Right side title bar buttons"))
+        right_label.set_alignment(0.0, 0.5)
+        right_label.set_line_wrap(True)
         right_box.pack_start(right_label, False, False, 0)
         right_grid = Gtk.Grid()
         right_grid.set_column_spacing(4)
         right_box.pack_end(right_grid, False, False, 0)
+        right_grid.set_valign(Gtk.Align.CENTER)
 
         self.left_side_widgets = []
         self.right_side_widgets = []
@@ -216,9 +224,11 @@ class TitleBarButtonsOrderSelector(SettingsBox):
         for i in self.left_side_widgets:
             index = self.left_side_widgets.index(i)
             left_grid.attach(i, index, 0, 1, 1)
+            i.set_valign(Gtk.Align.CENTER)
         for i in self.right_side_widgets:
             index = self.right_side_widgets.index(i)
             right_grid.attach(i, index, 0, 1, 1)
+            i.set_valign(Gtk.Align.CENTER)
 
         self.add_row(left_box)
         self.add_row(right_box)

--- a/files/usr/share/cinnamon/cinnamon-settings/xlet-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/xlet-settings.py
@@ -176,6 +176,7 @@ class MainWindow(object):
         self.menu_button.set_popup(menu)
 
         scw = Gtk.ScrolledWindow()
+        scw.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         main_box.pack_start(scw, True, True, 0)
         self.instance_stack = Gtk.Stack()
         scw.add(self.instance_stack)


### PR DESCRIPTION
We are running into cases where either translations or long label lengths in
applet settings are putting a horizontal scrollbar on the window. This can cause
the "action" widget, like a switch, to be hidden outside of the viewable area.
To better deal with these situations, line wrap the labels instead. This ensures
that whole settings widget is viewable when opening the window at the default
size.