### PR TITLE
extension: Use imports.searchPath instead of imports.addSubImporter

### DIFF
--- a/docs/reference/cinnamon-tutorials/importer.xml
+++ b/docs/reference/cinnamon-tutorials/importer.xml
@@ -146,10 +146,10 @@
       The best way is using <code>imports.ui.manager.xlet[UUID]</code>.
       <code>manager</code> is one of <code>appletManager</code>, <code>deskletManager</code>, or <code>extensionSystem</code>.
       <code>xlet</code> is the xlet type pluralized and is one of <code>applets</code>, <code>desklets</code>, or <code>extensions</code>.
-      <code>UUID</code> is a string of your xlet's UUID.
+      <code>UUID</code> is the string of your xlet's UUID.
 
       <para>
-        Importing applets:
+        Importing for applets:
         <informalexample>
           <programlisting>
             const Module = imports.ui.appletManager['foo@bar'].module; // get module.js in your applet directory
@@ -158,7 +158,7 @@
       </para>
 
       <para>
-        Importing desklets:
+        Importing for desklets:
         <informalexample>
           <programlisting>
             const Module = imports.ui.deskletManager['foo@bar'].module; // get module.js in your desklet directory
@@ -167,7 +167,7 @@
       </para>
 
       <para>
-        Importing extensions:
+        Importing for extensions:
         <informalexample>
           <programlisting>
             const Module = imports.ui.extensionSystem['foo@bar'].module; // get module.js in your extension directory
@@ -176,10 +176,10 @@
       </para>
     </para>
     <para>
-      In Cinnamon 3.6+, you can also import xlets by using imports.xletTypePluralized[UUID]. This method is not compatible with previous versions of Cinnamon.
+      In Cinnamon 3.6+, you can also import xlets by using <code>imports.xletTypePluralized[UUID]</code>. This method is not compatible with previous versions of Cinnamon.
 
       <para>
-        Importing applets:
+        Importing for applets:
         <informalexample>
           <programlisting>
             const Module = imports.applets['foo@bar'].module;
@@ -188,7 +188,7 @@
       </para>
 
       <para>
-        Importing desklets:
+        Importing for desklets:
         <informalexample>
           <programlisting>
             const Module = imports.desklets['foo@bar'].module;
@@ -197,7 +197,7 @@
       </para>
 
       <para>
-        Importing extensions:
+        Importing for extensions:
         <informalexample>
           <programlisting>
             const Module = imports.extensions['foo@bar'].module;

--- a/docs/reference/cinnamon-tutorials/importer.xml
+++ b/docs/reference/cinnamon-tutorials/importer.xml
@@ -142,60 +142,68 @@
     <title>Importing xlet modules</title>
 
     <para>
-      When you want to split a big xlet code into smaller files, you'll need to import them.
-      A simple way is using <code>imports.xlet</code>, where <code>xlet</code> is your xlet type
-      (<code>applet</code>, <code>desklet</code>, <code>extension</code>, <code>search_provider</code>)
-      <informalexample>
-        <programlisting>
-          imports.applet.foo // get foo.js in your applet directory
-        </programlisting>
-      </informalexample>
+      When you want to split a big xlet file into smaller files, you'll need to import them.
+      The best way is using <code>imports.ui.manager.xlet[UUID]</code>.
+      <code>manager</code> is one of <code>appletManager</code>, <code>deskletManager</code>, or <code>extensionSystem</code>.
+      <code>xlet</code> is the xlet type pluralized and is one of <code>applets</code>, <code>desklets</code>, or <code>extensions</code>.
+      <code>UUID</code> is a string of your xlet's UUID.
+
+      <para>
+        Importing applets:
+        <informalexample>
+          <programlisting>
+            const Module = imports.ui.appletManager['foo@bar'].module; // get module.js in your applet directory
+          </programlisting>
+        </informalexample>
+      </para>
+
+      <para>
+        Importing desklets:
+        <informalexample>
+          <programlisting>
+            const Module = imports.ui.deskletManager['foo@bar'].module; // get module.js in your desklet directory
+          </programlisting>
+        </informalexample>
+      </para>
+
+      <para>
+        Importing extensions:
+        <informalexample>
+          <programlisting>
+            const Module = imports.ui.extensionSystem['foo@bar'].module; // get module.js in your extension directory
+          </programlisting>
+        </informalexample>
+      </para>
     </para>
-  </sect2>
-
-  <sect2>
-    <title><code>__init__.js</code></title>
-
     <para>
-      When writing xlets, it is common that you have some functions or constants that you need in many files.
-      For that, there is <code>__init__.js</code>.
-      It is a normal JavaScript file, but every function or variable can be accessed directly via <code>import.*</code>.
-    </para>
+      In Cinnamon 3.6+, you can also import xlets by using imports.xletTypePluralized[UUID]. This method is not compatible with previous versions of Cinnamon.
 
-    <para>
-      Examples are often used functions, like a modified <code>_()</code> function for translating your xlet.
-    </para>
+      <para>
+        Importing applets:
+        <informalexample>
+          <programlisting>
+            const Module = imports.applets['foo@bar'].module;
+          </programlisting>
+        </informalexample>
+      </para>
 
-    <para>
-      <code>__init__.js</code>
-      <informalexample>
-        <programlisting>
-          const Gettext = imports.gettext;
+      <para>
+        Importing desklets:
+        <informalexample>
+          <programlisting>
+            const Module = imports.desklets['foo@bar'].module;
+          </programlisting>
+        </informalexample>
+      </para>
 
-          const uuid = "xlet@uuid";
-
-          Gettext.bindtextdomain(uuid, GLib.get_home_dir() + "/.local/share/locale");
-
-          function _(str){
-            return Gettext.dgettext(uuid, str);
-          }
-        </programlisting>
-      </informalexample>
-      In your other files:
-      <informalexample>
-        <programlisting>
-          const uuid = imports.xlet.uuid;
-          const _ = imports.xlet._;
-        </programlisting>
-      </informalexample>
-    </para>
-
-    <para>
-      Remember: replace <code>xlet</code> in <code>imports.xlet</code> to your xlet type.
-    </para>
-
-    <para>
-      There is no harm renaming <code>__init__.js</code> to something else (like <code>util.js</code>) and using <code>imports.xlet.util.*</code>.
+      <para>
+        Importing extensions:
+        <informalexample>
+          <programlisting>
+            const Module = imports.extensions['foo@bar'].module;
+          </programlisting>
+        </informalexample>
+      </para>
     </para>
   </sect2>
 </chapter>

--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
@@ -8,7 +8,7 @@ const Util = imports.misc.util;
 const PopupMenu = imports.ui.popupMenu;
 const UPowerGlib = imports.gi.UPowerGlib;
 const Settings = imports.ui.settings;
-const Calendar = imports.applet.calendar;
+const Calendar = imports.applets['calendar@cinnamon.org'].calendar;
 const CinnamonDesktop = imports.gi.CinnamonDesktop;
 
 String.prototype.capitalize = function() {

--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -51,7 +51,6 @@ function _createExtensionType(name, folder, manager, overrides){
 
     let path = GLib.build_filenamev([global.userdatadir, folder]);
     type.userDir = path;
-
     // create user directories if they don't exist.
     let dir = Gio.file_new_for_path(type.userDir)
     try {
@@ -121,7 +120,7 @@ Extension.prototype = {
         this.uuid = uuid;
         this.dir = dir;
         this.type = type;
-        this.lowerType = type.name.toLowerCase().replace(/" "/g, "_");
+        this.lowerType = type.name.toLowerCase().replace(/\s/g, "_");
         this.theme = null;
         this.stylesheet = null;
         this.iconDirectory = null;
@@ -511,6 +510,7 @@ function unloadExtension(uuid, type, deleteConfig = true) {
 }
 
 function forgetExtension(uuid, type, forgetMeta) {
+    delete imports[type.maps.objects[uuid].lowerType + 's'][uuid];
     delete type.maps.importObjects[uuid];
     delete type.maps.objects[uuid];
     if(forgetMeta)
@@ -528,8 +528,10 @@ function forgetExtension(uuid, type, forgetMeta) {
 function reloadExtension(uuid, type) {
     let extension = type.maps.objects[uuid];
 
-    if(extension)
+    if (extension) {
         unloadExtension(uuid, type, false);
+        Main._addXletDirectoriesToSearchPath();
+    }
 
     loadExtension(uuid, type);
 }

--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -121,7 +121,7 @@ Extension.prototype = {
         this.uuid = uuid;
         this.dir = dir;
         this.type = type;
-        this.lowerType = type.name.toLowerCase().replace(" ", "_");
+        this.lowerType = type.name.toLowerCase().replace(/" "/g, "_");
         this.theme = null;
         this.stylesheet = null;
         this.iconDirectory = null;
@@ -136,6 +136,11 @@ Extension.prototype = {
             this.dir = findExtensionSubdirectory(this.dir);
             this.meta.path = this.dir.get_path();
             type.maps.dirs[this.uuid] = this.dir;
+            let pathSections = this.meta.path.split('/');
+            let version = pathSections[pathSections.length - 1];
+            type.maps.importObjects[this.uuid] = imports[this.lowerType + 's'][this.uuid][version];
+        } else {
+            type.maps.importObjects[this.uuid] = imports[this.lowerType + 's'][this.uuid];
         }
 
         this.ensureFileExists(this.dir.get_child(this.lowerType + '.js'));
@@ -147,9 +152,6 @@ Extension.prototype = {
             }));
         }
         this.loadIconDirectory(this.dir);
-
-        imports.addSubImporter(this.lowerType, this.meta.path);
-        type.maps.importObjects[this.uuid] = imports[this.lowerType];
 
         try {
             this.module = type.maps.importObjects[this.uuid][this.lowerType]; // get [extension/applet/desklet].js

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -214,6 +214,26 @@ function _initRecorder() {
     });
 }
 
+function _addXletDirectoriesToSearchPath() {
+    imports.searchPath.unshift(global.datadir);
+    imports.searchPath.unshift(global.userdatadir);
+    // Including the system data directory also includes unnecessary system utilities,
+    // so we are making sure they are removed.
+    let types = ['applets', 'desklets', 'extensions'];
+    let importsCache = {};
+    for (let i = 0; i < types.length; i++) {
+        // Cache our existing xlet GJS importer objects
+        importsCache[types[i]] = imports[types[i]];
+    }
+    // Remove the two paths we added to the beginning of the array.
+    imports.searchPath.splice(0, 2);
+    for (let i = 0; i < types.length; i++) {
+        // Re-add cached xlet objects
+        imports[types[i]] = importsCache[types[i]];
+        importsCache[types[i]] = undefined;
+    }
+}
+
 function _initUserSession() {
     _initRecorder();
 
@@ -419,6 +439,7 @@ function start() {
     overview.init();
     expo.init();
 
+    _addXletDirectoriesToSearchPath();
     _initUserSession();
 
     // Provide the bus object for gnome-session to
@@ -451,8 +472,6 @@ function start() {
     _nWorkspacesChanged();
 
     startTime = new Date().getTime();
-    imports.searchPath.unshift(global.datadir);
-    imports.searchPath.unshift(global.userdatadir);
     AppletManager.init();
     global.log('AppletManager.init() started in %d ms'.format(new Date().getTime() - startTime));
 

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -451,6 +451,8 @@ function start() {
     _nWorkspacesChanged();
 
     startTime = new Date().getTime();
+    imports.searchPath.unshift(global.datadir);
+    imports.searchPath.unshift(global.userdatadir);
     AppletManager.init();
     global.log('AppletManager.init() started in %d ms'.format(new Date().getTime() - startTime));
 


### PR DESCRIPTION
This replaces the usage of ```imports.addSubImporter``` with ```imports.searchPath```. In main, both the global and local Cinnamon data directories are added to the search path. This allows us to import those xlet directories directly, e.g. ```imports.applets```. This is then aliased to each xlet's UUID property on the importObject object in extension.js, instead of the old import object the CJS patch provided.

The good part is we can remove this extra functionality from CJS and move a little closer towards upstream GJS. ~~The bad part is, and why this is a work in progress, is it breaks the ```imports.applet``` import object~~. The majority of xlets on Spices import files through appletManager, which should behave like normal.

Edit: I will be updating all Spices that break because of this PR. Spices maintainers can do it too if they would like to preempt the change. 

Applets:
```imports.ui.appletManager.applets[UUID]```

Desklets:
```imports.ui.deskletManager.desklets[UUID]```

Extensions:
```imports.ui.extensionSystem.extensions[UUID]```

This PR also includes an [example change](https://github.com/jaszhix/Cinnamon/blob/57776fbc2124728af432c4c9da7f921c896cb8af/files/usr/share/cinnamon/applets/calendar%40cinnamon.org/applet.js#L11) that is shorter to type, but is _not_ intended for applets that are not multi-version, as it will break xlets on older versions of Cinnamon.