### PR TITLE
dnd, appletManager: Fix applet DND on mozjs52

### DIFF
--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -541,6 +541,9 @@ function saveAppletsPositions() {
     for (let i = 0; i < enabled.length; i++) {
         let info = enabled[i].split(':');
         let applet = appletObj[info[4]];
+        if (!applet) {
+            continue;
+        }
         if (applet._newOrder !== null) {
             if (applet._newPanelId !== null) {
                 info[0] = 'panel' + applet._newPanelId;

--- a/js/ui/dnd.js
+++ b/js/ui/dnd.js
@@ -384,10 +384,15 @@ const _Draggable = new Lang.Class({
             }
         }
 
-        if (this.target)
+        if (this.target) {
             target = this.target;
-        else
-            target = this._dragActor.get_stage().get_actor_at_pos(Clutter.PickMode.ALL, x, y);
+        } else {
+            let stage = this._dragActor.get_stage();
+            if (!stage) {
+                return;
+            }
+            target = stage.get_actor_at_pos(Clutter.PickMode.ALL, x, y);
+        }
 
         let dragEvent = {
             x: this._dragX,


### PR DESCRIPTION
Fixes the following errors on GJS 1.49/mozjs52, and regression tested on CJS 3.4.4/mozjs38.

```
(cinnamon:3425): Gjs-WARNING **: JS ERROR: TypeError: applet is undefined
saveAppletsPositions@/usr/share/cinnamon/js/ui/appletManager.js:544:1
PanelZoneDNDHandler.prototype.acceptDrop@/usr/share/cinnamon/js/ui/panel.js:1762:9
_Draggable<._dragActorDropped@/usr/share/cinnamon/js/ui/dnd.js:502:21
wrapper@resource:///org/gnome/gjs/modules/_legacy.js:82:22
_Draggable<._onEvent@/usr/share/cinnamon/js/ui/dnd.js:188:24
wrapper@resource:///org/gnome/gjs/modules/_legacy.js:82:22
_getEventHandlerActor/<@/usr/share/cinnamon/js/ui/dnd.js:56:46


(cinnamon:3425): Gjs-WARNING **: JS ERROR: TypeError: this._dragActor.get_stage(...) is null
_Draggable<._dragActorDropped@/usr/share/cinnamon/js/ui/dnd.js:471:22
wrapper@resource:///org/gnome/gjs/modules/_legacy.js:82:22
_Draggable<._onEvent@/usr/share/cinnamon/js/ui/dnd.js:188:24
wrapper@resource:///org/gnome/gjs/modules/_legacy.js:82:22
_getEventHandlerActor/<@/usr/share/cinnamon/js/ui/dnd.js:56:46


(cinnamon:3425): Gjs-WARNING **: JS ERROR: TypeError: this._dragActor.get_stage(...) is null
_Draggable<._updateDragHover@/usr/share/cinnamon/js/ui/dnd.js:390:22
wrapper@resource:///org/gnome/gjs/modules/_legacy.js:82:22
```