### PR TITLE
messageTray: Show critical notifications in fullscreen

### DIFF
--- a/js/ui/messageTray.js
+++ b/js/ui/messageTray.js
@@ -1698,6 +1698,11 @@ MessageTray.prototype = {
         let margin = this._notification._table.get_theme_node().get_length('margin-from-right-edge-of-screen');
         this._notificationBin.x = monitor.x + monitor.width - this._notification._table.width - margin - rightGap;
         Main.soundManager.play('notification');
+        if (this._notification.urgency == Urgency.CRITICAL) {
+            Main.layoutManager._chrome.modifyActorParams(this._notificationBin, { visibleInFullscreen: true });
+        } else {
+            Main.layoutManager._chrome.modifyActorParams(this._notificationBin, { visibleInFullscreen: false });
+        }
         this._notificationBin.show();
 
         this._updateShowingNotification();


### PR DESCRIPTION
While we don't allow most notifications to show when running fullscreen
applications, we should allow notifications marked as critical. Since panels
are hidden there is no obvious indicator of things like the fact that your
battery is about to die.

Closes https://github.com/linuxmint/Cinnamon/issues/1646