### PR TITLE
Improve the way cinnamon handles applets that are added to an unsupported panel

### DIFF
--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -192,6 +192,7 @@ Applet.prototype = {
                                 // This value is set by Cinnamon when loading/listening_to gsettings.
         this._newOrder = null;      //  Used when moving an applet
         this._panelLocation = null;     // Backlink to the panel location our applet is in, set by Cinnamon.
+        this._newPanelId = null;  //  Used when moving an applet
         this._newPanelLocation = null;  //  Used when moving an applet
         this._applet_enabled = true;    // Whether the applet is enabled or not (if not it hides in the panel as if it wasn't there)
         this._orientation = orientation;  // orientation of the panel the applet is on  St.Side.TOP BOTTOM LEFT RIGHT

--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -441,52 +441,28 @@ function _removeAppletFromPanel(uuid, applet_id) {
 }
 
 function saveAppletsPositions() {
-    let zones_strings = ["left", "center", "right"];
-    let allApplets = new Array();
-    for (var i in Main.panelManager.panels){
-        let panel = Main.panelManager.panels[i];
-        if (!panel) continue;
-        for (var j in zones_strings){
-            let zone_string = zones_strings[j];
-            let zone = panel["_"+zone_string+"Box"];
-            let children = zone.get_children();
-            for (var k in children) if (children[k]._applet) allApplets.push(children[k]._applet);
-        }
-    }
-    let applets = new Array();
-    for (var i in Main.panelManager.panels){
-        let panel = Main.panelManager.panels[i];
-        if (!panel)
-            continue;
+    let enabled = global.settings.get_strv('enabled-applets');
+    let newEnabled = [];
 
-        let panel_string = "panel" + i;
-
-        for (var j in zones_strings){
-            let zone_string = zones_strings[j];
-            let zone = panel["_"+zone_string+"Box"];
-            for (var k in allApplets){
-                let applet = allApplets[k];
-                let appletZone;
-                if (applet._newPanelLocation != null)
-                    appletZone = applet._newPanelLocation;
-                else
-                    appletZone = applet._panelLocation;
-                let appletOrder;
-                if (applet._newOrder != null)
-                    appletOrder = applet._newOrder;
-                else
-                    appletOrder = applet._order;
-
-                if (appletZone == zone)
-                    applets.push(panel_string+":"+zone_string+":"+appletOrder+":"+applet._uuid+":"+applet.instance_id);
+    for (let i = 0; i < enabled.length; i++) {
+        let info = enabled[i].split(':');
+        let applet = appletObj[info[4]];
+        if (applet._newOrder !== null) {
+            if (applet._newPanelId !== null) {
+                info[0] = 'panel' + applet._newPanelId;
+                info[1] = applet._zoneString;
+                applet._newPanelId = null;
             }
+            info[2] = applet._newOrder;
+            applet._newOrder = null;
+            newEnabled.push(info.join(':'));
+        }
+        else {
+            newEnabled.push(enabled[i]);
         }
     }
-    for (var i in allApplets){
-        allApplets[i]._newPanelLocation = null;
-        allApplets[i]._newOrder = null;
-    }
-    global.settings.set_strv('enabled-applets', applets);
+
+    global.settings.set_strv('enabled-applets', newEnabled);
 }
 
 function updateAppletPanelHeights(force_recalc) {

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -1616,14 +1616,16 @@ PanelContextMenu.prototype = {
     }
 }
 
-function PanelZoneDNDHandler(panelZone){
-    this._init(panelZone);
+function PanelZoneDNDHandler(panelZone, zoneString, panelId){
+    this._init(panelZone, zoneString, panelId);
 }
 
 PanelZoneDNDHandler.prototype = {
-    _init : function(panelZone) {
+    _init : function(panelZone, zoneString, panelId) {
         this._panelZone = panelZone;
         this._panelZone._delegate = this;
+        this._zoneString = zoneString;
+        this._panelId = panelId;
         this._dragPlaceholder = null;
         this._dragPlaceholderPos = -1;
     },
@@ -1720,6 +1722,8 @@ PanelZoneDNDHandler.prototype = {
         }
         source.actor._applet._newOrder = insertAppletPos;
         source.actor._applet._newPanelLocation = this._panelZone;
+        source.actor._applet._zoneString = this._zoneString;
+        source.actor._applet._newPanelId = this._panelId;
 
         this._clearDragPlaceholder();
         actor.destroy();
@@ -1826,9 +1830,9 @@ Panel.prototype = {
         this.actor.add_actor(this._centerBox);
         this.actor.add_actor(this._rightBox);
 
-        this._leftBoxDNDHandler   = new PanelZoneDNDHandler(this._leftBox);
-        this._centerBoxDNDHandler = new PanelZoneDNDHandler(this._centerBox);
-        this._rightBoxDNDHandler  = new PanelZoneDNDHandler(this._rightBox);
+        this._leftBoxDNDHandler   = new PanelZoneDNDHandler(this._leftBox, 'left', this.panelId);
+        this._centerBoxDNDHandler = new PanelZoneDNDHandler(this._centerBox, 'center', this.panelId);
+        this._rightBoxDNDHandler  = new PanelZoneDNDHandler(this._rightBox, 'right', this.panelId);
 
         this.drawCorners(drawcorner);
 


### PR DESCRIPTION
Previously, Cinnamon would send a message to cinnamon-settings saying there was an error.
With this change, the user is now prompted with the following options:
1. Leave the applet on the panel anyway (some applets are still suitable for vertical panels under certain circumstances - even if they aren't marked as such). In this case an override is added to the applet definition to avoid the user being prompted in the future.
2. Remove the applet.
3. Try to move the applet to a different panel. If a suitable panel cannot be found, the applet is removed instead.

The first commit also rewrites the way applet positions are saved after a dnd operation so as to avoid the override being overwritten by a dnd operation. (note: the override is stored as another entry in the applet definition, and is implemented in such a way that other overrides can also be added - such as version control)

Due to the buggy nature of applet dnd,  https://github.com/linuxmint/Cinnamon/pull/6828 is recommended as well to avoid potential errors.