### PR TITLE
extension.js: Fix ReloadExtension error in forgetExtension

### DIFF
--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -510,15 +510,18 @@ function unloadExtension(uuid, type, deleteConfig = true) {
 }
 
 function forgetExtension(uuid, type, forgetMeta) {
-    if (type.maps.objects.hasOwnProperty(uuid) &&
-        imports[type.maps.objects[uuid].lowerType + 's'].hasOwnProperty(uuid))
-        delete imports[type.maps.objects[uuid].lowerType + 's'][uuid];
-    if (type.maps.importObjects.hasOwnProperty(uuid))
+    if (typeof type.maps.importObjects[uuid] !== 'undefined') {
         delete type.maps.importObjects[uuid];
-    if (type.maps.objects.hasOwnProperty(uuid))
+    }
+    if (typeof type.maps.objects[uuid] !== 'undefined') {
+        if (typeof imports[type.maps.objects[uuid].lowerType + 's'][uuid] !== 'undefined') {
+            delete imports[type.maps.objects[uuid].lowerType + 's'][uuid];
+        }
         delete type.maps.objects[uuid];
-    if (forgetMeta && type.maps.meta.hasOwnProperty(uuid))
+    }
+    if (forgetMeta && typeof type.maps.meta[uuid] !== 'undefined') {
         delete type.maps.meta[uuid];
+    }
 }
 
 /**


### PR DESCRIPTION
Corrects the following error when reloading an xlet:

```
(cinnamon:29502): Cjs-WARNING **: JS ERROR: Exception in method call: ReloadExtension: ImportError: No JS module 'hasOwnProperty' found in search path
forgetExtension@/usr/share/cinnamon/js/ui/extension.js:514:1
unloadExtension@/usr/share/cinnamon/js/ui/extension.js:508:9
reloadExtension@/usr/share/cinnamon/js/ui/extension.js:536:9
Melange.prototype.ReloadExtension@/usr/share/cinnamon/js/ui/lookingGlass.js:639:9
_handleMethodCall@resource:///org/cinnamon/cjs/modules/overrides/Gio.js:261:22
_wrapJSObject/<@resource:///org/cinnamon/cjs/modules/overrides/Gio.js:331:16
```