### PR TITLE
Performance: Do not write valid settings files again to the disk

### DIFF
--- a/js/ui/settings.js
+++ b/js/ui/settings.js
@@ -625,12 +625,14 @@ XletSettingsBase.prototype = {
                 let templateData = Cinnamon.get_file_contents_utf8_sync(templateFile.get_path());
                 let checksum = global.get_md5_for_string(templateData);
 
-                try {
-                    if (checksum != this.settingsData.__md5__) this._doUpgrade(templateData, checksum);
-                    this._saveToFile();
-                } catch(e) {
-                    if (e) global.logError(e);
-                    global.logWarning("upgrade failed for " + this.uuid + ": falling back to previous settings");
+                if (checksum != this.settingsData.__md5__) {
+                    try {
+                        this._doUpgrade(templateData, checksum);
+                        this._saveToFile();
+                    } catch(e) {
+                        if (e) global.logError(e);
+                        global.logWarning("upgrade failed for " + this.uuid + ": falling back to previous settings");
+                    }
                 }
             }
             // if settings-schema.json is missing, we can still load the settings from data, so we


### PR DESCRIPTION
With some naive benchmarks, I got following results with my configuration: (average of 20 hot-starts each)

type     | uuid                                |    before |    after |
---------|-------------------------------------|--------|--------|
applet   | `calendar@cinnamon.org`             |   65.8 |   14.8 |
applet   | `menu@cinnamon.org`                 |  328.1 |  254.2 |
applet   | `network@cinnamon.org`              |   67.9 |   48.1 |
applet   | `notifications@cinnamon.org`        |   58.3 |   10.1 |
applet   | `panel-launchers@cinnamon.org`      |  112.3 |   43.6 |
applet   | `recent@cinnamon.org`               |   31.3 |   24.1 |
applet   | `removable-drives@cinnamon.org`     |    9.5 |    7.1 |
applet   | `show-hide-applets@mohammad-sn`     |   55.0 |    9.7 |
applet   | `sound@cinnamon.org`                |   94.3 |   32.1 |
applet   | `system-monitor@pixunil`            |  188.4 |  108.0 |
applet   | `systray@cinnamon.org`              |   11.3 |    7.2 |
applet   | `window-list@cinnamon.org`          |   50.5 |    9.3 |
applet   | `windows-quick-list@cinnamon.org`   |    7.0 |    5.8 |
TOTAL    | cinnamon                            | 1338.5 |  828.2 |

_Note_: The fastest run from "before" was on par with the fastest "after" run. I assume that people with a modern SSD or very fast disks won't see a difference