### PR TITLE
[WIP] Improve the look of xlet settings

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
@@ -359,7 +359,7 @@ class SettingsBox(Gtk.Frame):
         frame_style = self.get_style_context()
         frame_style.add_class("view")
         self.size_group = Gtk.SizeGroup()
-        self.size_group.set_mode(Gtk.SizeGroupMode.VERTICAL)
+        self.size_group.set_mode(Gtk.SizeGroupMode.HORIZONTAL)
 
         self.box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self.add(self.box)

--- a/files/usr/share/cinnamon/cinnamon-settings/xlet-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/xlet-settings.py
@@ -273,6 +273,7 @@ class MainWindow(object):
                     elif settings_type in XLET_SETTINGS_WIDGETS:
                         widget = globals()[XLET_SETTINGS_WIDGETS[settings_type]](key, info["settings"], item)
                         section.add_row(widget)
+                        widget.add_to_size_group(section.size_group)
 
     def build_from_order(self, settings_map, info, box, first_key):
         page = SettingsPage()
@@ -298,6 +299,7 @@ class MainWindow(object):
                 elif settings_type in XLET_SETTINGS_WIDGETS:
                     widget = globals()[XLET_SETTINGS_WIDGETS[settings_type]](key, info["settings"], item)
                     section.add_row(widget)
+                    widget.add_to_size_group(section.size_group)
 
     def notify_dbus(self, handler, key, value):
         proxy.updateSetting('(ssss)', self.uuid, handler.instance_id, key, json.dumps(value))


### PR DESCRIPTION
This puts all xlet settings widgets into a horizontal size group, making it look better.
Until now, all widgets had their own width, now they all share the same width.
Atm, it may look strange in the menu applet's settings, because there's a hotkey definition and a text entry, which are also put into the size group, this can be improved further, that's why I marked this WIP.