### PR TITLE
panel.js: fix missing variable declaration

### DIFF
--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -3000,9 +3000,9 @@ Panel.prototype = {
                     this._shouldShow = false;
                     break;
                 }
-                let y;
+                let x, y;
 
-                /* Calculate the y instead of getting the actor y since the
+                /* Calculate the x or y instead of getting it from the actor since the
                  * actor might be hidden*/
                 switch (this.panelPosition) {
                     case PanelLoc.top:


### PR DESCRIPTION
This problem was only exposed after I changed the way _updatePanelVisibility was being called in PR #6438. This warning won't occur on master but this is still an issue.

Fixes:
Cjs-Message: JS WARNING: [/usr/share/cinnamon/js/ui/panel.js 3150]: assignment to undeclared variable x