### PR TITLE
st: Fix a couple icon/text-shadow bugs

### DIFF
--- a/src/st/st-icon.c
+++ b/src/st/st-icon.c
@@ -277,11 +277,6 @@ st_icon_paint (ClutterActor *actor)
           clutter_actor_get_allocation_box (priv->icon_texture, &allocation);
           clutter_actor_box_get_size (&allocation, &width, &height);
 
-          allocation.x1 = (width - priv->shadow_width) / 2;
-          allocation.y1 = (height - priv->shadow_height) / 2;
-          allocation.x2 = allocation.x1 + priv->shadow_width;
-          allocation.y2 = allocation.y1 + priv->shadow_height;
-
           _st_paint_shadow_with_opacity (priv->shadow_spec,
                                          priv->shadow_material,
                                          &allocation,

--- a/src/st/st-label.c
+++ b/src/st/st-label.c
@@ -220,10 +220,6 @@ st_label_paint (ClutterActor *actor)
       clutter_actor_get_allocation_box (priv->label, &allocation);
       clutter_actor_box_get_size (&allocation, &width, &height);
 
-      allocation.x1 = allocation.y1 = 0;
-      allocation.x2 = width;
-      allocation.y2 = height;
-
       if (priv->text_shadow_material == COGL_INVALID_HANDLE ||
           width != priv->shadow_width ||
           height != priv->shadow_height)

--- a/src/st/st-private.c
+++ b/src/st/st-private.c
@@ -631,6 +631,7 @@ _st_create_shadow_material_from_actor (StShadow     *shadow_spec,
       cogl_color_set_from_4ub (&clear_color, 0, 0, 0, 0);
       cogl_push_framebuffer (offscreen);
       cogl_clear (&clear_color, COGL_BUFFER_BIT_COLOR);
+      cogl_translate (-box.x1, -box.y1, 0);
       cogl_ortho (0, width, height, 0, 0, 1.0);
       clutter_actor_paint (actor);
       cogl_pop_framebuffer ();


### PR DESCRIPTION
Adapted from https://github.com/GNOME/gnome-shell/commit/d6fe008b2c334f8f7b48b28b87982c06035243e0

Closes https://github.com/linuxmint/Cinnamon/issues/6360
Closes https://github.com/linuxmint/Cinnamon/issues/6209