### PR TITLE
cinnamon-looking-glass.py: handle numpad enter in entry

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-looking-glass/cinnamon-looking-glass.py
+++ b/files/usr/share/cinnamon/cinnamon-looking-glass/cinnamon-looking-glass.py
@@ -137,7 +137,7 @@ class CommandLine(Gtk.Entry):
         if event.keyval == Gdk.KEY_Down:
             self.historyNext()
             return True
-        if event.keyval == Gdk.KEY_Return:
+        if event.keyval == Gdk.KEY_Return or event.keyval == Gdk.KEY_KP_Enter:
             self.execute()
             return True
 


### PR DESCRIPTION
Allows use of the numpad enter key to execute the command line.