### PR TITLE
panel.js: check if the panel corner has a parent

### DIFF
--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -1466,8 +1466,10 @@ PanelCorner.prototype = {
         // ugly hack: force the panel to reset its clip region since we just added
         // to the total allocation after it has already clipped to its own
         // allocation
-        let panel = this._box.get_parent()._delegate;
-        panel._setClipRegion(panel._hidden);
+        let panel = this._box.get_parent();
+        // for some reason style-changed is called on destroy
+        if (panel && panel._delegate)
+            panel._delegate._setClipRegion(panel._delegate._hidden);
     }
 }; // end of panel corner
 


### PR DESCRIPTION
Prevents this error when the panel is removed. I didn't expect the style-changed signal to be emitted on destroy...

(cinnamon:29644): Cjs-WARNING **: JS ERROR: TypeError: this._box.get_parent(...) is null
PanelCorner.prototype._styleChanged@/usr/share/cinnamon/js/ui/panel.js:1469:21
Panel.prototype._destroycorners@/usr/share/cinnamon/js/ui/panel.js:1965:9
Panel.prototype.destroy@/usr/share/cinnamon/js/ui/panel.js:2083:9
PanelManager.prototype._onPanelsEnabledChanged@/usr/share/cinnamon/js/ui/panel.js:802:17
check_key_and_set@/usr/share/cinnamon/js/ui/overrides.js:46:16
overrideGio/Gio.Settings.prototype.set_strv@/usr/share/cinnamon/js/ui/overrides.js:88:71
PanelManager.prototype.removePanel@/usr/share/cinnamon/js/ui/panel.js:464:9
populateSettingsMenu/menuItem.activate<@/usr/share/cinnamon/js/ui/panel.js:1519:9
PopupBaseMenuItem.prototype._onButtonReleaseEvent@/usr/share/cinnamon/js/ui/popupMenu.js:151:9