### PR TITLE
st-theme-node: Improve error reporting for length errors

### DIFF
--- a/src/st/st-theme-node.c
+++ b/src/st/st-theme-node.c
@@ -855,7 +855,8 @@ get_length_from_term (StThemeNode *node,
 
   if (term->type != TERM_NUMBER)
     {
-      g_warning ("Ignoring length property that isn't a number");
+      g_warning ("Ignoring length property that isn't a number at line %d, col %d",
+                 term->location.line, term->location.column);
       return VALUE_NOT_FOUND;
     }
 


### PR DESCRIPTION
from upstream https://github.com/GNOME/gnome-shell/commit/1d235395765226a981fd31f16adae505ad8642de#diff-ea7efd941b083a785ba5e4b928a26d59

Can be tested on the New Minty theme, which has   height: inherit   which triggers it