### PR TITLE
st-scroll-bar: add default to case statement to avoid compiler warning

### DIFF
--- a/src/st/st-scroll-bar.c
+++ b/src/st/st-scroll-bar.c
@@ -476,6 +476,9 @@ st_scroll_bar_scroll_event (ClutterActor       *actor,
     case CLUTTER_SCROLL_RIGHT:
       st_adjustment_set_value (priv->adjustment, value + step);
       break;
+    default:
+          g_return_val_if_reached (FALSE);
+      break;
     }
 
   return TRUE;


### PR DESCRIPTION
done using g_return_val_if_reached as upstream