### PR TITLE
systray-applet: don't crash in on_applet_removed_from_panel

### DIFF
--- a/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
@@ -115,9 +115,10 @@ MyApplet.prototype = {
             this.signalRemoved = 0;
         }
 
-        this._shellIndicators.forEach(function(iconActor) {
-            iconActor.destroy();
-        });
+        for (let id in this._shellIndicators) {
+            this._shellIndicators[id].destroy();
+        }
+
         this._shellIndicators = {};
 
     },


### PR DESCRIPTION
When _shellIndicators is empty, there is no forEach member function
and an exception is generated. Using a for loop instead, no exception
is generated when the object is empty.

fixes:
this._shellIndicators.forEach is not a function
Error during on_applet_removed_from_panel() call on applet: systray@cinnamon.org