### PR TITLE
js/ui/tooltips.js: Check if this.mousePosition is defined

### DIFF
--- a/js/ui/tooltips.js
+++ b/js/ui/tooltips.js
@@ -206,6 +206,8 @@ Tooltip.prototype = {
         this.desktop_settings = new Gio.Settings({
             schema_id: DESKTOP_SCHEMA
         });
+
+        this.mousePosition = null;
     },
 
     hide: function() {
@@ -215,7 +217,7 @@ Tooltip.prototype = {
     },
 
     show: function() {
-        if (this._tooltip.get_text() == "")
+        if (this._tooltip.get_text() == "" || !this.mousePosition)
             return;
 
         let tooltipWidth = this._tooltip.get_allocation_box().x2 - this._tooltip.get_allocation_box().x1;
@@ -297,7 +299,7 @@ PanelItemTooltip.prototype = {
     },
 
     show: function() {
-        if (this._tooltip.get_text() == "" || global.menuStackLength > 0)
+        if (this._tooltip.get_text() == "" || global.menuStackLength > 0 || !this.mousePosition)
             return;
 
         let op = this._tooltip.get_opacity();

--- a/js/ui/tooltips.js
+++ b/js/ui/tooltips.js
@@ -76,6 +76,7 @@ TooltipBase.prototype = {
         this.visible = false;
         this.item = item;
         this.preventShow = false;
+        this.mousePosition = null;
     },
 
     _onMotionEvent: function(actor, event) {
@@ -206,8 +207,6 @@ Tooltip.prototype = {
         this.desktop_settings = new Gio.Settings({
             schema_id: DESKTOP_SCHEMA
         });
-
-        this.mousePosition = null;
     },
 
     hide: function() {


### PR DESCRIPTION
Encountered this when calling a PanelItemTooltip instance from a child class in ITM.

```sh
(cinnamon:10020): Cjs-WARNING **: JS ERROR: TypeError: this.mousePosition is undefined
PanelItemTooltip.prototype.show@/usr/share/cinnamon/js/ui/tooltips.js:318
open@/home/jason/.local/share/cinnamon/applets/IcingTaskManager@json/specialMenus.js:653
hoverOpen@/home/jason/.local/share/cinnamon/applets/IcingTaskManager@json/specialMenus.js:635
_onMenuEnter/<@/home/jason/.local/share/cinnamon/applets/IcingTaskManager@json/specialMenus.js:610
setTimeout/<@/home/jason/.local/share/cinnamon/applets/IcingTaskManager@json/__init__.js:12
```