### PR TITLE
spices about dialog: clearify what the date means ...

### DIFF
--- a/js/ui/modalDialog.js
+++ b/js/ui/modalDialog.js
@@ -486,18 +486,17 @@ SpicesAboutDialog.prototype = {
         if ('last-edited' in metadata) {
             let lastEditedTimestamp = metadata['last-edited'];
             let date = new Date(lastEditedTimestamp*1000);
-            let dateUTC = date.toISOString().
-                replace(/T/, ' ').      // replace T with a space
-                replace(/\..+/, ' UTC') // delete the dot and everything after; set UTC label
+            let dateUTC = date.toISOString().replace(/T/, ' ');               // replace T with a space;
+            dateUTC = dateUTC.substring(0,dateUTC.lastIndexOf(':')) + ' UTC'; // remove seconds and append UTC label
 
-            let lastEdited = new St.Label({text: dateUTC, style_class: "about-uuid"});
+            let lastEdited = new St.Label({text: _("Build date:") + " " + dateUTC, style_class: "about-uuid"});
             topTextBox.add_actor(lastEdited);
-        } else {
-            //version
-            if (metadata.version) {
-                let version = new St.Label({text: "v%s".format(metadata.version), style_class: "about-uuid"});
-                topTextBox.add_actor(version);
-            }
+        }
+
+        //version
+        if (metadata.version) {
+            let version = new St.Label({text: _("Version:") + " " + "%s".format(metadata.version), style_class: "about-uuid"});
+            topTextBox.add_actor(version);
         }
 
         //description


### PR DESCRIPTION
...and show version again, for devs who want to use their own version control system

nightly builds usually show versions and build date, so why not for spices too?

... and remove seconds, because the spices are updated ONCE every 5 minutes, therefore the seconds are unnecessary