### PR TITLE
[WIP] load xlet after version check anyway

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/ExtensionCore.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/ExtensionCore.py
@@ -1021,8 +1021,8 @@ restarting Cinnamon."""
         if not version_check:
             if not self.show_prompt(_("Extension %s is not compatible with current version of cinnamon. Using it may break your system. Load anyway?") % uuid):
                 return
-            else:
-                uuid = "!" + uuid
+            #else:
+            #    uuid = "!" + uuid
 
         if not self.themes:
             if self.collection_type in ("applet", "desklet"):

--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -244,7 +244,7 @@ Extension.prototype = {
 
         // If cinnamon or js version are set, check them
         if('cinnamon-version' in this.meta && !versionCheck(this.meta['cinnamon-version'], Config.PACKAGE_VERSION)) {
-            throw this.logError('Extension is not compatible with current Cinnamon version', null, State.OUT_OF_DATE);
+            global.logError('[' + this.meta.uuid + '] Extension is not compatible with current Cinnamon version', null, State.OUT_OF_DATE);
         }
         if('js-version' in this.meta && !versionCheck(this.meta['js-version'], Config.GJS_VERSION)) {
             throw this.logError('Extension is not compatible with current GJS version', null, State.OUT_OF_DATE);


### PR DESCRIPTION
E.g. you use Cinnamon 3.2
If you want to add an xlet, which has the cinnamon-version flag in it's metadata.json file, but Cinnamon 3.2 is not included in this.
You get the following message:
> Extension %s is not compatible with current version of cinnamon. Using it may break your system. Load anyway?
> Yes, No

If you press yes, the xlet won't load anyway.

Allow xlet to load, if clicked Yes. Don't throw an error, log warning into LookingGlas instead.