### PR TITLE
panel-launchers: fix undeclared variable warning

### DIFF
--- a/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
@@ -69,7 +69,7 @@ PanelAppLauncherMenu.prototype = {
 
         this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
-        subMenu = new PopupMenu.PopupSubMenuMenuItem(_("Preferences"));
+        let subMenu = new PopupMenu.PopupSubMenuMenuItem(_("Preferences"));
         this.addMenuItem(subMenu);
 
         item = new PopupMenu.PopupIconMenuItem(_("About..."), "dialog-question", St.IconType.SYMBOLIC);


### PR DESCRIPTION
The original declaration was recently removed, add it back here.