### PR TITLE
st-theme-node.c: rename a confusing variable

### DIFF
--- a/src/st/st-theme-node.c
+++ b/src/st/st-theme-node.c
@@ -2745,7 +2745,7 @@ st_theme_node_get_border_image (StThemeNode *node)
           CRStyleSheet *base_stylesheet;
           int borders[4];
           int n_borders = 0;
-          int i;
+          int j;
 
           const char *url;
           int border_top;
@@ -2775,7 +2775,7 @@ st_theme_node_get_border_image (StThemeNode *node)
           /* Followed by 0 to 4 numbers or percentages. *Not lengths*. The interpretation
            * of a number is supposed to be pixels if the image is pixel based, otherwise CSS pixels.
            */
-          for (i = 0; i < 4; i++)
+          for (j = 0; j < 4; j++)
             {
               if (term == NULL)
                 break;


### PR DESCRIPTION
At the moment we have an outer loop on i, and then a separately declared internal loop on i
This changes the name of the variable in the internal loop to avoid confusion.

adapted from upstream. https://github.com/GNOME/gnome-shell/commit/a025b151efa892ede252af851a6d484fc8f0d8dd#diff-ea7efd941b083a785ba5e4b928a26d59