### PR TITLE
[3.6] Make cinnamon-settings unaware of installation location

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
@@ -16,6 +16,7 @@ try:
     import thread
     from time import sleep
     from PIL import Image
+    import config
 except Exception, detail:
     print detail
     sys.exit(1)
@@ -114,7 +115,7 @@ class Spice_Harvester:
 
         self.window = window
         self.builder = Gtk.Builder()
-        self.builder.add_from_file("/usr/share/cinnamon/cinnamon-settings/cinnamon-settings-spice-progress.ui")
+        self.builder.add_from_file(config.currentPath + "/cinnamon-settings-spice-progress.ui")
         self.progress_window = self.builder.get_object("progress_window")
         self.progress_window.set_transient_for(window)
         self.progress_window.set_destroy_with_parent(True)
@@ -450,9 +451,9 @@ class Spice_Harvester:
                            ui_thread_do(self.progresslabel.set_text, _("Installing %s...") % title)
                     elif "gschema.xml" in file.filename:
                         sentence = _("Please enter your password to install the required settings schema for %s") % (uuid)
-                        if os.path.exists("/usr/bin/gksu") and os.path.exists("/usr/share/cinnamon/cinnamon-settings/bin/installSchema.py"):
+                        if os.path.exists("/usr/bin/gksu") and os.path.exists(config.currentPath + "/bin/installSchema.py"):
                             launcher = "gksu  --message \"<b>%s</b>\"" % sentence
-                            tool = "/usr/share/cinnamon/cinnamon-settings/bin/installSchema.py %s" % (os.path.join(dirname, file.filename))
+                            tool = config.currentPath + "/bin/installSchema.py %s" % (os.path.join(dirname, file.filename))
                             command = "%s %s" % (launcher, tool)
                             os.system(command)
                             schema_filename = file.filename
@@ -552,9 +553,9 @@ class Spice_Harvester:
             if not self.themes:
                 if schema_filename != "":
                     sentence = _("Please enter your password to remove the settings schema for %s") % (uuid)
-                    if os.path.exists("/usr/bin/gksu") and os.path.exists("/usr/share/cinnamon/cinnamon-settings/bin/removeSchema.py"):
+                    if os.path.exists("/usr/bin/gksu") and os.path.exists(config.currentPath + "/bin/removeSchema.py"):
                         launcher = "gksu  --message \"<b>%s</b>\"" % sentence
-                        tool = "/usr/share/cinnamon/cinnamon-settings/bin/removeSchema.py %s" % (schema_filename)
+                        tool = config.currentPath + "/bin/removeSchema.py %s" % (schema_filename)
                         command = "%s %s" % (launcher, tool)
                         os.system(command)
                     else:

--- a/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
@@ -13,14 +13,15 @@ import locale
 import urllib2
 from functools import cmp_to_key
 import unicodedata
+import config
 
 import gi
 gi.require_version('Gtk', '3.0')
 gi.require_version('XApp', '1.0')
 from gi.repository import Gio, Gtk, Pango, Gdk, XApp
 
-sys.path.append('/usr/share/cinnamon/cinnamon-settings/modules')
-sys.path.append('/usr/share/cinnamon/cinnamon-settings/bin')
+sys.path.append(config.currentPath + "/modules")
+sys.path.append(config.currentPath + "/bin")
 import capi
 import proxygsettings
 import SettingsWidgets
@@ -29,13 +30,13 @@ import SettingsWidgets
 gettext.install("cinnamon", "/usr/share/locale")
 
 # Standard setting pages... this can be expanded to include applet dirs maybe?
-mod_files = glob.glob('/usr/share/cinnamon/cinnamon-settings/modules/*.py')
+mod_files = glob.glob(config.currentPath + "/modules/*.py")
 mod_files.sort()
 if len(mod_files) is 0:
     print "No settings modules found!!"
     sys.exit(1)
 
-mod_files = [x.split('/')[6].split('.')[0] for x in mod_files]
+mod_files = [x.split('/')[-1].split('.')[0] for x in mod_files]
 
 for mod_file in mod_files:
     if mod_file[0:3] != "cs_":
@@ -189,7 +190,7 @@ class MainWindow:
     ''' Create the UI '''
     def __init__(self):
         self.builder = Gtk.Builder()
-        self.builder.add_from_file("/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.ui")
+        self.builder.add_from_file(config.currentPath + "/cinnamon-settings.ui")
         self.window = XApp.GtkWindow(visible=True, window_position=Gtk.WindowPosition.CENTER,
                                      default_width=800, default_height=600)
         main_box = self.builder.get_object("main_box")

--- a/files/usr/share/cinnamon/cinnamon-settings/config.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/config.py
@@ -1,0 +1,2 @@
+import os
+currentPath = os.path.dirname(os.path.abspath(__file__))

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_backgrounds.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_backgrounds.py
@@ -20,7 +20,8 @@ import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gio, Gtk, GObject, Gdk, Pango, GLib
 
-sys.path.append('/usr/share/cinnamon/cinnamon-settings/bin')
+import config
+sys.path.append(config.currentPath + "/bin")
 from GSettingsWidgets import *
 
 gettext.install("cinnamon", "/usr/share/locale")

--- a/files/usr/share/cinnamon/cinnamon-settings/xlet-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/xlet-settings.py
@@ -4,7 +4,9 @@ import gi
 gi.require_version('Gtk', '3.0')
 gi.require_version('XApp', '1.0')
 import sys
-sys.path.append('/usr/share/cinnamon/cinnamon-settings/bin')
+
+import config
+sys.path.append(config.currentPath + "/bin")
 import gettext
 import json
 from JsonSettingsWidgets import *


### PR DESCRIPTION
This makes cinnamon-settings independent from the installation location,
making it easier for developers, because you don't have to install
Cinnamon for testing during development. You can just run it from where
it is.