### PR TITLE
ui/settings: Handle undefined old settings values

### DIFF
--- a/js/ui/settings.js
+++ b/js/ui/settings.js
@@ -553,7 +553,10 @@ XletSettingsBase.prototype = {
 
         let changed = false;
         for (let key in this.settingsData) {
-            if (this.settingsData[key].value === undefined) continue;
+            if (!this.settingsData[key]
+                || this.settingsData[key].value === undefined
+                || !oldSettings[key]
+                || oldSettings[key].value === undefined) continue;
 
             let oldValue = oldSettings[key].value;
             let value = this.settingsData[key].value;


### PR DESCRIPTION
(cinnamon:5111): Cjs-WARNING **: JS ERROR: TypeError: oldSettings[key]
is undefined
XletSettingsBase.prototype._checkSettings@/usr/share/cinnamon/js/ui/settings.js:558:17

How to reproduce:

Remove the layout section in an applet's settings-schema.json, reload the applet, add it back, and reload again. Can be seen when upgrading some applets that add a layout section to their schema.