### PR TITLE
cinnamon_dbus_acquire_name: don't leak the result

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -56,6 +56,7 @@ cinnamon_dbus_acquire_name (GDBusProxy *bus,
       exit (1);
     }
   g_variant_get (request_name_variant, "(u)", request_name_result);
+  g_variant_unref (request_name_variant);
 }
 
 static void


### PR DESCRIPTION
from upstream https://github.com/GNOME/gnome-shell/commit/3f0fbae7e213b2fbe7267b9d25ac7fcfaa8afcff