### PR TITLE
[Xlets] Expose config deletion request to xlet

### DIFF
--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -366,13 +366,13 @@ Applet.prototype = {
      *
      * This is meant to be overridden in individual applets.
      */
-    on_applet_removed_from_panel: function() {
+    on_applet_removed_from_panel: function(deleteConfig) {
     },
 
     // should only be called by appletManager
-    _onAppletRemovedFromPanel: function() {
+    _onAppletRemovedFromPanel: function(deleteConfig) {
         global.settings.disconnect(this._panelEditModeChangedId);
-        this.on_applet_removed_from_panel();
+        this.on_applet_removed_from_panel(deleteConfig);
 
         Main.AppletManager.callAppletInstancesChanged(this._uuid);
     },

--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -247,7 +247,7 @@ function removeAppletFromPanels(appletDefinition, deleteConfig) {
     let applet = appletObj[appletDefinition.applet_id];
     if (applet) {
         try {
-            applet._onAppletRemovedFromPanel();
+            applet._onAppletRemovedFromPanel(deleteConfig);
         } catch (e) {
             global.logError("Error during on_applet_removed_from_panel() call on applet: " + appletDefinition.uuid + "/" + appletDefinition.applet_id, e);
         }

--- a/js/ui/desklet.js
+++ b/js/ui/desklet.js
@@ -106,7 +106,7 @@ Desklet.prototype = {
      *
      * Callback when desklet is removed. To be overridden by individual desklets
      */
-    on_desklet_removed: function() {
+    on_desklet_removed: function(deleteConfig) {
     },
 
     /**
@@ -114,13 +114,13 @@ Desklet.prototype = {
      *
      * Destroys the actor with an fading animation
      */
-    destroy: function(){
+    destroy: function(deleteConfig){
         Tweener.addTween(this.actor,
                          { opacity: 0,
                            transition: 'linear',
                            time: DESKLET_DESTROY_TIME,
                            onComplete: Lang.bind(this, function(){
-                               this.on_desklet_removed();
+                               this.on_desklet_removed(deleteConfig);
                                this.actor.destroy();
                            })});
         this._menu.destroy();

--- a/js/ui/deskletManager.js
+++ b/js/ui/deskletManager.js
@@ -213,7 +213,7 @@ function _unloadDesklet(deskletDefinition, deleteConfig) {
     let desklet = deskletObj[deskletDefinition.desklet_id];
     if (desklet){
         try {
-            desklet.destroy();
+            desklet.destroy(deleteConfig);
         } catch (e) {
             global.logError("Failed to destroy desket: " + deskletDefinition.uuid + "/" + deskletDefinition.desklet_id, e);
         }


### PR DESCRIPTION
This exposes the request for deletion of config files to the xlet that is being removed, in order to enable them to clean up after themselves, e.g. if an xlet uses its own settings. there's no need to do this for plain extensions, because their disable()-function is only called when completely unloading it.