### PR TITLE
St: Margin: remove margin:auto from menu applet and default theme

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -1035,7 +1035,6 @@ StScrollBar StButton#vhandle:hover {
 /* Main menu title */
 
 .menu-favorites-box {
-    margin: auto;
     padding: 10px;
     border: 1px solid #666;
     border-radius: 8px;
@@ -1059,7 +1058,6 @@ StScrollBar StButton#vhandle:hover {
     border-radius: 4px;
 }
 .menu-places-box {
-    margin: auto;
     padding: 10px;
     border: 0px solid #666;
 }

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -943,7 +943,7 @@ FavoritesButton.prototype = {
         let icon_size = 0.6 * real_size / global.ui_scale;
         if (icon_size > MAX_FAV_ICON_SIZE)
             icon_size = MAX_FAV_ICON_SIZE;
-        this.actor.style = "padding-top: "+(icon_size / 3)+"px;padding-bottom: "+(icon_size / 3)+"px; margin:auto;"
+        this.actor.style = "padding-top: "+(icon_size / 3)+"px;padding-bottom: "+(icon_size / 3)+"px;"
 
         this.actor.add_style_class_name('menu-favorites-button');
         let icon = app.create_icon_texture(icon_size);
@@ -993,7 +993,7 @@ SystemButton.prototype = {
         let icon_size = 0.6 * real_size / global.ui_scale;
         if (icon_size > MAX_FAV_ICON_SIZE)
             icon_size = MAX_FAV_ICON_SIZE;
-        this.actor.style = "padding-top: "+(icon_size / 3)+"px;padding-bottom: "+(icon_size / 3)+"px; margin:auto;"
+        this.actor.style = "padding-top: "+(icon_size / 3)+"px;padding-bottom: "+(icon_size / 3)+"px;"
         this.actor.add_style_class_name('menu-favorites-button');
 
         let iconObj = new St.Icon({icon_name: icon, icon_size: icon_size, icon_type: St.IconType.FULLCOLOR});


### PR DESCRIPTION
This avoids warning messages as margin:auto is not supported
And it also means third party theme developers will not copy non-functional CSS
The warning messages for the programmatic insertion of margin:auto in the menu applet
were particularly cryptic

I have removed earlier PRs in the same area, on reflection I realised simple removal of the margin:auto statements that triggered warning messages was all that was needed.  I can roll this out into other themes.