### PR TITLE
trash applet: Fix arguments warnings

### DIFF
--- a/files/usr/share/cinnamon/applets/trash@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/trash@cinnamon.org/applet.js
@@ -34,7 +34,7 @@ MyApplet.prototype = {
 
             this._onTrashChange();
 
-            this.monitor = this.trash_directory.monitor_directory(0, null, null);
+            this.monitor = this.trash_directory.monitor_directory(0, null);
             this.monitor.connect('changed', Lang.bind(this, this._onTrashChange));
         }
         catch (e) {
@@ -77,7 +77,7 @@ MyApplet.prototype = {
         this.trash_changed_timeout = 0;
         if (this.trash_directory.query_exists(null)) {
             let children = this.trash_directory.enumerate_children('standard::*', Gio.FileQueryInfoFlags.NONE, null);
-            if (children.next_file(null, null) == null) {
+            if (children.next_file(null) == null) {
                 this.set_applet_icon_symbolic_name("user-trash");
             } else {
                 this.set_applet_icon_symbolic_name("user-trash-full");


### PR DESCRIPTION
Cjs-Message: JS WARNING:
[/usr/share/cinnamon/applets/trash@cinnamon.org/applet.js 37]: Too many
arguments to method Gio.File.monitor_directory: expected 2, got 3
Cjs-Message: JS WARNING:
[/usr/share/cinnamon/applets/trash@cinnamon.org/applet.js 80]: Too many
arguments to method Gio.FileEnumerator.next_file: expected 1, got 2