### PR TITLE
Fix undefined errors with mozjs38 in dnd, panel, extension, and appletManager

### DIFF
--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -257,7 +257,10 @@ function removeAppletFromPanels(appletDefinition, deleteConfig) {
             applet._panelLocation = null;
         }
 
-        delete applet._extension._loadedDefinitions[appletDefinition.applet_id];
+        if (applet._extension) {
+           delete applet._extension._loadedDefinitions[appletDefinition.applet_id];
+        }
+
         delete appletObj[appletDefinition.applet_id];
 
         if (deleteConfig)
@@ -311,8 +314,9 @@ function addAppletToPanels(extension, appletDefinition) {
         let location = appletDefinition.location;
 
         let before = location.get_children()
-            .find(x => (x._applet instanceof Applet.Applet) &&
-                       (appletDefinition.order < x._applet._order));
+            .find(x => {
+                return x._applet && (x._applet instanceof Applet.Applet) && (appletDefinition.order < x._applet._order)
+            });
 
         if (before)
             location.insert_child_below(applet.actor, before);

--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -283,7 +283,7 @@ function _removeAppletConfigFile(uuid, instanceId) {
     let file = Gio.File.new_for_path(config_path);
     if (file.query_exists(null)) {
         try {
-            file.delete(null, null);
+            file.delete(null);
         } catch (e) {
             global.logError("Problem removing applet config file during cleanup.  UUID is " + uuid + " and filename is " + config_path);
         }

--- a/js/ui/dnd.js
+++ b/js/ui/dnd.js
@@ -408,7 +408,7 @@ const _Draggable = new Lang.Class({
                                                              targX,
                                                              targY,
                                                              0);
-                if (result != DragMotionResult.CONTINUE) {
+                if (result != DragMotionResult.CONTINUE && DRAG_CURSOR_MAP[result]) {
                     global.set_cursor(DRAG_CURSOR_MAP[result]);
                     return false;
                 }

--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -379,7 +379,7 @@ function versionCheck(required, current) {
         let requiredArray = required[i].split('.');
         if (requiredArray[0] == major &&
             requiredArray[1] == minor &&
-            (requiredArray[2] == point || requiredArray[2] === undefined))
+            (requiredArray[2] === undefined || requiredArray[2] == point))
             return true;
     }
     return false;

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -2203,7 +2203,7 @@ Panel.prototype = {
 // For empty panels. If over left,right,center box then will not get here.
 //
         this._enterPanel();
-        if (this._dragShowId > 0)
+        if (this._dragShowId && this._dragShowId > 0)
             Mainloop.source_remove(this._dragShowId);
 
         let leaveIfOut = Lang.bind(this, function() {


### PR DESCRIPTION
The dnd and panel errors can be reproduced when dragging an applet that also has an undefined error in its code that gets called during dragging. After the change in dnd, the applet's stack trace showed instead.
```
(cinnamon:5100): Cjs-WARNING **: JS ERROR: Error: Expected type enum for Argument 'type' but got type 'undefined'
_Draggable<._updateDragHover@/usr/share/cinnamon/js/ui/dnd.js:412:21
wrapper@resource:///org/cinnamon/cjs/modules/lang.js:178:22
```
```
Cjs-Message: JS WARNING: [/usr/share/cinnamon/js/ui/appletManager.js 317]: reference to undefined property x._applet
```
```
Cjs-Message: JS WARNING: [/usr/share/cinnamon/js/ui/panel.js 2206]: reference to undefined property this._dragShowId
```
---
```
Cjs-Message: JS WARNING: [/usr/share/cinnamon/js/ui/extension.js 382]: reference to undefined property requiredArray[2]
```
---
```
Cjs-Message: JS WARNING: [/usr/share/cinnamon/js/ui/appletManager.js 286]: Too many arguments to method Gio.File.delete: expected 1, got 2
```