### PR TITLE
Expo: Don't reposition thumbnails on position-changed.

### DIFF
--- a/js/ui/expoThumbnail.js
+++ b/js/ui/expoThumbnail.js
@@ -52,7 +52,6 @@ ExpoWindowClone.prototype = {
         this.refreshClone();
         this._signalManager = new SignalManager.SignalManager(this);
 
-        this._signalManager.connect(this.realWindow, 'position-changed', this.onPositionChanged);
         this._signalManager.connect(this.realWindow, 'size-changed', this.onSizeChanged);
         this._signalManager.connect(this.metaWindow, 'workspace-changed', function(w, oldws) {
             this.emit('workspace-changed', oldws);


### PR DESCRIPTION
Using the 'position-changed' signal repositions thumbnail while the expo is open. It is unnecessary as the positions are updated elsewhere (not sure where, but testing it seems fine) and is also sometimes signaled too much (very obvious with gnome-system-monitor on 'Resources' tab, but happens occasionally elsewhere).

fixes #5442