### PR TITLE
spawn_async: clean up the callbacks after we're done

### DIFF
--- a/files/usr/bin/cinnamon-subprocess-wrapper
+++ b/files/usr/bin/cinnamon-subprocess-wrapper
@@ -11,8 +11,14 @@ import dbus
 
 if __name__ == "__main__":
     process_id = int(sys.argv[1])
-    result = subprocess.check_output(sys.argv[2:])
+    try:
+        result = subprocess.check_output(sys.argv[2:])
+        success = true
+    except:
+        result = ""
+        success = false
+
     session_bus = dbus.SessionBus()
     dbus = session_bus.get_object("org.Cinnamon", "/org/Cinnamon")
     PushSubprocessResult = dbus.get_dbus_method('PushSubprocessResult', 'org.Cinnamon')
-    PushSubprocessResult(process_id, result)
+    PushSubprocessResult(process_id, result, success)

--- a/js/ui/cinnamonDBus.js
+++ b/js/ui/cinnamonDBus.js
@@ -100,6 +100,7 @@ const CinnamonIface =
             <method name="PushSubprocessResult"> \
                 <arg type="i" direction="in" name="process_id" /> \
                 <arg type="s" direction="in" name="result" /> \
+                <arg type="b" direction="in" name="success" /> \
             </method> \
             <method name="ToggleKeyboard"/> \
         </interface> \
@@ -368,9 +369,11 @@ CinnamonDBus.prototype = {
             Main.expo.toggle();
     },
 
-    PushSubprocessResult: function(process_id, result) {
+    PushSubprocessResult: function(process_id, result, success) {
         if (Util.subprocess_callbacks[process_id]) {
-            Util.subprocess_callbacks[process_id](result);
+            if (success)
+                Util.subprocess_callbacks[process_id](result);
+            delete Util.subprocess_callbacks[process_id];
         }
     },
 


### PR DESCRIPTION
This ensures that cinnamon-process-wrapper never fails due to an uncaught
exception when launching a process. With this, we can always call back into
cinnamonDbus.js and cleanup the subprocess_wrapper callback. The callback
is only invoked if the command runs successfully and exits with a status
code of 0. NFCI

Note: spawn_async can only be used if your command exits with a status of 0. If you're trying to differentiate between program exit states then you'll need to look elsewhere. An example is "gksudo", if the user cancels then you get status 255, incorrect password is status 1, and success is status 0. With this command you will not be able to tell if the user canceled, or typed the password wrong.