### PR TITLE
Settings widgets range: Add an optional argument to show the current …

### DIFF
--- a/docs/reference/cinnamon-tutorials/xlet-settings-ref.xml
+++ b/docs/reference/cinnamon-tutorials/xlet-settings-ref.xml
@@ -39,6 +39,7 @@
         <listitem><code>min</code>: minimum value</listitem>
         <listitem><code>max</code>: maximum value</listitem>
         <listitem><code>step</code>: adjustment amount</listitem>
+        <listitem><code>show-value</code>: (optional) whether to show the current value on the slider - default: true</listitem>
         <listitem><code>description</code>: String describing the setting</listitem>
       </itemizedlist>
 

--- a/files/usr/share/cinnamon/applets/settings-example@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/settings-example@cinnamon.org/settings-schema.json
@@ -88,6 +88,7 @@
         "min" : 0.0,
         "max" : 1.0,
         "step" : 0.05,
+        "show-value" : false,
         "description" : "Here is a demonstration of bidirectional control",
         "tooltip" : "If you adjust this scale, it updates in the applet.  If you adjust the scale in the applet, it updates here"
     },

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py
@@ -8,6 +8,7 @@ JSON_SETTINGS_PROPERTIES_MAP = {
     "max"           : "maxi",
     "step"          : "step",
     "units"         : "units",
+    "show-value"    : "show_value",
     "select-dir"    : "dir_select",
     "height"        : "height",
     "tooltip"       : "tooltip",

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
@@ -631,7 +631,7 @@ class Range(SettingsWidget):
     bind_prop = "value"
     bind_dir = Gio.SettingsBindFlags.GET | Gio.SettingsBindFlags.NO_SENSITIVITY
 
-    def __init__(self, label, min_label="", max_label="", mini=None, maxi=None, step=None, invert=False, log=False, dep_key=None, tooltip=""):
+    def __init__(self, label, min_label="", max_label="", mini=None, maxi=None, step=None, invert=False, log=False, show_value=True, dep_key=None, tooltip=""):
         super(Range, self).__init__(dep_key=dep_key)
 
         self.set_orientation(Gtk.Orientation.VERTICAL)
@@ -677,7 +677,7 @@ class Range(SettingsWidget):
 
         self.content_widget = Gtk.Scale.new_with_range(Gtk.Orientation.HORIZONTAL, mini, maxi, self.step)
         self.content_widget.set_inverted(invert)
-        self.content_widget.set_draw_value(False)
+        self.content_widget.set_draw_value(show_value)
         self.bind_object = self.content_widget.get_adjustment()
 
         if invert:

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_accessibility.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_accessibility.py
@@ -273,7 +273,7 @@ class Module:
                                     "org.cinnamon.desktop.a11y.keyboard",
                                     "slowkeys-delay",
                                     _("Short"), _("Long"),
-                                    0, 500, 10)
+                                    0, 500, 10, show_value=False)
 
             settings.add_reveal_row(slider, "org.cinnamon.desktop.a11y.keyboard", "slowkeys-enable")
 
@@ -299,7 +299,7 @@ class Module:
                                     "org.cinnamon.desktop.a11y.keyboard",
                                     "bouncekeys-delay",
                                     _("Short"), _("Long"),
-                                    0, 900, 10)
+                                    0, 900, 10, show_value=False)
 
             settings.add_reveal_row(slider, "org.cinnamon.desktop.a11y.keyboard", "bouncekeys-enable")
 
@@ -323,7 +323,7 @@ class Module:
                                     "org.cinnamon.desktop.a11y.keyboard",
                                     "mousekeys-init-delay",
                                     _("Shorter"), _("Longer"),
-                                    10, 2000, 10)
+                                    10, 2000, 10, show_value=False)
 
             settings.add_reveal_row(slider, "org.cinnamon.desktop.a11y.keyboard", "mousekeys-enable")
 
@@ -331,7 +331,7 @@ class Module:
                                     "org.cinnamon.desktop.a11y.keyboard",
                                     "mousekeys-accel-time",
                                     _("Shorter"), _("Longer"),
-                                    10, 2000, 10)
+                                    10, 2000, 10, show_value=False)
 
             settings.add_reveal_row(slider, "org.cinnamon.desktop.a11y.keyboard", "mousekeys-enable")
 
@@ -339,7 +339,7 @@ class Module:
                                     "org.cinnamon.desktop.a11y.keyboard",
                                     "mousekeys-max-speed",
                                     _("Slower"), _("Faster"),
-                                    1, 500, 1)
+                                    1, 500, 1, show_value=False)
 
             settings.add_reveal_row(slider, "org.cinnamon.desktop.a11y.keyboard", "mousekeys-enable")
 
@@ -378,7 +378,7 @@ class Module:
                                     "org.cinnamon.desktop.a11y.mouse",
                                     "secondary-click-time",
                                     _("Shorter"), _("Longer"),
-                                    0.5, 3.0, 0.1)
+                                    0.5, 3.0, 0.1, show_value=False)
 
             settings.add_reveal_row(slider, "org.cinnamon.desktop.a11y.mouse", "secondary-click-enabled")
 
@@ -398,7 +398,7 @@ class Module:
                                     "org.cinnamon.desktop.a11y.mouse",
                                     "dwell-time",
                                     _("Short"), _("Long"),
-                                    0.2, 3.0, 0.1)
+                                    0.2, 3.0, 0.1, show_value=False)
 
             settings.add_reveal_row(slider, "org.cinnamon.desktop.a11y.mouse", "dwell-click-enabled")
 
@@ -406,7 +406,7 @@ class Module:
                                     "org.cinnamon.desktop.a11y.mouse",
                                     "dwell-threshold",
                                     _("Small"), _("Large"),
-                                    1, 30, 1)
+                                    1, 30, 1, show_value=False)
 
             settings.add_reveal_row(slider, "org.cinnamon.desktop.a11y.mouse", "dwell-click-enabled")
 

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_keyboard.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_keyboard.py
@@ -228,10 +228,10 @@ class Module:
             switch = GSettingsSwitch(_("Enable key repeat"), "org.cinnamon.settings-daemon.peripherals.keyboard", "repeat")
             settings.add_row(switch)
 
-            slider = GSettingsRange(_("Repeat delay:"), "org.cinnamon.settings-daemon.peripherals.keyboard", "delay", _("Short"), _("Long"), 100, 2000)
+            slider = GSettingsRange(_("Repeat delay:"), "org.cinnamon.settings-daemon.peripherals.keyboard", "delay", _("Short"), _("Long"), 100, 2000, show_value=False)
             settings.add_reveal_row(slider, "org.cinnamon.settings-daemon.peripherals.keyboard", "repeat")
 
-            slider = GSettingsRange(_("Repeat speed:"), "org.cinnamon.settings-daemon.peripherals.keyboard", "repeat-interval", _("Slow"), _("Fast"), 20, 2000, invert=True, log=True)
+            slider = GSettingsRange(_("Repeat speed:"), "org.cinnamon.settings-daemon.peripherals.keyboard", "repeat-interval", _("Slow"), _("Fast"), 20, 2000, invert=True, log=True, show_value=False)
             settings.add_reveal_row(slider, "org.cinnamon.settings-daemon.peripherals.keyboard", "repeat")
 
             settings = page.add_section(_("Text cursor"))
@@ -239,7 +239,7 @@ class Module:
             switch = GSettingsSwitch(_("Text cursor blinks"), "org.cinnamon.desktop.interface", "cursor-blink")
             settings.add_row(switch)
 
-            slider = GSettingsRange(_("Blink speed:"), "org.cinnamon.desktop.interface", "cursor-blink-time", _("Slow"), _("Fast"), 100, 2500, invert=True)
+            slider = GSettingsRange(_("Blink speed:"), "org.cinnamon.desktop.interface", "cursor-blink-time", _("Slow"), _("Fast"), 100, 2500, invert=True, show_value=False)
             settings.add_reveal_row(slider, "org.cinnamon.desktop.interface", "cursor-blink")
 
             # vbox.add(Gtk.Label.new(_("Test Box")))

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_mouse.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_mouse.py
@@ -44,19 +44,19 @@ class Module:
 
             settings = page.add_section(_("Pointer size and speed"))
 
-            widget = GSettingsRange(_("Size"), "org.cinnamon.desktop.interface", "cursor-size", _("Smaller"), _("Larger"), 5, 50)
+            widget = GSettingsRange(_("Size"), "org.cinnamon.desktop.interface", "cursor-size", _("Smaller"), _("Larger"), 5, 50, show_value=False)
             widget.add_mark(24.0, Gtk.PositionType.TOP, None)
             settings.add_row(widget)
 
-            slider = GSettingsRange(_("Acceleration"), "org.cinnamon.settings-daemon.peripherals.mouse", "motion-acceleration", _("Slow"), _("Fast"), 1, 10)
+            slider = GSettingsRange(_("Acceleration"), "org.cinnamon.settings-daemon.peripherals.mouse", "motion-acceleration", _("Slow"), _("Fast"), 1, 10, show_value=False)
             settings.add_row(slider)
 
-            slider = GSettingsRange(_("Sensitivity"), "org.cinnamon.settings-daemon.peripherals.mouse", "motion-threshold", _("Low"), _("High"), 1, 10, invert=True)
+            slider = GSettingsRange(_("Sensitivity"), "org.cinnamon.settings-daemon.peripherals.mouse", "motion-threshold", _("Low"), _("High"), 1, 10, invert=True, show_value=False)
             settings.add_row(slider)
 
             settings = page.add_section(_("Double-Click timeout"))
 
-            slider = GSettingsRange(_("Timeout"), "org.cinnamon.settings-daemon.peripherals.mouse", "double-click", _("Short"), _("Long"), 100, 1000)
+            slider = GSettingsRange(_("Timeout"), "org.cinnamon.settings-daemon.peripherals.mouse", "double-click", _("Short"), _("Long"), 100, 1000, show_value=False)
             settings.add_row(slider)
 
             box = SettingsWidget()
@@ -114,10 +114,10 @@ class Module:
             settings = SettingsBox(_("Pointer speed"))
             revealer.add(settings)
 
-            slider = GSettingsRange(_("Acceleration"), "org.cinnamon.settings-daemon.peripherals.touchpad", "motion-acceleration", _("Slow"), _("Fast"), 1, 10)
+            slider = GSettingsRange(_("Acceleration"), "org.cinnamon.settings-daemon.peripherals.touchpad", "motion-acceleration", _("Slow"), _("Fast"), 1, 10, show_value=False)
             settings.add_row(slider)
 
-            slider = GSettingsRange(_("Sensitivity"), "org.cinnamon.settings-daemon.peripherals.touchpad", "motion-threshold", _("Low"), _("High"), 1, 10, invert=True)
+            slider = GSettingsRange(_("Sensitivity"), "org.cinnamon.settings-daemon.peripherals.touchpad", "motion-threshold", _("Low"), _("High"), 1, 10, invert=True, show_value=False)
             settings.add_row(slider)
 
             self.sidePage.stack.add_titled(page, "touchpad", _("Touchpad"))


### PR DESCRIPTION
…value of on the scale widget. This was originally the way it worked in the xlet settings, but with the rework, that functionality wasn't re-implemented. This rendered the settings of several applets less useful. This pull request re-implements the functionality for applets and also makes it available for cinnamon settings as well.

Fixes #6315