### PR TITLE
photoframe-desklet: Fix a few issues

### DIFF
--- a/files/usr/share/cinnamon/desklets/photoframe@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/desklets/photoframe@cinnamon.org/settings-schema.json
@@ -1,6 +1,6 @@
 {
     "directory": {
-        "default": "~/Pictures", 
+        "default": " ", 
         "type": "filechooser", 
         "description" : "Folder",
         "allow-none" : false,


### PR DESCRIPTION
The xlet settings widget used to choose a folder for the images was changed to
use a URI instead of path. The code in the applet was never updated to reflect
that so choosing a new directory was broken.

Clean up a few of the signal values while as well.