### PR TITLE
xlet settings: add list widget

### DIFF
--- a/data/icons/Makefile.am
+++ b/data/icons/Makefile.am
@@ -13,6 +13,7 @@ public_icons = \
 	hicolor_actions_scalable_pan-up-symbolic.svg \
     hicolor_actions_scalable_caps-lock-symbolic.svg \
     hicolor_actions_scalable_caps-lock-off-symbolic.svg \
+    hicolor_actions_scalable_list-edit-symbolic.svg \
     hicolor_actions_scalable_num-lock-symbolic.svg \
     hicolor_actions_scalable_num-lock-off-symbolic.svg \
 	hicolor_apps_scalable_cinnamon-panel-launcher.svg \

--- a/data/icons/hicolor_actions_scalable_list-edit-symbolic.svg
+++ b/data/icons/hicolor_actions_scalable_list-edit-symbolic.svg
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg7384"
+   height="16"
+   width="16"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="list-edit-symbolic.svg">
+  <defs
+     id="defs9" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1888"
+     inkscape:window-height="999"
+     id="namedview7"
+     showgrid="true"
+     showguides="false"
+     inkscape:zoom="29.5"
+     inkscape:cx="1.791146"
+     inkscape:cy="12.696566"
+     inkscape:window-x="32"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g4156"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:object-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4142" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <title
+     id="title9167">Gnome Symbolic Icon Theme</title>
+  <g
+     id="layer12"
+     transform="translate(-40 -726)">
+    <g
+       id="g4141"
+       transform="matrix(1,0,0,1.49985,0.14644561,-367.46435)">
+      <g
+         id="g4146"
+         transform="translate(-0.15531039,-0.2500338)">
+        <g
+           id="g4151"
+           transform="matrix(0.70710678,-0.47145167,1.0605541,0.70710678,-765.05661,237.80289)">
+          <g
+             id="g4156"
+             transform="matrix(0.70710679,0.47145167,-1.0605541,0.70710678,793.33489,192.28516)">
+            <path
+               inkscape:connector-curvature="0"
+               d="m 41.16418,738.21673 9,-6.0006 c 1,0 2,0.66674 2,1.33347 l -9,6.0006 -2,0 z"
+               id="path2273-6-2"
+               sodipodi:nodetypes="cccccc"
+               style="fill:#bebebe;fill-opacity:1;fill-rule:evenodd;stroke:none" />
+            <path
+               inkscape:connector-curvature="0"
+               d="m 51.16418,731.5494 c 1,0 2,0.66674 2,1.33347 l 2,-1.33347 c 0,-0.66674 -0.75185,-1.33347 -2,-1.33347 z"
+               id="path4113-1-6-3"
+               sodipodi:nodetypes="ccccc"
+               style="display:inline;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new" />
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/docs/reference/cinnamon-tutorials/xlet-settings-ref.xml
+++ b/docs/reference/cinnamon-tutorials/xlet-settings-ref.xml
@@ -297,6 +297,38 @@
       <para>Note: for an applet or desklet, the callback function must be a method of the applet or desklet object. For an extension, it can be a method of any object, but that object must be returned from the <code>enabled()</code> function of your extension in order for it to work.</para>
 
     </sect3>
+    <sect3>
+      <title>list</title>
+      <itemizedlist>
+        <listitem><code>type</code>: should be <code>list</code></listitem>
+        <listitem><code>description</code>: (optional) String to describe the setting</listitem>
+        <listitem><code>columns</code>: Array of objects specifying the columns in the list widget</listitem>
+        <listitem><code>default</code>: default value</listitem>
+      </itemizedlist>
+
+      <para>
+        This widget provides a list which can be edited and reordered from the settings window. The columns in the list are specified by the <code>columns</code> propery. Each column object in the array must have the following properties:
+        <itemizedlist>
+          <listitem><code>id</code>: a unique string for identifying the column</listitem>
+          <listitem><code>title</code>: the title that will be displayed in the column header</listitem>
+          <listitem><code>type</code>: the data type for the column</listitem>
+        </itemizedlist>
+      </para>
+      <para>
+        Each column type determines the data type that is stored. In addition, it specifies the widget that is generated when the user clicks the add or edit buttons. These widgets act just like the corresponding widgets in this document, and all the same properties are available, with the exception of <code>description</code> and <code>type</code>. The following types are currently available:
+        <itemizedlist>
+          <listitem><code>string</code>: this type stores data as a string. An <code>entry</code> is generated in the add/edit dialog. The default value for new entries is an empty string unless specified with the <code>default</code> property.</listitem>
+          <listitem><code>file</code>: this type stores data as a string. A <code>filechooser</code> is generated in the add/edit dialog. The default value for new entries is an empty string unless specified with the <code>default</code> property.</listitem>
+          <listitem><code>integer</code>: this type stores data as an integer. A <code>spinbutton</code> is generated in the add/edit dialog. The default value for new entries is 0 unless specified with the <code>default</code> property.</listitem>
+          <listitem><code>float</code>: this type stores data as a floating point number. A <code>spinbutton</code> is generated in the add/edit dialog. The default value for new entries is 0.0 unless specified with the <code>default</code> property.</listitem>
+          <listitem><code>boolean</code>: this type stores data as a bool. A <code>switch</code> is generated in the add/edit dialog. The default value for new entries is false unless specified with the <code>default</code> property.</listitem>
+        </itemizedlist>
+      </para>
+      <para>The values are stored as an array of row objects. Each row object has a set of key:value pairs where the key is the <code>column id</code> of the column to which the value corresponds.</para>
+      <para>Note: For appearance, it is recommended that you do not use the description property of this setting, but rather place it in it's own <code>section</code>.</para>
+      <para>New in Cinnamon 3.4</para>
+
+    </sect3>
   </sect2>
 
   <sect2>

--- a/files/usr/share/cinnamon/applets/settings-example@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/settings-example@cinnamon.org/settings-schema.json
@@ -1,7 +1,7 @@
 {
     "layout1": {
         "type": "layout",
-        "pages": ["page1", "page2", "page3"],
+        "pages": ["page1", "page2", "page3", "page4"],
         "page1": {
             "type": "page",
             "title": "Visible settings",
@@ -16,6 +16,11 @@
             "type": "page",
             "title": "Command settings",
             "sections": ["section5"]
+        },
+        "page4": {
+            "type": "page",
+            "title": "Editable list settings",
+            "sections": ["section7"]
         },
         "section1": {
             "type": "section",
@@ -46,6 +51,11 @@
             "type": "section",
             "title": "Other choosers",
             "keys": ["font-select", "date-select"]
+        },
+        "section7": {
+            "type": "section",
+            "title": "My list",
+            "keys": ["tree"]
         }
     },
     "icon-name": {
@@ -170,5 +180,19 @@
             "m" : 1,
             "y" : 2000
         }
+    },
+    "tree" : {
+        "type" : "list",
+        "description" : "Custom tree widget",
+        "columns" : [
+            {"id": "name", "title": "Name", "type": "string"},
+            {"id": "resident", "title": "Resident", "type": "boolean"},
+            {"id": "address", "title": "Address", "type": "string", "default": "none"},
+            {"id": "number", "title": "Id number", "type": "integer", "min": 0, "max": 100},
+            {"id": "icon", "title": "Icon", "type": "icon"},
+            {"id": "key", "title": "Shortcut key", "type": "keybinding"},
+            {"id": "file", "title": "File Path", "type": "file", "select-dir": false}
+        ],
+        "default" : []
     }
 }

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py
@@ -1,9 +1,13 @@
 from gi.repository import Gio, GObject
 from SettingsWidgets import *
+from TreeListWidgets import List
 import collections
 import json
 
+CAN_BACKEND.append("List")
+
 JSON_SETTINGS_PROPERTIES_MAP = {
+    "description"   : "label",
     "min"           : "mini",
     "max"           : "maxi",
     "step"          : "step",
@@ -13,7 +17,8 @@ JSON_SETTINGS_PROPERTIES_MAP = {
     "tooltip"       : "tooltip",
     "possible"      : "possible",
     "dependency"    : "dep_key",
-    "expand-width"  : "expand_width"
+    "expand-width"  : "expand_width",
+    "columns"       : "columns"
 }
 
 class JSONSettingsHandler(object):
@@ -237,7 +242,7 @@ def json_settings_factory(subclass):
                     kwargs["options"] = []
                     for value, label in properties[prop].items():
                         kwargs["options"].append((label, value))
-            super(NewClass, self).__init__(properties["description"], **kwargs)
+            super(NewClass, self).__init__(**kwargs)
             self.attach()
 
         def set_dep_key(self, dep_key):

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/TreeListWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/TreeListWidgets.py
@@ -1,0 +1,301 @@
+#!/usr/bin/python
+
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
+from SettingsWidgets import *
+
+VARIABLE_TYPE_MAP = {
+    "string"        :   str,
+    "file"          :   str,
+    "icon"          :   str,
+    "sound"         :   str,
+    "keybinding"    :   str,
+    "integer"       :   int,
+    "float"         :   float,
+    "boolean"       :   bool
+}
+
+CLASS_TYPE_MAP = {
+    "string"        :   Entry,
+    "file"          :   FileChooser,
+    "icon"          :   IconChooser,
+    "sound"         :   SoundFileChooser,
+    "keybinding"    :   Keybinding,
+    "integer"       :   SpinButton,
+    "float"         :   SpinButton,
+    "boolean"       :   Switch
+}
+
+PROPERTIES_MAP = {
+    "title"         : "label",
+    "min"           : "mini",
+    "max"           : "maxi",
+    "step"          : "step",
+    "units"         : "units",
+    "select-dir"    : "dir_select",
+    "expand-width"  : "expand_width"
+}
+
+def list_edit_factory(options):
+    class Widget(CLASS_TYPE_MAP[options["type"]]):
+        def __init__(self, **kwargs):
+            super(Widget, self).__init__(**kwargs)
+
+            if self.bind_dir is None:
+                self.connect_widget_handlers()
+
+        def get_range(self):
+            return None
+
+        def set_value(self, value):
+            self.widget_value = value
+
+        def get_value(self):
+            if hasattr(self, "widget_value"):
+                return self.widget_value
+            else:
+                return None
+
+        def set_widget_value(self, value):
+            if self.bind_dir is None:
+                self.widget_value = value
+                self.on_setting_changed()
+            else:
+                if hasattr(self, "bind_object"):
+                    self.bind_object.set_property(self.bind_prop, value)
+                else:
+                    self.content_widget.set_property(self.bind_prop, value)
+
+        def get_widget_value(self):
+            if self.bind_dir is None:
+                try:
+                    return self.widget_value
+                except Exception as e:
+                    return None
+            else:
+                if hasattr(self, "bind_object"):
+                    return self.bind_object.get_property(self.bind_prop)
+                return self.content_widget.get_property(self.bind_prop)
+
+    kwargs = {}
+    for prop in options:
+        if prop in PROPERTIES_MAP:
+            kwargs[PROPERTIES_MAP[prop]] = options[prop]
+
+    return Widget(**kwargs)
+
+
+class List(SettingsWidget):
+    bind_dir = None
+
+    def __init__(self, label=None, columns=None, height=200, size_group=None, dep_key=None, tooltip=""):
+        super(List, self).__init__(dep_key=dep_key)
+        self.columns = columns
+
+        self.set_orientation(Gtk.Orientation.VERTICAL)
+        self.set_spacing(0)
+        self.set_margin_left(0)
+        self.set_margin_right(0)
+        self.set_border_width(0)
+
+        if label is not None:
+            self.label = Gtk.Label(label)
+
+        self.content_widget = Gtk.TreeView()
+
+        scrollbox = Gtk.ScrolledWindow()
+        scrollbox.set_size_request(-1, height)
+        scrollbox.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        self.pack_start(scrollbox, True, True, 0)
+        scrollbox.add(self.content_widget)
+
+        types = []
+        tv_columns = []
+        for i in range(len(columns)):
+            types.append(VARIABLE_TYPE_MAP[columns[i]["type"]])
+            renderer = Gtk.CellRendererText()
+            column = Gtk.TreeViewColumn(columns[i]["title"], renderer, text=i)
+            column.set_resizable(True)
+            self.content_widget.append_column(column)
+        self.model = Gtk.ListStore(*types)
+        self.content_widget.set_model(self.model)
+
+        button_toolbar = Gtk.Toolbar()
+        button_toolbar.set_icon_size(1)
+        Gtk.StyleContext.add_class(Gtk.Widget.get_style_context(button_toolbar), "inline-toolbar")
+        self.pack_start(button_toolbar, False, False, 0)
+
+        self.add_button = Gtk.ToolButton(None, None)
+        self.add_button.set_icon_name("list-add-symbolic")
+        self.add_button.set_tooltip_text(_("Add new entry"))
+        self.add_button.connect("clicked", self.add_item)
+        self.remove_button = Gtk.ToolButton(None, None)
+        self.remove_button.set_icon_name("list-remove-symbolic")
+        self.remove_button.set_tooltip_text(_("Remove selected entry"))
+        self.remove_button.connect("clicked", self.remove_item)
+        self.remove_button.set_sensitive(False)
+        self.edit_button = Gtk.ToolButton(None, None)
+        self.edit_button.set_icon_name("list-edit-symbolic")
+        self.edit_button.set_tooltip_text(_("Edit selected entry"))
+        self.edit_button.connect("clicked", self.edit_item)
+        self.edit_button.set_sensitive(False)
+        self.move_up_button = Gtk.ToolButton(None, None)
+        self.move_up_button.set_icon_name("go-up-symbolic")
+        self.move_up_button.set_tooltip_text(_("Move selected entry up"))
+        self.move_up_button.connect("clicked", self.move_item_up)
+        self.move_up_button.set_sensitive(False)
+        self.move_down_button = Gtk.ToolButton(None, None)
+        self.move_down_button.set_icon_name("go-down-symbolic")
+        self.move_down_button.set_tooltip_text(_("Move selected entry down"))
+        self.move_down_button.connect("clicked", self.move_item_down)
+        self.move_down_button.set_sensitive(False)
+        button_toolbar.insert(self.add_button, 0)
+        button_toolbar.insert(self.remove_button, 1)
+        button_toolbar.insert(self.edit_button, 2)
+        button_toolbar.insert(self.move_up_button, 3)
+        button_toolbar.insert(self.move_down_button, 4)
+
+        self.content_widget.get_selection().connect("changed", self.update_button_sensitivity)
+
+        self.set_tooltip_text(tooltip)
+
+    def update_button_sensitivity(self, *args):
+        model, selected = self.content_widget.get_selection().get_selected()
+        if selected is None:
+            self.remove_button.set_sensitive(False)
+            self.edit_button.set_sensitive(False)
+        else:
+            self.remove_button.set_sensitive(True)
+            self.edit_button.set_sensitive(True)
+
+        if selected is None or model.iter_previous(selected) is None:
+            self.move_up_button.set_sensitive(False)
+        else:
+            self.move_up_button.set_sensitive(True)
+
+        if selected is None or model.iter_next(selected) is None:
+            self.move_down_button.set_sensitive(False)
+        else:
+            self.move_down_button.set_sensitive(True)
+
+    def add_item(self, *args):
+        data = self.open_add_edit_dialog()
+        if data is not None:
+            self.model.append(data)
+            self.list_changed()
+
+    def remove_item(self, *args):
+        model, t_iter = self.content_widget.get_selection().get_selected()
+        model.remove(t_iter)
+
+        self.list_changed()
+
+    def edit_item(self, *args):
+        model, t_iter = self.content_widget.get_selection().get_selected()
+        data = self.open_add_edit_dialog(model[t_iter])
+        if data is not None:
+            for i in range(len(data)):
+                self.model[t_iter][i] = data[i]
+            self.list_changed()
+
+    def move_item_up(self, *args):
+        model, t_iter = self.content_widget.get_selection().get_selected()
+        model.swap(t_iter, model.iter_previous(t_iter))
+        self.list_changed()
+
+    def move_item_down(self, *args):
+        model, t_iter = self.content_widget.get_selection().get_selected()
+        model.swap(t_iter, model.iter_next(t_iter))
+        self.list_changed()
+
+    def open_add_edit_dialog(self, info=None):
+        if info is None:
+            title = _("Add new entry")
+        else:
+            title = _("Edit entry")
+        dialog = Gtk.Dialog(title, self.get_toplevel(), Gtk.DialogFlags.MODAL,
+                            (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
+                             Gtk.STOCK_OK, Gtk.ResponseType.OK))
+
+        content_area = dialog.get_content_area()
+        content_area.set_margin_right(30)
+        content_area.set_margin_left(30)
+        content_area.set_margin_top(20)
+        content_area.set_margin_bottom(20)
+
+        frame = Gtk.Frame()
+        frame.set_shadow_type(Gtk.ShadowType.IN)
+        frame_style = frame.get_style_context()
+        frame_style.add_class("view")
+        content_area.add(frame)
+
+        content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        frame.add(content)
+
+        widgets = []
+        for i in range(len(self.columns)):
+            if len(widgets) != 0:
+                content.add(Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL))
+
+            widget = list_edit_factory(self.columns[i])
+            widgets.append(widget)
+
+            settings_box = Gtk.ListBox()
+            settings_box.set_selection_mode(Gtk.SelectionMode.NONE)
+
+            content.pack_start(settings_box, True, True, 0)
+            settings_box.add(widget)
+
+            if info is not None and info[i] is not None:
+                widget.set_widget_value(info[i])
+            elif "default" in self.columns[i]:
+                widget.set_widget_value(self.columns[i]["default"])
+
+        content_area.show_all()
+        response = dialog.run()
+
+        if response == Gtk.ResponseType.OK:
+            values = []
+            for widget in widgets:
+                values.append(widget.get_widget_value())
+
+            dialog.destroy()
+            return values
+
+        dialog.destroy()
+        return None
+
+    def list_changed(self, *args):
+        data = []
+        for row in self.model:
+            i = 0
+            row_info = {}
+            for column in self.columns:
+                row_info[column["id"]] = row[i]
+                i += 1
+            data.append(row_info)
+
+        self.set_value(data)
+        self.update_button_sensitivity()
+
+    def on_setting_changed(self, *args):
+        self.model.clear()
+        rows = self.get_value()
+        for row in rows:
+            row_info = []
+            for column in self.columns:
+                cid = column["id"]
+                if cid in row:
+                    row_info.append(row[column["id"]])
+                elif "default" in column:
+                    row_info.append(column["default"])
+                else:
+                    row_info.append(None)
+            self.model.append(row_info)
+
+        self.content_widget.columns_autosize()
+
+    def connect_widget_handlers(self, *args):
+        pass
+

--- a/files/usr/share/cinnamon/cinnamon-settings/xlet-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/xlet-settings.py
@@ -35,7 +35,8 @@ XLET_SETTINGS_WIDGETS = {
     "tween"             :   "JSONSettingsTweenChooser",
     "effect"            :   "JSONSettingsEffectChooser",
     "datechooser"       :   "JSONSettingsDateChooser",
-    "keybinding"        :   "JSONSettingsKeybinding"
+    "keybinding"        :   "JSONSettingsKeybinding",
+    "list"              :   "JSONSettingsList"
 }
 
 class XLETSettingsButton(Button):
@@ -234,7 +235,7 @@ class MainWindow(object):
                                 new_opt_data[translate(self.uuid, option)] = opt_data[option]
                             settings_map[setting][key] = new_opt_data
             finally:
-                # if a layout is not expicitly defined, generate the settings
+                # if a layout is not explicitly defined, generate the settings
                 # widgets based on the order they occur
                 if first_key["type"] == "layout":
                     self.build_with_layout(settings_map, info, instance_box, first_key)

--- a/js/ui/settings.js
+++ b/js/ui/settings.js
@@ -171,6 +171,13 @@ var SETTINGS_TYPES = {
             "default",
             "description"
         ]
+    },
+    "list" : {
+        "required-fields": [
+            "type",
+            "default",
+            "columns"
+        ]
     }
 };
 


### PR DESCRIPTION
* Allows adding/removing/editing/reordering entries in settings
* Allows a variable number of columns, each with it's own properties and data type
* Currently supports string, integer, float, bool, sound, icon, keybinding, and file variable types (more can be added easily - let me know if you have any ideas or requests)

![list widget 2](https://cloud.githubusercontent.com/assets/4095021/23190301/0e9be700-f865-11e6-851c-e9c3c7617590.png)
![list widget 3](https://cloud.githubusercontent.com/assets/4095021/23190302/0eb5bc98-f865-11e6-880a-a724ea57adf8.png)
