### PR TITLE
st-entry.c: Fix spacing on right icon in entry

### DIFF
--- a/src/st/st-entry.c
+++ b/src/st/st-entry.c
@@ -443,7 +443,7 @@ st_entry_allocate (ClutterActor          *actor,
                               flags);
 
       /* reduce the size for the entry */
-      child_box.x2 -= icon_w - priv->spacing;
+      child_box.x2 -= icon_w + priv->spacing;
     }
 
   clutter_actor_get_preferred_height (priv->entry, child_box.x2 - child_box.x1,


### PR DESCRIPTION
https://github.com/GNOME/gnome-shell/commit/954d262d674f597a35a4b4342a6d4fc41dc8ff43#diff-b948bb195b709c61ce7275142a2fbdfd