### PR TITLE
window-list applet: fix argument warning

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -887,7 +887,7 @@ AppMenuButtonRightClickMenu.prototype = {
         } else {
             item = new PopupMenu.PopupIconMenuItem(_("Minimize"), "view-sort-ascending", St.IconType.SYMBOLIC);
             item.connect('activate', function() {
-                mw.minimize(global.get_current_time());
+                mw.minimize();
             });
         }
         this.addMenuItem(item);


### PR DESCRIPTION
meta_window_minimize() only takes one argument and it is the meta window object