### PR TITLE
keyboard: destroy the key's boxpointer

### DIFF
--- a/js/ui/keyboard.js
+++ b/js/ui/keyboard.js
@@ -53,6 +53,7 @@ Key.prototype = {
         this._key = key;
 
         this.actor = this._makeKey();
+        this.actor.connect('destroy', Lang.bind(this, this._onDestroy));
 
         this._extended_keys = this._key.get_extended_keys();
         this._extended_keyboard = null;
@@ -79,6 +80,13 @@ Key.prototype = {
             this.actor._extended_keys = this._extended_keyboard;
             this._boxPointer.actor.hide();
             Main.layoutManager.addChrome(this._boxPointer.actor, { visibleInFullscreen: true });
+        }
+    },
+
+    _onDestroy: function() {
+        if (this._boxPointer) {
+            this._boxPointer.actor.destroy();
+            this._boxPointer = null;
         }
     },
 


### PR DESCRIPTION
from upstream https://github.com/GNOME/gnome-shell/commit/9d933356e171a1dc49b61b5864826531c0f24d97

Am not convinced I have exercised this code path in testing, so would be grateful if someone who understands 'extended keys' could check, or give me some idea on how to do it. 