### PR TITLE
[3.6] StDrawingArea: fix texture drawing

### DIFF
--- a/src/st/st-drawing-area.c
+++ b/src/st/st-drawing-area.c
@@ -153,7 +153,7 @@ st_drawing_area_paint (ClutterActor *self)
 
       cogl_set_source (priv->material);
       cogl_rectangle_with_texture_coords (content_box.x1, content_box.y1,
-                                          width, height,
+                                          content_box.x2, content_box.y2,
                                           0.0f, 0.0f, 1.0f, 1.0f);
     }
 }


### PR DESCRIPTION
https://github.com/GNOME/gnome-shell/commit/587c93eadf01fafc6a6a6cb53aac94d9802de44d#diff-b948bb195b709c61ce7275142a2fbdfd
