### PR TITLE
Use pkexec instead deprecated gksu for cinnamon-settings-users

### DIFF
--- a/files/usr/bin/cinnamon-settings-users
+++ b/files/usr/bin/cinnamon-settings-users
@@ -5,4 +5,4 @@
 
 import os
 
-os.system("gksu /usr/share/cinnamon/cinnamon-settings-users/cinnamon-settings-users.py")
+os.system("pkexec /usr/share/cinnamon/cinnamon-settings-users/cinnamon-settings-users.py")


### PR DESCRIPTION
Policy settings about cinnamon-settings-users is already present, use
policykit instead deprecated gksu for cinnamon-settings-users works
correctly and is already used in fedora package.