### PR TITLE
[RFC][WIP] Peek panels for 1.5 seconds while highlighted when hidden

### DIFF
--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -3015,66 +3015,74 @@ Panel.prototype = {
      * position of mouse/active window. It then calls the _queueShowHidePanel
      * function to show or hide the panel as necessary.
      *
-     * false = autohide, true = always show, intel = Intelligent
+     * "false" = always show, "true" = autohide, "intel" = Intelligent
      */
     _updatePanelVisibility: function() {
+        // default for always-show or undefined states
+        let shouldShow = true;
 
-        switch (this._autohideSettings) {
-            case "false":
-                this._shouldShow = true;
-                break;
-            case "true":
-                this._shouldShow = this._mouseEntered;
-                break;
-            default:
-                if (this._mouseEntered || !global.display.focus_window ||
-                    global.display.focus_window.get_window_type() == Meta.WindowType.DESKTOP) {
-                    this._shouldShow = true;
-                    break;
-                }
+        if (!this._panelEditMode) {
+            let setting = this._autohideSettings
+            if (setting === "false")
+                shouldShow = true;
+            else if (setting === "true")
+                shouldShow = this._mouseEntered;
+            else if (setting === "intel")
+                shouldShow = this._checkIntelAutoHide();
+        }
 
-                if (global.display.focus_window.get_monitor() != this.monitorIndex) {
-                    this._shouldShow = false;
-                    break;
-                }
-                let x, y;
-
-                /* Calculate the x or y instead of getting it from the actor since the
-                 * actor might be hidden*/
-                switch (this.panelPosition) {
-                    case PanelLoc.top:
-                        y = this.monitor.y;
-                        break;
-                    case PanelLoc.bottom:
-                        y = this.monitor.y + this.monitor.height - this.actor.height;
-                        break;
-                    case PanelLoc.left:
-                        x = this.monitor.x;
-                        break;
-                    case PanelLoc.right:
-                        x = this.monitor.x + this.monitor.width - this.actor.width;
-                        break;
-                    default:
-                        global.log("updatePanelVisibility - unrecognised panel position "+this.panelPosition);
-                }
-
-                let a = this.actor;
-                let b = global.display.focus_window.get_compositor_private();
-                /* Magic to check whether the panel position overlaps with the
-                 * current focused window */
-                if (this.panelPosition == PanelLoc.top || this.panelPosition == PanelLoc.bottom) {
-                    this._shouldShow = !(Math.max(a.x, b.x) < Math.min(a.x + a.width, b.x + b.width) &&
-                                         Math.max(y, b.y) < Math.min(y + a.height, b.y + b.height));
-                } else {
-                    this._shouldShow = !(Math.max(x, b.x) < Math.min(x + a.width, b.x + b.width) &&
-                                         Math.max(a.y, b.y) < Math.min(a.y + a.height, b.y + b.height));
-                }
-
-        } // end of switch on autohidesettings
-
-        if (this._panelEditMode)
-            this._shouldShow = true;
+        this._shouldShow = shouldShow;
         this._queueShowHidePanel();
+    },
+
+    _checkIntelAutoHide: function() {
+        // default to showing
+        let shouldShow = true;
+
+        if (this._mouseEntered
+            || !global.display.focus_window
+            || global.display.focus_window.get_window_type() == Meta.WindowType.DESKTOP)
+            shouldShow = true;
+
+        else if (global.display.focus_window.get_monitor() != this.monitorIndex)
+            shouldShow = false;
+
+        else {
+            let x, y;
+
+            /* Calculate the x or y instead of getting it from the actor since the
+             * actor might be hidden*/
+            switch (this.panelPosition) {
+                case PanelLoc.top:
+                    y = this.monitor.y;
+                    break;
+                case PanelLoc.bottom:
+                    y = this.monitor.y + this.monitor.height - this.actor.height;
+                    break;
+                case PanelLoc.left:
+                    x = this.monitor.x;
+                    break;
+                case PanelLoc.right:
+                    x = this.monitor.x + this.monitor.width - this.actor.width;
+                    break;
+                default:
+                    global.log("updatePanelVisibility - unrecognised panel position "+this.panelPosition);
+            }
+
+            let a = this.actor;
+            let b = global.display.focus_window.get_compositor_private();
+            /* Magic to check whether the panel position overlaps with the
+             * current focused window */
+            if (this.panelPosition == PanelLoc.top || this.panelPosition == PanelLoc.bottom) {
+                shouldShow = !(Math.max(a.x, b.x) < Math.min(a.x + a.width, b.x + b.width) &&
+                               Math.max(y, b.y) < Math.min(y + a.height, b.y + b.height));
+            } else {
+                shouldShow = !(Math.max(x, b.x) < Math.min(x + a.width, b.x + b.width) &&
+                               Math.max(a.y, b.y) < Math.min(a.y + a.height, b.y + b.height));
+            }
+        }
+
+        return shouldShow;
     },
 
     /**


### PR DESCRIPTION
This helps to bring attention to the panel since the highlighted state is not easily noticeable without this. Before my _moveResizePanel refactor a while back, the panel would be immediately moved into showing state on style change (not intended). This restores that behavior for the highlight style change, except does it with a smooth animate in/out.

This likely has merge conflicts with other open PRs. I will rebase as needed.