### PR TITLE
Fix for non translated applet names on Remove context menu items.

### DIFF
--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -15,6 +15,7 @@ const Mainloop = imports.mainloop;
 const Flashspot = imports.ui.flashspot;
 const ModalDialog = imports.ui.modalDialog;
 const Signals = imports.signals;
+const Gettext = imports.gettext;
 
 const COLOR_ICON_HEIGHT_FACTOR = .875;  // Panel height factor for normal color icons
 const PANEL_FONT_DEFAULT_HEIGHT = 11.5; // px
@@ -485,7 +486,8 @@ Applet.prototype = {
         let items = this._applet_context_menu._getMenuItems();
 
         if (this.context_menu_item_remove == null) {
-            this.context_menu_item_remove = new PopupMenu.PopupIconMenuItem(_("Remove '%s'").format(_(this._meta.name)),
+            this.context_menu_item_remove = new PopupMenu.PopupIconMenuItem(_("Remove '%s'")
+                .format(this._(this._meta.name)),
                    "edit-delete",
                    St.IconType.SYMBOLIC);
             this.context_menu_item_remove.connect('activate', Lang.bind(this, function() {
@@ -527,6 +529,18 @@ Applet.prototype = {
         if (items.indexOf(this.context_menu_item_remove) == -1) {
             this._applet_context_menu.addMenuItem(this.context_menu_item_remove);
         }
+    },
+
+    // translation
+    _: function(str) {
+        // look into the text domain first
+        let translated = Gettext.dgettext(this._uuid, str);
+
+        // if it looks translated, return the translation of the domain
+        if (translated !== str)
+            return translated;
+        // else, use the default cinnamon domain
+        return _(str);
     },
 
     /**

--- a/js/ui/modalDialog.js
+++ b/js/ui/modalDialog.js
@@ -446,14 +446,13 @@ SpicesAboutDialog.prototype = {
 
         //prepare translation
         this.uuid = metadata.uuid;
-        Gettext.bindtextdomain(metadata.uuid, GLib.get_home_dir() + "/.local/share/locale");
 
         let contentBox = new St.BoxLayout({vertical: true, style_class: "about-content" });
         this.contentLayout.add_actor(contentBox);
-        
+
         let topBox = new St.BoxLayout();
         contentBox.add_actor(topBox);
-        
+
         //icon
         let icon;
         if (metadata.icon) {
@@ -468,17 +467,17 @@ SpicesAboutDialog.prototype = {
             }
         }
         topBox.add_actor(icon);
-        
+
         let topTextBox = new St.BoxLayout({vertical: true});
         topBox.add_actor(topTextBox);
-        
+
         /*title*/
         let titleBox = new St.BoxLayout();
         topTextBox.add_actor(titleBox);
 
         let title = new St.Label({text: this._(metadata.name), style_class: "about-title"});
         titleBox.add_actor(title);
-        
+
         //version
         if (!('last-edited' in metadata) && metadata.version) {
             let versionBin = new St.Bin({x_align: St.Align.START, y_align: St.Align.END});
@@ -486,7 +485,7 @@ SpicesAboutDialog.prototype = {
             let version = new St.Label({text: " v%s".format(metadata.version), style_class: "about-version"});
             versionBin.add_actor(version);
         }
-        
+
         //uuid
         let uuid = new St.Label({text: metadata.uuid, style_class: "about-uuid"});
         topTextBox.add_actor(uuid);
@@ -502,7 +501,7 @@ SpicesAboutDialog.prototype = {
             let lastEdited = new St.Label({text: dateUTC + "\n", style_class: "about-uuid"});
             topTextBox.add_actor(lastEdited);
         }
-        
+
         //description
         let desc = new St.Label({text: this._(metadata.description), style_class: "about-description"});
         let dText = desc.clutter_text;
@@ -562,7 +561,7 @@ SpicesAboutDialog.prototype = {
                 infoBox.add_actor(contributors);
             }
         }
-        
+
         //dialog buttons, if it's a spice, add a "More info" button
         let spicesID = this._getSpicesID(metadata.uuid, type);
         if (spicesID) {
@@ -576,7 +575,7 @@ SpicesAboutDialog.prototype = {
                 {label: _("Close"), key: "", focus: true, action: Lang.bind(this, this._onOk)}
             ]);
         }
-        
+
         this.open(global.get_current_time());
     },
 
@@ -618,7 +617,7 @@ SpicesAboutDialog.prototype = {
     _onOk: function() {
         this.close(global.get_current_time());
     },
-    
+
     _launchSite: function(a, b, site) {
         Util.spawnCommandLine("xdg-open " + site);
         this.close(global.get_current_time());
@@ -746,7 +745,7 @@ InfoOSD.prototype = {
      * show:
      * @monitorIndex (int): (optional) Monitor to display OSD on. Default is
      * primary monitor
-     * 
+     *
      * Shows the OSD at the center of monitor @monitorIndex. Shows at the
      * primary monitor if not specified.
      */
@@ -776,7 +775,7 @@ InfoOSD.prototype = {
 
     /**
      * destroy:
-     * 
+     *
      * Destroys the OSD
      */
     destroy: function() {


### PR DESCRIPTION
Currently, the applet name of the **Remove** context menu items of third party applets  aren't translated. This is because the translated string is currently fetched from Cinnamon's domain and not the third party applet's domain. Default Cinnamon applets doesn't have this problem.

This commit uses a mechanism similar to the used by the **SpicesAboutDialog** prototype to try to fetch the correct translated string.

Also, some trailing spaces were removed and some missing semicolons were added.

## Technicalities
- I moved the call to **Gettext.bindtextdomain** from the **modalDialog.js** file to the **appletManager.js** file so the applet's domain it's binded (don't know if I express this correctly) before the first call to the **finalizeContextMenu** function. This way, the translated strings are available when it's required (when the **this.context_menu_item_remove** is created and when the **About** dialog is opened). Like always, it's up to the real experts to decide if this pull request is the correct way to fix this issue.
- I wasn't sure if this bug would be considered serious or not serious at all. That's why I didn't added the **[3.4]** tag to this pull request title.
