### PR TITLE
Added missed gettext and xdg-utils to cinnamon-common deps

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -135,7 +135,10 @@ Package: cinnamon-common
 Replaces: cinnamon (<< ${cinnamon:Version})
 Breaks: cinnamon (<< ${cinnamon:Version})
 Architecture: all
-Depends: ${misc:Depends}, python
+Depends: gettext,
+         python,
+         xdg-utils,
+         ${misc:Depends}
 Description: Cinnamon desktop (Common data files)
  Cinnamon is a modern Linux desktop which provides advanced innovative
  features and a traditional user experience. It's easy to use, powerful


### PR DESCRIPTION
As reported by some users and with a fast search in cinnamon-common
files gettext and xdg-utils are required but missed.