### PR TITLE
[3.6] st: Remove _st_allocate_fill

### DIFF
--- a/src/cinnamon-slicer.c
+++ b/src/cinnamon-slicer.c
@@ -104,7 +104,7 @@ cinnamon_slicer_paint_child (CinnamonSlicer *self)
     return;
 
   st_bin_get_alignment (ST_BIN (self), &x_align, &y_align);
-  _st_get_align_factors (ST_WIDGET (self), x_align, y_align,
+  _st_get_align_factors (x_align, y_align,
                          &x_align_factor, &y_align_factor);
 
   clutter_actor_get_allocation_box (CLUTTER_ACTOR (self), &self_box);

--- a/src/st/st-bin.c
+++ b/src/st/st-bin.c
@@ -117,12 +117,15 @@ st_bin_allocate (ClutterActor          *self,
     {
       StThemeNode *theme_node = st_widget_get_theme_node (ST_WIDGET (self));
       ClutterActorBox childbox;
+      gdouble x_align_f, y_align_f;
 
       st_theme_node_get_content_box (theme_node, box, &childbox);
-      _st_allocate_fill (ST_WIDGET (self), priv->child, &childbox,
-                         priv->x_align, priv->y_align,
-                         priv->x_fill, priv->y_fill);
-      clutter_actor_allocate (priv->child, &childbox, flags);
+      _st_get_align_factors (priv->x_align, priv->y_align,
+                             &x_align_f, &y_align_f);
+      clutter_actor_allocate_align_fill (priv->child, &childbox,
+                                         x_align_f, y_align_f,
+                                         priv->x_fill, priv->y_fill,
+                                         flags);
     }
 }
 

--- a/src/st/st-box-layout.c
+++ b/src/st/st-box-layout.c
@@ -768,6 +768,7 @@ st_box_layout_allocate (ClutterActor          *actor,
       gfloat child_min, child_nat, child_allocated;
       gboolean xfill, yfill, expand, fixed;
       StAlign xalign, yalign;
+      gdouble xalign_f, yalign_f;
 
       if (!CLUTTER_ACTOR_IS_VISIBLE (child))
         goto next_child;
@@ -786,6 +787,8 @@ st_box_layout_allocate (ClutterActor          *actor,
                                    "y-align", &yalign,
                                    "expand", &expand,
                                    NULL);
+
+      _st_get_align_factors (xalign, yalign, &xalign_f, &yalign_f);
 
       if (priv->is_vertical)
         {
@@ -826,10 +829,6 @@ st_box_layout_allocate (ClutterActor          *actor,
 
           child_box.x1 = content_box.x1;
           child_box.x2 = content_box.x2;
-
-          _st_allocate_fill (ST_WIDGET (actor), child, &child_box,
-                             xalign, yalign, xfill, yfill);
-          clutter_actor_allocate (child, &child_box, flags);
         }
       else
         {
@@ -846,11 +845,11 @@ st_box_layout_allocate (ClutterActor          *actor,
 
           child_box.y1 = content_box.y1;
           child_box.y2 = content_box.y2;
-
-          _st_allocate_fill (ST_WIDGET (actor), child, &child_box,
-                             xalign, yalign, xfill, yfill);
-          clutter_actor_allocate (child, &child_box, flags);
         }
+
+      clutter_actor_allocate_align_fill (child, &child_box,
+                                         xalign_f, yalign_f,
+                                         xfill, yfill, flags);
 
       if (flip)
         position = next_position - priv->spacing;

--- a/src/st/st-icon.c
+++ b/src/st/st-icon.c
@@ -247,9 +247,9 @@ st_icon_allocate (ClutterActor           *actor,
        * of doing this is that it may not be obvious that they have to turn off
        * fill to align the icon non-centered in the parent container.
        *
-       * We don't use _st_allocate_fill() for a bit of efficiency and because we
-       * expect to get rid of the child actor in favor of a CoglTexture in the
-       * future.
+       * We don't use clutter_actor_allocate_align_fill() for a bit of efficiency
+       * and because we expect to get rid of the child actor in favor of a
+       * CoglTexture in the future.
        */
       content_box.x1 = (int)(0.5 + content_box.x1 + (content_box.x2 - content_box.x1 - (priv->icon_size * priv->icon_scale)) / 2.);
       content_box.x2 = content_box.x1 + (priv->icon_size * priv->icon_scale);

--- a/src/st/st-private.c
+++ b/src/st/st-private.c
@@ -99,140 +99,18 @@ _st_actor_get_preferred_height (ClutterActor *actor,
   clutter_actor_get_preferred_height (actor, for_width, min_height_p, natural_height_p);
 }
 
-/**
- * _st_allocate_fill:
- * @parent: the parent #StWidget
- * @child: the child (not necessarily an #StWidget)
- * @childbox: total space that could be allocated to @child
- * @x_alignment: horizontal alignment within @childbox
- * @y_alignment: vertical alignment within @childbox
- * @x_fill: whether or not to fill @childbox horizontally
- * @y_fill: whether or not to fill @childbox vertically
- *
- * Given @childbox, containing the initial allocation of @child, this
- * adjusts the horizontal allocation if @x_fill is %FALSE, and the
- * vertical allocation if @y_fill is %FALSE, by:
- *
- *     - reducing the allocation if it is larger than @child's natural
- *       size.
- *
- *     - adjusting the position of the child within the allocation
- *       according to @x_alignment/@y_alignment (and flipping
- *       @x_alignment if @parent has %ST_TEXT_DIRECTION_RTL)
- *
- * If @x_fill and @y_fill are both %TRUE, or if @child's natural size
- * is larger than the initial allocation in @childbox, then @childbox
- * will be unchanged.
- *
- * If you are allocating children with _st_allocate_fill(), you should
- * determine their preferred sizes using
- * _st_actor_get_preferred_width() and
- * _st_actor_get_preferred_height(), not with the corresponding
- * Clutter methods.
- */
-void
-_st_allocate_fill (StWidget        *parent,
-                   ClutterActor    *child,
-                   ClutterActorBox *childbox,
-                   StAlign          x_alignment,
-                   StAlign          y_alignment,
-                   gboolean         x_fill,
-                   gboolean         y_fill)
-{
-  gfloat natural_width, natural_height;
-  gfloat min_width, min_height;
-  gfloat child_width, child_height;
-  gfloat available_width, available_height;
-  ClutterRequestMode request;
-  gdouble x_align, y_align;
-
-  available_width  = childbox->x2 - childbox->x1;
-  available_height = childbox->y2 - childbox->y1;
-
-  if (available_width < 0)
-    {
-      available_width = 0;
-      childbox->x2 = childbox->x1;
-    }
-
-  if (available_height < 0)
-    {
-      available_height = 0;
-      childbox->y2 = childbox->y1;
-    }
-
-  /* If we are filling both horizontally and vertically then we don't
-   * need to do anything else.
-   */
-  if (x_fill && y_fill)
-    return;
-
-  _st_get_align_factors (parent, x_alignment, y_alignment,
-                         &x_align, &y_align);
-
-  /* The following is based on clutter_actor_get_preferred_size(), but
-   * modified to cope with the fact that the available size may be
-   * less than the preferred size.
-   */
-  request = clutter_actor_get_request_mode (child);
-
-  if (request == CLUTTER_REQUEST_HEIGHT_FOR_WIDTH)
-    {
-      clutter_actor_get_preferred_width (child, -1,
-                                         &min_width,
-                                         &natural_width);
-
-      child_width = CLAMP (natural_width, min_width, available_width);
-
-      clutter_actor_get_preferred_height (child, child_width,
-                                          &min_height,
-                                          &natural_height);
-
-      child_height = CLAMP (natural_height, min_height, available_height);
-    }
-  else
-    {
-      clutter_actor_get_preferred_height (child, -1,
-                                          &min_height,
-                                          &natural_height);
-
-      child_height = CLAMP (natural_height, min_height, available_height);
-
-      clutter_actor_get_preferred_width (child, child_height,
-                                         &min_width,
-                                         &natural_width);
-
-      child_width = CLAMP (natural_width, min_width, available_width);
-    }
-
-  if (!x_fill)
-    {
-      childbox->x1 += (int)((available_width - child_width) * x_align);
-      childbox->x2 = childbox->x1 + (int) child_width;
-    }
-
-  if (!y_fill)
-    {
-      childbox->y1 += (int)((available_height - child_height) * y_align);
-      childbox->y2 = childbox->y1 + (int) child_height;
-    }
-}
 
 /**
  * _st_get_align_factors:
- * @widget: an #StWidget
  * @x_align: an #StAlign
  * @y_align: an #StAlign
  * @x_align_out: (out) (allow-none): @x_align as a #gdouble
  * @y_align_out: (out) (allow-none): @y_align as a #gdouble
  *
- * Converts @x_align and @y_align to #gdouble values. If @widget has
- * %ST_TEXT_DIRECTION_RTL, the @x_align_out value will be flipped
- * relative to @x_align.
+ * Converts @x_align and @y_align to #gdouble values.
  */
 void
-_st_get_align_factors (StWidget *widget,
-                       StAlign   x_align,
+_st_get_align_factors (StAlign   x_align,
                        StAlign   y_align,
                        gdouble  *x_align_out,
                        gdouble  *y_align_out)
@@ -257,9 +135,6 @@ _st_get_align_factors (StWidget *widget,
           g_warn_if_reached ();
           break;
         }
-
-      if (st_widget_get_direction (widget) == ST_TEXT_DIRECTION_RTL)
-        *x_align_out = 1.0 - *x_align_out;
     }
 
   if (y_align_out)

--- a/src/st/st-private.h
+++ b/src/st/st-private.h
@@ -45,8 +45,7 @@ G_END_DECLS
 
 ClutterActor *_st_widget_get_dnd_clone (StWidget *widget);
 
-void _st_get_align_factors (StWidget *widget,
-                            StAlign   x_align,
+void _st_get_align_factors (StAlign   x_align,
                             StAlign   y_align,
                             gdouble  *x_align_out,
                             gdouble  *y_align_out);
@@ -61,14 +60,6 @@ void _st_actor_get_preferred_height (ClutterActor *actor,
                                      gboolean      x_fill,
                                      gfloat       *min_height_p,
                                      gfloat       *natural_height_p);
-
-void _st_allocate_fill (StWidget        *parent,
-                        ClutterActor    *child,
-                        ClutterActorBox *childbox,
-                        StAlign          x_align,
-                        StAlign          y_align,
-                        gboolean         x_fill,
-                        gboolean         y_fill);
 
 void _st_set_text_from_style (ClutterText *text,
                               StThemeNode *theme_node);

--- a/src/st/st-table.c
+++ b/src/st/st-table.c
@@ -244,8 +244,7 @@ st_table_homogeneous_allocate (ClutterActor          *self,
       gint row, col, row_span, col_span;
       StTableChild *meta;
       ClutterActorBox childbox;
-      StAlign x_align, y_align;
-      gboolean x_fill, y_fill;
+      gdouble x_align_f, y_align_f;
 
       meta = (StTableChild *) clutter_container_get_child_meta (CLUTTER_CONTAINER (self), child);
 
@@ -257,10 +256,8 @@ st_table_homogeneous_allocate (ClutterActor          *self,
       row = meta->row;
       row_span = meta->row_span;
       col_span = meta->col_span;
-      x_align = meta->x_align;
-      y_align = meta->y_align;
-      x_fill = meta->x_fill;
-      y_fill = meta->y_fill;
+      _st_get_align_factors (meta->x_align, meta->y_align,
+                             &x_align_f, &y_align_f);
 
       if (ltr)
         {
@@ -276,10 +273,10 @@ st_table_homogeneous_allocate (ClutterActor          *self,
       childbox.y1 = content_box->y1 + (row_height + row_spacing) * row;
       childbox.y2 = childbox.y1 + (row_height * row_span) + (row_spacing * (row_span - 1));
 
-      _st_allocate_fill (ST_WIDGET (self), child, &childbox,
-                         x_align, y_align, x_fill, y_fill);
-
-      clutter_actor_allocate (child, &childbox, flags);
+      clutter_actor_allocate_align_fill (child, &childbox,
+                                         x_align_f, y_align_f,
+                                         meta->x_fill, meta->y_fill,
+                                         flags);
     }
 
 }
@@ -598,8 +595,7 @@ st_table_preferred_allocate (ClutterActor          *self,
       StTableChild *meta;
       ClutterActorBox childbox;
       gint child_x, child_y;
-      StAlign x_align, y_align;
-      gboolean x_fill, y_fill;
+      gdouble x_align_f, y_align_f;
 
       meta = (StTableChild *) clutter_container_get_child_meta (CLUTTER_CONTAINER (self), child);
 
@@ -611,10 +607,8 @@ st_table_preferred_allocate (ClutterActor          *self,
       row = meta->row;
       row_span = meta->row_span;
       col_span = meta->col_span;
-      x_align = meta->x_align;
-      y_align = meta->y_align;
-      x_fill = meta->x_fill;
-      y_fill = meta->y_fill;
+      _st_get_align_factors (meta->x_align, meta->y_align,
+                             &x_align_f, &y_align_f);
 
 
       /* initialise the width and height */
@@ -691,11 +685,10 @@ st_table_preferred_allocate (ClutterActor          *self,
       childbox.y1 = (float) child_y;
       childbox.y2 = (float) MAX (0, child_y + row_height);
 
-
-      _st_allocate_fill (ST_WIDGET (self), child, &childbox,
-                         x_align, y_align, x_fill, y_fill);
-
-      clutter_actor_allocate (child, &childbox, flags);
+      clutter_actor_allocate_align_fill (child, &childbox,
+                                         x_align_f, y_align_f,
+                                         meta->x_fill, meta->y_fill,
+                                         flags);
     }
 }
 


### PR DESCRIPTION
https://github.com/GNOME/gnome-shell/commit/24ad59ea3728cf55ad127085e486d73345e33a35#diff-578ccc5ce70c4a11d7f30e3f38002f0b
plus a very minor simplification in st-box-layout