### PR TITLE
power-applet: Add support for warning and error style classes

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -344,6 +344,14 @@ StScrollBar StButton#vhandle:hover {
     margin: 0px;
 }
 
+.system-status-icon.warning {
+    color: #e5e887;
+}
+
+.system-status-icon.error {
+    color: #fb5858;
+}
+
 .panel-corner {
     -panel-corner-radius: 0px;
     -panel-corner-background-color: black;

--- a/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
@@ -426,8 +426,8 @@ MyApplet.prototype = {
             this._applet_label.set_margin_left(1.0);
         }
 
-        if(icon){
-            if(this.panel_icon_name != icon){
+        if (icon) {
+            if(this.panel_icon_name != icon) {
                 this.panel_icon_name = icon;
                 this.set_applet_icon_symbolic_name('battery-full');
                 let gicon = Gio.icon_new_for_string(icon);
@@ -439,6 +439,18 @@ MyApplet.prototype = {
                 this.panel_icon_name = 'battery-full';
                 this.set_applet_icon_symbolic_name('battery-full');
             }
+        }
+
+        if (device_type == UPDeviceType.BATTERY) {
+            if (percentage > 20) {
+                this._applet_icon.set_style_class_name('system-status-icon');
+            } else if (percentage > 5) {
+                this._applet_icon.set_style_class_name('system-status-icon warning');
+            } else {
+                this._applet_icon.set_style_class_name('system-status-icon error');
+            }
+        } else {
+            this._applet_icon.set_style_class_name ('system-status-icon');
         }
     },
 
@@ -558,7 +570,6 @@ MyApplet.prototype = {
                     }
                 }
             }
-
         }));
     },
 


### PR DESCRIPTION
These allow us to recolor the applets icon depending on the current state of
the battery. Use a 'warning' style class when the percentage drops below 20 and
an 'error' class when it drops below 5.