### PR TITLE
window-list-applet: fix undefined reference warning

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -1074,7 +1074,7 @@ MyApplet.prototype = {
 
     _onWindowAdded: function(screen, metaWindow, monitor) {
         if (this._shouldAdd(metaWindow))
-            this._addWindow(metaWindow);
+            this._addWindow(metaWindow, false);
     },
 
     _onWindowRemoved: function(screen, metaWindow) {
@@ -1083,7 +1083,7 @@ MyApplet.prototype = {
 
     _onWindowMonitorChanged: function(screen, metaWindow, monitor) {
         if (this._shouldAdd(metaWindow))
-            this._addWindow(metaWindow);
+            this._addWindow(metaWindow, false);
         else
             this._removeWindow(metaWindow);
     },
@@ -1221,7 +1221,7 @@ MyApplet.prototype = {
 
         for (let window of windows) {
             if (this._shouldAdd(window))
-                this._addWindow(window);
+                this._addWindow(window, false);
             else
                 this._removeWindow(window);
         }
@@ -1230,7 +1230,7 @@ MyApplet.prototype = {
     _addWindow: function(metaWindow, alert) {
         for (let window of this._windows)
             if (window.metaWindow == metaWindow &&
-                window.temp == alert)
+                window.alert == alert)
                 return;
 
         let appButton = new AppMenuButton(this, metaWindow, alert);


### PR DESCRIPTION
We are checking if the AppMenuButton is temporary, but the temporary property
is actually stored as 'alert'. This corrects that typo and in addition changes
all existing calls to _addWindow() to include the alert argument for consistency.
This ensures that window.alert is always initialized to either true or false.

fixes js38 warning at line 1233:
reference to undefined property window.temp