### PR TITLE
Panel highlighting and _updatePanelVisibility cleanup

### DIFF
--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -1877,6 +1877,7 @@ Panel.prototype = {
 
         this._hidden = false;
         this._disabled = false;
+        this._highlighted = false;
         this._panelEditMode = false;
         this._autohideSettings = this._getProperty(PANEL_AUTOHIDE_KEY, "s");
         this._themeFontSize = null;
@@ -2146,6 +2147,8 @@ Panel.prototype = {
      * Turns on/off the highlight of the panel
      */
     highlight: function(highlight) {
+        if (this._highlighted == highlight) return;
+        this._highlighted = highlight;
         this.actor.change_style_pseudo_class('highlight', highlight);
     },
 
@@ -3035,7 +3038,8 @@ Panel.prototype = {
 
         } // end of switch on autohidesettings
 
-        if (this._panelEditMode)
+        // panel should always show if it is being edited or highlighted
+        if (this._panelEditMode || this._highlighted)
             this._shouldShow = true;
         this._queueShowHidePanel();
     },

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -2984,63 +2984,63 @@ Panel.prototype = {
      * false = autohide, true = always show, intel = Intelligent
      */
     _updatePanelVisibility: function() {
-
-        switch (this._autohideSettings) {
-            case "false":
-                this._shouldShow = true;
-                break;
-            case "true":
-                this._shouldShow = this._mouseEntered;
-                break;
-            default:
-                if (this._mouseEntered || !global.display.focus_window ||
-                    global.display.focus_window.get_window_type() == Meta.WindowType.DESKTOP) {
+        // panel should always show if it is being edited or highlighted
+        if (this._panelEditMode || this._highlighted) {
+            this._shouldShow = true;
+        } else {
+            switch (this._autohideSettings) {
+                case "false":
                     this._shouldShow = true;
                     break;
-                }
-
-                if (global.display.focus_window.get_monitor() != this.monitorIndex) {
-                    this._shouldShow = false;
+                case "true":
+                    this._shouldShow = this._mouseEntered;
                     break;
-                }
-                let y;
-
-                /* Calculate the y instead of getting the actor y since the
-                 * actor might be hidden*/
-                switch (this.panelPosition) {
-                    case PanelLoc.top:
-                        y = this.monitor.y;
+                default:
+                    if (this._mouseEntered || !global.display.focus_window ||
+                        global.display.focus_window.get_window_type() == Meta.WindowType.DESKTOP) {
+                        this._shouldShow = true;
                         break;
-                    case PanelLoc.bottom:
-                        y = this.monitor.y + this.monitor.height - this.actor.height;
-                        break;
-                    case PanelLoc.left:
-                        x = this.monitor.x;
-                        break;
-                    case PanelLoc.right:
-                        x = this.monitor.x + this.monitor.width - this.actor.width;
-                        break;
-                    default:
-                        global.log("updatePanelVisibility - unrecognised panel position "+this.panelPosition);
-                }
+                    }
 
-                let a = this.actor;
-                let b = global.display.focus_window.get_compositor_private();
-                /* Magic to check whether the panel position overlaps with the
-                 * current focused window */
-                if (this.panelPosition == PanelLoc.top || this.panelPosition == PanelLoc.bottom) {
-                    this._shouldShow = !(Math.max(a.x, b.x) < Math.min(a.x + a.width, b.x + b.width) &&
-                                         Math.max(y, b.y) < Math.min(y + a.height, b.y + b.height));
-                } else {
-                    this._shouldShow = !(Math.max(x, b.x) < Math.min(x + a.width, b.x + b.width) &&
-                                         Math.max(a.y, b.y) < Math.min(a.y + a.height, b.y + b.height));
-                }
+                    if (global.display.focus_window.get_monitor() != this.monitorIndex) {
+                        this._shouldShow = false;
+                        break;
+                    }
+                    let y;
 
-        } // end of switch on autohidesettings
+                    /* Calculate the y instead of getting the actor y since the
+                     * actor might be hidden*/
+                    switch (this.panelPosition) {
+                        case PanelLoc.top:
+                            y = this.monitor.y;
+                            break;
+                        case PanelLoc.bottom:
+                            y = this.monitor.y + this.monitor.height - this.actor.height;
+                            break;
+                        case PanelLoc.left:
+                            x = this.monitor.x;
+                            break;
+                        case PanelLoc.right:
+                            x = this.monitor.x + this.monitor.width - this.actor.width;
+                            break;
+                        default:
+                            global.log("updatePanelVisibility - unrecognised panel position "+this.panelPosition);
+                    }
 
-        // panel should always show if it is being edited or highlighted
-        if (this._panelEditMode || this._highlighted)
-            this._shouldShow = true;
+                    let a = this.actor;
+                    let b = global.display.focus_window.get_compositor_private();
+                    /* Magic to check whether the panel position overlaps with the
+                     * current focused window */
+                    if (this.panelPosition == PanelLoc.top || this.panelPosition == PanelLoc.bottom) {
+                        this._shouldShow = !(Math.max(a.x, b.x) < Math.min(a.x + a.width, b.x + b.width) &&
+                                             Math.max(y, b.y) < Math.min(y + a.height, b.y + b.height));
+                    } else {
+                        this._shouldShow = !(Math.max(x, b.x) < Math.min(x + a.width, b.x + b.width) &&
+                                             Math.max(a.y, b.y) < Math.min(a.y + a.height, b.y + b.height));
+                    }
+
+            } // end of switch on autohidesettings
+        }
         this._queueShowHidePanel();
     },
 


### PR DESCRIPTION
The first change keeps track of panel highlight state so that we can avoid noop style changes and ensure panel visibility while highlighted.

The second change slightly refactors _updatePanelVisibility to stick the body of the code in a conditional based on whether we are forcing visibility or not. This avoids wasting time calculating autohide during panel edit mode or highlighting.