### PR TITLE
Suppress CJS mozjs38 warnings in applet, dbusMenu, indicator...

### DIFF
--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -202,7 +202,7 @@ Applet.prototype = {
 
         try {
             if (AppletManager.enabledAppletDefinitions.idMap[instance_id]) {
-               this._scaleMode = AppletManager.enabledAppletDefinitions.idMap[instance_id].panel.scaleMode;
+                this._scaleMode = AppletManager.enabledAppletDefinitions.idMap[instance_id].panel.scaleMode;
             } else {
                 throw new Error();
             }

--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -201,7 +201,11 @@ Applet.prototype = {
         this._draggable.connect('drag-end', Lang.bind(this, this._onDragEnd));
 
         try {
-            this._scaleMode = AppletManager.enabledAppletDefinitions.idMap[instance_id].panel.scaleMode;
+            if (AppletManager.enabledAppletDefinitions.idMap[instance_id]) {
+               this._scaleMode = AppletManager.enabledAppletDefinitions.idMap[instance_id].panel.scaleMode;
+            } else {
+                throw new Error();
+            }
         } catch (e) {
             // Sometimes applets are naughty and don't pass us our instance_id. In that case, we just find the first non-empty panel and pretend we are on it.
             for (let i in Main.panelManager.panels) {

--- a/js/ui/dbusMenu.js
+++ b/js/ui/dbusMenu.js
@@ -362,7 +362,7 @@ DbusMenuItem.prototype = {
 
     _getFactoryType: function(child_display, child_type) {
         if ((child_display) || (child_type)) {
-            if ((child_display == "rootmenu")||(this._id == this._client.getRootId()))
+            if ((child_display == "rootmenu")||(this._id && this._id == this._client.getRootId()))
                 return PopupMenu.FactoryClassTypes.RootMenuClass;
             if (child_display == "submenu")
                 return PopupMenu.FactoryClassTypes.SubMenuMenuItemClass;

--- a/js/ui/indicatorManager.js
+++ b/js/ui/indicatorManager.js
@@ -407,7 +407,7 @@ AppIndicator.prototype = {
     },
 
     get label() {
-        if (!this._proxy)
+        if (!this._proxy || !this._proxy.cachedProperties.XAyatanaLabel)
             return null;
         return this._proxy.cachedProperties.XAyatanaLabel;
     },
@@ -516,7 +516,7 @@ AppIndicator.prototype = {
                     global.logWarning("Incompatible dbusmenu version: "+version);
                     return callback(false);
                 }
-            }, null
+            }
         );
     },
 

--- a/js/ui/modalDialog.js
+++ b/js/ui/modalDialog.js
@@ -175,6 +175,9 @@ ModalDialog.prototype = {
 
         for (let i = 0; i < buttons.length; i ++) {
             let buttonInfo = buttons[i];
+            if (!buttonInfo.focused) {
+                buttonInfo.focused = false;
+            }
             let label = buttonInfo['label'];
             let action = buttonInfo['action'];
             let key = buttonInfo['key'];


### PR DESCRIPTION
...indicatorManager, and ui/modalDialog.

```sh
Cjs-Message: JS WARNING: [/usr/share/cinnamon/js/ui/indicatorManager.js 502]: Too many arguments to method Gio.DBusConnection.call: expected 10, got 11
Cjs-Message: JS WARNING: [/usr/share/cinnamon/js/ui/indicatorManager.js 502]: Too many arguments to method Gio.DBusConnection.call: expected 10, got 11
Cjs-Message: JS WARNING: [/usr/share/cinnamon/js/ui/indicatorManager.js 413]: reference to undefined property this._proxy.cachedProperties.XAyatanaLabel
Cjs-Message: JS WARNING: [/usr/share/cinnamon/js/ui/indicatorManager.js 502]: Too many arguments to method Gio.DBusConnection.call: expected 10, got 11
Cjs-Message: JS WARNING: [/usr/share/cinnamon/js/ui/indicatorManager.js 502]: Too many arguments to method Gio.DBusConnection.call: expected 10, got 11
Cjs-Message: JS WARNING: [/usr/share/cinnamon/js/ui/dbusMenu.js 365]: reference to undefined property this._id
Cjs-Message: JS WARNING: [/usr/share/cinnamon/js/ui/applet.js 204]: reference to undefined property AppletManager.enabledAppletDefinitions.idMap[instance_id]
Cjs-Message: JS WARNING: [/usr/share/cinnamon/js/ui/modalDialog.js 181]: reference to undefined property buttonInfo.focused
```