### PR TITLE
main.js: remove obsolete Meta enum member reference

### DIFF
--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -1226,7 +1226,6 @@ function _stageEventHandler(actor, event) {
             expo.hide();
             return true;
         case Meta.KeyBindingAction.PANEL_RUN_DIALOG:
-        case Meta.KeyBindingAction.COMMAND_2:
             getRunDialog().open();
             return true;
         case Meta.KeyBindingAction.PANEL_MAIN_MENU:


### PR DESCRIPTION
The COMMAND_2 enum member was removed from muffin in 2012.
https://github.com/linuxmint/muffin/commit/0fd28e63a9bf02c68d735756e826db7bba5b7c49#diff-15c3f0c014bba808df3ba2b17c812e9aL191

fixes warning:
main.js 1229: reference to undefined property Meta.KeyBindingAction.COMMAND_2