### PR TITLE
slideshow-applet: fix translation

### DIFF
--- a/files/usr/share/cinnamon/applets/slideshow@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/slideshow@cinnamon.org/applet.js
@@ -5,8 +5,6 @@ const Main = imports.ui.main;
 const Applet = imports.ui.applet;
 const PopupMenu = imports.ui.popupMenu;
 const Util = imports.misc.util;
-const Gettext = imports.gettext.domain("cinnamon-applets");
-const _ = Gettext.gettext;
 
 function MyApplet(metadata, orientation, panel_height, instanceId) {
     this._init(metadata, orientation, panel_height, instanceId);
@@ -62,7 +60,7 @@ MyApplet.prototype = {
         catch(e) {
             global.logError(e);
         }
-  
+
     },
 
     on_applet_clicked: function(event) {


### PR DESCRIPTION
Translations are available, but do not show because of the imported gettext lines.
Remove the those lines and the applet shows the right locale