### PR TITLE
[3.6] [RFC] Melange normal window, scrolling fixes, and cleanup

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-looking-glass/cinnamon-looking-glass.py
+++ b/files/usr/share/cinnamon/cinnamon-looking-glass/cinnamon-looking-glass.py
@@ -15,9 +15,9 @@ import os
 import pyinotify
 import gi
 gi.require_version('Gtk', '3.0')
-from gi.repository import Gio, Gtk, GObject, Gdk, Pango, GLib
+from gi.repository import Gio, Gtk, GObject, Gdk
 import dbus, dbus.service, dbus.glib
-from pageutils import *
+import pageutils
 from lookingglass_proxy import LookingGlassProxy
 from dbus.mainloop.glib import DBusGMainLoop
 import signal
@@ -299,7 +299,7 @@ class ClosableTabLabel(Gtk.Box):
     def button_clicked(self, button, data=None):
         self.emit("close-clicked")
 
-class CinnamonLog(dbus.service.Object):
+class MelangeApp(dbus.service.Object):
     def __init__ (self):
         global lookingGlassProxy
         lookingGlassProxy = LookingGlassProxy()
@@ -389,7 +389,7 @@ class CinnamonLog(dbus.service.Object):
         table.attach(self.notebook, 0, numColumns, 0, 1)
 
         column = 0
-        pickerButton = ImageButton("gtk-color-picker", Gtk.IconSize.SMALL_TOOLBAR)
+        pickerButton = pageutils.ImageButton("gtk-color-picker", Gtk.IconSize.SMALL_TOOLBAR)
         pickerButton.connect("clicked", self.onPickerClicked)
         table.attach(pickerButton, column, column+1, 1, 2, 0, 0, 2)
         column += 1
@@ -409,9 +409,9 @@ class CinnamonLog(dbus.service.Object):
         column += 1
 
         settings = Gio.Settings("org.cinnamon.desktop.keybindings")
-        arr = settings.get_strv("looking-glass-keybinding");
+        arr = settings.get_strv("looking-glass-keybinding")
         accel = ""
-        done_one = False;
+        done_one = False
 
         for element in arr:
             if done_one:
@@ -479,7 +479,7 @@ class CinnamonLog(dbus.service.Object):
 
     def onAboutClicked(self, menuItem):
         dialog = Gtk.MessageDialog(self.window, 0,
-                                   Gtk.MessageType.QUESTION, Gtk.ButtonsType.CLOSE);
+                                   Gtk.MessageType.QUESTION, Gtk.ButtonsType.CLOSE)
 
         dialog.set_title("About Melange")
         dialog.set_markup("""\
@@ -532,7 +532,7 @@ If you defined a hotkey for Melange, pressing it while Melange is visible it wil
     def createPage(self, text, moduleName):
         module = __import__("page_%s" % moduleName)
         module.lookingGlassProxy = self.lookingGlassProxy
-        module.cinnamonLog = self
+        module.melangeApp = self
         label = Gtk.Label(text)
         page = module.ModulePage(self)
         self.pages[moduleName] = page
@@ -548,7 +548,7 @@ if __name__ == "__main__":
     sessionBus = dbus.SessionBus ()
     request = sessionBus.request_name(MELANGE_DBUS_NAME, dbus.bus.NAME_FLAG_DO_NOT_QUEUE)
     if request != dbus.bus.REQUEST_NAME_REPLY_EXISTS:
-        app = CinnamonLog()
+        app = MelangeApp()
     else:
         object = sessionBus.get_object(MELANGE_DBUS_NAME, MELANGE_DBUS_PATH)
         app = dbus.Interface(object, MELANGE_DBUS_NAME)

--- a/files/usr/share/cinnamon/cinnamon-looking-glass/lookingglass_proxy.py
+++ b/files/usr/share/cinnamon/cinnamon-looking-glass/lookingglass_proxy.py
@@ -1,5 +1,5 @@
 import dbus
-from gi.repository import Gio, Gtk, GObject, Gdk, Pango, GLib
+from gi.repository import Gio
 
 LG_DBUS_NAME = "org.Cinnamon.LookingGlass"
 LG_DBUS_PATH = "/org/Cinnamon/LookingGlass"

--- a/files/usr/share/cinnamon/cinnamon-looking-glass/page_extensions.py
+++ b/files/usr/share/cinnamon/cinnamon-looking-glass/page_extensions.py
@@ -1,14 +1,14 @@
 import pageutils
 import os
-from gi.repository import Gio, Gtk, GObject, Gdk, Pango, GLib
+from gi.repository import Gtk, Gdk
 
 class ModulePage(pageutils.BaseListView):
     def __init__(self, parent):
         store = Gtk.ListStore(str, str, str, str, str, str, str, bool, str)
         pageutils.BaseListView.__init__(self, store)
-        self.parent = parent;
+        self.parent = parent
 
-        column = self.createTextColumn(0, "Status")
+        self.createTextColumn(0, "Status")
         self.createTextColumn(1, "Type")
         self.createTextColumn(2, "Name")
         self.createTextColumn(3, "Description")
@@ -36,25 +36,24 @@ class ModulePage(pageutils.BaseListView):
         self.treeView.connect("button-press-event", self.on_button_press_event)
 
     def onViewSource(self, menuItem):
-        iter = self.store.get_iter(self.selectedPath)
-        folder = self.store.get_value(iter, 5)
+        treeIter = self.store.get_iter(self.selectedPath)
+        folder = self.store.get_value(treeIter, 5)
         os.system("xdg-open \"" + folder + "\" &")
 
     def onReloadCode(self, menuItem):
-        iter = self.store.get_iter(self.selectedPath)
-        uuid = self.store.get_value(iter, 4)
-        xletType = self.store.get_value(iter, 1)
+        treeIter = self.store.get_iter(self.selectedPath)
+        uuid = self.store.get_value(treeIter, 4)
+        xletType = self.store.get_value(treeIter, 1)
         lookingGlassProxy.ReloadExtension(uuid, xletType.upper())
 
     def onViewWebPage(self, menuItem):
-        iter = self.store.get_iter(self.selectedPath)
-        url = self.store.get_value(iter, 6)
+        treeIter = self.store.get_iter(self.selectedPath)
+        url = self.store.get_value(treeIter, 6)
         os.system("xdg-open \"" + url + "\" &")
 
     def on_button_press_event(self, treeview, event):
         x = int(event.x)
         y = int(event.y)
-        time = event.time
         pthinfo = treeview.get_path_at_pos(x, y)
         if pthinfo is not None:
             path, col, cellx, celly = pthinfo
@@ -62,12 +61,12 @@ class ModulePage(pageutils.BaseListView):
             treeview.grab_focus()
             treeview.set_cursor( path, col, 0)
 
-            iter = self.store.get_iter(self.selectedPath)
+            treeIter = self.store.get_iter(self.selectedPath)
 
         if event.button == 3:
             if pthinfo is not None:
-                uuid = self.store.get_value(iter, 4)
-                url = self.store.get_value(iter, 6)
+                uuid = self.store.get_value(treeIter, 4)
+                url = self.store.get_value(treeIter, 6)
 
                 self.viewWebPage.set_sensitive(url != "")
                 self.viewSource.set_label(uuid + " (View Source)")
@@ -75,7 +74,7 @@ class ModulePage(pageutils.BaseListView):
             return True
         elif event.type == Gdk.EventType.DOUBLE_BUTTON_PRESS:
             if pthinfo is not None:
-                error = self.store.get_value(iter, 7)
+                error = self.store.get_value(treeIter, 7)
                 if error:
                     self.parent.activatePage("log")
 

--- a/files/usr/share/cinnamon/cinnamon-looking-glass/page_inspect.py
+++ b/files/usr/share/cinnamon/cinnamon-looking-glass/page_inspect.py
@@ -11,7 +11,36 @@ class InspectView(BaseListView):
         self.createTextColumn(1, "Type")
         self.createTextColumn(2, "Value")
 
+        self.popup = Gtk.Menu()
+        self.insertCommand = Gtk.MenuItem("Insert into command entry")
+        self.insertCommand.connect("activate", self.onInsertCommand)
+        self.popup.append(self.insertCommand)
+        self.popup.show_all()
+
+        self.treeView.connect("button-press-event", self.onButtonPressEvent)
         self.treeView.connect("row-activated", self.onRowActivated)
+
+    def onButtonPressEvent(self, treeview, event):
+        x = int(event.x)
+        y = int(event.y)
+        time = event.time
+        pthinfo = treeview.get_path_at_pos(x, y)
+        if pthinfo is not None and event.button == 3:
+            path, col, cellx, celly = pthinfo
+            self.selectedPath = path
+            treeview.grab_focus()
+            treeview.set_cursor( path, col, 0)
+            self.popup.popup( None, None, None, None, event.button, event.time)
+            return True
+
+    def onInsertCommand(self, widget):
+        treeIter = self.store.get_iter(self.selectedPath)
+        objType = self.store.get_value(treeIter, 1)
+        objPath = self.store.get_value(treeIter, 4)
+        if objType == "function":
+            objPath += "()"
+        Gtk.Entry.do_insert_at_cursor(cinnamonLog.commandline, objPath)
+        cinnamonLog.commandline.grab_focus_without_selecting()
 
     def onRowActivated(self, treeview, path, view_column):
         iter = self.store.get_iter(path)

--- a/files/usr/share/cinnamon/cinnamon-looking-glass/page_inspect.py
+++ b/files/usr/share/cinnamon/cinnamon-looking-glass/page_inspect.py
@@ -1,11 +1,11 @@
-from pageutils import *
-from gi.repository import Gio, Gtk, GObject, Gdk, Pango, GLib
+import pageutils
+from gi.repository import Gtk
 
-class InspectView(BaseListView):
+class InspectView(pageutils.BaseListView):
     def __init__(self, parent):
         self.parent = parent
         store = Gtk.ListStore(str, str, str, str, str)
-        BaseListView.__init__(self, store)
+        pageutils.BaseListView.__init__(self, store)
 
         self.createTextColumn(0, "Name")
         self.createTextColumn(1, "Type")
@@ -23,13 +23,12 @@ class InspectView(BaseListView):
     def onButtonPressEvent(self, treeview, event):
         x = int(event.x)
         y = int(event.y)
-        time = event.time
         pthinfo = treeview.get_path_at_pos(x, y)
         if pthinfo is not None and event.button == 3:
             path, col, cellx, celly = pthinfo
             self.selectedPath = path
             treeview.grab_focus()
-            treeview.set_cursor( path, col, 0)
+            treeview.set_cursor(path, col, 0)
             self.popup.popup( None, None, None, None, event.button, event.time)
             return True
 
@@ -39,36 +38,36 @@ class InspectView(BaseListView):
         objPath = self.store.get_value(treeIter, 4)
         if objType == "function":
             objPath += "()"
-        Gtk.Entry.do_insert_at_cursor(cinnamonLog.commandline, objPath)
-        cinnamonLog.commandline.grab_focus_without_selecting()
+        Gtk.Entry.do_insert_at_cursor(melangeApp.commandline, objPath)
+        melangeApp.commandline.grab_focus_without_selecting()
 
     def onRowActivated(self, treeview, path, view_column):
-        iter = self.store.get_iter(path)
-        name = self.store.get_value(iter, 0)
-        type = self.store.get_value(iter, 1)
-        value = self.store.get_value(iter, 3)
-        path = self.store.get_value(iter, 4)
+        treeIter = self.store.get_iter(path)
+        name = self.store.get_value(treeIter, 0)
+        objType = self.store.get_value(treeIter, 1)
+        value = self.store.get_value(treeIter, 3)
+        path = self.store.get_value(treeIter, 4)
 
-        self.parent.updateInspector(path, type, name, value, True)
+        self.parent.updateInspector(path, objType, name, value, True)
 
     def setInspectionData(self, path, data):
         self.store.clear()
         for item in data:
             self.store.append([item["name"], item["type"], item["shortValue"], item["value"], path + "['" + item["name"] + "']"])
 
-class ModulePage(WindowAndActionBars):
+class ModulePage(pageutils.WindowAndActionBars):
     def __init__(self, parent):
         self.view = InspectView(self)
-        WindowAndActionBars.__init__(self, self.view)
+        pageutils.WindowAndActionBars.__init__(self, self.view)
         self.parent = parent
 
-        self.back = ImageButton("back")
+        self.back = pageutils.ImageButton("back")
         self.back.set_tooltip_text("Go back")
         self.back.set_sensitive(False)
         self.back.connect("clicked", self.onBackButton)
         self.addToLeftBar(self.back, 1)
 
-        self.insert = ImageButton("insert-object")
+        self.insert = pageutils.ImageButton("insert-object")
         self.insert.set_tooltip_text("Insert into results")
         self.insert.set_sensitive(False)
         self.insert.connect("clicked", self.onInsertButton)
@@ -132,7 +131,7 @@ class ModulePage(WindowAndActionBars):
             self.typeLabel.set_text(objType)
             self.nameLabel.set_text(name)
 
-            cinnamonLog.activatePage("inspect")
+            melangeApp.activatePage("inspect")
             success, data = lookingGlassProxy.Inspect(path)
             if success:
                 try:
@@ -143,9 +142,9 @@ class ModulePage(WindowAndActionBars):
             else:
                 self.view.store.clear()
         elif objType == "undefined":
-            ResultTextDialog("Value for '" + name + "'", "Value is <undefined>")
+            pageutils.ResultTextDialog("Value for '" + name + "'", "Value is <undefined>")
         else:
-            ResultTextDialog("Value for " + objType + " '" + name + "'", value)
+            pageutils.ResultTextDialog("Value for " + objType + " '" + name + "'", value)
 
     def inspectElement(self, path, objType, name, value):
         del self.stack[:]

--- a/files/usr/share/cinnamon/cinnamon-looking-glass/page_log.py
+++ b/files/usr/share/cinnamon/cinnamon-looking-glass/page_log.py
@@ -1,6 +1,6 @@
 import datetime
-from pageutils import *
-from gi.repository import Gio, Gtk, GObject, Gdk, Pango, GLib
+import pageutils
+from gi.repository import Gtk
 
 class LogEntry():
     def __init__(self, category, time, message):
@@ -54,19 +54,15 @@ class LogView(Gtk.ScrolledWindow):
         active = button.get_active()
         self.enabledTypes[data] = active
         self.typeTags[data].props.invisible = active != True
-
         self.textbuffer.set_modified(True)
-        #print self.textview.get_preferred_height()
-        adj = self.get_vadjustment()
-        #adj.set_upper(self.textview.get_allocated_height())
 
     def onStatusChange(self, online):
-        iter = self.textbuffer.get_end_iter()
+        textIter = self.textbuffer.get_end_iter()
         if online:
             entry = self.append("info", 0, "================ DBus connection established ===============")
         else:
             entry = self.append("warning", 0, "================ DBus connection lost ===============")
-        self.textbuffer.insert_with_tags(iter, entry.formattedText, self.typeTags[entry.category])
+        self.textbuffer.insert_with_tags(textIter, entry.formattedText, self.typeTags[entry.category])
         self.getUpdates(True)
 
     def getUpdates(self, reread = False):
@@ -85,20 +81,20 @@ class LogView(Gtk.ScrolledWindow):
                         start, end = self.textbuffer.get_bounds()
                         self.textbuffer.delete(start, end)
 
-                    iter = self.textbuffer.get_end_iter()
+                    textIter = self.textbuffer.get_end_iter()
                     for item in data[self.addedMessages:]:
                         entry = self.append(item["category"], float(item["timestamp"])*0.001, item["message"])
-                        self.textbuffer.insert_with_tags(iter, entry.formattedText, self.typeTags[entry.category])
+                        self.textbuffer.insert_with_tags(textIter, entry.formattedText, self.typeTags[entry.category])
                         self.addedMessages += 1
                     self.textview.scroll_to_mark(self.scroll_mark, 0, True, 1, 1)
             except Exception as e:
                 print e
 
-class ModulePage(WindowAndActionBars):
+class ModulePage(pageutils.WindowAndActionBars):
     def __init__(self, parent):
         self.view = LogView()
-        WindowAndActionBars.__init__(self, self.view)
-        self.parent = parent;
+        pageutils.WindowAndActionBars.__init__(self, self.view)
+        self.parent = parent
 
         self.addToggleButton("info", "dialog-information", "Show/Hide Messages tagged as 'info'")
         self.addToggleButton("warning", "dialog-warning", "Show/Hide Messages tagged as 'warning'")
@@ -106,7 +102,7 @@ class ModulePage(WindowAndActionBars):
         self.addToggleButton("trace", "dialog-question", "Show/Hide Messages tagged as 'trace'")
 
     def addToggleButton(self, logType, icon, tooltip):
-        button = ImageToggleButton(icon)
+        button = pageutils.ImageToggleButton(icon)
         button.connect("toggled", self.view.onButtonToggled, logType)
         button.set_active(self.view.enabledTypes[logType])
         button.set_tooltip_text(tooltip)

--- a/files/usr/share/cinnamon/cinnamon-looking-glass/page_log.py
+++ b/files/usr/share/cinnamon/cinnamon-looking-glass/page_log.py
@@ -22,6 +22,7 @@ class LogView(Gtk.ScrolledWindow):
         self.add(self.textview)
 
         self.textbuffer = self.textview.get_buffer()
+        self.scroll_mark =  self.textbuffer.create_mark(None, self.textbuffer.get_end_iter(), False)
 
         self.log = []
         self.addedMessages = 0
@@ -50,7 +51,6 @@ class LogView(Gtk.ScrolledWindow):
         return entry
 
     def onButtonToggled(self, button, data):
-        self.textview.hide()
         active = button.get_active()
         self.enabledTypes[data] = active
         self.typeTags[data].props.invisible = active != True
@@ -59,7 +59,6 @@ class LogView(Gtk.ScrolledWindow):
         #print self.textview.get_preferred_height()
         adj = self.get_vadjustment()
         #adj.set_upper(self.textview.get_allocated_height())
-        self.textview.show()
 
     def onStatusChange(self, online):
         iter = self.textbuffer.get_end_iter()
@@ -86,13 +85,12 @@ class LogView(Gtk.ScrolledWindow):
                         start, end = self.textbuffer.get_bounds()
                         self.textbuffer.delete(start, end)
 
-                    self.textview.hide()
                     iter = self.textbuffer.get_end_iter()
                     for item in data[self.addedMessages:]:
                         entry = self.append(item["category"], float(item["timestamp"])*0.001, item["message"])
                         self.textbuffer.insert_with_tags(iter, entry.formattedText, self.typeTags[entry.category])
                         self.addedMessages += 1
-                    self.textview.show()
+                    self.textview.scroll_to_mark(self.scroll_mark, 0, True, 1, 1)
             except Exception as e:
                 print e
 

--- a/files/usr/share/cinnamon/cinnamon-looking-glass/page_memory.py
+++ b/files/usr/share/cinnamon/cinnamon-looking-glass/page_memory.py
@@ -1,10 +1,10 @@
-from pageutils import *
-from gi.repository import Gio, Gtk, GObject, Gdk, Pango, GLib
+import pageutils
+from gi.repository import Gtk
 
-class MemoryView(BaseListView):
+class MemoryView(pageutils.BaseListView):
     def __init__(self):
         store = Gtk.ListStore(str, int)
-        BaseListView.__init__(self, store)
+        pageutils.BaseListView.__init__(self, store)
 
         self.createTextColumn(0, "Name")
         self.createTextColumn(1, "Size (bytes)")
@@ -39,17 +39,17 @@ class MemoryView(BaseListView):
         lookingGlassProxy.FullGc()
         self.getUpdates()
 
-class ModulePage(WindowAndActionBars):
+class ModulePage(pageutils.WindowAndActionBars):
     def __init__(self, parent):
         self.view = MemoryView()
-        WindowAndActionBars.__init__(self, self.view)
+        pageutils.WindowAndActionBars.__init__(self, self.view)
         self.parent = parent
 
-        refresh = ImageButton("view-refresh")
+        refresh = pageutils.ImageButton("view-refresh")
         refresh.set_tooltip_text("Refresh")
         refresh.connect("clicked", self.view.getUpdates)
         self.addToLeftBar(refresh, 1)
-        fullGc = ImageButton("user-trash-full")
+        fullGc = pageutils.ImageButton("user-trash-full")
         fullGc.set_tooltip_text("Full Garbage Collection")
         fullGc.connect ('clicked', self.view.onFullGc)
 

--- a/files/usr/share/cinnamon/cinnamon-looking-glass/page_results.py
+++ b/files/usr/share/cinnamon/cinnamon-looking-glass/page_results.py
@@ -23,10 +23,13 @@ class ModulePage(BaseListView):
         lookingGlassProxy.connect("InspectorDone", self.onInspectorDone)
         lookingGlassProxy.addStatusChangeCallback(self.onStatusChange)
 
-        self.connect("size-allocate", self.scrollToBottom);
+        self._changed = False
+        self.treeView.connect("size-allocate", self.scrollToBottom)
 
     def scrollToBottom (self, widget, data):
-        self.adjust.set_value(self.adjust.get_upper())
+        if self._changed:
+            self.adjust.set_value(self.adjust.get_upper() - self.adjust.get_page_size())
+            self._changed = False
 
     def cellDataFuncID(self, column, cell, model, iter, data=None):
         cell.set_property("text", "r(%d)" %  model.get_value(iter, 0))
@@ -51,6 +54,7 @@ class ModulePage(BaseListView):
             try:
                 for item in data:
                     self.store.append([int(item["index"]), item["command"], item["type"], item["object"], item["tooltip"]])
+                self._changed = True
                 self.parent.activatePage("results")
             except Exception as e:
                 print e

--- a/files/usr/share/cinnamon/cinnamon-looking-glass/page_results.py
+++ b/files/usr/share/cinnamon/cinnamon-looking-glass/page_results.py
@@ -1,10 +1,10 @@
-from pageutils import *
-from gi.repository import Gio, Gtk, GObject, Gdk, Pango, GLib
+import pageutils
+from gi.repository import Gtk
 
-class ModulePage(BaseListView):
+class ModulePage(pageutils.BaseListView):
     def __init__(self, parent):
         store = Gtk.ListStore(int, str, str, str, str)
-        BaseListView.__init__(self, store)
+        pageutils.BaseListView.__init__(self, store)
 
         self.parent = parent
         self.adjust = self.get_vadjustment()
@@ -35,13 +35,13 @@ class ModulePage(BaseListView):
         cell.set_property("text", "r(%d)" %  model.get_value(iter, 0))
 
     def onRowActivated(self, treeview, path, view_column):
-        iter = self.store.get_iter(path)
-        id = self.store.get_value(iter, 0)
-        name = self.store.get_value(iter, 1)
-        objType = self.store.get_value(iter, 2)
-        value = self.store.get_value(iter, 3)
+        treeIter = self.store.get_iter(path)
+        resultId = self.store.get_value(treeIter, 0)
+        name = self.store.get_value(treeIter, 1)
+        objType = self.store.get_value(treeIter, 2)
+        value = self.store.get_value(treeIter, 3)
 
-        cinnamonLog.pages["inspect"].inspectElement("r(%d)" % id, objType, name, value)
+        melangeApp.pages["inspect"].inspectElement("r(%d)" % resultId, objType, name, value)
 
     def onStatusChange(self, online):
         if online:
@@ -60,6 +60,6 @@ class ModulePage(BaseListView):
                 print e
 
     def onInspectorDone(self):
-        cinnamonLog.show()
-        cinnamonLog.activatePage("results")
+        melangeApp.show()
+        melangeApp.activatePage("results")
         self.getUpdates()

--- a/files/usr/share/cinnamon/cinnamon-looking-glass/page_windows.py
+++ b/files/usr/share/cinnamon/cinnamon-looking-glass/page_windows.py
@@ -1,10 +1,10 @@
-from pageutils import *
-from gi.repository import Gio, Gtk, GObject, Gdk, Pango, GLib
+import pageutils
+from gi.repository import Gtk
 
-class ModulePage(BaseListView):
+class ModulePage(pageutils.BaseListView):
     def __init__(self, parent):
         store = Gtk.ListStore(int, str, str, str)
-        BaseListView.__init__(self, store)
+        pageutils.BaseListView.__init__(self, store)
         self.parent = parent
 
         column = self.createTextColumn(0, "ID")
@@ -34,36 +34,35 @@ class ModulePage(BaseListView):
         self.popup.append(self.inspectApp)
         self.popup.show_all()
 
-    def cellDataFuncID(self, column, cell, model, iter, data=None):
-        value = model.get_value(iter, 0)
+    def cellDataFuncID(self, column, cell, model, treeIter, data=None):
+        value = model.get_value(treeIter, 0)
         cell.set_property("text", "w(%d) / a(%d)" %  (value, value))
 
     def onRowActivated(self, treeview, path, view_column):
-        iter = self.store.get_iter(path)
-        id = self.store.get_value(iter, 0)
-        title = self.store.get_value(iter, 1)
+        treeIter = self.store.get_iter(path)
+        objId = self.store.get_value(treeIter, 0)
+        title = self.store.get_value(treeIter, 1)
 
-        cinnamonLog.pages["inspect"].inspectElement("w(%d)" % id, "object", title, "<window>")
+        melangeApp.pages["inspect"].inspectElement("w(%d)" % objId, "object", title, "<window>")
 
     def onInspectWindow(self, menuItem):
-        iter = self.store.get_iter(self.selectedPath)
-        id = self.store.get_value(iter, 0)
-        title = self.store.get_value(iter, 1)
+        treeIter = self.store.get_iter(self.selectedPath)
+        objId = self.store.get_value(treeIter, 0)
+        title = self.store.get_value(treeIter, 1)
 
-        cinnamonLog.pages["inspect"].inspectElement("w(%d)" % id, "object", title, "<window>")
+        melangeApp.pages["inspect"].inspectElement("w(%d)" % objId, "object", title, "<window>")
 
     def onInspectApplication(self, menuItem):
-        iter = self.store.get_iter(self.selectedPath)
-        id = self.store.get_value(iter, 0)
-        application = self.store.get_value(iter, 3)
+        treeIter = self.store.get_iter(self.selectedPath)
+        objId = self.store.get_value(treeIter, 0)
+        application = self.store.get_value(treeIter, 3)
 
-        cinnamonLog.pages["inspect"].inspectElement("a(%d)" % id, "object", application, "<application>")
+        melangeApp.pages["inspect"].inspectElement("a(%d)" % objId, "object", application, "<application>")
 
     def onButtonPress(self, treeview, event):
         if event.button == 3:
             x = int(event.x)
             y = int(event.y)
-            time = event.time
             pthinfo = treeview.get_path_at_pos(x, y)
             if pthinfo is not None:
                 path, col, cellx, celly = pthinfo
@@ -71,8 +70,8 @@ class ModulePage(BaseListView):
                 treeview.grab_focus()
                 treeview.set_cursor( path, col, 0)
 
-                iter = self.store.get_iter(self.selectedPath)
-                app = self.store.get_value(iter, 3)
+                treeIter = self.store.get_iter(self.selectedPath)
+                app = self.store.get_value(treeIter, 3)
 
                 self.inspectApp.set_sensitive(app != "<untracked>")
                 self.popup.popup( None, None, None, None, event.button, event.time)

--- a/files/usr/share/cinnamon/cinnamon-looking-glass/pageutils.py
+++ b/files/usr/share/cinnamon/cinnamon-looking-glass/pageutils.py
@@ -1,4 +1,4 @@
-from gi.repository import Gio, Gtk, GObject, Gdk, Pango, GLib
+from gi.repository import Gtk
 
 class ResultTextDialog(Gtk.Dialog):
     def __init__(self, title, text):
@@ -34,7 +34,6 @@ class BaseListView(Gtk.ScrolledWindow):
 
         self.add(self.treeView)
         self.rendererText = Gtk.CellRendererText()
-        #self.rendererText.set_property('ellipsize', pango.ELLIPSIZE_END)
 
     def createTextColumn(self, index, text):
         column = Gtk.TreeViewColumn(text, self.rendererText, text=index)


### PR DESCRIPTION
This converts melange from a docked window into a normal toplevel window, fixes broken scrolling on the results page, implements autoscrolling on the log page, and adds a menu to inspect page that allows you to insert the selected property's path into the command line entry.

The last commit is a wide range of cleanups that I wanted to do after working on the code. This can be removed if anyone objects.