### PR TITLE
cinnamon-app.c: Don't crash when trying to dispose

### DIFF
--- a/src/cinnamon-app.c
+++ b/src/cinnamon-app.c
@@ -1477,11 +1477,8 @@ cinnamon_app_dispose (GObject *object)
       app->entry = NULL;
     }
 
-  if (app->running_state)
-    {
-      while (app->running_state->windows)
-        _cinnamon_app_remove_window (app, app->running_state->windows->data);
-    }
+  while (app->running_state)
+    _cinnamon_app_remove_window (app, app->running_state->windows->data);
 
   g_clear_pointer (&app->keywords, g_free);
 


### PR DESCRIPTION
https://github.com/GNOME/gnome-shell/commit/36c69124f749c48f583e8ff2413d27e10d1229e0

Spotted while browsing gnome commits. The original cause appears pretty obscure. 