### PR TITLE
Fix cursor black background when taking screenshot

### DIFF
--- a/src/cinnamon-screenshot.c
+++ b/src/cinnamon-screenshot.c
@@ -101,7 +101,7 @@ do_grab_screenshot (_screenshot_data *screenshot_data,
   backend = clutter_get_default_backend ();
   context = clutter_backend_get_cogl_context (backend);
 
-  screenshot_data->image = cairo_image_surface_create (CAIRO_FORMAT_RGB24,
+  screenshot_data->image = cairo_image_surface_create (CAIRO_FORMAT_ARGB32,
                                                        width, height);
 
 
@@ -120,6 +120,8 @@ do_grab_screenshot (_screenshot_data *screenshot_data,
                                             x, y,
                                             COGL_READ_PIXELS_COLOR_BUFFER,
                                             bitmap);
+
+  cairo_surface_mark_dirty (screenshot_data->image);
   cogl_object_unref (bitmap);
 }
 


### PR DESCRIPTION
Should fix https://github.com/linuxmint/Cinnamon/issues/6229

Based on https://git.gnome.org/browse/gnome-shell/patch/src/shell-screenshot.c?id=cdc4f85e478f2bf59dcffe1a1449af54b9086381