### PR TITLE
[3.6]st-widget: Unset hover when setting track_hover to FALSE

### DIFF
--- a/src/st/st-widget.c
+++ b/src/st/st-widget.c
@@ -1732,6 +1732,8 @@ st_widget_set_track_hover (StWidget *widget,
 
       if (priv->track_hover)
         st_widget_sync_hover (widget);
+      else
+        st_widget_set_hover (widget, FALSE);
     }
 }
 


### PR DESCRIPTION
https://github.com/GNOME/gnome-shell/commit/79bfea5970a055a3990f7e52a3669a59594851a1#diff-b948bb195b709c61ce7275142a2fbdfd