### PR TITLE
workspace-switcher: correct undefined property warning (mozjs38)

### DIFF
--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
@@ -271,6 +271,10 @@ MyApplet.prototype = {
             }));
             this._applet_context_menu.addMenuItem(this.removeWorkspaceMenuItem);
             this.removeWorkspaceMenuItem.setSensitive(global.screen.n_workspaces > 1);
+
+            this._focusWindow = 0;
+            if (global.display.focus_window)
+                this._focusWindow = global.display.focus_window.get_compositor_private();
         }
         catch (e) {
             global.logError(e);


### PR DESCRIPTION
flagged by the new cjs