### PR TITLE
windows-quick-list: fix argument warning

### DIFF
--- a/files/usr/share/cinnamon/applets/windows-quick-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/windows-quick-list@cinnamon.org/applet.js
@@ -114,7 +114,7 @@ MyApplet.prototype = {
     activateWindow: function(metaWorkspace, metaWindow) {
         this.menu.toggle();
         if(!metaWindow.is_on_all_workspaces()) { metaWorkspace.activate(global.get_current_time()); }
-        metaWindow.unminimize(global.get_current_time());
+        metaWindow.unminimize();
         metaWindow.activate(global.get_current_time());
     },
 


### PR DESCRIPTION
meta_window_unminimize() only takes one argument and it is the meta window object

edited to add:
Cjs-Message: JS WARNING: [/usr/share/cinnamon/applets/windows-quick-list@cinnamon.org/applet.js 117]: Too many arguments to method Meta.Window.unminimize: expected 0, got 1