### PR TITLE
keyboard-applet: applet icon vanishes when moved in edit mode

### DIFF
--- a/files/usr/share/cinnamon/applets/keyboard@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/keyboard@cinnamon.org/applet.js
@@ -190,7 +190,12 @@ MyApplet.prototype = {
     on_applet_added_to_panel: function() {
         this._config = new XApp.KbdLayoutController();
 
-        this._syncConfig();
+        if (global.settings.get_boolean(PANEL_EDIT_MODE_KEY)) {
+            this._syncConfig();
+            this._onPanelEditModeChanged();
+        } else {
+            this._syncConfig();
+        }
 
         this._config.connect('layout-changed', Lang.bind(this, this._syncGroup));
         this._config.connect('config-changed', Lang.bind(this, this._syncConfig));


### PR DESCRIPTION
If applet is only visible in panel-edit-mode and you move it, it vanishes.
This PR makes sure to always show the applet in panel-edit-mode.

Also show applet icon, when you add this applet with panel-edit-mode enabled.