### PR TITLE
modalDialog: avoid a js warning

### DIFF
--- a/js/ui/modalDialog.js
+++ b/js/ui/modalDialog.js
@@ -603,6 +603,7 @@ SpicesAboutDialog.prototype = {
             return null;
         } catch (e) {
             global.log('Failed to load/parse index.json', e);
+            return null;
         }
     },
 


### PR DESCRIPTION
Cjs-Message: JS WARNING: [/usr/share/cinnamon/js/ui/modalDialog.js 594]: anonymous function does not always return a value