### PR TITLE
Update cs_power.py

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_power.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_power.py
@@ -166,7 +166,7 @@ class Module:
         if self.has_lid:
             section.add_row(GSettingsSwitch(_("Perform lid-closed action even with external monitors attached"), CSD_SCHEMA, "lid-close-suspend-with-external-monitor"))
 
-        if self.has_battery and UPowerGlib.MAJOR_VERSION == 0 and UPowerGlib.MINOR_VERSION < 99:
+        if self.has_battery and UPowerGlib.MAJOR_VERSION == 0 and UPowerGlib.MINOR_VERSION <= 99:
             section.add_row(GSettingsComboBox(_("When the battery is critically low"), CSD_SCHEMA, "critical-battery-action", critical_options, size_group=size_group))
 
         # Batteries


### PR DESCRIPTION
was not getting  low battery setting on ubuntu 16.04 running cinnamon 3.2.8-1 since it has gir1.2-upowerglib-1.0 version 0.99.4-2ubuntu0.3 so the minor version should be <= to 99