### PR TITLE
Set items unreactive during panel edit mode for window list and panel launchers

### DIFF
--- a/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
@@ -168,7 +168,7 @@ PanelAppLauncher.prototype = {
         this._draggable.connect('drag-cancelled', Lang.bind(this, this._onDragCancelled));
         this._draggable.connect('drag-end', Lang.bind(this, this._onDragEnd));
 
-        this._draggable.inhibit = !this.launchersBox.allowDragging || global.settings.get_boolean(PANEL_EDIT_MODE_KEY);
+        this._updateInhibit();
         this.launchersBox.connect("launcher-draggable-setting-changed", Lang.bind(this, this._updateInhibit));
         global.settings.connect('changed::' + PANEL_EDIT_MODE_KEY, Lang.bind(this, this._updateInhibit));
     },
@@ -191,7 +191,9 @@ PanelAppLauncher.prototype = {
     },
 
     _updateInhibit: function(){
-        this._draggable.inhibit = !this.launchersBox.allowDragging || global.settings.get_boolean(PANEL_EDIT_MODE_KEY);
+        let editMode = global.settings.get_boolean(PANEL_EDIT_MODE_KEY);
+        this._draggable.inhibit = !this.launchersBox.allowDragging || editMode;
+        this.actor.reactive = !editMode;
     },
 
     getDragActor: function() {

--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -341,8 +341,10 @@ AppMenuButton.prototype = {
     },
 
     onPanelEditModeChanged: function() {
+        let editMode = global.settings.get_boolean("panel-edit-mode");
         if (this._draggable)
-            this._draggable.inhibit = global.settings.get_boolean("panel-edit-mode");
+            this._draggable.inhibit = editMode;
+        this.actor.reactive = !editMode;
     },
 
     onScrollModeChanged: function() {


### PR DESCRIPTION
This fixes the cause of multiple menus opening for these two applets, but does not fix the cause of the stuck menu. See #6550