### PR TITLE
systray: add css class to permit theming

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -1824,3 +1824,14 @@ StScrollBar StButton#vhandle:hover {
     border-right-width: 0px;
     border-radius: 8px 0px 0px 0px;
 }
+/* ===================================================================
+ * Systray Applet
+ *
+ * .systray is for theming to be applied to the systray as a whole
+ * .applet-box is used for indicators (not tray icons) within the systray
+ * tray icons are not themed
+ * ===================================================================*/
+.systray {
+    spacing: 5px;
+}
+

--- a/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
@@ -54,8 +54,9 @@ MyApplet.prototype = {
 
         this.setAllowedLayout(Applet.AllowedLayout.BOTH);
 
-        this.actor.remove_style_class_name("applet-box");
-        this.actor.style="spacing: 5px;";
+        this.actor.remove_style_class_name('applet-box');
+        this.actor.set_style_class_name('systray');
+        this.actor.set_important(true);  // ensure we get class details from the default theme if not present
 
         this._signalManager = new SignalManager.SignalManager(this);
         let manager;


### PR DESCRIPTION
This PR allows theming of the systray.  Not that theming the systray per se is hugely useful, as it is really the tray icons within the systray that would be more useful to theme [so that, for example, they could be made to behave like applet-box on hover].  However I have bounced off that for now.  The most immediate use is to allow the hard-coded spacing in the systray applet to be moved to CSS, and I think that removing hard-coding from applets is worthwhile.  The important attribute is used so that no changes have to be made to themes other than the default cinnamon theme. I've left systray hover CSS in the Photocopy spices theme for ease of testing - as JosephM commented, highlighting the whole of the systray is a bit of an odd thing to have, but it does at least demonstrate this new CSS functionality working easily :)