### PR TITLE
[3.6] st-bin: Don't allocate a hidden actor

### DIFF
--- a/src/st/st-bin.c
+++ b/src/st/st-bin.c
@@ -137,7 +137,7 @@ st_bin_get_preferred_width (ClutterActor *self,
 
   st_theme_node_adjust_for_height (theme_node, &for_height);
 
-  if (priv->child == NULL)
+  if (priv->child == NULL || !CLUTTER_ACTOR_IS_VISIBLE (priv->child))
     {
       if (min_width_p)
         *min_width_p = 0;
@@ -166,7 +166,7 @@ st_bin_get_preferred_height (ClutterActor *self,
 
   st_theme_node_adjust_for_width (theme_node, &for_width);
 
-  if (priv->child == NULL)
+  if (priv->child == NULL || !CLUTTER_ACTOR_IS_VISIBLE (priv->child))
     {
       if (min_height_p)
         *min_height_p = 0;


### PR DESCRIPTION
https://github.com/GNOME/gnome-shell/commit/50f8ae6fc756d1a0fb33912e6b9d08a8fa71c197#diff-b948bb195b709c61ce7275142a2fbdfd