### PR TITLE
A Logo in System Info that goes on top of the System Info Text

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
@@ -149,18 +149,23 @@ class Module:
 
             page = SettingsPage()
             self.sidePage.add_widget(page)
+	    settings = page.add_section(_("System info"))
+	    #if os.path.exists('/usr/share/linuxmint/logo.png'): (Other Method)
+	    try:
+	        widget = SettingsWidget()
+	        widget.set_spacing(40)
+		image = Gtk.Image()
+		image.set_from_icon_name("distributor-logo", 48) #I don't know why it spams invalid icon size warnings, at least they don't cause exceptions though
+	        widget.pack_start(image, True, False, 0)
+	        widget.pack_end(image, True, False, 0)
+	        settings.add_row(widget)
+	    except: #If you want the other method, just use this code in place of the above code from 'Image =', downwards
+                image = Gtk.Image()
+	        image.set_from_file("/usr/share/linuxmint/logo.png")
+	        widget.pack_start(image, True, False, 0)
+	        widget.pack_end(image, True, False, 0)
+	        settings.add_row(widget)
 
-            settings = page.add_section(_("System info"))
-
-            if os.path.exists('/usr/share/linuxmint/logo.png'): #Be sure to change the other path below, if you don't want to risk exceptions
-	            widget = SettingsWidget()
-	            widget.set_spacing(40)
-	            image = Gtk.Image()
-	            image.set_from_file("/usr/share/linuxmint/logo.png")
-	            widget.pack_start(image, True, False, 0)
-	            widget.pack_end(image, True, False, 0)
-	            settings.add_row(widget)
-            
             for (key, value) in infos:
                 widget = SettingsWidget()
                 widget.set_spacing(40)

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
@@ -147,8 +147,8 @@ class Module:
 
             infos = createSystemInfos()
 
-            page = SettingsPage()
-            self.sidePage.add_widget(page)
+             page = SettingsPage()
+             self.sidePage.add_widget(page)
 	    settings = page.add_section(_("System info"))
 	    #if os.path.exists('/usr/share/linuxmint/logo.png'): (Other Method)
 	    try:
@@ -160,29 +160,26 @@ class Module:
 	        widget.pack_end(image, True, False, 0)
 	        settings.add_row(widget)
 	    except: #If you want the other method, just use this code in place of the above code from 'Image =', downwards
-                image = Gtk.Image()
+            settings = page.add_section(_("System info"))
+            #if os.path.exists('/usr/share/linuxmint/logo.png'): (Other Method)
+            try:
+                widget = SettingsWidget()
+                widget.set_spacing(40)
+                 image = Gtk.Image()
 	        image.set_from_file("/usr/share/linuxmint/logo.png")
 	        widget.pack_start(image, True, False, 0)
 	        widget.pack_end(image, True, False, 0)
 	        settings.add_row(widget)
-
-            for (key, value) in infos:
-                widget = SettingsWidget()
-                widget.set_spacing(40)
-                labelKey = Gtk.Label.new(key)
-                widget.pack_start(labelKey, False, False, 0)
-                labelKey.get_style_context().add_class("dim-label")
-                labelValue = Gtk.Label.new(value)
-                widget.pack_end(labelValue, False, False, 0)
+                image.set_from_icon_name("distributor-logo", 6) #I don't know why it spams invalid icon size warnings, at least they don't cause exceptions though
+                widget.pack_start(image, True, False, 0)
+                widget.pack_end(image, True, False, 0)
                 settings.add_row(widget)
-
-            if os.path.exists("/usr/bin/upload-system-info"):
-                widget = SettingsWidget()
-                button = Gtk.Button(_("Upload system information"))
-                button.set_tooltip_text(_("No personal information included"))
-                button.connect("clicked", self.on_button_clicked)
-                widget.pack_start(button, True, True, 0)
+            except: #If you want the other method, just use this code in place of the above code from 'Image =', downwards
+                image = Gtk.Image()
+                image.set_from_file("/usr/share/linuxmint/logo.png")
+                widget.pack_start(image, True, False, 0)
+                widget.pack_end(image, True, False, 0)
                 settings.add_row(widget)
-
-    def on_button_clicked(self, button):
-        subprocess.Popen(["upload-system-info"])
+ 
+             for (key, value) in infos:
+                 widget = SettingsWidget()

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
@@ -152,6 +152,15 @@ class Module:
 
             settings = page.add_section(_("System info"))
 
+            if os.path.exists('/usr/share/linuxmint/logo.png'): #Be sure to change the other path below, if you don't want to risk exceptions
+	            widget = SettingsWidget()
+	            widget.set_spacing(40)
+	            image = Gtk.Image()
+	            image.set_from_file("/usr/share/linuxmint/logo.png")
+	            widget.pack_start(image, True, False, 0)
+	            widget.pack_end(image, True, False, 0)
+	            settings.add_row(widget)
+            
             for (key, value) in infos:
                 widget = SettingsWidget()
                 widget.set_spacing(40)

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
@@ -155,7 +155,7 @@ class Module:
 	        widget = SettingsWidget()
 	        widget.set_spacing(40)
 		image = Gtk.Image()
-		image.set_from_icon_name("distributor-logo", 48) #I don't know why it spams invalid icon size warnings, at least they don't cause exceptions though
+		image.set_from_icon_name("distributor-logo", 6) #I don't know why it spams invalid icon size warnings, at least they don't cause exceptions though
 	        widget.pack_start(image, True, False, 0)
 	        widget.pack_end(image, True, False, 0)
 	        settings.add_row(widget)


### PR DESCRIPTION
I recently managed to implement this in feren OS, and thought it'd be a nice little idea to put upstream. It needs a bit of work to it (for example, it would be better having a bigger image for the logo), but the fundamentals for making it work and appear nicely, and also work nicely when the file doesn't exist, work just fine and are included.

Ideas for how this could be used:
1. Replacement for the 'Operating System: X' section
2. OEM Logo Placeholder for the OEM to place their Logo in when applicable

Preview of how it looks in feren OS: https://media.discordapp.net/attachments/294920830280925184/348502833982865418/Screenshot_from_2017-08-19_17-25-36.png