### PR TITLE
avoid signed ints for bit flags

### DIFF
--- a/src/cinnamon-app.c
+++ b/src/cinnamon-app.c
@@ -39,7 +39,7 @@ typedef struct {
   GSList *windows;
 
   /* Whether or not we need to resort the windows; this is done on demand */
-  gboolean window_sort_stale : 1;
+  guint window_sort_stale : 1;
 } CinnamonAppRunningState;
 
 /**

--- a/src/st/st-adjustment.c
+++ b/src/st/st-adjustment.c
@@ -44,7 +44,7 @@ struct _StAdjustmentPrivate
 {
   /* Do not sanity-check values while constructing,
    * not all properties may be set yet. */
-  gboolean is_constructing : 1;
+  guint is_constructing : 1;
 
   gdouble  lower;
   gdouble  upper;

--- a/src/st/st-box-layout-child.h
+++ b/src/st/st-box-layout-child.h
@@ -64,8 +64,8 @@ struct _StBoxLayoutChild
   ClutterChildMeta parent;
 
   gboolean expand;
-  gboolean x_fill : 1;
-  gboolean y_fill : 1;
+  guint x_fill : 1;
+  guint y_fill : 1;
   StAlign x_align;
   StAlign y_align;
 };

--- a/src/st/st-scroll-view.c
+++ b/src/st/st-scroll-view.c
@@ -114,12 +114,12 @@ struct _StScrollViewPrivate
 
   StScrollViewFade *vfade_effect;
 
-  gboolean      row_size_set : 1;
-  gboolean      column_size_set : 1;
+  guint         row_size_set : 1;
+  guint         column_size_set : 1;
   guint         mouse_scroll : 1;
   guint         hscrollbar_visible : 1;
   guint         vscrollbar_visible : 1;
-  gboolean      auto_scroll : 1;
+  guint         auto_scroll : 1;
   guint         auto_scroll_timeout_id;
 };
 

--- a/src/st/st-widget.c
+++ b/src/st/st-widget.c
@@ -60,13 +60,13 @@ struct _StWidgetPrivate
 
   StThemeNodeTransition *transition_animation;
 
-  gboolean      is_style_dirty : 1;
-  gboolean      draw_bg_color : 1;
-  gboolean      draw_border_internal : 1;
-  gboolean      track_hover : 1;
-  gboolean      hover : 1;
-  gboolean      can_focus : 1;
-  gboolean      important : 1;
+  guint      is_style_dirty : 1;
+  guint      draw_bg_color : 1;
+  guint      draw_border_internal : 1;
+  guint      track_hover : 1;
+  guint      hover : 1;
+  guint      can_focus : 1;
+  guint      important : 1;
 
   StTextDirection   direction;
 


### PR DESCRIPTION
results are implementation specific and can give odd results if bit operators are used.  
gboolean maps to int, not unsigned, so replace gboolean bit flags with guint.
based on https://github.com/GNOME/gnome-shell/commit/69f17da5ca191c57acb6dfc5bbedc6f14f768e9b#diff-9ad11fdf581414b0f2501e50921d1052
with one additional instance found