### PR TITLE
St: support margin: corrections to PR 6271

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -1527,6 +1527,10 @@ StScrollBar StButton#vhandle:hover {
     text-shadow: black 0px 0px 2px;
     transition-duration: 300;
 }
+.panel-top .applet-box,
+.panel-bottom .applet-box {
+    spacing: 3px;
+}
 .applet-box:checked,
 .applet-box:hover {
     color: #fff;
@@ -1545,10 +1549,6 @@ StScrollBar StButton#vhandle:hover {
 .applet-label {
     font-weight: bold;
     color: #ccc;
-}
-.panel-top .applet-label,
-.panel-bottom .applet-label {
-    margin-left: 6px;
 }
 .applet-box:checked > .applet-label,
 .applet-box:hover > .applet-label {

--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -805,25 +805,6 @@ TextIconApplet.prototype = {
     },
 
     /**
-     * update_label_margin:
-     *
-     * The margin is set from the CSS.  However if the label is blank/null
-     * then the margin will still display, which is not desirable. So in this
-     * case hide the label.  In a vertical panel the label is going to get blanked
-     * out regardless.
-     */
-    update_label_margin: function () {
-        let text = this._applet_label.get_text();
-
-        if ((text && text != "") && this._applet_icon_box.child &&
-            (this._orientation == St.Side.TOP || this._orientation == St.Side.BOTTOM)) {
-            this.showLabel(); // in case it has been previously hidden
-        } else {
-            this.hideLabel();
-        }
-    },
-
-    /**
      * set_applet_label:
      * @text (string): text to be displayed at the label
      *
@@ -831,7 +812,6 @@ TextIconApplet.prototype = {
      */
     set_applet_label: function (text) {
         this._applet_label.set_text(text);
-        this.update_label_margin();
     },
 
     /**
@@ -865,8 +845,6 @@ TextIconApplet.prototype = {
         } else {
             this.showLabel();
         }
-
-        this.update_label_margin();
     },
     /**
      * hideLabel:


### PR DESCRIPTION
Was affecting text-only applets unintentionally.  Use spacing rather than margin to avoid this.  This has the happy side effect of being able to remove some code that is not needed anymore