### PR TITLE
panel.js: don't error on nonexistent panel

### DIFF
--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -429,6 +429,8 @@ PanelManager.prototype = {
      */
     lowerActorBelowPanels: function(actor, group) {
         for (let i = 0, len = this.panels.length; i < len; i++) {
+            if (!this.panels[i])
+                continue;
             Main.uiGroup.set_child_below_sibling(actor, this.panels[i].actor);
             break;
         }


### PR DESCRIPTION
Fixes on screen keyboard

Cjs-WARNING **: JS ERROR: TypeError: this.panels[i] is undefined
PanelManager.prototype.lowerActorBelowPanels@/usr/share/cinnamon/js/ui/panel.js:432:13
LayoutManager.prototype.showKeyboard@/usr/share/cinnamon/js/ui/layout.js:269:9
Keyboard.prototype.show@/usr/share/cinnamon/js/ui/keyboard.js:470:9
Keyboard.prototype._setupKeyboard@/usr/share/cinnamon/js/ui/keyboard.js:282:13
Keyboard.prototype._settingsChanged@/usr/share/cinnamon/js/ui/keyboard.js:243:13