### PR TITLE
hotcorners: remove the icon option

### DIFF
--- a/data/org.cinnamon.gschema.xml.in
+++ b/data/org.cinnamon.gschema.xml.in
@@ -359,9 +359,15 @@
     </key>
 
     <key name="overview-corner" type="as">
-      <default>['expo:false:false:0', 'scale:false:false:0', 'scale:false:false:0', 'desktop:false:false:0']</default>
-      <_summary>Properties of overview corners</_summary>
-      <_description>Properties of overview corners, in the form functionality:hover:icon. The order in which properties are displayed is top left, top right, bottom left, bottom right.</_description>
+      <default>["DEPRECATED"]</default>
+      <_summary>Obsolete - unused</_summary>
+      <_description>Obsolete - unused</_description>
+    </key>
+
+    <key name="hotcorner-layout" type="as">
+      <default>['expo:false:0', 'scale:false:0', 'scale:false:0', 'desktop:false:0']</default>
+      <_summary>Properties of hotcorners</_summary>
+      <_description>Properties of hotcorners, in the form functionality:hover-enabled:hover-delay. The order in which properties are displayed is top left, top right, bottom left, bottom right.</_description>
     </key>
 
     <key name="panel-launchers" type="as">


### PR DESCRIPTION
This is a left over legacy from gnome shell and simply doesn't work well the
various panel layouts we allow. It just appears broken/unfinished.

Remove the ability to use them and add a new gsettings key to manage our
settings for them. This should ensure nothing gets broken when Cinnamon is
upgraded.