### PR TITLE
cinnamon_dbus_acquire_name: Don't leak error

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -51,6 +51,7 @@ cinnamon_dbus_acquire_name (GDBusProxy *bus,
                                                        &error)))
     {
       g_printerr ("failed to acquire %s: %s\n", name, error->message);
+      g_clear_error (&error);
       if (!fatal)
         return;
       exit (1);


### PR DESCRIPTION
from upstream https://github.com/GNOME/gnome-shell/commit/7f1a258ff9fc768a7fc13e5c37e1fd6d7ab5c33b