### PR TITLE
windowManager: Move handling of workspace switch effects to one place

### DIFF
--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -729,6 +729,9 @@ WindowManager.prototype = {
             return;
         }
 
+        Main.soundManager.play('switch');
+        this.showWorkspaceOSD();
+
         let windows = global.get_window_actors();
 
         /* @direction is the direction that the "camera" moves, so the
@@ -953,7 +956,6 @@ WindowManager.prototype = {
         if (workspace != global.screen.get_active_workspace()) {
             window.change_workspace(workspace);
             workspace.activate_with_focus(window, global.get_current_time());
-            this.showWorkspaceOSD();
         }
     },
 
@@ -968,12 +970,10 @@ WindowManager.prototype = {
     moveToWorkspace: function(workspace, direction_hint) {
         let active = global.screen.get_active_workspace();
         if (workspace != active) {
-            Main.soundManager.play('switch');
             if (direction_hint)
                 workspace.activate_with_direction_hint(direction_hint, global.get_current_time());
             else
                 workspace.activate(global.get_current_time());
-            this.showWorkspaceOSD();
         }
     },
 


### PR DESCRIPTION
We are missing the workspaceOSD and switch effect in some cases like assigning
a hotkey to direct navigation. Move showing the workspaceOSD and playing the
sound effect to _switchWorkspace since it always gets called.