### PR TITLE
[3.6] st-bin: Make sure not to allocate hidden children

### DIFF
--- a/src/st/st-bin.c
+++ b/src/st/st-bin.c
@@ -113,7 +113,7 @@ st_bin_allocate (ClutterActor          *self,
 
   clutter_actor_set_allocation (self, box, flags);
 
-  if (priv->child)
+  if (priv->child && CLUTTER_ACTOR_IS_VISIBLE (priv->child))
     {
       StThemeNode *theme_node = st_widget_get_theme_node (ST_WIDGET (self));
       ClutterActorBox childbox;


### PR DESCRIPTION
https://github.com/GNOME/gnome-shell/commit/7e343f11f28a736d88619b85c9b9c6ea52a7e142#diff-b948bb195b709c61ce7275142a2fbdfd