### PR TITLE
window-list: Don't lose our focus style class when opening the contex…

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -540,6 +540,10 @@ AppMenuButton.prototype = {
         if (!this.alert && event.get_button() == 3) {
             this.rightClickMenu.mouseEvent = event;
             this.rightClickMenu.toggle();
+
+            if (this._hasFocus()) {
+                this.actor.add_style_pseudo_class('focus');
+            }
         }
     },
 


### PR DESCRIPTION
…t menu

We don't want to lose the focus styling for a window list item when opening the right
click menu for an already focused window. While technically I suppose the menu
now has the focus instead of the window, that isn't what we want for styling
purposes. So ensure that the 'focus' style class isn't lost in this case.

Closes: https://github.com/linuxmint/Cinnamon/issues/5862