### PR TITLE
[RFC] window-list: remove hard coded CSS

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -1030,35 +1030,28 @@ MyApplet.prototype = {
             this.actor.set_important(true);
         }
 
-        // Any padding/margin is removed on one side so that the AppMenuButton
-        // boxes butt up against the edge of the screen
-
         if (orientation == St.Side.TOP) {
             for (let child of this.manager_container.get_children()) {
-                child.set_style_class_name('window-list-item-box top');
-                child.set_style('margin-top: 0px; padding-top: 0px;');
+                child.set_style_class_name('window-list-item-box panel-top');
+                child.add_style_class_name('window-list-item-box top'); /* for compatibility */
             }
-            this.actor.set_style('margin-top: 0px; padding-top: 0px;');
         } else if (orientation == St.Side.BOTTOM) {
             for (let child of this.manager_container.get_children()) {
-                child.set_style_class_name('window-list-item-box bottom');
-                child.set_style('margin-bottom: 0px; padding-bottom: 0px;');
+                child.set_style_class_name('window-list-item-box panel-bottom');
+                child.add_style_class_name('window-list-item-box bottom');
             }
-            this.actor.set_style('margin-bottom: 0px; padding-bottom: 0px;');
         } else if (orientation == St.Side.LEFT) {
             for (let child of this.manager_container.get_children()) {
-                child.set_style_class_name('window-list-item-box left');
-                child.set_style('margin-left 0px; padding-left: 0px; padding-right: 0px; margin-right: 0px;');
+                child.set_style_class_name('window-list-item-box panel-left');
+                child.add_style_class_name('window-list-item-box left');
                 child.set_x_align(Clutter.ActorAlign.CENTER);
             }
-            this.actor.set_style('margin-left: 0px; padding-left: 0px; padding-right: 0px; margin-right: 0px;');
         } else if (orientation == St.Side.RIGHT) {
             for (let child of this.manager_container.get_children()) {
-                child.set_style_class_name('window-list-item-box right');
-                child.set_style('margin-left: 0px; padding-left: 0px; padding-right: 0px; margin-right: 0px;');
+                child.set_style_class_name('window-list-item-box panel-right');
+                child.add_style_class_name('window-list-item-box right');
                 child.set_x_align(Clutter.ActorAlign.CENTER);
             }
-            this.actor.set_style('margin-right: 0px; padding-right: 0px; padding-left: 0px; margin-left: 0px;');
         }
 
         if (this.appletEnabled) {


### PR DESCRIPTION
(not switcher list)
There's nothing here that can't be handled in static CSS, so it makes sense to get rid of
the hard-coding so it actually behaves as themed

Two things : 1) Mint-Y and Mint-X have 1 pixel of top padding that would require some theme changes, as currently that would lead to an annoying single pixel unreactive edge strip in the top panel.  Not difficult, but it's a bit of forced work that accepting this PR would make necessary.
2) panel-top and top (etc. for left, right, bottom) are both used in themes.  I've allowed for both, but perhaps we ought to cut down to one.  panel-top ?

The preview box could benefit from similar removal of hard-coding, but that's not addressed here. 