### PR TITLE
 	[xlets-about-dialog] show timestamp if exists else show version & show "more info" button

### DIFF
--- a/files/usr/share/cinnamon/applets/user@cinnamon.org/metadata.json
+++ b/files/usr/share/cinnamon/applets/user@cinnamon.org/metadata.json
@@ -1,5 +1,4 @@
 {
-    "last-edited": "1334576529", 
     "description": "An applet to access your account details, switch users and quickly logout or power off the computer", 
     "uuid": "user@cinnamon.org", 
     "name": "User Applet",


### PR DESCRIPTION
If `last-edited` exists in metadata, show the timestamp in UTC and don't show `version` of metadata.
If `last-edited` not in metadata, show `version` if exists.

If xlet is a spice, add a "More info" button, which opens the spices website in browser.

[user@cinnamon.org] remove last-edited entry form applets metadata

![screenshot-area-2017-03-22-172838](https://cloud.githubusercontent.com/assets/8415124/24209072/87a07928-0f25-11e7-99ae-859a7bc2e20c.png)