### PR TITLE
cs_user.py: Save appropriately sized .face for cinnamon-screensaver

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_user.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_user.py
@@ -146,7 +146,7 @@ class Module:
         bottom = (height + new_height) / 2
 
         image = image.crop((left, top, right, bottom))
-        image.thumbnail((96, 96), PIL.Image.ANTIALIAS)
+        image.thumbnail((255, 255), PIL.Image.ANTIALIAS)
 
         face_path = os.path.join(self.accountService.get_home_dir(), ".face")
 
@@ -187,7 +187,7 @@ class Module:
             right = (width + new_width)/2
             bottom = (height + new_height)/2
             image = image.crop((left, top, right, bottom))
-            image.thumbnail((96, 96), PIL.Image.ANTIALIAS)
+            image.thumbnail((255, 255), PIL.Image.ANTIALIAS)
             face_path = os.path.join(self.accountService.get_home_dir(), ".face")
             image.save(face_path, "png")
             self.accountService.set_icon_file(face_path)


### PR DESCRIPTION
I have upped the image.thumbnail resolution from 96x96 to 255x255. This will save an appropriately .face image for the new larger face thumbnail on the lockscreen for cinnamon-screensaver.

This push resolves bug linuxmint/cinnamon-screensaver#187 and closed duplicate #6173.