### PR TITLE
A few looking-glass fixes

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-looking-glass/page_inspect.py
+++ b/files/usr/share/cinnamon/cinnamon-looking-glass/page_inspect.py
@@ -25,7 +25,7 @@ class InspectView(BaseListView):
     def setInspectionData(self, path, data):
         self.store.clear()
         for item in data:
-            self.store.append([item["name"], item["type"], item["shortValue"], item["value"], path + "." + item["name"]])
+            self.store.append([item["name"], item["type"], item["shortValue"], item["value"], path + "['" + item["name"] + "']"])
 
 class ModulePage(WindowAndActionBars):
     def __init__(self, parent):

--- a/js/ui/environment.js
+++ b/js/ui/environment.js
@@ -65,10 +65,14 @@ function init() {
     let origToString = Object.prototype.toString;
     Object.prototype.toString = function() {
         let base = origToString.call(this);
-        if ('actor' in this && this.actor instanceof Clutter.Actor)
-            return base.replace(/\]$/, ' delegate for ' + this.actor.toString().substring(1));
-        else
+        try {
+            if ('actor' in this && this.actor instanceof Clutter.Actor)
+                return base.replace(/\]$/, ' delegate for ' + this.actor.toString().substring(1));
+            else
+                return base;
+        } catch(e) {
             return base;
+        }
     };
 
     // Work around https://bugzilla.mozilla.org/show_bug.cgi?id=508783

--- a/js/ui/lookingGlass.js
+++ b/js/ui/lookingGlass.js
@@ -463,9 +463,12 @@ Melange.prototype = {
 
             //fixme: move this shortvalue stuff to python lg
             let shortValue, value;
-            if (type === "undefined" || result[key] === null) {
+            if (type === "undefined") {
                 value = "";
                 shortValue = "";
+            } else if (result[key] === null) {
+                value = "[null]";
+                shortValue = value;
             } else {
                 value = result[key].toString();
                 shortValue = value;


### PR DESCRIPTION
This fixes inspection of certain objects whose member's names are not compatible with dot notation such as `Main.AppletManager.appletObj`, and sets null values to "[null]" so they can easily be distinguished from empty objects in the inspector view.

A third fix here makes sure toString() doesn't fail for certain objects when inspecting. I'm not sure about the actual details of this problem, but I could reproduce the issue and I found this fix over in gnome-shell. It's simply adding a try..catch and returning the original toString value for that object if searching for the actor generates an exception.