### PR TITLE
Make touchpad settings compatible with libinput

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_mouse.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_mouse.py
@@ -94,7 +94,7 @@ class Module:
             switch = GSettingsSwitch(_("Disable touchpad while typing"), "org.cinnamon.settings-daemon.peripherals.touchpad", "disable-while-typing")
             settings.add_row(switch)
 
-            clickpad_list = [[0, _("Left click only")], [1, _("Emulate mouse buttons")], [2, _("Use multiple fingers for right and middle click")]]
+            clickpad_list = [[0, _("Left click only")], [3, _("Automatic")], [1, _("Emulate mouse buttons")], [2, _("Use multiple fingers for right and middle click")]]
 
             combo = GSettingsComboBox(_("Clickpad click action:"), "org.cinnamon.settings-daemon.peripherals.touchpad", "clickpad-click", clickpad_list, valtype="int")
             settings.add_row(combo)
@@ -105,7 +105,7 @@ class Module:
             switch = GSettingsSwitch(_("Reverse scrolling direction"), "org.cinnamon.settings-daemon.peripherals.touchpad", "natural-scroll")
             settings.add_row(switch)
 
-            clickpad_list = [[0, _("No scrolling")], [1, _("Two-finger scrolling")], [2, _("Edge scrolling")]]
+            clickpad_list = [[0, _("No scrolling")], [3, _("Automatic")], [1, _("Two-finger scrolling")], [2, _("Edge scrolling")]]
             combo = GSettingsComboBox(_("Scrolling method:"), "org.cinnamon.settings-daemon.peripherals.touchpad", "scrolling-method", clickpad_list, valtype="int")
             settings.add_row(combo)
             switch = GSettingsSwitch(_("Horizontal scrolling"), "org.cinnamon.settings-daemon.peripherals.touchpad", "horizontal-scrolling")

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_mouse.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_mouse.py
@@ -94,15 +94,8 @@ class Module:
             switch = GSettingsSwitch(_("Disable touchpad while typing"), "org.cinnamon.settings-daemon.peripherals.touchpad", "disable-while-typing")
             settings.add_row(switch)
 
-            button_list = [[0, _("Disabled")], [1, _("Left button")], [2, _("Middle button")], [3, _("Right button")]]
             clickpad_list = [[0, _("Left click only")], [1, _("Emulate mouse buttons")], [2, _("Use multiple fingers for right and middle click")]]
 
-            combo = GSettingsComboBox(_("Two-finger click emulation:"), "org.cinnamon.settings-daemon.peripherals.touchpad", "two-finger-click", button_list, valtype="int")
-            settings.add_row(combo)
-
-            combo = GSettingsComboBox(_("Three-finger click emulation:"), "org.cinnamon.settings-daemon.peripherals.touchpad", "three-finger-click", button_list, valtype="int")
-            settings.add_row(combo)
-            
             combo = GSettingsComboBox(_("Clickpad click action:"), "org.cinnamon.settings-daemon.peripherals.touchpad", "clickpad-click", clickpad_list, valtype="int")
             settings.add_row(combo)
 

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_mouse.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_mouse.py
@@ -95,11 +95,15 @@ class Module:
             settings.add_row(switch)
 
             button_list = [[0, _("Disabled")], [1, _("Left button")], [2, _("Middle button")], [3, _("Right button")]]
+            clickpad_list = [[0, _("Left click only")], [1, _("Emulate mouse buttons")], [2, _("Use multiple fingers for right and middle click")]]
 
             combo = GSettingsComboBox(_("Two-finger click emulation:"), "org.cinnamon.settings-daemon.peripherals.touchpad", "two-finger-click", button_list, valtype="int")
             settings.add_row(combo)
 
             combo = GSettingsComboBox(_("Three-finger click emulation:"), "org.cinnamon.settings-daemon.peripherals.touchpad", "three-finger-click", button_list, valtype="int")
+            settings.add_row(combo)
+            
+            combo = GSettingsComboBox(_("Clickpad click action:"), "org.cinnamon.settings-daemon.peripherals.touchpad", "clickpad-click", clickpad_list, valtype="int")
             settings.add_row(combo)
 
             settings = SettingsBox(_("Scrolling"))

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_mouse.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_mouse.py
@@ -105,13 +105,10 @@ class Module:
             switch = GSettingsSwitch(_("Reverse scrolling direction"), "org.cinnamon.settings-daemon.peripherals.touchpad", "natural-scroll")
             settings.add_row(switch)
 
-            switch = GSettingsSwitch(_("Vertical edge scrolling"), "org.cinnamon.settings-daemon.peripherals.touchpad", "vertical-edge-scrolling")
-            settings.add_row(switch)
-            switch = GSettingsSwitch(_("Horizontal edge scrolling"), "org.cinnamon.settings-daemon.peripherals.touchpad", "horizontal-edge-scrolling")
-            settings.add_row(switch)
-            switch = GSettingsSwitch(_("Vertical two-finger scrolling"), "org.cinnamon.settings-daemon.peripherals.touchpad", "vertical-two-finger-scrolling")
-            settings.add_row(switch)
-            switch = GSettingsSwitch(_("Horizontal two-finger scrolling"), "org.cinnamon.settings-daemon.peripherals.touchpad", "horizontal-two-finger-scrolling")
+            clickpad_list = [[0, _("No scrolling")], [1, _("Two-finger scrolling")], [2, _("Edge scrolling")]]
+            combo = GSettingsComboBox(_("Scrolling method:"), "org.cinnamon.settings-daemon.peripherals.touchpad", "scrolling-method", clickpad_list, valtype="int")
+            settings.add_row(combo)
+            switch = GSettingsSwitch(_("Horizontal scrolling"), "org.cinnamon.settings-daemon.peripherals.touchpad", "horizontal-scrolling")
             settings.add_row(switch)
 
             settings = SettingsBox(_("Pointer speed"))


### PR DESCRIPTION
Requires linuxmint/cinnamon-settings-daemon#181.

The scrolling work is compatible with either driver. Clickpad support works differently: synaptics does not disable button emulation in any case, at least on the laptop I have at hand.

If you need a reminder why libinput makes sense: see https://fedoraproject.org/wiki/Changes/LibinputForXorg
TL;DR other distros are moving towards it, and it can handle a number of modern input devices better. The synaptics driver was for instance not built for laptops where buttons need to be emulated and its default (and only) way of handling those devices causes issues for some (especially Lenovos).