### PR TITLE
Panel.js: _moveResizePanel refactor and cleanups

### DIFF
--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -951,6 +951,7 @@ PanelManager.prototype = {
                 }
 
             } else { // Nothing happens. Re-allocate panel
+                this.panels[i]._monitorsChanged = true;
                 this.panels[i]._moveResizePanel();
             }
         }
@@ -1881,6 +1882,8 @@ Panel.prototype = {
         this._autohideSettings = null;
         this._themeFontSize = null;
         this._destroyed = false;
+        this._positionChanged = false;
+        this._monitorsChanged = false;
         this._signalManager = new SignalManager.SignalManager(this);
         this.margin_top = 0;
         this.margin_bottom = 0;
@@ -2028,6 +2031,7 @@ Panel.prototype = {
     updatePosition: function(monitorIndex, panelPosition) {
         this.monitorIndex = monitorIndex
         this.panelPosition = panelPosition;
+        this._positionChanged = true;
 
         this.monitor = global.screen.get_monitor_geometry(monitorIndex);
         //
@@ -2533,6 +2537,9 @@ Panel.prototype = {
 
         if (this._destroyed)
             return false;
+
+        this._positionChanged = false;
+        this._monitorsChanged = false;
 
         this.monitor = global.screen.get_monitor_geometry(this.monitorIndex);
         let horizontal_panel = ((this.panelPosition == PanelLoc.top || this.panelPosition == PanelLoc.bottom) ? true : false);

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -3129,7 +3129,6 @@ Panel.prototype = {
 
         // setup panel tween - slide in from edge of monitor
         // if horizontal panel, animation on y. if vertical, animation on x.
-        let origPos;
         let isHorizontal = this.panelPosition == PanelLoc.top
                            || this.panelPosition == PanelLoc.bottom;
         let animationTime = AUTOHIDE_ANIMATION_TIME;
@@ -3150,29 +3149,28 @@ Panel.prototype = {
         }
 
         // set up original and destination positions and add tween
-        // destination position paramater
+        // destination parameter
+        let origPos, destPos;
         if (isHorizontal) {
             let height = this.actor.get_height();
-            let destY;
             if (this.panelPosition == PanelLoc.top) {
-                destY = this.monitor.y;
+                destPos = this.monitor.y;
                 origPos = this.monitor.y - height;
             } else {
-                destY = this.monitor.y + this.monitor.height - height;
+                destPos = this.monitor.y + this.monitor.height - height;
                 origPos = this.monitor.y + this.monitor.height;
             }
-            panelParams['y'] = destY;
+            panelParams['y'] = destPos;
         } else {
             let width = this.actor.get_width();
-            let destX;
             if (this.panelPosition == PanelLoc.left) {
-                destX = this.monitor.x;
+                destPos = this.monitor.x;
                 origPos = this.monitor.x - width;
             } else {
-                destX = this.monitor.width - width + this.monitor.x;
+                destPos = this.monitor.width - width + this.monitor.x;
                 origPos = this.monitor.width + this.monitor.x;
             }
-            panelParams['x'] = destX;
+            panelParams['x'] = destPos;
         }
 
         // setup onUpdate tween parameter to set the actor clip region during animation.
@@ -3247,33 +3245,31 @@ Panel.prototype = {
         let panelParams = { time: animationTime,
                             transition: 'easeOutQuad' };
 
-        // setup destination position and onUpdateParams for clipping later
+        // setup destination position and add tween destination parameter
         // remember to always leave a vestigial 1px strip or the panel
         // will become inaccessible
+        let destPos;
         if (isHorizontal) {
             let height = this.actor.get_height();
-            let destY;
             if (this.panelPosition == PanelLoc.top)
-                destY = this.monitor.y - height + 1;
+                destPos = this.monitor.y - height + 1;
             else
-                destY = this.monitor.y + this.monitor.height - 1;
-            panelParams['y'] = destY;
-            panelParams['onUpdateParams'] = [destY, this.panelPosition, isHorizontal];
+                destPos = this.monitor.y + this.monitor.height - 1;
+            panelParams['y'] = destPos;
         } else {
             let width = this.actor.get_width();
-            let destX;
             if (this.panelPosition == PanelLoc.left)
-                destX = this.monitor.x - width + 1;
+                destPos = this.monitor.x - width + 1;
             else
-                destX = this.monitor.x + this.monitor.width - 1;
-            panelParams['x'] = destX;
-            panelParams['onUpdateParams'] = [destX, this.panelPosition, isHorizontal];
+                destPos = this.monitor.x + this.monitor.width - 1;
+            panelParams['x'] = destPos;
         }
 
         // setup onUpdate tween parameter to update the actor clip region during animation
         // we need to account for the the exposed part of the panel when setting the clip
         // size and offset.
         // note: ensure at least one exposed panel pixel strip remains after the clip
+        panelParams['onUpdateParams'] = [destPos, this.panelPosition, isHorizontal];
         panelParams['onUpdate'] =
             Lang.bind(this, function(destPos, panelPosition, isHorizontal) {
                 // Force the layout manager to update the input region

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -1878,7 +1878,7 @@ Panel.prototype = {
         this._hidden = false;
         this._disabled = false;
         this._panelEditMode = false;
-        this._autohideSettings = this._getProperty(PANEL_AUTOHIDE_KEY, "s");
+        this._autohideSettings = null;
         this._themeFontSize = null;
         this._destroyed = false;
         this._signalManager = new SignalManager.SignalManager(this);
@@ -1923,6 +1923,7 @@ Panel.prototype = {
         Main.layoutManager.addChrome(this.actor, { addToWindowgroup: false });
         this._moveResizePanel();
         this._onPanelEditModeChanged();
+        this._processPanelAutoHide();
 
         this.actor.connect('button-press-event', Lang.bind(this, this._onButtonPressEvent));
         this.actor.connect('style-changed', Lang.bind(this, this._moveResizePanel));
@@ -2338,7 +2339,7 @@ Panel.prototype = {
         this._rightBox.change_style_pseudo_class('dnd', this._panelEditMode);
 
         if (old_mode != this._panelEditMode) {
-            this._processPanelAutoHide();
+            this._updatePanelVisibility();
         }
 
         this.actor.queue_relayout();
@@ -2495,7 +2496,7 @@ Panel.prototype = {
             vertpanelHeight = this.monitor.height - this.toppanelHeight - this.bottompanelHeight
                               - global.ui_scale*(this.margin_top + this.margin_bottom);
         }
-        this._processPanelAutoHide();
+        this._updatePanelVisibility();
         //
         // layouts set to be full width horizontal panels, and vertical panels set to use as much available space as is left 
         //


### PR DESCRIPTION
This fixes most instances of hidden panel flashing, and also has a minor fix and some cleanups. See commit messages for detailed descriptions. Please test and comment if you find any bugs.

This branch exposes an issue in existing code which is fixed in #6460

Fixed issues that I don't know if are reported:
- Panel shadows show up on adjacent monitors
- Hidden panels flash on any settings or theme change
- Panel sometimes disappears when moving a panel with autohide enabled
- Hidden vertical panels partially show when activating a horizontal panel menu
- Recently added shadow clipping code in _showPanel doesn't handle all shadow types correctly

Existing issues:
- <s>Partial vertical panels don't have a shadow on top or bottom. These should be unclipped when the panel above or below hides. This is not worth the added complexity IMO. </s> I now believe that this is the intended behavior.
- Horizontal panels shadow overlaps vertical panels. I don't know how to solve this as the clip region would need to be non-rectangular.
- When activating a menu on a hidden panel, the menu can briefly appear behind the panel if the panel shows while the menu is active. The menu pops into place once hovered, so it is not a big issue.
- When activating a menu on a hidden panel, the menu may briefly appear on an adjacent monitor. I don't know the fix for this, but I don't think it is in the panel code.

Fixes #6385 