### PR TITLE
Progress bar text initializes and resets

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
@@ -543,6 +543,7 @@ class Spice_Harvester:
         self.progress_window.show()
         self.progresslabel.set_text(_("Installing %s...") % (title))
         self.progressbar.set_fraction(0)
+        self.progressbar.set_text('0%')
 
     def uninstall(self, uuid, name, schema_filename, onFinished=None):
         ui_thread_do(self.ui_uninstalling_xlet, name)


### PR DESCRIPTION
Existing behavior for installation progress bar text :
- Before installation : _no changes_ (_empty_ when initialized, stays at `100%` when continued from previous installation instead of reset to _empty_ or to `0%`)

Behavior after this change : 
- Before installation : initializes (or reset) to `0%` along with all other relevant components (`progressbar.set_fraction` and `progresslabel`)