### PR TITLE
layout.js optimizations and docs

### DIFF
--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -64,8 +64,6 @@ LayoutManager.prototype = {
         this.hideIdleId = 0;
         this._chrome = new Chrome(this);
 
-        this._isPopupWindowVisible = false;
-
         this.enabledEdgeFlip = global.settings.get_boolean("enable-edge-flip");
         this.edgeFlipDelay = global.settings.get_int("edge-flip-delay");
 
@@ -425,6 +423,7 @@ Chrome.prototype = {
 
         this._monitors = [];
         this._inOverview = false;
+        this._isPopupWindowVisible = false;
         this._updateRegionIdle = 0;
         this._freezeUpdateCount = 0;
 
@@ -676,12 +675,7 @@ Chrome.prototype = {
     },
 
     _windowsRestacked: function() {
-        let changed = false;
-
-        if (this._isPopupWindowVisible != global.top_window_group.get_children().some(isPopupMetaWindow))
-            changed = true;
-
-        if (changed) {
+        if (this._isPopupWindowVisible != global.top_window_group.get_children().some(isPopupMetaWindow)) {
             this._updateVisibility();
             this._queueUpdateRegions();
         }

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -414,7 +414,7 @@ Chrome.prototype = {
                                     Lang.bind(this, this._relayout));
         global.screen.connect('restacked',
                               Lang.bind(this, this._windowsRestacked));
-        global.screen.connect('in-fullscreen-changed', Lang.bind(this, this._updateFullscreen));
+        global.screen.connect('in-fullscreen-changed', Lang.bind(this, this._updateVisibility));
         global.window_manager.connect('switch-workspace', Lang.bind(this, this._queueUpdateRegions));
 
         // Need to update struts on new workspaces when they are added
@@ -561,26 +561,23 @@ Chrome.prototype = {
                 visible = true;
             Main.uiGroup.set_skip_paint(actorData.actor, !visible);
         }
+        this._queueUpdateRegions();
     },
 
     _overviewShowing: function() {
         this._inOverview = true;
         this._updateVisibility();
-        this._queueUpdateRegions();
     },
 
     _overviewHidden: function() {
         this._inOverview = false;
         this._updateVisibility();
-        this._queueUpdateRegions();
     },
 
     _relayout: function() {
         this._monitors = this._layoutManager.monitors;
         this._primaryMonitor = this._layoutManager.primaryMonitor;
-        this._updateFullscreen();
         this._updateVisibility();
-        this._queueUpdateRegions();
     },
 
     _findMonitorForRect: function(x, y, w, h) {
@@ -652,15 +649,11 @@ Chrome.prototype = {
         this._queueUpdateRegions();
     },
 
-    _updateFullscreen: function() {
-        this._updateVisibility();
-        this._queueUpdateRegions();
-    },
-
     _windowsRestacked: function() {
         if (this._isPopupWindowVisible != global.top_window_group.get_children().some(isPopupMetaWindow))
             this._updateVisibility();
-        this._queueUpdateRegions();
+        else
+            this._queueUpdateRegions();
     },
 
     updateRegions: function() {

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -405,6 +405,8 @@ Chrome.prototype = {
         this._monitors = [];
         this._inOverview = false;
         this._isPopupWindowVisible = false;
+        this._primaryMonitor = null;
+        this._primaryIndex = -1;
         this._updateRegionIdle = 0;
         this._freezeUpdateCount = 0;
 
@@ -577,6 +579,7 @@ Chrome.prototype = {
     _relayout: function() {
         this._monitors = this._layoutManager.monitors;
         this._primaryMonitor = this._layoutManager.primaryMonitor;
+        this._primaryIndex = this._layoutManager.primaryIndex
         this._updateVisibility();
     },
 
@@ -629,7 +632,9 @@ Chrome.prototype = {
 
     findMonitorIndexForActor: function(actor) {
         let [index, monitor] = this.getMonitorInfoForActor(actor);
-        return index;
+        if (monitor)
+            return index;
+        return this._primaryIndex; // Not on any monitor, pretend its on the primary
     },
 
     _queueUpdateRegions: function() {

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -82,13 +82,7 @@ LayoutManager.prototype = {
 
         global.settings.connect("changed::enable-edge-flip", Lang.bind(this, this._onEdgeFlipChanged));
         global.settings.connect("changed::edge-flip-delay", Lang.bind(this, this._onEdgeFlipChanged));
-        global.screen.connect('restacked', Lang.bind(this, this._windowsRestacked));
-        global.screen.connect('monitors-changed',
-                              Lang.bind(this, this._monitorsChanged));
-        global.screen.connect('in-fullscreen-changed',
-                              Lang.bind(this, this._updateFullscreen));
-        global.window_manager.connect('switch-workspace',
-                                      Lang.bind(this, this._windowsRestacked));
+        global.screen.connect('monitors-changed', Lang.bind(this, this._monitorsChanged));
     },
 
     _onEdgeFlipChanged: function(){
@@ -98,14 +92,6 @@ LayoutManager.prototype = {
         this.edgeRight.delay = this.edgeFlipDelay;
         this.edgeLeft.enabled = this.enabledEdgeFlip;
         this.edgeLeft.delay = this.edgeFlipDelay;
-    },
-
-    _windowsRestacked: function() {
-        this._chrome.updateRegions();
-    },
-
-    _updateFullscreen: function() {
-        this._chrome._updateFullscreen();
     },
 
     // This is called by Main after everything else is constructed;
@@ -433,6 +419,8 @@ Chrome.prototype = {
                                     Lang.bind(this, this._relayout));
         global.screen.connect('restacked',
                               Lang.bind(this, this._windowsRestacked));
+        global.screen.connect('in-fullscreen-changed', Lang.bind(this, this._updateFullscreen));
+        global.window_manager.connect('switch-workspace', Lang.bind(this, this._queueUpdateRegions));
 
         // Need to update struts on new workspaces when they are added
         global.screen.connect('notify::n-workspaces',
@@ -675,10 +663,9 @@ Chrome.prototype = {
     },
 
     _windowsRestacked: function() {
-        if (this._isPopupWindowVisible != global.top_window_group.get_children().some(isPopupMetaWindow)) {
+        if (this._isPopupWindowVisible != global.top_window_group.get_children().some(isPopupMetaWindow))
             this._updateVisibility();
-            this._queueUpdateRegions();
-        }
+        this._queueUpdateRegions();
     },
 
     updateRegions: function() {

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -692,8 +692,8 @@ Chrome.prototype = {
             w = Math.round(w);
             h = Math.round(h);
 
-            if (actorData.affectsInputRegion
-                && wantsInputRegion
+            if (wantsInputRegion
+                && actorData.affectsInputRegion
                 && actorData.actor.get_paint_visibility()
                 && !Main.uiGroup.get_skip_paint(actorData.actor)) {
 

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -148,20 +148,15 @@ LayoutManager.prototype = {
         this.bottomMonitor = this.monitors[this.bottomIndex];
     },
 
-    _updateHotCorners: function() {
+    _updateBoxes: function() {
         if (this.hotCornerManager)
             this.hotCornerManager.updatePosition(this.primaryMonitor, this.bottomMonitor);
-    },
-
-    _updateBoxes: function() {
-        this._updateHotCorners();
         this._chrome._queueUpdateRegions();
     },
 
     _monitorsChanged: function() {
         this._updateMonitors();
         this._updateBoxes();
-        this._updateHotCorners();
         this.emit('monitors-changed');
     },
 

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -2434,7 +2434,7 @@ Panel.prototype = {
             this.actor.set_clip(clipOffsetX, 0, exposedAmount, this.actor.height);
         }
         // Force the layout manager to update the input region
-        Main.layoutManager._chrome.updateRegions()
+        Main.layoutManager.updateChrome()
     },
 
     /**
@@ -3160,9 +3160,6 @@ Panel.prototype = {
         if (this._disabled) return;
         if (!this._hidden) return;
 
-        // Force the panel to be on top (hack to correct issues when switching workspace)
-        Main.layoutManager._windowsRestacked();
-
         // setup panel tween - slide in from edge of monitor
         // if horizontal panel, animation on y. if vertical, animation on x.
         let isHorizontal = this.panelPosition == PanelLoc.top
@@ -3232,9 +3229,6 @@ Panel.prototype = {
         this._showHideTimer = 0;
 
         if ((this._shouldShow && !force) || global.menuStackLength > 0) return;
-
-        // Force the panel to be on top (hack to correct issues when switching workspace)
-        Main.layoutManager._windowsRestacked();
 
         // setup panel tween - slide out the monitor edge leaving one pixel
         // if horizontal panel, animation on y. if vertical, animation on x.


### PR DESCRIPTION
Wide range of optimizations and documentation fixes for layout.js. See individual commits for more details.

Optimizations that may improve performance:
- from 2 to 1 connections to screen signal windows-restacked
- remove unused var and if conditional from windows-restacked handler
- on screen windows-restacked - from 2 to 1 calls to _queueUpdateRegions if popup window is visible
- on screen monitors-changed - from 2 to 1 calls to hotCornerManager.updatePosition
- on layoutmanager monitors-changed -  from 2 to 1 calls to both _queueUpdateRegions and _updateVisibility
- when popupmenu is visible, one less comparison in Chrome actors loop during _updateRegions

Non-performance optimizations:
- call _queueUpdateRegions directly in _updateVisibility since we call it directly after, avoids an extra line of code everywhere that it is called
- replace clip region based input region correction with panel specific fix that instead intersects panel actor and monitor rect to determine on-monitor input region

New functionality:
- new "public" method LayoutManager.updateChrome() for externally forcing Chrome to update input region/visibility/etc. reason: panel.js called directly into chrome/layoutmanager underscore methods and i broke it during this series.
- new hideable-panel-specific special case in Chrome.getMonitorInfoForActor() to return the most up to date monitor. prevents returning adjacent monitor when panel is hidden.
- Chrome.findMonitorIndexForActor() now returns the primary monitor index if the index to be returned was invalid. this brings the behavior in line with the non-index variant. these are exposed through LayoutManager, so I wanted them to be consistent.