### PR TITLE
Switch to vp9

### DIFF
--- a/src/cinnamon-recorder.c
+++ b/src/cinnamon-recorder.c
@@ -150,7 +150,7 @@ G_DEFINE_TYPE(CinnamonRecorder, cinnamon_recorder, G_TYPE_OBJECT);
  * (Theora does have some support for frames at non-uniform times, but
  * things seem to break down if there are large gaps.)
  */
-#define DEFAULT_PIPELINE "vp8enc min_quantizer=13 max_quantizer=13 cpu-used=5 deadline=1000000 threads=%T ! queue ! webmmux"
+#define DEFAULT_PIPELINE "vp9enc min_quantizer=13 max_quantizer=13 cpu-used=5 deadline=1000000 threads=%T ! queue ! webmmux"
 
 /* The default filename pattern. Example cinnamon-20090311b-2.webm
  */
@@ -1627,7 +1627,7 @@ cinnamon_recorder_set_filename (CinnamonRecorder *recorder,
  * might be used to send the output to an icecast server
  * via shout2send or similar.
  *
- * The default value is 'vp8enc min_quantizer=13 max_quantizer=13 cpu-used=5 deadline=1000000 threads=%T ! queue ! webmmux'
+ * The default value is 'vp9enc min_quantizer=13 max_quantizer=13 cpu-used=5 deadline=1000000 threads=%T ! queue ! webmmux'
  */
 void
 cinnamon_recorder_set_pipeline (CinnamonRecorder *recorder,


### PR DESCRIPTION
Based on https://git.gnome.org/browse/gnome-shell/commit/?id=d183f13456991d12ea57ad14ba38a1f7407d0037

From d183f13456991d12ea57ad14ba38a1f7407d0037 Mon Sep 17 00:00:00 2001
From: Adel Gadllah <adel.gadllah@gmail.com>
Date: Sun, 11 Jan 2015 12:16:40 +0100
Subject: recorder: Switch to vp9

Currently we have been using the vp8 codec because it was the best unencumbered codec at that time. With vp9 we now have a successor that leads to smaller
files at at the same video quality and has been supported by current browsers
for a while.

With the raise of hidpi and 4K displays we need a better codec that handles
those resolutions better, so switch to vp9.

https://bugzilla.gnome.org/show_bug.cgi?id=742744