### PR TITLE
[cinnamon-settings, "Preferred Applications"] Add a chooser for File Manager

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_default.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_default.py
@@ -26,6 +26,7 @@ DEF_HEADING = 2
 preferred_app_defs = [
     # 1st mimetype is to let us find apps
     # 2nd mimetype is to set default handler for (so we handle all of that type, not just a specific format)
+    ( "inode/directory",         "inode/directory",            _("File Manager") ),
     ( "x-scheme-handler/http",   "x-scheme-handler/http",      _("_Web") ),
     ( "x-scheme-handler/mailto", "x-scheme-handler/mailto",    _("_Mail") ),
     ( "application/msword",      "application/msword",       _("Documents") ),


### PR DESCRIPTION
This enables users to chose the default file manager, e.g. in case other applications "steal" it from nemo because of alphabetical order of .desktop files.
Addresses #3695, fixes #5598 indirectly