### PR TITLE
[3.6] st-widget: remove stylable property

### DIFF
--- a/src/st/st-widget.c
+++ b/src/st/st-widget.c
@@ -60,7 +60,6 @@ struct _StWidgetPrivate
 
   StThemeNodeTransition *transition_animation;
 
-  gboolean      is_stylable : 1;
   gboolean      is_style_dirty : 1;
   gboolean      draw_bg_color : 1;
   gboolean      draw_border_internal : 1;
@@ -104,7 +103,6 @@ enum
   PROP_PSEUDO_CLASS,
   PROP_STYLE_CLASS,
   PROP_STYLE,
-  PROP_STYLABLE,
   PROP_TRACK_HOVER,
   PROP_HOVER,
   PROP_CAN_FOCUS,
@@ -162,14 +160,6 @@ st_widget_set_property (GObject      *gobject,
 
     case PROP_STYLE:
       st_widget_set_style (actor, g_value_get_string (value));
-      break;
-
-    case PROP_STYLABLE:
-      if (actor->priv->is_stylable != g_value_get_boolean (value))
-        {
-          actor->priv->is_stylable = g_value_get_boolean (value);
-          clutter_actor_queue_relayout ((ClutterActor *) gobject);
-        }
       break;
 
     case PROP_TRACK_HOVER:
@@ -231,10 +221,6 @@ st_widget_get_property (GObject    *gobject,
 
     case PROP_STYLE:
       g_value_set_string (value, priv->inline_style);
-      break;
-
-    case PROP_STYLABLE:
-      g_value_set_boolean (value, priv->is_stylable);
       break;
 
     case PROP_TRACK_HOVER:
@@ -484,12 +470,6 @@ notify_children_of_style_change (ClutterActor *self)
 static void
 st_widget_real_style_changed (StWidget *self)
 {
-  StWidgetPrivate *priv = ST_WIDGET (self)->priv;
-
-  /* application has request this widget is not stylable */
-  if (!priv->is_stylable)
-    return;
-
   clutter_actor_queue_redraw ((ClutterActor *) self);
 
   notify_children_of_style_change ((ClutterActor *) self);
@@ -882,20 +862,6 @@ st_widget_class_init (StWidgetClass *klass)
                                                         "Theme override",
                                                         ST_TYPE_THEME,
                                                         ST_PARAM_READWRITE));
-
-  /**
-   * StWidget:stylable:
-   *
-   * Enable or disable styling of the widget
-   */
-  pspec = g_param_spec_boolean ("stylable",
-                                "Stylable",
-                                "Whether the table should be styled",
-                                TRUE,
-                                ST_PARAM_READWRITE);
-  g_object_class_install_property (gobject_class,
-                                   PROP_STYLABLE,
-                                   pspec);
 
   /**
    * StWidget:track-hover:
@@ -1558,7 +1524,6 @@ st_widget_init (StWidget *actor)
   StWidgetPrivate *priv;
 
   actor->priv = priv = ST_WIDGET_GET_PRIVATE (actor);
-  priv->is_stylable = TRUE;
   priv->transition_animation = NULL;
   priv->local_state_set = atk_state_set_new ();
 


### PR DESCRIPTION
https://github.com/GNOME/gnome-shell/commit/5c0ee02251ebd21f72ee8d32b93d707547a06803#diff-b948bb195b709c61ce7275142a2fbdfd