### PR TITLE
cinnamon-settings: Fix some sliders being drawn backwards

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
@@ -631,7 +631,7 @@ class Range(SettingsWidget):
     bind_prop = "value"
     bind_dir = Gio.SettingsBindFlags.GET | Gio.SettingsBindFlags.NO_SENSITIVITY
 
-    def __init__(self, label, min_label="", max_label="", mini=None, maxi=None, step=None, invert=False, log=False, show_value=True, dep_key=None, tooltip=""):
+    def __init__(self, label, min_label="", max_label="", mini=None, maxi=None, step=None, invert=False, log=False, show_value=True, dep_key=None, tooltip="", flipped=False):
         super(Range, self).__init__(dep_key=dep_key)
 
         self.set_orientation(Gtk.Orientation.VERTICAL)
@@ -639,6 +639,7 @@ class Range(SettingsWidget):
 
         self.log = log
         self.invert = invert
+        self.flipped = flipped
         self.timer = None
         self.value = 0
 
@@ -667,8 +668,20 @@ class Range(SettingsWidget):
         if log:
             mini = math.log(mini)
             maxi = math.log(maxi)
-            self.map_get = lambda x: math.log(x)
-            self.map_set = lambda x: math.exp(x)
+            if self.flipped:
+                self.map_get = lambda x: -1 * (math.log(x))
+                self.map_set = lambda x: math.exp(x)
+            else:
+                self.map_get = lambda x: math.log(x)
+                self.map_set = lambda x: math.exp(x)
+        elif self.flipped:
+            self.map_get = lambda x: x * -1
+            self.map_set = lambda x: x * -1
+
+        if self.flipped:
+            tmp_mini = mini
+            mini = maxi * -1
+            maxi = tmp_mini * -1
 
         if step is None:
             self.step = (maxi - mini) * 0.02
@@ -677,7 +690,7 @@ class Range(SettingsWidget):
 
         self.content_widget = Gtk.Scale.new_with_range(Gtk.Orientation.HORIZONTAL, mini, maxi, self.step)
         self.content_widget.set_inverted(invert)
-        self.content_widget.set_draw_value(show_value)
+        self.content_widget.set_draw_value(show_value and not self.flipped)
         self.bind_object = self.content_widget.get_adjustment()
 
         if invert:
@@ -698,9 +711,12 @@ class Range(SettingsWidget):
     def apply_later(self, *args):
         def apply(self):
             if self.log:
-                self.set_value(math.exp(self.content_widget.get_value()))
+                self.set_value(math.exp(abs(self.content_widget.get_value())))
             else:
-                self.set_value(self.content_widget.get_value())
+                if self.flipped:
+                    self.set_value(self.content_widget.get_value() * -1)
+                else:
+                    self.set_value(self.content_widget.get_value())
             self.timer = None
 
         if self.timer:

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_keyboard.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_keyboard.py
@@ -231,7 +231,7 @@ class Module:
             slider = GSettingsRange(_("Repeat delay:"), "org.cinnamon.settings-daemon.peripherals.keyboard", "delay", _("Short"), _("Long"), 100, 2000, show_value=False)
             settings.add_reveal_row(slider, "org.cinnamon.settings-daemon.peripherals.keyboard", "repeat")
 
-            slider = GSettingsRange(_("Repeat speed:"), "org.cinnamon.settings-daemon.peripherals.keyboard", "repeat-interval", _("Slow"), _("Fast"), 20, 2000, invert=True, log=True, show_value=False)
+            slider = GSettingsRange(_("Repeat speed:"), "org.cinnamon.settings-daemon.peripherals.keyboard", "repeat-interval", _("Slow"), _("Fast"), 20, 2000, log=True, show_value=False, flipped=True)
             settings.add_reveal_row(slider, "org.cinnamon.settings-daemon.peripherals.keyboard", "repeat")
 
             settings = page.add_section(_("Text cursor"))
@@ -239,7 +239,7 @@ class Module:
             switch = GSettingsSwitch(_("Text cursor blinks"), "org.cinnamon.desktop.interface", "cursor-blink")
             settings.add_row(switch)
 
-            slider = GSettingsRange(_("Blink speed:"), "org.cinnamon.desktop.interface", "cursor-blink-time", _("Slow"), _("Fast"), 100, 2500, invert=True, show_value=False)
+            slider = GSettingsRange(_("Blink speed:"), "org.cinnamon.desktop.interface", "cursor-blink-time", _("Slow"), _("Fast"), 100, 2500, show_value=False, flipped=True)
             settings.add_reveal_row(slider, "org.cinnamon.desktop.interface", "cursor-blink")
 
             # vbox.add(Gtk.Label.new(_("Test Box")))

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_mouse.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_mouse.py
@@ -51,7 +51,7 @@ class Module:
             slider = GSettingsRange(_("Acceleration"), "org.cinnamon.settings-daemon.peripherals.mouse", "motion-acceleration", _("Slow"), _("Fast"), 1, 10, show_value=False)
             settings.add_row(slider)
 
-            slider = GSettingsRange(_("Sensitivity"), "org.cinnamon.settings-daemon.peripherals.mouse", "motion-threshold", _("Low"), _("High"), 1, 10, invert=True, show_value=False)
+            slider = GSettingsRange(_("Sensitivity"), "org.cinnamon.settings-daemon.peripherals.mouse", "motion-threshold", _("Low"), _("High"), 1, 10, show_value=False, flipped=True)
             settings.add_row(slider)
 
             settings = page.add_section(_("Double-Click timeout"))
@@ -117,7 +117,7 @@ class Module:
             slider = GSettingsRange(_("Acceleration"), "org.cinnamon.settings-daemon.peripherals.touchpad", "motion-acceleration", _("Slow"), _("Fast"), 1, 10, show_value=False)
             settings.add_row(slider)
 
-            slider = GSettingsRange(_("Sensitivity"), "org.cinnamon.settings-daemon.peripherals.touchpad", "motion-threshold", _("Low"), _("High"), 1, 10, invert=True, show_value=False)
+            slider = GSettingsRange(_("Sensitivity"), "org.cinnamon.settings-daemon.peripherals.touchpad", "motion-threshold", _("Low"), _("High"), 1, 10, show_value=False, flipped=True)
             settings.add_row(slider)
 
             self.sidePage.stack.add_titled(page, "touchpad", _("Touchpad"))

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_mouse.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_mouse.py
@@ -48,11 +48,17 @@ class Module:
             widget.add_mark(24.0, Gtk.PositionType.TOP, None)
             settings.add_row(widget)
 
+            widget = GSettingsSwitch(_("Custom Acceleration"), "org.cinnamon.settings-daemon.peripherals.mouse", "custom-acceleration")
+            settings.add_row(widget)
+
             slider = GSettingsRange(_("Acceleration"), "org.cinnamon.settings-daemon.peripherals.mouse", "motion-acceleration", _("Slow"), _("Fast"), 1, 10, show_value=False)
-            settings.add_row(slider)
+            settings.add_reveal_row(slider, "org.cinnamon.settings-daemon.peripherals.mouse", "custom-acceleration")
+
+            widget = GSettingsSwitch(_("Custom Sensitivity"), "org.cinnamon.settings-daemon.peripherals.mouse", "custom-threshold")
+            settings.add_row(widget)
 
             slider = GSettingsRange(_("Sensitivity"), "org.cinnamon.settings-daemon.peripherals.mouse", "motion-threshold", _("Low"), _("High"), 1, 10, show_value=False, flipped=True)
-            settings.add_row(slider)
+            settings.add_reveal_row(slider, "org.cinnamon.settings-daemon.peripherals.mouse", "custom-threshold")
 
             settings = page.add_section(_("Double-Click timeout"))
 
@@ -114,11 +120,17 @@ class Module:
             settings = SettingsBox(_("Pointer speed"))
             revealer.add(settings)
 
+            switch = GSettingsSwitch(_("Custom Acceleration"), "org.cinnamon.settings-daemon.peripherals.touchpad", "custom-acceleration")
+            settings.add_row(switch)
+
             slider = GSettingsRange(_("Acceleration"), "org.cinnamon.settings-daemon.peripherals.touchpad", "motion-acceleration", _("Slow"), _("Fast"), 1, 10, show_value=False)
-            settings.add_row(slider)
+            settings.add_reveal_row(slider, "org.cinnamon.settings-daemon.peripherals.touchpad", "custom-acceleration")
+
+            switch = GSettingsSwitch(_("Custom Sensitivity"), "org.cinnamon.settings-daemon.peripherals.touchpad", "custom-threshold")
+            settings.add_row(switch)
 
             slider = GSettingsRange(_("Sensitivity"), "org.cinnamon.settings-daemon.peripherals.touchpad", "motion-threshold", _("Low"), _("High"), 1, 10, show_value=False, flipped=True)
-            settings.add_row(slider)
+            settings.add_reveal_row(slider, "org.cinnamon.settings-daemon.peripherals.touchpad", "custom-threshold")
 
             self.sidePage.stack.add_titled(page, "touchpad", _("Touchpad"))
 


### PR DESCRIPTION
Add a flipped argument to the cinnamon settings range widget. Gtk.Scale is a
little limited in what it allows. There is no way built in to map a range from
a big->small value without drawing the fill value in reverse. Add a bit of a
hack to allow working around this limitation.