### PR TITLE
st-theme: add missing enums and default case

### DIFF
--- a/src/st/st-theme.c
+++ b/src/st/st-theme.c
@@ -632,6 +632,9 @@ additional_selector_matches_style (StTheme         *a_this,
           if (!pseudo_class_add_sel_matches_style (a_this, cur_add_sel, a_node))
             return FALSE;
           break;
+        default:
+          g_warning ("Unhandled selector type %d", cur_add_sel->type);
+          return FALSE;
         }
     }
 
@@ -926,6 +929,10 @@ add_matched_properties (StTheme      *a_this,
               }
           }
           break;
+        case AT_RULE_STMT:
+        case AT_PAGE_RULE_STMT:
+        case AT_CHARSET_RULE_STMT:
+        case AT_FONT_FACE_RULE_STMT:
         default:
           break;
         }


### PR DESCRIPTION
avoids compiler warnings
done upstream