### PR TITLE
st-entry.c: make it recognise ctrl-C, X, V in the same way as ctrl-c,x,v

### DIFF
--- a/src/st/st-entry.c
+++ b/src/st/st-entry.c
@@ -748,7 +748,7 @@ st_entry_key_press_event (ClutterActor    *actor,
 
   /* paste */
   if ((event->modifier_state & CLUTTER_CONTROL_MASK)
-      && event->keyval == CLUTTER_v)
+      && (event->keyval == CLUTTER_v || event->keyval == CLUTTER_V))
     {
       StClipboard *clipboard;
 
@@ -761,7 +761,7 @@ st_entry_key_press_event (ClutterActor    *actor,
 
   /* copy */
   if ((event->modifier_state & CLUTTER_CONTROL_MASK)
-      && event->keyval == CLUTTER_c)
+      && (event->keyval == CLUTTER_c || event->keyval == CLUTTER_C))
     {
       StClipboard *clipboard;
       gchar *text;
@@ -779,7 +779,7 @@ st_entry_key_press_event (ClutterActor    *actor,
 
   /* cut */
   if ((event->modifier_state & CLUTTER_CONTROL_MASK)
-      && event->keyval == CLUTTER_x)
+      && (event->keyval == CLUTTER_x || event->keyval == CLUTTER_X))
     {
       StClipboard *clipboard;
       gchar *text;


### PR DESCRIPTION
adapted from https://github.com/GNOME/gnome-shell/commit/387f5143f02f720b4d084aa4fca65e2ff31176b0#diff-b948bb195b709c61ce7275142a2fbdfd