### PR TITLE
cin-debug: don't suggest backgrounding

### DIFF
--- a/utils/cin-debug
+++ b/utils/cin-debug
@@ -11,7 +11,7 @@ if len(sys.argv) != 2:
     print """
     Run as:
 
-        cin-debug <process-name> &
+        cin-debug <process-name>
 
     """
     quit()


### PR DESCRIPTION
The script uses sudo to gain privs to attach the debugger, so we must
run interactively to display the password prompt. It will work in cases
where sudo auth is already cached, but that's probably not likely in
most cases.