### PR TITLE
added support to manage the systemd services available on the system (requires systemd-manager installed)

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
@@ -83,7 +83,8 @@ STANDALONE_MODULES = [
     [_("Driver Manager"),                "mintdrivers",                  "cs-drivers",         "admin",          _("video, driver, wifi, card, hardware, proprietary, nvidia, radeon, nouveau, fglrx")],
     [_("Software Sources"),              "mintsources",                  "cs-sources",         "admin",          _("ppa, repository, package, source, download")],
     [_("Users and Groups"),              "cinnamon-settings-users",      "cs-user-accounts",   "admin",          _("user, users, account, accounts, group, groups, password")],
-    [_("Bluetooth"),                     "blueberry",                    "cs-bluetooth",       "hardware",       _("bluetooth, dongle, transfer, mobile")]
+    [_("Bluetooth"),                     "blueberry",                    "cs-bluetooth",       "hardware",       _("bluetooth, dongle, transfer, mobile")],
+    [_("Manage Services and Units"),     "systemd-manager-pkexec",       "cs-sources",         "admin",          _("SystemD, units, services, systemctl, init")]
 ]
 
 def print_timing(func):


### PR DESCRIPTION
Greetings, I was planning to create an app that would allow us to manage and edit the systemd units and services on Cinnamon, but I just stumble across an app called systemd-manager (you can check all of the information here: [systemd-manager](https://github.com/mmstick/systemd-manager). Now I would like to explain some points which you might disagree with at first, but I would like to let you know anyway:

1. I do understand that you do not like CSD apps (don't hate them either but you have your reasons to dislike them, and I understand), but leaving aside that first fact it has the basic things along with the options of enable/disable, start/stop them, check the journal, check possible dependencies on other services and even edit the services available at will; something that will help the user to manage in a GUI way the systemd services and units without resorting to the terminal.

2. The app is written in Rust, a language that I haven't checked (yet since I don't have an Ubuntu/Linux Mint installation available) if it is available on the Ubuntu 16.04 repos, but since the author of the application created a deb file, it means that it shouldn't be a problem at all. Related to GTK dependencies it requires GTK >= 3.16.

3. I have put the label "Manage Services and Units" which I think it might be good for that, also I have used the cs-sources icon since it might describe the app as something related to admin only or kind of warning. You can let me know if you believe I might use something else.

Since Archlinux is the only thing I have installed for now, I have tested some things and so far is working on my own copy (I added the files manually and I have already installed the application). Here are some screenshots

![code added](https://cloud.githubusercontent.com/assets/1509924/23714303/511b8f42-03ee-11e7-88b8-a723f76915ff.png)

![systemd-manager_002](https://cloud.githubusercontent.com/assets/1509924/23714308/55d3948a-03ee-11e7-9ed4-e942b57e38cd.png)

![system settings_003](https://cloud.githubusercontent.com/assets/1509924/23714317/59c45c14-03ee-11e7-8153-d66a044bdb32.png)
