### PR TITLE
desklet.js: Ignore an extra argument to setContent()

### DIFF
--- a/js/ui/desklet.js
+++ b/js/ui/desklet.js
@@ -93,12 +93,13 @@ Desklet.prototype = {
     /**
      * setContent:
      * @actor (Clutter.Actor): actor to be set as child
-     * @params (dictionary): (optional) parameters to be sent
+     * @params (dictionary): (optional) parameters to be sent. This argument
+     * is ignored. Only kept for compatibility reasons
      *
      * Sets the content actor of the desklet as @actor
      */
     setContent: function(actor, params){
-        this.content.set_child(actor, params);
+        this.content.set_child(actor);
     },
 
     /**


### PR DESCRIPTION
st_bin_set_child() only takes a single argument. In previous versions of cjs
the extra argument must have just been silently ignored. Now it complains so
quit trying to pass it. Leaving it in the function params just to avoid
breaking anything.