### PR TITLE
st-entry: change variable type to avoid compiler warning

### DIFF
--- a/src/st/st-entry.c
+++ b/src/st/st-entry.c
@@ -530,7 +530,7 @@ blink_cb (gpointer data)
 {
   StEntry *entry;
   StEntryPrivate *priv;
-  gint blink_timeout;
+  guint blink_timeout;
 
   entry = ST_ENTRY (data);
   priv = entry->priv;


### PR DESCRIPTION
was comparing signed and unsigned int before, and generating a compiler warning