### PR TITLE
[cinnamon-json-makepot] Added support to extract "title" and "units" keys on list elements

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-json-makepot/cinnamon-json-makepot.py
+++ b/files/usr/share/cinnamon/cinnamon-json-makepot/cinnamon-json-makepot.py
@@ -233,6 +233,13 @@ class Main:
                         continue
                     comment = "%s->settings-schema.json->%s->%s" % (self.current_parent_dir, parent, key)
                     self.save_entry(option, comment)
+            elif key == "columns":
+                columns = data[key]
+                for i, col in enumerate(columns):
+                    for col_key in col:
+                        if col_key in ("title", "units"):
+                            comment = "%s->settings-schema.json->%s->columns->%s" % (self.current_parent_dir, parent, col_key)
+                            self.save_entry(col[col_key], comment)
             try:
                 self.extract_strings(data[key], key)
             except AttributeError:


### PR DESCRIPTION
With the introduction of list widgets to the xlets settings system (#6303), there is a new *title* key that needs to be extracted to be translated.

This commit adds the ability to the `cinnamon-json-makepot` command to extract from the settings-schema.json file those keys when said command is used to create a .pot file.