### PR TITLE
appletManager.js: don't error removing broken applet

### DIFF
--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -257,7 +257,8 @@ function removeAppletFromPanels(appletDefinition, deleteConfig) {
             applet._panelLocation = null;
         }
 
-        delete applet._extension._loadedDefinitions[appletDefinition.applet_id];
+        if (applet._extension)
+            delete applet._extension._loadedDefinitions[appletDefinition.applet_id];
         delete appletObj[appletDefinition.applet_id];
 
         if (deleteConfig)


### PR DESCRIPTION
Avoids an error when the applet is added and then immediately removed
upon failure.

error t=2017-04-30T21:28:42Z applet._extension is undefined
trace t=2017-04-30T21:28:42Z 
<----------------
removeAppletFromPanels@/usr/share/cinnamon/js/ui/appletManager.js:261:9
onEnabledAppletsChanged@/usr/share/cinnamon/js/ui/appletManager.js:209:17
---------------->
error t=2017-04-30T21:28:42Z Failed to refresh list of applets