### PR TITLE
window-tracker: fix memory leak

### DIFF
--- a/src/cinnamon-window-tracker.c
+++ b/src/cinnamon-window-tracker.c
@@ -435,6 +435,7 @@ update_focus_app (CinnamonWindowTracker *self)
   new_focus_app = new_focus_win ? cinnamon_window_tracker_get_window_app (self, new_focus_win) : NULL;
 
   set_focus_app (self, new_focus_app);
+  g_clear_object (&new_focus_app);
 }
 
 static void


### PR DESCRIPTION
from upstream https://github.com/GNOME/gnome-shell/commit/ac22172a6ec37a158ca4cecf8c18f8fb29c1aa97