### PR TITLE
Correct errors/warnings in popupMenu, environment, and cinnamonDBus

### DIFF
--- a/js/ui/cinnamonDBus.js
+++ b/js/ui/cinnamonDBus.js
@@ -307,7 +307,7 @@ CinnamonDBus.prototype = {
 
     highlightXlet: function(uuid, instance_id, highlight) {
         let obj = this._getXletObject(uuid, instance_id);
-        if (obj.highlight) obj.highlight(highlight);
+        if (obj && obj.highlight) obj.highlight(highlight);
     },
 
     highlightPanel: function(id, highlight) {

--- a/js/ui/environment.js
+++ b/js/ui/environment.js
@@ -34,6 +34,9 @@ function _patchContainerClass(containerClass) {
     // method. We conveniently, but somewhat dubiously, take the
     // this opportunity to make it do something more useful.
     containerClass.prototype.add = function(actor, props) {
+        if (actor === undefined) {
+            return false;
+        }
         this.add_actor(actor);
         if (props)
             this.child_set(actor, props);

--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -2021,10 +2021,11 @@ PopupMenuBase.prototype = {
     },
 
     _getMenuItems: function() {
-        return this.box.get_children().map(function (actor) {
+        return this.box.get_children().filter(function(actor) {
+            return (actor._delegate !== undefined
+                && (actor._delegate instanceof PopupBaseMenuItem || actor._delegate instanceof PopupMenuSection));
+        }).map(function (actor) {
             return actor._delegate;
-        }).filter(function(item) {
-            return item instanceof PopupBaseMenuItem || item instanceof PopupMenuSection;
         });
     },
 


### PR DESCRIPTION
This corrects the following errors.

```
Cjs-Message: JS WARNING: [/usr/share/cinnamon/js/ui/popupMenu.js 2025]:
reference to undefined property actor._delegate
```
```
(cinnamon:5111): Cjs-WARNING **: JS ERROR: Error: Expected type object
for Argument 'actor' but got type 'undefined'
_patchContainerClass/containerClass.prototype.add@/usr/share/cinnamon/js/ui/environment.js:37:9
```
```
(cinnamon:5111): Cjs-WARNING **: JS ERROR: Exception in method call:
highlightXlet: TypeError: obj is null
CinnamonDBus.prototype.highlightXlet@/usr/share/cinnamon/js/ui/cinnamonDBus.js:310:1
_handleMethodCall@resource:///org/cinnamon/cjs/modules/overrides/Gio.js:261:22
_wrapJSObject/<@resource:///org/cinnamon/cjs/modules/overrides/Gio.js:331:16
```
I encountered these during development of my own applet, and in most cases these are likely caused by problems with the xlets themselves, but these added checks will prevent Cinnamon from propagating side effects from them.
