### PR TITLE
Refactor the extension system and add commonjs compatible module importation

### DIFF
--- a/docs/reference/cinnamon-tutorials/importer.xml
+++ b/docs/reference/cinnamon-tutorials/importer.xml
@@ -176,31 +176,49 @@
       </para>
     </para>
     <para>
-      In Cinnamon 3.6+, you can also import xlets by using <code>imports.xletTypePluralized[UUID]</code>. This method is not compatible with previous versions of Cinnamon.
+      In Cinnamon 3.6+, there is now a simpler way to import files using <code>require</code>. This method is not compatible with previous versions of Cinnamon.
 
       <para>
-        Importing for applets:
+        Importing GI modules:
         <informalexample>
           <programlisting>
-            const Module = imports.applets['foo@bar'].module;
+            const Cinnamon = require('gi.Cinnamon');
           </programlisting>
         </informalexample>
       </para>
 
       <para>
-        Importing for desklets:
+        Importing Cinnamon modules:
         <informalexample>
           <programlisting>
-            const Module = imports.desklets['foo@bar'].module;
+            const DND = require('ui.dnd');
           </programlisting>
         </informalexample>
       </para>
 
       <para>
-        Importing for extensions:
+        Importing other JS files (".js" extension is optional):
         <informalexample>
           <programlisting>
-            const Module = imports.extensions['foo@bar'].module;
+            const MenuItem = require('./menuItem.js').MenuItem;
+          </programlisting>
+        </informalexample>
+      </para>
+
+      <para>
+        You can also manually export your modules by adding them to <code>module.exports</code> at the end of the file.
+        Inside your module file:
+        <informalexample>
+          <programlisting>
+            function MenuItem() {...}
+            ...
+            module.exports = MenuItem;
+          </programlisting>
+        </informalexample>
+        Then from the file you want import MenuItem from:
+        <informalexample>
+          <programlisting>
+            const MenuItem = require('./menuItem');
           </programlisting>
         </informalexample>
       </para>

--- a/js/misc/fileUtils.js
+++ b/js/misc/fileUtils.js
@@ -102,7 +102,18 @@ function findModuleIndex(path) {
 }
 
 function getModuleByIndex(index) {
+    if (!LoadedModules[index]) {
+        return;
+    }
     return LoadedModules[index].module;
+}
+
+function unloadModule(index) {
+    if (!LoadedModules[index]) {
+        return;
+    }
+    LoadedModules[index] = undefined;
+    LoadedModules.splice(index, 1);
 }
 
 function createExports(path, dir, file, size, JS, returnIndex) {
@@ -126,7 +137,7 @@ function createExports(path, dir, file, size, JS, returnIndex) {
         // Module already exists, check if its been updated
         if (size === LoadedModules[moduleIndex].size) {
             // Return the cache
-            return LoadedModules[moduleIndex].exports;
+            return returnIndex ? moduleIndex : LoadedModules[moduleIndex].module;
         }
         // Module has been updated
         LoadedModules[moduleIndex] = importerData;
@@ -172,14 +183,10 @@ function createExports(path, dir, file, size, JS, returnIndex) {
             dir,
             file.get_basename()
         );
-        if (returnIndex) {
-            return moduleIndex;
-        }
-        return importerData.module;
+        return returnIndex ? moduleIndex : importerData.module;
     } catch(e) {
         // Remove the module from the index
-        LoadedModules[moduleIndex] = undefined;
-        LoadedModules.splice(moduleIndex, 1);
+        unloadModule(index);
         throw requireModuleError(path, e);
     }
 }

--- a/js/misc/fileUtils.js
+++ b/js/misc/fileUtils.js
@@ -130,7 +130,7 @@ function getModuleByIndex(index) {
 
 function unloadModule(index) {
     if (!LoadedModules[index]) {
-        throw requireModuleError('<unloadModule>', new Error('Unable to unload module.'));
+        return;
     }
     LoadedModules[index] = undefined;
     LoadedModules.splice(index, 1);

--- a/js/misc/fileUtils.js
+++ b/js/misc/fileUtils.js
@@ -151,7 +151,7 @@ function requireModule(path, dir) {
     } catch(e) {
         // Since constructing functions obscures the path in stack traces, we will put the correct path back.
         e.stack = e.stack.replace(/([^@]*(?=\s)\sFunction)/g, path);
-        global.logError(e.stack)
+        global.logError(`requireModule: Unable to load ${path}`, e);
         return null;
     }
 }

--- a/js/misc/fileUtils.js
+++ b/js/misc/fileUtils.js
@@ -3,7 +3,7 @@
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 
-const importNames = [
+var importNames = [
     'mainloop',
     'jsUnit',
     'format',
@@ -18,17 +18,17 @@ const importNames = [
     'byteArray',
     'cairoNative'
 ];
-const cinnamonImportNames = [
+var cinnamonImportNames = [
     'ui',
     'misc',
     'perf'
 ];
-const giImportNames = imports.gi.GIRepository.Repository
+var giImportNames = imports.gi.GIRepository.Repository
     .get_default()
     .get_loaded_namespaces();
-const LoadedModules = [];
-const FunctionConstructor = Symbol();
-const Symbols = {};
+var LoadedModules = [];
+var FunctionConstructor = Symbol();
+var Symbols = {};
 Symbols[FunctionConstructor] = 0..constructor.constructor;
 
 function listDirAsync(file, callback) {

--- a/js/misc/util.js
+++ b/js/misc/util.js
@@ -363,7 +363,7 @@ function latinise(string){
  * queryCollection:
  * @collection (array): an array of objects to query
  * @query (object): key-value pairs to find in the collection
- * @indexOnly (false): defaults to false, returns only the matching
+ * @indexOnly (boolean): defaults to false, returns only the matching
  * object's index if true.
  *
  * Returns (object|null): the matched object, or null if no object

--- a/js/misc/util.js
+++ b/js/misc/util.js
@@ -358,3 +358,29 @@ function latinise(string){
     }
     return string;
 }
+
+/**
+ * queryCollection:
+ * @collection (array): an array of objects to query
+ * @query (object): key-value pairs to find in the collection
+ * @indexOnly (false): defaults to false, returns only the matching
+ * object's index if true.
+ *
+ * Returns (object|null): the matched object, or null if no object
+ * in the collection matches all conditions of the query.
+ */
+function queryCollection(collection, query, indexOnly = false) {
+    let queryKeys = Object.keys(query);
+    for (let i = 0; i < collection.length; i++) {
+        let matches = 0;
+        for (let z = 0; z < queryKeys.length; z++) {
+            if (collection[i][queryKeys[z]] === query[queryKeys[z]]) {
+                matches += 1;
+            }
+        }
+        if (matches === queryKeys.length) {
+            return indexOnly ? i : collection[i];
+        }
+    }
+    return indexOnly ? -1 : null;
+}

--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -211,7 +211,10 @@ Applet.prototype = {
         try {
             let appletDefinition = AppletManager.getAppletDefinition({applet_id: instance_id});
             if (appletDefinition) {
-                this._scaleMode = Main.panelManager.panels[appletDefinition.panelId].scaleMode;
+                let panelIndex = Main.panelManager.panels.findIndex(function(panel) {
+                    return panel && (panel.panelId === appletDefinition.panelId);
+                });
+                this._scaleMode = Main.panelManager.panels[panelIndex].scaleMode;
             } else {
                 throw new Error();
             }

--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -213,7 +213,9 @@ Applet.prototype = {
                 let panelIndex = Main.panelManager.panels.findIndex(function(panel) {
                     return panel && (panel.panelId === appletDefinition.panelId);
                 });
-                this._scaleMode = Main.panelManager.panels[panelIndex].scaleMode;
+                if (panelIndex > -1) {
+                    this._scaleMode = Main.panelManager.panels[panelIndex].scaleMode;
+                }
             } else {
                 throw new Error();
             }

--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -8,7 +8,6 @@ const Main = imports.ui.main;
 const DND = imports.ui.dnd;
 const Clutter = imports.gi.Clutter;
 const AppletManager = imports.ui.appletManager;
-const Gtk = imports.gi.Gtk;
 const Util = imports.misc.util;
 const Pango = imports.gi.Pango;
 const Mainloop = imports.mainloop;
@@ -17,14 +16,14 @@ const ModalDialog = imports.ui.modalDialog;
 const Signals = imports.signals;
 const Gettext = imports.gettext;
 
-const COLOR_ICON_HEIGHT_FACTOR = .875;  // Panel height factor for normal color icons
-const PANEL_FONT_DEFAULT_HEIGHT = 11.5; // px
-const PANEL_SYMBOLIC_ICON_DEFAULT_HEIGHT = 1.14 * PANEL_FONT_DEFAULT_HEIGHT; // ems conversion
-const DEFAULT_PANEL_HEIGHT = 25;
-const DEFAULT_ICON_HEIGHT = 22;
-const FALLBACK_ICON_HEIGHT = 22;
+var COLOR_ICON_HEIGHT_FACTOR = .875;  // Panel height factor for normal color icons
+var PANEL_FONT_DEFAULT_HEIGHT = 11.5; // px
+var PANEL_SYMBOLIC_ICON_DEFAULT_HEIGHT = 1.14 * PANEL_FONT_DEFAULT_HEIGHT; // ems conversion
+var DEFAULT_PANEL_HEIGHT = 25;
+var DEFAULT_ICON_HEIGHT = 22;
+var FALLBACK_ICON_HEIGHT = 22;
 
-const AllowedLayout = {  // the panel layout that an applet is suitable for
+var AllowedLayout = {  // the panel layout that an applet is suitable for
     VERTICAL: 'vertical',
     HORIZONTAL: 'horizontal',
     BOTH: 'both'

--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -210,7 +210,8 @@ Applet.prototype = {
 
         try {
             if (AppletManager.enabledAppletDefinitions.idMap[instance_id]) {
-                this._scaleMode = AppletManager.enabledAppletDefinitions.idMap[instance_id].panel.scaleMode;
+                let panelId = AppletManager.enabledAppletDefinitions.idMap[instance_id].panelId;
+                this._scaleMode = Main.panelManager.panels[panelId].scaleMode;
             } else {
                 throw new Error();
             }

--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -209,9 +209,9 @@ Applet.prototype = {
         this._draggable.connect('drag-end', Lang.bind(this, this._onDragEnd));
 
         try {
-            if (AppletManager.enabledAppletDefinitions.idMap[instance_id]) {
-                let panelId = AppletManager.enabledAppletDefinitions.idMap[instance_id].panelId;
-                this._scaleMode = Main.panelManager.panels[panelId].scaleMode;
+            let appletDefinition = AppletManager.getAppletDefinition({applet_id: instance_id});
+            if (appletDefinition) {
+                this._scaleMode = Main.panelManager.panels[appletDefinition.panelId].scaleMode;
             } else {
                 throw new Error();
             }

--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -470,7 +470,7 @@ Applet.prototype = {
         if (panel_height && panel_height > 0) {
             this._panelHeight = panel_height;
         }
-        this._scaleMode = AppletManager.enabledAppletDefinitions.idMap[this.instance_id].panel.scaleMode;
+        this._scaleMode = this.panel.scaleMode;
         this.on_panel_height_changed_internal();
     },
 

--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -57,7 +57,8 @@ function unloadRemovedApplets(removedApplets) {
     });
 }
 
-function init(startTime) {
+function init() {
+    let startTime = new Date().getTime();
     try {
         applets = imports.applets;
     } catch (e) {
@@ -72,7 +73,7 @@ function init(startTime) {
     return initEnabledApplets().then(function() {
         appletsLoaded = true;
         global.settings.connect('changed::enabled-applets', onEnabledAppletsChanged);
-        global.log('AppletManager.init() started in %d ms'.format(new Date().getTime() - startTime));
+        global.log(`AppletManager started in ${new Date().getTime() - startTime} ms`);
     });
 }
 

--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -13,8 +13,6 @@ const ModalDialog = imports.ui.modalDialog;
 const {getModuleByIndex} = imports.misc.fileUtils;
 const Gettext = imports.gettext;
 
-// Maps uuid -> metadata object
-let appletMeta;
 // Maps uuid -> importer object (applet directory tree)
 let applets;
 // Maps applet_id -> applet objects
@@ -67,8 +65,7 @@ function unloadRemovedApplets(oldEnabledAppletDefinitions) {
 
 function init() {
     return new Promise(function(resolve) {
-        applets = Extension.Type.APPLET.maps.importObjects;
-        appletMeta = Extension.Type.APPLET.maps.meta;
+        applets = imports.applets;
 
         appletsLoaded = false;
 
@@ -253,8 +250,8 @@ function onEnabledAppletsChanged() {
                 let oldDef = oldEnabledAppletDefinitions.idMap[applet_id];
 
                 if(!oldDef || !appletDefinitionsEqual(newDef, oldDef)) {
-                    let extension = Extension.Type.APPLET.maps.objects[newDef.uuid];
-                    if(extension) {
+                    let extension = Extension.getExtension(newDef.uuid);
+                    if (extension) {
                         addAppletToPanels(extension, newDef);
                     }
                 }
@@ -653,9 +650,8 @@ function loadAppletsOnPanel(panel) {
             definition.panel = panel;
             definition.location = getLocation(panel, definition.location_label);
             definition.orientation = orientation;
-
-            let extension = Extension.Type.APPLET.maps.objects[definition.uuid];
-            if(extension) {
+            let extension = Extension.getExtension(definition.uuid);
+            if (extension) {
                 addAppletToPanels(extension, definition);
             }
         }
@@ -690,7 +686,7 @@ function updateAppletsOnPanel (panel) {
                 } catch (e) {
                     global.logError("Error during setPanelHeight() and setOrientation() call on applet: " + definition.uuid + "/" + applet_id, e);
                 }
-                removeAppletFromInappropriatePanel (Extension.Type.APPLET.maps.objects[definition.uuid], appletObj[applet_id], definition);
+                removeAppletFromInappropriatePanel(getExtension(definition.uuid), appletObj[applet_id], definition);
             }
         }
     }

--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -518,7 +518,8 @@ function createApplet(extension, appletDefinition) {
 
     panel_height = setHeightForPanel(
         Main.panelManager.panels[appletDefinition.panelId],
-        Main.panelManager.panels[appletDefinition.panelId].panelPosition);
+        Main.panelManager.panels[appletDefinition.panelId].panelPosition
+    );
 
     if (appletObj[applet_id] != undefined) {
         global.log(applet_id + ' applet already loaded');

--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -58,7 +58,11 @@ function unloadRemovedApplets(removedApplets) {
 }
 
 function init(startTime) {
-    applets = imports.applets;
+    try {
+        applets = imports.applets;
+    } catch (e) {
+        applets = {};
+    }
     appletMeta = Extension.Type.APPLET.legacyMeta;
     appletsLoaded = false;
 

--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -590,7 +590,8 @@ function updateAppletPanelHeights(force_recalc) {
 
 // Deprecated, kept for compatibility reasons
 function _find_applet(uuid) {
-    return Extension.findExtensionDirectory(uuid, Extension.Type.APPLET);
+    const {userDir, folder} = Extension.Type.APPLET;
+    return Extension.findExtensionDirectory(uuid, userDir, folder);
 }
 
 function get_object_for_instance (appletId) {

--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -15,6 +15,8 @@ const Gettext = imports.gettext;
 
 // Maps uuid -> importer object (applet directory tree)
 let applets;
+// Kept for compatibility
+let appletMeta;
 // Maps applet_id -> applet objects
 const appletObj = [];
 let appletsLoaded = false;
@@ -66,7 +68,7 @@ function unloadRemovedApplets(oldEnabledAppletDefinitions) {
 function init() {
     return new Promise(function(resolve) {
         applets = imports.applets;
-
+        appletMeta = Extension.Type.APPLET.legacyMeta;
         appletsLoaded = false;
 
         // Load all applet extensions, the applets themselves will be added in finishExtensionLoad

--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -65,7 +65,7 @@ function unloadRemovedApplets(oldEnabledAppletDefinitions) {
     });
 }
 
-function init() {
+function init(startTime) {
     return new Promise(function(resolve) {
         applets = imports.applets;
         appletMeta = Extension.Type.APPLET.legacyMeta;
@@ -77,14 +77,16 @@ function init() {
         initEnabledApplets().then(function() {
             appletsLoaded = true;
             global.settings.connect('changed::enabled-applets', onEnabledAppletsChanged);
+            global.log('AppletManager.init() started in %d ms'.format(new Date().getTime() - startTime));
             resolve();
         });
     });
 }
 
 // Callback for extension.js
-function finishExtensionLoad(extension) {
+function finishExtensionLoad(extensionIndex) {
     // Add all applet instances for this extension
+    let extension = Extension.extensions[extensionIndex];
     let definitions = enabledAppletDefinitions.uuidMap[extension.uuid];
     if (definitions) {
         for(let i=0; i<definitions.length; i++) {
@@ -367,7 +369,7 @@ function addAppletToPanels(extension, appletDefinition) {
         return true;
     } catch(e) {
         extension.unlockRole();
-        extension.logError('Failed to load applet: ' + appletDefinition.uuid + "/" + appletDefinition.applet_id, e);
+        Extension.logError('Failed to load applet: ' + appletDefinition.uuid + "/" + appletDefinition.applet_id, e);
         return false;
     }
 }
@@ -532,7 +534,7 @@ function createApplet(extension, appletDefinition) {
     try {
         applet = getModuleByIndex(extension.moduleIndex).main(extension.meta, orientation, panel_height, applet_id);
     } catch (e) {
-        extension.logError('Failed to evaluate \'main\' function on applet: ' + appletDefinition.uuid + "/" + appletDefinition.applet_id, e);
+        Extension.logError('Failed to evaluate \'main\' function on applet: ' + appletDefinition.uuid + "/" + appletDefinition.applet_id, e);
         return null;
     }
 

--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -13,12 +13,12 @@ const {queryCollection} = imports.misc.util;
 const Gettext = imports.gettext;
 
 // Maps uuid -> importer object (applet directory tree)
-let applets;
+var applets;
 // Kept for compatibility
-let appletMeta;
+var appletMeta;
 // Maps applet_id -> applet objects
-const appletObj = [];
-let appletsLoaded = false;
+var appletObj = [];
+var appletsLoaded = false;
 
 // An applet can assume a role
 // Instead of hardcoding looking for a particular applet,
@@ -27,15 +27,15 @@ let appletsLoaded = false;
 // For now, just notifications, but could be expanded.
 // question - should multiple applets be able to fill
 // the same role?
-const Roles = {
+var Roles = {
     NOTIFICATIONS: 'notifications',
     PANEL_LAUNCHER: 'panellauncher'
 };
 
-let rawDefinitions;
-let definitions = [];
-let clipboard = [];
-let promises = [];
+var rawDefinitions;
+var definitions = [];
+var clipboard = [];
+var promises = [];
 
 function initEnabledApplets() {
     for (let i = 0; i < definitions.length; i++) {

--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -3,8 +3,6 @@
 const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
 const St = imports.gi.St;
-const Cinnamon = imports.gi.Cinnamon;
-const Lang = imports.lang;
 
 const Main = imports.ui.main;
 const Applet = imports.ui.applet;
@@ -92,7 +90,8 @@ function finishExtensionLoad(extensionIndex) {
     // Add all applet instances for this extension
     let extension = Extension.extensions[extensionIndex];
     for (let i = 0; i < definitions.length; i++) {
-        if (definitions[i].uuid !== extension.uuid) {
+        if (definitions[i].uuid !== extension.uuid
+            || definitions[i].applet != null) {
             continue;
         }
         if (!addAppletToPanels(extension, definitions[i])) {
@@ -513,9 +512,11 @@ function moveApplet(appletDefinition, allowedLayout) {
 }
 
 function get_role_provider(role) {
-    if (Extension.Type.APPLET.roles[role]
-        && Extension.Type.APPLET.roles[role].roleProvider) {
-        return Extension.Type.APPLET.roles[role].roleProvider;
+    if (Extension.Type.APPLET.roles[role]) {
+        let instances = getRunningInstancesForUuid(Extension.Type.APPLET.roles[role]);
+        if (instances.length > 0) {
+            return instances[0];
+        }
     }
     return null;
 }

--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -10,6 +10,7 @@ const Main = imports.ui.main;
 const Applet = imports.ui.applet;
 const Extension = imports.ui.extension;
 const ModalDialog = imports.ui.modalDialog;
+const FileUtils = imports.misc.fileUtils;
 const Gettext = imports.gettext;
 
 // Maps uuid -> metadata object
@@ -533,7 +534,7 @@ function createApplet(extension, appletDefinition) {
 
     let applet;
     try {
-        applet = extension.module.main(extension.meta, orientation, panel_height, applet_id);
+        applet = FileUtils.LoadedModules[extension.moduleIndex].module.main(extension.meta, orientation, panel_height, applet_id);
     } catch (e) {
         extension.logError('Failed to evaluate \'main\' function on applet: ' + appletDefinition.uuid + "/" + appletDefinition.applet_id, e);
         return null;

--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -348,7 +348,7 @@ function addAppletToPanels(extension, appletDefinition) {
 
         applet._order = appletDefinition.order;
 
-        let location = appletDefinition.location;
+        let location = getLocation(applet.panel, appletDefinition.location_label);
 
         // Remove it from its previous panel location (if it had one)
         if (applet._panelLocation != null && location != applet._panelLocation) {

--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -193,17 +193,17 @@ function setOrientationForPanel(panelPos) {
     return orientation;
 }
 
-function setHeightForPanel(panelObj, panelPos) {
+function setHeightForPanel(panel) {
     let height;
-    switch (panelPos)  // for vertical panels use the width instead of the height
+    switch (panel.panelPosition)  // for vertical panels use the width instead of the height
     {
         case 0:
         case 1:
-                height = panelObj.actor.get_height();
+                height = panel.actor.get_height();
         break;
         case 2:
         case 3:
-                height = panelObj.actor.get_width();
+                height = panel.actor.get_width();
         break;
     }
     return height;
@@ -516,10 +516,7 @@ function createApplet(extension, appletDefinition) {
     let orientation = appletDefinition.orientation;
     let panel_height;
 
-    panel_height = setHeightForPanel(
-        Main.panelManager.panels[appletDefinition.panelId],
-        Main.panelManager.panels[appletDefinition.panelId].panelPosition
-    );
+    panel_height = setHeightForPanel(Main.panelManager.panels[appletDefinition.panelId]);
 
     if (appletObj[applet_id] != undefined) {
         global.log(applet_id + ' applet already loaded');
@@ -603,10 +600,7 @@ function updateAppletPanelHeights(force_recalc) {
         if (appletObj[applet_id]) {
             let appletDefinition = enabledAppletDefinitions.idMap[applet_id];
             let newheight;
-            newheight = setHeightForPanel(
-                Main.panelManager.panels[appletDefinition.panelId],
-                Main.panelManager.panels[appletDefinition.panelId].panelPosition
-            );
+            newheight = setHeightForPanel(Main.panelManager.panels[appletDefinition.panelId]);
 
             if (appletObj[applet_id]._panelHeight != newheight || force_recalc) {
                 appletObj[applet_id].setPanelHeight(newheight);
@@ -673,7 +667,7 @@ function updateAppletsOnPanel (panel) {
     let orientation;
 
     orientation = setOrientationForPanel(panel.panelPosition);
-    height = setHeightForPanel(panel, panel.panelPosition);
+    height = setHeightForPanel(panel);
 
     let definition;
 

--- a/js/ui/cinnamonDBus.js
+++ b/js/ui/cinnamonDBus.js
@@ -305,16 +305,15 @@ CinnamonDBus.prototype = {
         let res = [];
 
         if (type == "applet") {
-            list = AppletManager.appletObj;
-            for (let key in list) {
-                res.push(list[key]._uuid);
+            for (var i = 0; i < AppletManager.definitions.length; i++) {
+                res.push(AppletManager.definitions[i].uuid);
             }
-        } else if (type == "desklet") {
+        } else if (type == "desklet") { // TODO
             list = DeskletManager.deskletObj;
             for (let key in list) {
                 res.push(list[key]._uuid);
             }
-        } else {
+        } else { // TODO
             list = ExtensionSystem.runningExtensions;
             for (let uuid in list) {
                 res.push(uuid);

--- a/js/ui/cinnamonDBus.js
+++ b/js/ui/cinnamonDBus.js
@@ -304,19 +304,17 @@ CinnamonDBus.prototype = {
         let list = null;
         let res = [];
 
-        if (type == "applet") {
-            for (var i = 0; i < AppletManager.definitions.length; i++) {
+        if (type === 'applet') {
+            for (let i = 0; i < AppletManager.definitions.length; i++) {
                 res.push(AppletManager.definitions[i].uuid);
             }
-        } else if (type == "desklet") { // TODO
-            list = DeskletManager.deskletObj;
-            for (let key in list) {
-                res.push(list[key]._uuid);
+        } else if (type === 'desklet') {
+            for (let i = 0; i < DeskletManager.definitions.length; i++) {
+                res.push(DeskletManager.definitions[i].uuid);
             }
-        } else { // TODO
-            list = ExtensionSystem.runningExtensions;
-            for (let uuid in list) {
-                res.push(uuid);
+        } else {
+            for (let i = 0; i < ExtensionSystem.runningExtensions.length; i++) {
+                res.push(ExtensionSystem.runningExtensions[i]);
             }
         }
 

--- a/js/ui/cinnamonDBus.js
+++ b/js/ui/cinnamonDBus.js
@@ -403,10 +403,11 @@ CinnamonDBus.prototype = {
     ToggleKeyboard: function() {
         Main.keyboard.toggle();
     },
-    
+
     OpenSpicesAbout: function(uuid, type) {
-        let metadata = Extension.getMetadata(uuid, Extension.Type[type.toUpperCase()]);
-        new ModalDialog.SpicesAboutDialog(metadata, type+"s");
+        Extension.getMetadata(uuid, Extension.Type[type.toUpperCase()]).then(function(metadata) {
+            new ModalDialog.SpicesAboutDialog(metadata, `${type}s`);
+        });
     },
 
     GetMonitors: function() {

--- a/js/ui/deskletManager.js
+++ b/js/ui/deskletManager.js
@@ -175,8 +175,9 @@ function getEnabledDeskletDefinitions() {
 }
 
 // Callback for extension.js
-function finishExtensionLoad(extension) {
+function finishExtensionLoad(extensionIndex) {
     // Add all desklet instances for this extension
+    let extension = Extension.extensions[extensionIndex];
     let definitions = enabledDeskletDefinitions.uuidMap[extension.uuid];
     if (definitions) {
         for(let i=0; i<definitions.length; i++) {
@@ -292,7 +293,7 @@ function _loadDesklet(extension, deskletDefinition) {
 
         return true;
     } catch (e) {
-        extension.logError('Failed to load desklet: ' + deskletDefinition.uuid + "/" + deskletDefinition.desklet_id, e);
+        Extension.logError('Failed to load desklet: ' + deskletDefinition.uuid + "/" + deskletDefinition.desklet_id, e);
         return false;
     }
 }
@@ -309,7 +310,7 @@ function _createDesklets(extension, deskletDefinition) {
     try {
         desklet = getModuleByIndex(extension.moduleIndex).main(extension.meta, desklet_id);
     } catch (e) {
-        extension.logError('Failed to evaluate \'main\' function on desklet: ' + deskletDefinition.uuid + "/" + deskletDefinition.desklet_id, e);
+        Extension.logError('Failed to evaluate \'main\' function on desklet: ' + deskletDefinition.uuid + "/" + deskletDefinition.desklet_id, e);
         return null;
     }
 

--- a/js/ui/deskletManager.js
+++ b/js/ui/deskletManager.js
@@ -15,6 +15,8 @@ const FileUtils = imports.misc.fileUtils;
 
 // Maps uuid -> importer object (desklet directory tree)
 let desklets;
+// Kept for compatibility
+let deskletMeta;
 // Maps uuid -> desklet objects
 let deskletObj = {};
 
@@ -70,7 +72,7 @@ function unloadRemovedDesklets() {
 function init(){
     return new Promise(function(resolve) {
         desklets = imports.desklets;
-
+        deskletMeta = Extension.Type.DESKLET.legacyMeta;
         deskletsLoaded = false
 
         enabledDeskletDefinitions = getEnabledDeskletDefinitions();

--- a/js/ui/deskletManager.js
+++ b/js/ui/deskletManager.js
@@ -311,7 +311,7 @@ function _createDesklets(extension, deskletDefinition) {
 
     let desklet;
     try {
-        desklet = FileUtils.LoadedModules[extension.moduleIndex].module.main(extension.meta, desklet_id);
+        desklet = getModuleByIndex(extension.moduleIndex).main(extension.meta, desklet_id);
     } catch (e) {
         extension.logError('Failed to evaluate \'main\' function on desklet: ' + deskletDefinition.uuid + "/" + deskletDefinition.desklet_id, e);
         return null;

--- a/js/ui/deskletManager.js
+++ b/js/ui/deskletManager.js
@@ -13,8 +13,6 @@ const Extension = imports.ui.extension;
 const Main = imports.ui.main;
 const FileUtils = imports.misc.fileUtils;
 
-// Maps uuid -> metadata object
-let deskletMeta;
 // Maps uuid -> importer object (desklet directory tree)
 let desklets;
 // Maps uuid -> desklet objects
@@ -71,8 +69,7 @@ function unloadRemovedDesklets() {
  */
 function init(){
     return new Promise(function(resolve) {
-        desklets = Extension.Type.DESKLET.maps.importObjects;
-        deskletMeta = Extension.Type.DESKLET.maps.meta;
+        desklets = imports.desklets;
 
         deskletsLoaded = false
 
@@ -214,7 +211,7 @@ function _onEnabledDeskletsChanged(){
                 let oldDef = enabledDeskletDefinitions.idMap[desklet_id];
 
                 if (!oldDef || !_deskletDefinitionsEqual(newDef, oldDef)) {
-                    let extension = Extension.Type.DESKLET.maps.objects[newDef.uuid];
+                    let extension = Extension.getExtension(newDef.uuid);
                     if (extension) {
                         _loadDesklet(extension, newDef);
                     }

--- a/js/ui/deskletManager.js
+++ b/js/ui/deskletManager.js
@@ -60,7 +60,11 @@ function unloadRemovedDesklets(removedDeskletUUIDs) {
  * Initialize desklet manager
  */
 function init(){
-    desklets = imports.desklets;
+    try {
+        desklets = imports.desklets;
+    } catch (e) {
+        desklets = {};
+    }
     deskletMeta = Extension.Type.DESKLET.legacyMeta;
     deskletsLoaded = false
 

--- a/js/ui/deskletManager.js
+++ b/js/ui/deskletManager.js
@@ -37,30 +37,24 @@ const DESKLET_SNAP_KEY = 'desklet-snap';
 const DESKLET_SNAP_INTERVAL_KEY = 'desklet-snap-interval';
 
 function initEnabledDesklets() {
-    return new Promise(function(resolve) {
-        let uuidList = Object.keys(enabledDeskletDefinitions.uuidMap);
-        for (let i = 0; i < uuidList.length; i++) {
-            promises.push(Extension.loadExtension(uuidList[i], Extension.Type.DESKLET))
-        }
-        Promise.all(promises).then(function() {
-            promises = [];
-            resolve();
-        });
+    let uuidList = Object.keys(enabledDeskletDefinitions.uuidMap);
+    for (let i = 0; i < uuidList.length; i++) {
+        promises.push(Extension.loadExtension(uuidList[i], Extension.Type.DESKLET))
+    }
+    return Promise.all(promises).then(function() {
+        promises = [];
     });
 }
 
 function unloadRemovedDesklets() {
-    return new Promise(function(resolve) {
-        let uuidList = Object.keys(enabledDeskletDefinitions.uuidMap);
-        for (let i = 0; i < uuidList.length; i++) {
-            if (!enabledDeskletDefinitions.uuidMap[uuidList[i]]) {
-                promises.push(Extension.unloadExtension(uuidList[i], Extension.Type.DESKLET));
-            }
+    let uuidList = Object.keys(enabledDeskletDefinitions.uuidMap);
+    for (let i = 0; i < uuidList.length; i++) {
+        if (!enabledDeskletDefinitions.uuidMap[uuidList[i]]) {
+            promises.push(Extension.unloadExtension(uuidList[i], Extension.Type.DESKLET));
         }
-        Promise.all(promises).then(function() {
-            promises = [];
-            resolve();
-        });
+    }
+    return Promise.all(promises).then(function() {
+        promises = [];
     });
 }
 
@@ -70,22 +64,19 @@ function unloadRemovedDesklets() {
  * Initialize desklet manager
  */
 function init(){
-    return new Promise(function(resolve) {
-        desklets = imports.desklets;
-        deskletMeta = Extension.Type.DESKLET.legacyMeta;
-        deskletsLoaded = false
+    desklets = imports.desklets;
+    deskletMeta = Extension.Type.DESKLET.legacyMeta;
+    deskletsLoaded = false
 
-        enabledDeskletDefinitions = getEnabledDeskletDefinitions();
+    enabledDeskletDefinitions = getEnabledDeskletDefinitions();
 
-        initEnabledDesklets().then(function() {
-            global.settings.connect('changed::' + ENABLED_DESKLETS_KEY, _onEnabledDeskletsChanged);
-            global.settings.connect('changed::' + DESKLET_SNAP_KEY, _onDeskletSnapChanged);
-            global.settings.connect('changed::' + DESKLET_SNAP_INTERVAL_KEY, _onDeskletSnapChanged);
+    return initEnabledDesklets().then(function() {
+        global.settings.connect('changed::' + ENABLED_DESKLETS_KEY, _onEnabledDeskletsChanged);
+        global.settings.connect('changed::' + DESKLET_SNAP_KEY, _onDeskletSnapChanged);
+        global.settings.connect('changed::' + DESKLET_SNAP_INTERVAL_KEY, _onDeskletSnapChanged);
 
-            deskletsLoaded = true;
-            enableMouseTracking(true);
-            resolve();
-        });
+        deskletsLoaded = true;
+        enableMouseTracking(true);
     });
 }
 

--- a/js/ui/deskletManager.js
+++ b/js/ui/deskletManager.js
@@ -244,7 +244,6 @@ function _unloadDesklet(deskletDefinition, deleteConfig) {
         if (deleteConfig)
             _removeDeskletConfigFile(deskletDefinition.uuid, deskletDefinition.desklet_id);
 
-        delete desklet._extension._loadedDefinitions[deskletDefinition.desklet_id];
         delete deskletObj[deskletDefinition.desklet_id];
     }
 }
@@ -278,8 +277,6 @@ function _loadDesklet(extension, deskletDefinition) {
         // Now actually lock the desklets role and set the provider
         if(!extension.lockRole(desklet))
             return false;
-
-        desklet._extension = extension;
 
         if (!Main.deskletContainer.contains(desklet.actor)) Main.deskletContainer.addDesklet(desklet.actor);
         desklet.actor.set_position(deskletDefinition.x, deskletDefinition.y);

--- a/js/ui/deskletManager.js
+++ b/js/ui/deskletManager.js
@@ -1,5 +1,4 @@
 // -*- indent-tabs-mode: nil -*-
-const Cinnamon = imports.gi.Cinnamon;
 const Clutter = imports.gi.Clutter;
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;

--- a/js/ui/deskletManager.js
+++ b/js/ui/deskletManager.js
@@ -14,22 +14,22 @@ const {getModuleByIndex} = imports.misc.fileUtils;
 const {queryCollection} = imports.misc.util;
 
 // Maps uuid -> importer object (desklet directory tree)
-let desklets;
+var desklets;
 // Kept for compatibility
-let deskletMeta;
+var deskletMeta;
 
-let rawDefinitions;
-let definitions = [];
+var rawDefinitions;
+var definitions = [];
 
-let deskletsLoaded = false;
+var deskletsLoaded = false;
 
-let deskletsDragging = false;
+var deskletsDragging = false;
 
-let userDeskletsDir;
+var userDeskletsDir;
 
-let mouseTrackEnabled = false;
-let mouseTrackTimoutId = 0;
-let promises = [];
+var mouseTrackEnabled = false;
+var mouseTrackTimoutId = 0;
+var promises = [];
 
 const ENABLED_DESKLETS_KEY = 'enabled-desklets';
 const DESKLET_SNAP_KEY = 'desklet-snap';

--- a/js/ui/deskletManager.js
+++ b/js/ui/deskletManager.js
@@ -60,6 +60,7 @@ function unloadRemovedDesklets(removedDeskletUUIDs) {
  * Initialize desklet manager
  */
 function init(){
+    let startTime = new Date().getTime();
     try {
         desklets = imports.desklets;
     } catch (e) {
@@ -77,6 +78,7 @@ function init(){
 
         deskletsLoaded = true;
         enableMouseTracking(true);
+        global.log(`DeskletManager started in ${new Date().getTime() - startTime} ms`);
     });
 }
 

--- a/js/ui/deskletManager.js
+++ b/js/ui/deskletManager.js
@@ -11,16 +11,15 @@ const Desklet = imports.ui.desklet;
 const DND = imports.ui.dnd;
 const Extension = imports.ui.extension;
 const Main = imports.ui.main;
-const FileUtils = imports.misc.fileUtils;
+const {getModuleByIndex} = imports.misc.fileUtils;
 
 // Maps uuid -> importer object (desklet directory tree)
 let desklets;
 // Kept for compatibility
 let deskletMeta;
-// Maps uuid -> desklet objects
-let deskletObj = {};
 
-let enabledDeskletDefinitions;
+let rawDefinitions;
+let definitions = [];
 
 let deskletsLoaded = false;
 
@@ -37,21 +36,17 @@ const DESKLET_SNAP_KEY = 'desklet-snap';
 const DESKLET_SNAP_INTERVAL_KEY = 'desklet-snap-interval';
 
 function initEnabledDesklets() {
-    let uuidList = Object.keys(enabledDeskletDefinitions.uuidMap);
-    for (let i = 0; i < uuidList.length; i++) {
-        promises.push(Extension.loadExtension(uuidList[i], Extension.Type.DESKLET))
+    for (let i = 0; i < definitions.length; i++) {
+        promises.push(Extension.loadExtension(definitions[i].uuid, Extension.Type.DESKLET))
     }
     return Promise.all(promises).then(function() {
         promises = [];
     });
 }
 
-function unloadRemovedDesklets() {
-    let uuidList = Object.keys(enabledDeskletDefinitions.uuidMap);
-    for (let i = 0; i < uuidList.length; i++) {
-        if (!enabledDeskletDefinitions.uuidMap[uuidList[i]]) {
-            promises.push(Extension.unloadExtension(uuidList[i], Extension.Type.DESKLET));
-        }
+function unloadRemovedDesklets(removedDeskletUUIDs) {
+    for (let i = 0; i < removedDeskletUUIDs.length; i++) {
+        promises.push(Extension.unloadExtension(removedDeskletUUIDs[i], Extension.Type.DESKLET));
     }
     return Promise.all(promises).then(function() {
         promises = [];
@@ -68,7 +63,7 @@ function init(){
     deskletMeta = Extension.Type.DESKLET.legacyMeta;
     deskletsLoaded = false
 
-    enabledDeskletDefinitions = getEnabledDeskletDefinitions();
+    definitions = getDefinitions();
 
     return initEnabledDesklets().then(function() {
         global.settings.connect('changed::' + ENABLED_DESKLETS_KEY, _onEnabledDeskletsChanged);
@@ -80,34 +75,48 @@ function init(){
     });
 }
 
+function getDeskletDefinition({uuid, desklet_id}) {
+    let index = definitions.findIndex(function(definition) {
+        return definition.uuid === uuid || definition.desklet_id === desklet_id;
+    });
+    if (!definitions[index]) {
+        return null;
+    }
+    return definitions[index];
+}
+
 function enableMouseTracking(enable) {
-    if(enable && !mouseTrackTimoutId)
+    if (enable && !mouseTrackTimoutId) {
         mouseTrackTimoutId = Mainloop.timeout_add(500, checkMouseTracking);
-    else if (!enable && mouseTrackTimoutId) {
+    } else if (!enable && mouseTrackTimoutId) {
         Mainloop.source_remove(mouseTrackTimoutId);
         mouseTrackTimoutId = 0;
-        for(let desklet_id in deskletObj) {
-            deskletObj[desklet_id]._untrackMouse();
+
+        for (let i = 0; i < definitions.length; i++) {
+            if (definitions[i].desklet) {
+                definitions[i].desklet._untrackMouse();
+            }
         }
     }
 }
 
 function hasMouseWindow(){
     let window = global.screen.get_mouse_window(null);
-    return window && window.window_type != Meta.WindowType.DESKTOP;
+    return window && window.window_type !== Meta.WindowType.DESKTOP;
 }
 
 function checkMouseTracking() {
     let enable = !hasMouseWindow();
-    if(mouseTrackEnabled != enable) {
+    if (mouseTrackEnabled !== enable) {
         mouseTrackEnabled = enable;
-        if(enable) {
-            for(let desklet_id in deskletObj) {
-                deskletObj[desklet_id]._trackMouse();
+        for (let i = 0; i < definitions.length; i++) {
+            if (!definitions[i].desklet) {
+                continue;
             }
-        } else {
-            for(let desklet_id in deskletObj) {
-                deskletObj[desklet_id]._untrackMouse();
+            if (enable) {
+                definitions[i].desklet._trackMouse();
+            } else {
+                definitions[i].desklet._untrackMouse();
             }
         }
     }
@@ -118,7 +127,7 @@ function checkMouseTracking() {
  * removeDesklet:
  * @uuid (string): uuid of the desklet
  * @desklet_id (int): id of the desklet
- * 
+ *
  * Disable and remove the desklet @uuid:@desklet_id
  */
 function removeDesklet(uuid, desklet_id){
@@ -132,48 +141,39 @@ function removeDesklet(uuid, desklet_id){
 }
 
 /**
- * getEnabledDeskletDefinitons:
+ * getDefinitons:
  *
  * Gets the list of enabled desklets. Returns an associative array of three items:
  * raw: the unprocessed array from gsettings
- * uuidMap: maps uuid -> list of desklet definitions
- * idMap: maps desklet_id -> single desklet definition
+ * definitions: Array(Object)
  *
  * Returns (dictionary): Associative array of three items
  */
-function getEnabledDeskletDefinitions() {
-    let result = {
-        // the raw list from gsettings
-        raw: global.settings.get_strv(ENABLED_DESKLETS_KEY),
-        // maps uuid -> list of desklet definitions
-        uuidMap: {},
-        // maps desklet_id -> single desklet definition
-        idMap: {}
-    };
+function getDefinitions() {
+    let _definitions = [];
+    rawDefinitions = global.settings.get_strv(ENABLED_DESKLETS_KEY);
 
     // Parse all definitions
-    for (let i=0; i<result.raw.length; i++) {
-        let deskletDefinition = _getDeskletDefinition(result.raw[i]);
-        if(deskletDefinition) {
-            if(!result.uuidMap[deskletDefinition.uuid])
-                result.uuidMap[deskletDefinition.uuid] = [];
-            result.uuidMap[deskletDefinition.uuid].push(deskletDefinition);
-            result.idMap[deskletDefinition.desklet_id] = deskletDefinition;
+    for (let i=0; i < rawDefinitions.length; i++) {
+        let deskletDefinition = createDeskletDefinition(rawDefinitions[i]);
+        if (deskletDefinition) {
+            _definitions.push(deskletDefinition);
         }
     }
 
-    return result;
+    return _definitions;
 }
 
 // Callback for extension.js
 function finishExtensionLoad(extensionIndex) {
     // Add all desklet instances for this extension
     let extension = Extension.extensions[extensionIndex];
-    let definitions = enabledDeskletDefinitions.uuidMap[extension.uuid];
-    if (definitions) {
-        for(let i=0; i<definitions.length; i++) {
-            if (!_loadDesklet(extension, definitions[i]))
-                return false;
+    for (let i = 0; i < definitions.length; i++) {
+        if (definitions[i].uuid !== extension.uuid) {
+            continue;
+        }
+        if (!_loadDesklet(extension, definitions[i])) {
+            return false;
         }
     }
     return true;
@@ -182,61 +182,84 @@ function finishExtensionLoad(extensionIndex) {
 // Callback for extension.js
 function prepareExtensionUnload(extension, deleteConfig) {
     // Remove all desklet instances for this extension
-    for(let desklet_id in extension._loadedDefinitions) {
-        _unloadDesklet(extension._loadedDefinitions[desklet_id], deleteConfig);
+    for (let i = 0; i < definitions.length; i++) {
+        definitions[i]
+        if (extension.uuid !== definitions[i].uuid) {
+            continue;
+        }
+        _unloadDesklet(definitions[i], deleteConfig);
     }
 }
 
-function _onEnabledDeskletsChanged(){
+function _onEnabledDeskletsChanged() {
     try {
-        let newEnabledDeskletDefinitions = getEnabledDeskletDefinitions();
+        let oldDefinitions = definitions;
+        definitions = getDefinitions();
+        let removedDeskletUUIDs = [];
         // Remove all desklet instances that do not exist in the definition anymore.
-        for (let desklet_id in enabledDeskletDefinitions.idMap) {
-            if (!newEnabledDeskletDefinitions.idMap[desklet_id]) {
-                _unloadDesklet(enabledDeskletDefinitions.idMap[desklet_id], true);
+        for (let i = 0; i < oldDefinitions.length; i++) {
+            let deskletDefinition = getDeskletDefinition({desklet_id: oldDefinitions[i].desklet_id});
+            if (!deskletDefinition) {
+                removedDeskletUUIDs.push(oldDefinitions[i].uuid);
+                _unloadDesklet(oldDefinitions[i], true);
             }
         }
-
+        // Make a unique array of removed UUIDs
+        let uniqueSet = new Set();
+        let uniqueRemovedUUIDs = [];
+        for (let i = 0; i < removedDeskletUUIDs.length; i++) {
+          if (uniqueSet.has(removedDeskletUUIDs[i]) === false) {
+            uniqueRemovedUUIDs.push(removedDeskletUUIDs[i]);
+            uniqueSet.add(removedDeskletUUIDs[i]);
+          }
+        }
         // Unload all desklet extensions that do not exist in the definition anymore.
-        unloadRemovedDesklets().then(function() {
+        unloadRemovedDesklets(uniqueRemovedUUIDs).then(function() {
             // Add or move desklet instances of already loaded desklet extensions
-            for (let desklet_id in newEnabledDeskletDefinitions.idMap) {
-                let newDef = newEnabledDeskletDefinitions.idMap[desklet_id];
-                let oldDef = enabledDeskletDefinitions.idMap[desklet_id];
+            const getOlddeskletDefinition = function(desklet_id) {
+                let index = oldDefinitions.findIndex(function(definition) {
+                    return definition.desklet_id === desklet_id;
+                });
+                if (index === -1) {
+                    return null;
+                }
+                return oldDefinitions[index];
+            };
+            for (let i = 0; i < definitions.length; i++) {
+                let newDefinition = getDeskletDefinition({desklet_id: definitions[i].desklet_id});
+                let oldDefinition = getOlddeskletDefinition(definitions[i].desklet_id);
 
-                if (!oldDef || !_deskletDefinitionsEqual(newDef, oldDef)) {
-                    let extension = Extension.getExtension(newDef.uuid);
+                if (!oldDefinition || !_deskletDefinitionsEqual(newDefinition, oldDefinition)) {
+                    let extension = Extension.getExtension(newDefinition.uuid);
                     if (extension) {
-                        _loadDesklet(extension, newDef);
+                        _loadDesklet(extension, newDefinition);
                     }
                 }
             }
-
-            enabledDeskletDefinitions = newEnabledDeskletDefinitions;
 
             // Make sure all desklet extensions are loaded.
             // Once loaded, the desklets will add themselves via finishExtensionLoad
             initEnabledDesklets();
         });
-
-    } catch (e) {
+    } catch(e) {
         global.logError('Failed to refresh list of desklets', e);
     }
 }
 
 function _unloadDesklet(deskletDefinition, deleteConfig) {
-    let desklet = deskletObj[deskletDefinition.desklet_id];
-    if (desklet){
+    let {uuid, desklet_id} = deskletDefinition;
+    if (deskletDefinition.desklet) {
         try {
-            desklet.destroy(deleteConfig);
+            deskletDefinition.desklet.destroy(deleteConfig);
         } catch (e) {
-            global.logError("Failed to destroy desket: " + deskletDefinition.uuid + "/" + deskletDefinition.desklet_id, e);
+            global.logError("Failed to destroy desket: " + uuid + "/" + desklet_id, e);
         }
 
-        if (deleteConfig)
-            _removeDeskletConfigFile(deskletDefinition.uuid, deskletDefinition.desklet_id);
+        if (deleteConfig) {
+            _removeDeskletConfigFile(uuid, desklet_id);
+        }
 
-        delete deskletObj[deskletDefinition.desklet_id];
+        deskletDefinition.desklet = null;
     }
 }
 
@@ -260,23 +283,18 @@ function _loadDesklet(extension, deskletDefinition) {
     // Try to lock the desklets role
     if(!extension.lockRole(null))
         return false;
-    
+
     try {
         let desklet = _createDesklets(extension, deskletDefinition);
         if (!desklet)
             return false;
-        
+
         // Now actually lock the desklets role and set the provider
         if(!extension.lockRole(desklet))
             return false;
 
         if (!Main.deskletContainer.contains(desklet.actor)) Main.deskletContainer.addDesklet(desklet.actor);
         desklet.actor.set_position(deskletDefinition.x, deskletDefinition.y);
-
-        if(!extension._loadedDefinitions) {
-            extension._loadedDefinitions = {};
-        }
-        extension._loadedDefinitions[deskletDefinition.desklet_id] = deskletDefinition;
 
         desklet.on_desklet_added_to_desktop_internal(deskletsLoaded && !deskletsDragging);
 
@@ -290,39 +308,40 @@ function _loadDesklet(extension, deskletDefinition) {
 }
 
 function _createDesklets(extension, deskletDefinition) {
-    let desklet_id = deskletDefinition.desklet_id;
+    let {uuid, desklet_id} = deskletDefinition;
 
-    if (deskletObj[desklet_id]) {
+    if (deskletDefinition.desklet) {
         global.log(desklet_id + ' desklet already loaded');
-        return deskletObj[desklet_id];
+        return deskletDefinition.desklet;
     }
 
     let desklet;
     try {
         desklet = getModuleByIndex(extension.moduleIndex).main(extension.meta, desklet_id);
     } catch (e) {
-        Extension.logError('Failed to evaluate \'main\' function on desklet: ' + deskletDefinition.uuid + "/" + deskletDefinition.desklet_id, e);
+        Extension.logError('Failed to evaluate \'main\' function on desklet: ' + uuid + "/" + desklet_id, e);
         return null;
     }
 
-    deskletObj[desklet_id] = desklet;
+    deskletDefinition.desklet = desklet;
     desklet._uuid = extension.uuid;
     desklet._meta = extension.meta;
     desklet.instance_id = desklet_id;  // In case desklet constructor didn't set this
-    
+
     desklet.finalizeContextMenu();
-    
+
     return desklet;
 }
 
-function _getDeskletDefinition(definition) {
+function createDeskletDefinition(definition) {
     let elements = definition.split(":");
     if (elements.length == 4) {
         return {
             uuid: elements[0],
             desklet_id: elements[1],
             x: elements[2],
-            y: elements[3]
+            y: elements[3],
+            desklet: null
         };
     } else {
         global.logError("Bad desklet definition: " + definition);
@@ -331,26 +350,28 @@ function _getDeskletDefinition(definition) {
 }
 
 function _deskletDefinitionsEqual(a, b) {
-    return (a.uuid == b.uuid && a.x == b.x && a.y == b.y);
+    return (a && b && (a.uuid === b.uuid && a.x === b.x && a.y === b.y));
 }
 
 function get_object_for_instance (deskletId) {
-    if (deskletId in deskletObj) {
-        return deskletObj[deskletId];
-    } else {
+    let {desklet} = getDeskletDefinition({desklet_id: deskletId});
+    if (!desklet) {
         return null;
     }
+    return desklet;
 }
 
 function get_object_for_uuid (uuid, instanceId) {
-    for (let thisInstanceId in deskletObj) {
-        if (deskletObj[thisInstanceId]._uuid == uuid) {
-            if (instanceId == uuid || thisInstanceId == instanceId) {
-                return deskletObj[thisInstanceId]
-            }
-        }
+    let index = definitions.findIndex(function(definition) {
+        return (definition
+            && definition.desklet
+            && definition.desklet._uuid === uuid
+            && (definition.desklet_id === instanceId || instanceId === uuid));
+    });
+    if (index === -1) {
+        return null;
     }
-    return null;
+    return definitions[index].desklet;
 }
 
 function _onDeskletSnapChanged(){
@@ -375,7 +396,7 @@ function _onDeskletSnapChanged(){
 
 /**
  * #DeskletContainer
- * 
+ *
  * Container that contains manages all desklets actors
  */
 function DeskletContainer(){
@@ -397,7 +418,7 @@ DeskletContainer.prototype = {
     /**
      * addDesklet:
      * @actor (Clutter.Actor): actor of desklet to be added
-     * 
+     *
      * Adds @actor to the desklet container
      */
     addDesklet: function(actor){
@@ -407,7 +428,7 @@ DeskletContainer.prototype = {
     /**
      * contains:
      * @actor (Clutter.Actor): actor to be tested
-     * 
+     *
      * Whether the desklet container contains @actor
      *
      * Returns (boolean): whether the desklet container contains the actor

--- a/js/ui/deskletManager.js
+++ b/js/ui/deskletManager.js
@@ -11,6 +11,7 @@ const Desklet = imports.ui.desklet;
 const DND = imports.ui.dnd;
 const Extension = imports.ui.extension;
 const Main = imports.ui.main;
+const FileUtils = imports.misc.fileUtils;
 
 // Maps uuid -> metadata object
 let deskletMeta;
@@ -310,7 +311,7 @@ function _createDesklets(extension, deskletDefinition) {
 
     let desklet;
     try {
-        desklet = extension.module.main(extension.meta, desklet_id);
+        desklet = FileUtils.LoadedModules[extension.moduleIndex].module.main(extension.meta, desklet_id);
     } catch (e) {
         extension.logError('Failed to evaluate \'main\' function on desklet: ' + deskletDefinition.uuid + "/" + deskletDefinition.desklet_id, e);
         return null;

--- a/js/ui/deskletManager.js
+++ b/js/ui/deskletManager.js
@@ -12,6 +12,7 @@ const DND = imports.ui.dnd;
 const Extension = imports.ui.extension;
 const Main = imports.ui.main;
 const {getModuleByIndex} = imports.misc.fileUtils;
+const {queryCollection} = imports.misc.util;
 
 // Maps uuid -> importer object (desklet directory tree)
 let desklets;
@@ -75,14 +76,8 @@ function init(){
     });
 }
 
-function getDeskletDefinition({uuid, desklet_id}) {
-    let index = definitions.findIndex(function(definition) {
-        return definition.uuid === uuid || definition.desklet_id === desklet_id;
-    });
-    if (!definitions[index]) {
-        return null;
-    }
-    return definitions[index];
+function getDeskletDefinition(definition) {
+    return queryCollection(definitions, definition);
 }
 
 function enableMouseTracking(enable) {

--- a/js/ui/environment.js
+++ b/js/ui/environment.js
@@ -45,7 +45,7 @@ function _patchContainerClass(containerClass) {
 
 function init() {
     const readOnlyError = function(property) {
-        return `The ${property} object is read-only.`;
+        global.logError(`The ${property} object is read-only.`);
     };
     // Add some bindings to the global JS namespace; (gjs keeps the web
     // browser convention of having that namespace be called 'window'.)

--- a/js/ui/environment.js
+++ b/js/ui/environment.js
@@ -44,13 +44,51 @@ function _patchContainerClass(containerClass) {
 }
 
 function init() {
+    const readOnlyError = function(property) {
+        return `The ${property} object is read-only.`;
+    };
     // Add some bindings to the global JS namespace; (gjs keeps the web
     // browser convention of having that namespace be called 'window'.)
-    window.global = Cinnamon.Global.get();
-
-    window._ = Gettext.gettext;
-    window.C_ = Gettext.pgettext;
-    window.ngettext = Gettext.ngettext;
+    Object.defineProperty(window, 'global', {
+        get: function() {
+            return Cinnamon.Global.get();
+        },
+        set: function() {
+            readOnlyError('global');
+        },
+        configurable: false,
+        enumerable: false
+    });
+    Object.defineProperty(window, '_', {
+        get: function() {
+            return Gettext.gettext;
+        },
+        set: function() {
+            readOnlyError('gettext');
+        },
+        configurable: false,
+        enumerable: false
+    });
+    Object.defineProperty(window, 'C_', {
+        get: function() {
+            return Gettext.pgettext;
+        },
+        set: function() {
+            readOnlyError('pgettext');
+        },
+        configurable: false,
+        enumerable: false
+    });
+    Object.defineProperty(window, 'ngettext', {
+        get: function() {
+            return Gettext.ngettext;
+        },
+        set: function() {
+            readOnlyError('ngettext');
+        },
+        configurable: false,
+        enumerable: false
+    });
 
     // Set the default direction for St widgets (this needs to be done before any use of St)
     if (Gtk.Widget.get_default_direction() == Gtk.TextDirection.RTL) {

--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -15,7 +15,7 @@ const Main = imports.ui.main;
 const {requireModule, unloadModule, getModuleByIndex} = imports.misc.fileUtils;
 const {queryCollection} = imports.misc.util;
 
-const State = {
+var State = {
     INITIALIZING: 0,
     LOADED: 1,
     ERROR: 2,
@@ -74,9 +74,9 @@ function _createExtensionType(name, folder, manager, overrides){
  * Extension types with some attributes helping to load these extension types.
  * Properties are nested, with lowerCamelCase properties (e.g. requiredFunctions) as sub-properties of CAPITAL one (EXTENSION). Thus they are referred to as, e.g., Type.EXTENSION.requiredFunctions
  */
-let startTime;
-const extensions = [];
-const Type = {
+var startTime;
+var extensions = [];
+var Type = {
     EXTENSION: _createExtensionType("Extension", "extensions", ExtensionSystem, {
         requiredFunctions: ["init", "disable", "enable"],
         requiredProperties: ["uuid", "name", "description", "cinnamon-version"],

--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -211,7 +211,6 @@ Extension.prototype = {
                 if (moduleIndex == null) {
                     throw new Error(`Could not find module index: ${moduleIndex}`);
                 }
-                global.log(this.uuid, moduleIndex)
                 this.moduleIndex = moduleIndex;
                 let module = getModuleByIndex(moduleIndex);
                 for (let i = 0; i < type.requiredFunctions.length; i++) {

--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -36,7 +36,8 @@ function _createExtensionType(name, folder, manager, overrides){
             finishExtensionLoad: manager.finishExtensionLoad,
             prepareExtensionUnload: manager.prepareExtensionUnload
         },
-        userDir: GLib.build_filenamev([global.userdatadir, folder])
+        userDir: GLib.build_filenamev([global.userdatadir, folder]),
+        legacyMeta: {}
     };
 
     Object.assign(type, overrides);
@@ -189,6 +190,9 @@ Extension.prototype = {
                         imports[type.folder][this.uuid] = imports[type.folder][this.uuid][version];
                     } catch (e) {/* Extension was reloaded */}
                 }
+
+                // Many xlets still use appletMeta/deskletMeta to get the path
+                type.legacyMeta[uuid] = {path: this.meta.path};
 
                 this.ensureFileExists(this.dir.get_child(`${this.lowerType}.js`));
                 this.loadStylesheet(this.dir.get_child('stylesheet.css'));

--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -492,14 +492,14 @@ function unloadExtension(uuid, type, deleteConfig = true) {
         // but it will be removed on next reboot, and hopefully nothing
         // broke too much.
         try {
-            extension.type.callbacks.prepareExtensionUnload(extension, deleteConfig);
+            Type[extension.upperType].callbacks.prepareExtensionUnload(extension, deleteConfig);
         } catch(e) {
             global.logError('Error disabling ' + extension.lowerType + ' ' + extension.uuid, e);
         }
         extension.unloadStylesheet();
         extension.unloadIconDirectory();
 
-        extension.type.emit('extension-unloaded', extension.uuid);
+        Type[extension.upperType].emit('extension-unloaded', extension.uuid);
 
         forgetExtension(extension.uuid, type, true);
     }

--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -154,14 +154,17 @@ Extension.prototype = {
         try {
             // get [extension/applet/desklet].js
             this.module = FileUtils.requireModule(`${this.meta.path}/${this.lowerType}.js`, this.meta.path);
+            if (!this.module) {
+                throw new Error();
+            }
         } catch (e) {
-            throw this.logError('Error importing ' + this.lowerType + '.js from ' + this.uuid, e);
+            throw this.logError(`Error importing ${this.lowerType}.js from ${this.uuid}`, e);
         }
 
         for (let i = 0; i < type.requiredFunctions.length; i++) {
             let func = type.requiredFunctions[i];
             if (!this.module[func]) {
-                throw this.logError('Function "' + func + '" is missing');
+                throw this.logError(`Function "${func}" is missing`);
             }
         }
 
@@ -198,7 +201,7 @@ Extension.prototype = {
             this.unlockRole();
             this.unloadStylesheet();
             this.unloadIconDirectory();
-            forgetExtension(this.uuid);
+            forgetExtension(this.uuid, Type[this.upperType]);
         }
         error._alreadyLogged = true;
         return error;
@@ -346,7 +349,7 @@ Extension.prototype = {
     },
 
     unlockRole: function() {
-        if (this.meta.role && Type[this.upperType].roles[role] === this.uuid) {
+        if (this.meta.role && Type[this.upperType].roles[this.meta.role] === this.uuid) {
             Type[this.upperType].roles[this.meta.role] = null;
             this.roleProvider = null;
             global.log(`Role unlocked: ${this.meta.role}`);

--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -159,23 +159,17 @@ function ensureFileExists(file) {
 
 // The Extension object itself
 function Extension(type, uuid) {
-    return new Promise((resolve, reject) => {
-        let extension = getExtension(uuid);
-        if (extension) {
-           resolve(true);
-            return;
-        }
-        let dir = findExtensionDirectory(uuid, type.userDir, type.folder);
+    let extension = getExtension(uuid);
+    if (extension) {
+        return Promise.resolve(true);
+    }
+    let dir = findExtensionDirectory(uuid, type.userDir, type.folder);
 
-        if (dir == null) {
-            forgetExtension(uuid, type, true);
-            resolve(null);
-            return;
-        }
-        this._init(dir, type, uuid).then(function() {
-            resolve(true);
-        });
-    });
+    if (dir == null) {
+        forgetExtension(uuid, type, true);
+        return Promise.resolve(null);
+    }
+    return this._init(dir, type, uuid);
 }
 
 Extension.prototype = {

--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -441,7 +441,7 @@ function loadExtension(uuid, type) {
     let extension = type.maps.objects[uuid];
     if(!extension) {
         try {
-            type.maps.dirs[uuid] = findExtensionDirectory(uuid, type);
+            type.maps.dirs[uuid] = findExtensionDirectory(uuid, type.userDir, type.folder);
 
             if (type.maps.dirs[uuid] == null)
                 throw ("not-found");
@@ -542,8 +542,8 @@ function reloadExtension(uuid, type) {
     loadExtension(uuid, type);
 }
 
-function findExtensionDirectory(uuid, type) {
-    let dirPath = type.userDir + "/" + uuid;
+function findExtensionDirectory(uuid, userDir, folder) {
+    let dirPath = `${userDir}/${uuid}`;
     let dir = Gio.file_new_for_path(dirPath);
     if (dir.query_file_type(Gio.FileQueryInfoFlags.NONE, null)
             == Gio.FileType.DIRECTORY)
@@ -551,7 +551,7 @@ function findExtensionDirectory(uuid, type) {
 
     let systemDataDirs = GLib.get_system_data_dirs();
     for (let datadir of systemDataDirs) {
-        dirPath = datadir + '/cinnamon/' + type.folder + '/' + uuid;
+        dirPath = `${datadir}/cinnamon/${folder}/${uuid}`;
         dir = Gio.file_new_for_path(dirPath);
         if (dir.query_file_type(Gio.FileQueryInfoFlags.NONE, null)
                 == Gio.FileType.DIRECTORY)
@@ -561,7 +561,7 @@ function findExtensionDirectory(uuid, type) {
 }
 
 function getMetadata(uuid, type) {
-    let dir = findExtensionDirectory(uuid, type);
+    let dir = findExtensionDirectory(uuid, type.userDir, type.folder);
     let metadataFile = dir.get_child('metadata.json');
 
     let metadataContents = Cinnamon.get_file_contents_utf8_sync(metadataFile.get_path());

--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -105,8 +105,8 @@ const Type = {
 };
 
 // Create a dummy metadata object when metadata parsing failed or was not done yet.
-function createMetaDummy(uuid, path, state, type) {
-    return { name: uuid, description: 'Metadata load failed', state: state, path: path, error: '', type: type };
+function createMetaDummy(uuid, path, state) {
+    return { name: uuid, description: 'Metadata load failed', state: state, path: path, error: ''};
 }
 
 // The Extension object itself
@@ -123,7 +123,7 @@ Extension.prototype = {
         this.theme = null;
         this.stylesheet = null;
         this.iconDirectory = null;
-        this.meta = createMetaDummy(this.uuid, dir.get_path(), State.INITIALIZING, type);
+        this.meta = createMetaDummy(this.uuid, dir.get_path(), State.INITIALIZING);
         this.startTime = new Date().getTime();
 
         this.loadMetaData(dir.get_child('metadata.json'));
@@ -221,7 +221,6 @@ Extension.prototype = {
             // Store some additional crap here
             this.meta.state = oldState;
             this.meta.path = oldPath;
-            this.meta.type = this.type;
             this.meta.error = '';
 
             this.type.maps.meta[this.uuid] = this.meta;

--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -1,10 +1,8 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
-const Cinnamon = imports.gi.Cinnamon;
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 const Gtk = imports.gi.Gtk;
-const Lang = imports.lang;
 const Signals = imports.signals;
 const St = imports.gi.St;
 

--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -195,7 +195,8 @@ Extension.prototype = {
             // get [extension/applet/desklet].js
             return requireModule(
                 `${this.meta.path}/${this.lowerType}.js`, // path
-                this.meta.path, // dir
+                this.meta.path, // dir,
+                this.lowerType, // type
                 true, // async
                 true // returnIndex
             );

--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -38,20 +38,18 @@ function _createExtensionType(name, folder, manager, overrides){
         },
         maps: {
             importObjects: {},
-            objects: {},
+            objects: {}, // Extension constructor instances
             meta: {},
             dirs: {}
         }
     };
 
-    for(let prop in overrides)
-        type[prop] = overrides[prop];
+    Object.assign(type, overrides);
 
     // Add signal methods
     Signals.addSignalMethods(type);
 
-    let path = GLib.build_filenamev([global.userdatadir, folder]);
-    type.userDir = path;
+    type.userDir = GLib.build_filenamev([global.userdatadir, folder]);
     // create user directories if they don't exist.
     let dir = Gio.file_new_for_path(type.userDir)
     try {

--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -218,7 +218,6 @@ Extension.prototype = {
                 return findExtensionSubdirectory(this.dir).then((dir) => {
                     this.dir = dir;
                     this.meta.path = this.dir.get_path();
-                    this.meta.path = this.dir.get_path();
                     let pathSections = this.meta.path.split('/');
                     let version = pathSections[pathSections.length - 1];
                     try {
@@ -233,11 +232,10 @@ Extension.prototype = {
                 throw new Error(`Could not find module index: ${moduleIndex}`);
             }
             this.moduleIndex = moduleIndex;
-            let module = getModuleByIndex(moduleIndex);
             for (let i = 0; i < type.requiredFunctions.length; i++) {
                 let func = type.requiredFunctions[i];
-                if (!module[func]) {
-                    reject(logError(`Function "${func}" is missing`, uuid));
+                if (!getModuleByIndex(moduleIndex)[func]) {
+                    throw new Error(`Function "${func}" is missing`);
                 }
             }
 

--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -14,6 +14,7 @@ const DeskletManager = imports.ui.deskletManager;
 const ExtensionSystem = imports.ui.extensionSystem;
 const SearchProviderManager = imports.ui.searchProviderManager;
 const Main = imports.ui.main;
+const FileUtils = imports.misc.fileUtils;
 
 const State = {
     INITIALIZING: 0,
@@ -153,7 +154,8 @@ Extension.prototype = {
         this.loadIconDirectory(this.dir);
 
         try {
-            this.module = type.maps.importObjects[this.uuid][this.lowerType]; // get [extension/applet/desklet].js
+            // get [extension/applet/desklet].js
+            this.module = FileUtils.requireModule(`${this.meta.path}/${this.lowerType}.js`, this.meta.path);
         } catch (e) {
             throw this.logError('Error importing ' + this.lowerType + '.js from ' + this.uuid, e);
         }

--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -124,6 +124,12 @@ function logError(message, uuid, error, state) {
         error.message += `\n${errorMessage}`;
     }
 
+    error.stack = error.stack.split('\n')
+        .filter(function(line) {
+            return !line.match(/<Promise>|wrapPromise/);
+        })
+        .join('\n');
+
     global.logError(error);
 
     // An error during initialization leads to unloading the extension again.
@@ -494,7 +500,7 @@ function unloadExtension(uuid, type, deleteConfig = true) {
             try {
                 Type[extension.upperType].callbacks.prepareExtensionUnload(extension, deleteConfig);
             } catch(e) {
-                global.logError(`Error disabling ${extension.lowerType} ${extension.uuid}`, e);
+                logError(`Error disabling ${extension.lowerType} ${extension.uuid}`, extension.uuid, e);
             }
             extension.unloadStylesheet();
             extension.unloadIconDirectory();
@@ -583,7 +589,7 @@ function loadMetaData({state, path, uuid, userDir, folder}) {
                 }
                 meta = JSON.parse(json);
             } catch (e) {
-                global.logError(`Failed to load/parse metadata.json`, e);
+                logError(`Failed to load/parse metadata.json`, uuid, e);
                 meta = createMetaDummy(uuid, oldPath, State.ERROR);
 
             }
@@ -639,7 +645,7 @@ function findExtensionSubdirectory(dir) {
                 fileEnum.close(null);
                 resolve(largest ? largest[1] : dir);
             } catch (e) {
-                global.logError(`Error looking for extension version for ${dir.get_basename()} in directory ${dir}`, e);
+                logError(`Error looking for extension version for ${dir.get_basename()} in directory ${dir}`, 'findExtensionSubdirectory', e);
                 resolve(dir)
             }
 

--- a/js/ui/extensionSystem.js
+++ b/js/ui/extensionSystem.js
@@ -102,7 +102,9 @@ function initEnabledExtensions(callback = null) {
 }
 
 function unloadRemovedExtensions() {
-    let uuidList = Extension.extensions;
+    let uuidList = Extension.extensions.filter(function(extension) {
+        return extension.lowerType === 'extension';
+    });
     for (let i = 0; i < uuidList.length; i++) {
         if (enabledExtensions.indexOf(uuidList[i].uuid) === -1) {
             promises.push(Extension.unloadExtension(uuidList[i].uuid, Extension.Type.EXTENSION));

--- a/js/ui/extensionSystem.js
+++ b/js/ui/extensionSystem.js
@@ -90,41 +90,32 @@ function onEnabledExtensionsChanged() {
 }
 
 function initEnabledExtensions(callback = null) {
-    return new Promise(function(resolve) {
-        for (let i = 0; i < enabledExtensions.length; i++) {
-            promises.push(Extension.loadExtension(enabledExtensions[i], Extension.Type.EXTENSION))
-        }
-        Promise.all(promises).then(function() {
-            promises = [];
-            resolve();
-        });
+    for (let i = 0; i < enabledExtensions.length; i++) {
+        promises.push(Extension.loadExtension(enabledExtensions[i], Extension.Type.EXTENSION))
+    }
+    return Promise.all(promises).then(function() {
+        promises = [];
     });
 }
 
 function unloadRemovedExtensions() {
-    return new Promise(function(resolve) {
-        let uuidList = Extension.extensions;
-        for (let i = 0; i < uuidList.length; i++) {
-            if (enabledExtensions.indexOf(uuidList[i].uuid) === -1) {
-                promises.push(Extension.unloadExtension(uuidList[i].uuid, Extension.Type.EXTENSION));
-            }
+    let uuidList = Extension.extensions;
+    for (let i = 0; i < uuidList.length; i++) {
+        if (enabledExtensions.indexOf(uuidList[i].uuid) === -1) {
+            promises.push(Extension.unloadExtension(uuidList[i].uuid, Extension.Type.EXTENSION));
         }
-        Promise.all(promises).then(function() {
-            promises = [];
-            resolve();
-        });
+    }
+    return Promise.all(promises).then(function() {
+        promises = [];
     });
 }
 
 function init() {
-    return new Promise(function(resolve) {
-        extensions = imports.extensions;
-        ExtensionState = Extension.State;
+    extensions = imports.extensions;
+    ExtensionState = Extension.State;
 
-        enabledExtensions = global.settings.get_strv(ENABLED_EXTENSIONS_KEY);
-        initEnabledExtensions().then(function() {
-            global.settings.connect('changed::' + ENABLED_EXTENSIONS_KEY, onEnabledExtensionsChanged);
-            resolve();
-        });
+    enabledExtensions = global.settings.get_strv(ENABLED_EXTENSIONS_KEY);
+    return initEnabledExtensions().then(function() {
+        global.settings.connect('changed::' + ENABLED_EXTENSIONS_KEY, onEnabledExtensionsChanged);
     });
 }

--- a/js/ui/extensionSystem.js
+++ b/js/ui/extensionSystem.js
@@ -32,7 +32,7 @@ function prepareExtensionUnload(extension) {
     try {
         getModuleByIndex(extension.moduleIndex).disable();
     } catch (e) {
-        extension.logError('Failed to evaluate \'disable\' function on extension: ' + extension.uuid, e);
+        Extension.logError('Failed to evaluate \'disable\' function on extension: ' + extension.uuid, e);
     }
     delete runningExtensions[extension.uuid];
 
@@ -41,7 +41,8 @@ function prepareExtensionUnload(extension) {
 }
 
 // Callback for extension.js
-function finishExtensionLoad(extension) {
+function finishExtensionLoad(extensionIndex) {
+    let extension = Extension.extensions[extensionIndex];
     if (!extension.lockRole(getModuleByIndex(extension.moduleIndex))) {
         return false;
     }
@@ -49,7 +50,7 @@ function finishExtensionLoad(extension) {
     try {
         getModuleByIndex(extension.moduleIndex).init(extension.meta);
     } catch (e) {
-        extension.logError('Failed to evaluate \'init\' function on extension: ' + extension.uuid, e);
+        Extension.logError('Failed to evaluate \'init\' function on extension: ' + extension.uuid, e);
         return false;
     }
 
@@ -57,7 +58,7 @@ function finishExtensionLoad(extension) {
     try {
         extensionCallbacks = getModuleByIndex(extension.moduleIndex).enable();
     } catch (e) {
-        extension.logError('Failed to evaluate \'enable\' function on extension: ' + extension.uuid, e);
+        Extension.logError('Failed to evaluate \'enable\' function on extension: ' + extension.uuid, e);
         return false;
     }
 

--- a/js/ui/extensionSystem.js
+++ b/js/ui/extensionSystem.js
@@ -1,6 +1,7 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
 const Extension = imports.ui.extension;
+const FileUtils = imports.misc.fileUtils;
 
 // Maps uuid -> importer object (extension directory tree)
 let extensions;
@@ -31,7 +32,7 @@ function enableExtension(uuid) {
 // Callback for extension.js
 function prepareExtensionUnload(extension) {
     try {
-        extension.module.disable();
+        FileUtils.LoadedModules[extension.moduleIndex].module.disable();
     } catch (e) {
         extension.logError('Failed to evaluate \'disable\' function on extension: ' + extension.uuid, e);
     }
@@ -43,12 +44,12 @@ function prepareExtensionUnload(extension) {
 
 // Callback for extension.js
 function finishExtensionLoad(extension) {
-    if (!extension.lockRole(extension.module)) {
+    if (!extension.lockRole(FileUtils.LoadedModules[extension.moduleIndex].module)) {
         return false;
     }
 
     try {
-        extension.module.init(extension.meta);
+        FileUtils.LoadedModules[extension.moduleIndex].module.init(extension.meta);
     } catch (e) {
         extension.logError('Failed to evaluate \'init\' function on extension: ' + extension.uuid, e);
         return false;
@@ -56,7 +57,7 @@ function finishExtensionLoad(extension) {
 
     let extensionCallbacks;
     try {
-        extensionCallbacks = extension.module.enable();
+        extensionCallbacks = FileUtils.LoadedModules[extension.moduleIndex].module.enable();
     } catch (e) {
         extension.logError('Failed to evaluate \'enable\' function on extension: ' + extension.uuid, e);
         return false;

--- a/js/ui/extensionSystem.js
+++ b/js/ui/extensionSystem.js
@@ -116,7 +116,11 @@ function unloadRemovedExtensions() {
 }
 
 function init() {
-    extensions = imports.extensions;
+    try {
+        extensions = imports.extensions;
+    } catch (e) {
+        extensions = {};
+    }
     ExtensionState = Extension.State;
 
     enabledExtensions = global.settings.get_strv(ENABLED_EXTENSIONS_KEY);

--- a/js/ui/extensionSystem.js
+++ b/js/ui/extensionSystem.js
@@ -92,7 +92,7 @@ function onEnabledExtensionsChanged() {
     unloadRemovedExtensions().then(initEnabledExtensions);
 }
 
-function initEnabledExtensions(callback = null) {
+function initEnabledExtensions() {
     for (let i = 0; i < enabledExtensions.length; i++) {
         promises.push(Extension.loadExtension(enabledExtensions[i], Extension.Type.EXTENSION))
     }
@@ -116,6 +116,7 @@ function unloadRemovedExtensions() {
 }
 
 function init() {
+    let startTime = new Date().getTime();
     try {
         extensions = imports.extensions;
     } catch (e) {
@@ -126,5 +127,6 @@ function init() {
     enabledExtensions = global.settings.get_strv(ENABLED_EXTENSIONS_KEY);
     return initEnabledExtensions().then(function() {
         global.settings.connect('changed::' + ENABLED_EXTENSIONS_KEY, onEnabledExtensionsChanged);
+        global.log(`ExtensionSystem started in ${new Date().getTime() - startTime} ms`);
     });
 }

--- a/js/ui/extensionSystem.js
+++ b/js/ui/extensionSystem.js
@@ -5,8 +5,6 @@ const {getModuleByIndex} = imports.misc.fileUtils;
 
 // Maps uuid -> importer object (extension directory tree)
 let extensions;
-// Maps uuid -> metadata object
-let extensionMeta;
 // Lists extension uuid's that are currently active;
 const runningExtensions = {};
 // Arrays of uuids
@@ -104,10 +102,10 @@ function initEnabledExtensions(callback = null) {
 
 function unloadRemovedExtensions() {
     return new Promise(function(resolve) {
-        let uuidList = Object.keys(Extension.Type.EXTENSION.maps.objects);
+        let uuidList = Extension.extensions;
         for (let i = 0; i < uuidList.length; i++) {
-            if (enabledExtensions.indexOf(uuidList[i]) === -1) {
-                promises.push(Extension.unloadExtension(uuidList[i], Extension.Type.EXTENSION));
+            if (enabledExtensions.indexOf(uuidList[i].uuid) === -1) {
+                promises.push(Extension.unloadExtension(uuidList[i].uuid, Extension.Type.EXTENSION));
             }
         }
         Promise.all(promises).then(function() {
@@ -119,8 +117,7 @@ function unloadRemovedExtensions() {
 
 function init() {
     return new Promise(function(resolve) {
-        extensions = Extension.Type.EXTENSION.maps.importObjects;
-        extensionMeta = Extension.Type.EXTENSION.maps.meta;
+        extensions = imports.extensions;
         ExtensionState = Extension.State;
 
         enabledExtensions = global.settings.get_strv(ENABLED_EXTENSIONS_KEY);

--- a/js/ui/extensionSystem.js
+++ b/js/ui/extensionSystem.js
@@ -4,18 +4,18 @@ const Extension = imports.ui.extension;
 const {getModuleByIndex} = imports.misc.fileUtils;
 
 // Maps uuid -> importer object (extension directory tree)
-let extensions;
+var extensions;
 // Lists extension uuid's that are currently active;
-const runningExtensions = [];
+var runningExtensions = [];
 // Arrays of uuids
-let enabledExtensions;
+var enabledExtensions;
 // Maps extension.uuid -> extension objects
-const extensionObj = [];
-let promises = [];
-const ENABLED_EXTENSIONS_KEY = 'enabled-extensions';
+var extensionObj = [];
+var promises = [];
+var ENABLED_EXTENSIONS_KEY = 'enabled-extensions';
 
 // Deprecated, kept for compatibility reasons
-let ExtensionState;
+var ExtensionState;
 
 // Deprecated, kept for compatibility reasons
 function disableExtension(uuid) {

--- a/js/ui/extensionSystem.js
+++ b/js/ui/extensionSystem.js
@@ -6,7 +6,7 @@ const {getModuleByIndex} = imports.misc.fileUtils;
 // Maps uuid -> importer object (extension directory tree)
 let extensions;
 // Lists extension uuid's that are currently active;
-const runningExtensions = {};
+const runningExtensions = [];
 // Arrays of uuids
 let enabledExtensions;
 // Maps extension.uuid -> extension objects
@@ -34,7 +34,10 @@ function prepareExtensionUnload(extension) {
     } catch (e) {
         Extension.logError('Failed to evaluate \'disable\' function on extension: ' + extension.uuid, e);
     }
-    delete runningExtensions[extension.uuid];
+    let runningExtensionIndex = runningExtensions.findIndex(function(uuid) {
+        return extension.uuid === uuid;
+    });
+    runningExtensions.splice(runningExtensionIndex, 1);
 
     if (extensionObj[extension.uuid])
         delete extensionObj[extension.uuid];
@@ -62,7 +65,7 @@ function finishExtensionLoad(extensionIndex) {
         return false;
     }
 
-    runningExtensions[extension.uuid] = true;
+    runningExtensions.push(extension.uuid);
 
     // extensionCallbacks is an object returned by the enable() function defined in extension.js.
     // The extensionCallbacks object should contain functions that can be used by the "callback" key

--- a/js/ui/extensionSystem.js
+++ b/js/ui/extensionSystem.js
@@ -1,7 +1,7 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
 const Extension = imports.ui.extension;
-const FileUtils = imports.misc.fileUtils;
+const {getModuleByIndex} = imports.misc.fileUtils;
 
 // Maps uuid -> importer object (extension directory tree)
 let extensions;
@@ -32,7 +32,7 @@ function enableExtension(uuid) {
 // Callback for extension.js
 function prepareExtensionUnload(extension) {
     try {
-        FileUtils.LoadedModules[extension.moduleIndex].module.disable();
+        getModuleByIndex(extension.moduleIndex).disable();
     } catch (e) {
         extension.logError('Failed to evaluate \'disable\' function on extension: ' + extension.uuid, e);
     }
@@ -44,12 +44,12 @@ function prepareExtensionUnload(extension) {
 
 // Callback for extension.js
 function finishExtensionLoad(extension) {
-    if (!extension.lockRole(FileUtils.LoadedModules[extension.moduleIndex].module)) {
+    if (!extension.lockRole(getModuleByIndex(extension.moduleIndex))) {
         return false;
     }
 
     try {
-        FileUtils.LoadedModules[extension.moduleIndex].module.init(extension.meta);
+        getModuleByIndex(extension.moduleIndex).init(extension.meta);
     } catch (e) {
         extension.logError('Failed to evaluate \'init\' function on extension: ' + extension.uuid, e);
         return false;
@@ -57,7 +57,7 @@ function finishExtensionLoad(extension) {
 
     let extensionCallbacks;
     try {
-        extensionCallbacks = FileUtils.LoadedModules[extension.moduleIndex].module.enable();
+        extensionCallbacks = getModuleByIndex(extension.moduleIndex).enable();
     } catch (e) {
         extension.logError('Failed to evaluate \'enable\' function on extension: ' + extension.uuid, e);
         return false;

--- a/js/ui/lookingGlass.js
+++ b/js/ui/lookingGlass.js
@@ -605,26 +605,23 @@ Melange.prototype = {
     // DBus function
     GetExtensionList: function() {
         try {
-            let extensionList = [];
-            for (let type in Extension.Type) {
-                type = Extension.Type[type];
-                for(let uuid in type.maps.meta){
-                    let meta = type.maps.meta[uuid];
-                    // There can be cases where we create dummy extension metadata
-                    // that's not really a proper extension. Don't bother with these.
-                    if (meta.name) {
-                        extensionList.push({
-                            status: Extension.getMetaStateString(meta.state),
-                            name: meta.name,
-                            description: meta.description,
-                            uuid: uuid,
-                            folder: meta.path,
-                            url: meta.url ? meta.url : '',
-                            type: type.name,
-                            error_message: meta.error ? meta.error : _("Loaded successfully"),
-                            error: meta.error ? "true" : "false" // Must use string due to dbus restrictions
-                        });
-                    }
+            let extensionList = Array(Extension.extensions.length);
+            for (let i = 0; i < extensionList.length; i++) {
+                let meta = Extension.extensions[i].meta;
+                // There can be cases where we create dummy extension metadata
+                // that's not really a proper extension. Don't bother with these.
+                if (meta.name) {
+                    extensionList[i] = {
+                        status: Extension.getMetaStateString(meta.state),
+                        name: meta.name,
+                        description: meta.description,
+                        uuid: Extension.extensions[i].uuid,
+                        folder: meta.path,
+                        url: meta.url ? meta.url : '',
+                        type: Extension.extensions[i].name,
+                        error_message: meta.error ? meta.error : _("Loaded successfully"),
+                        error: meta.error ? "true" : "false" // Must use string due to dbus restrictions
+                    };
                 }
             }
             return [true, extensionList];

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -3,7 +3,7 @@
  * FILE:main.js
  * @short_description: This is the heart of Cinnamon, the mother of everything.
  * @placesManager (PlacesManager.PlacesManager): The places manager
- * @overview (Overview.Overview): The "scale" overview 
+ * @overview (Overview.Overview): The "scale" overview
  * @expo (Expo.Expo): The "expo" overview
  * @runDialog (RunDialog.RunDialog): The run dialog
  * @lookingGlass (LookingGlass.Melange): The looking glass object
@@ -258,8 +258,6 @@ function _initUserSession() {
 
     systrayManager = new Systray.SystrayManager();
     indicatorManager = new IndicatorManager.IndicatorManager();
-    
-    ExtensionSystem.init();
 
     Meta.keybindings_set_custom_handler('panel-run-dialog', function() {
        getRunDialog().open();
@@ -320,13 +318,13 @@ function start() {
 
     log("About to start Cinnamon");
     if (GLib.getenv('CINNAMON_SOFTWARE_RENDERING')) {
-        log("ACTIVATING SOFTWARE RENDERING");        
+        log("ACTIVATING SOFTWARE RENDERING");
         global.logError("Cinnamon Software Rendering mode enabled");
         software_rendering = true;
     }
 
     // Chain up async errors reported from C
-    global.connect('notify-error', function (global, msg, detail) { notifyError(msg, detail); });    
+    global.connect('notify-error', function (global, msg, detail) { notifyError(msg, detail); });
 
     Gio.DesktopAppInfo.set_desktop_env('X-Cinnamon');
 
@@ -352,9 +350,9 @@ function start() {
     // actor so set it anyways.
     global.stage.color = DEFAULT_BACKGROUND_COLOR;
     global.stage.no_clear_hint = true;
-    
+
     Gtk.IconTheme.get_default().append_search_path("/usr/share/cinnamon/icons/");
-    _defaultCssStylesheet = global.datadir + '/theme/cinnamon.css';    
+    _defaultCssStylesheet = global.datadir + '/theme/cinnamon.css';
 
     soundManager = new SoundManager.SoundManager();
 
@@ -365,7 +363,7 @@ function start() {
     backgroundManager = new BackgroundManager.BackgroundManager();
 
     slideshowManager = new SlideshowManager.SlideshowManager();
-    
+
     deskletContainer = new DeskletManager.DeskletContainer();
 
     // Set up stage hierarchy to group all UI actors under one container.
@@ -433,17 +431,17 @@ function start() {
     overview = new Overview.Overview();
     expo = new Expo.Expo();
 
-    statusIconDispatcher = new StatusIconDispatcher.StatusIconDispatcher();  
+    statusIconDispatcher = new StatusIconDispatcher.StatusIconDispatcher();
 
     layoutManager._updateBoxes();
-    
+
     wm = new WindowManager.WindowManager();
     messageTray = new MessageTray.MessageTray();
     keyboard = new Keyboard.Keyboard();
     notificationDaemon = new NotificationDaemon.NotificationDaemon();
     windowAttentionHandler = new WindowAttentionHandler.WindowAttentionHandler();
 
-    placesManager = new PlacesManager.PlacesManager();    
+    placesManager = new PlacesManager.PlacesManager();
 
     keybindingManager = new Keybindings.KeybindingManager();
     magnifier = new Magnifier.Magnifier();
@@ -451,7 +449,7 @@ function start() {
     Meta.later_add(Meta.LaterType.BEFORE_REDRAW, _checkWorkspaces);
 
     dynamicWorkspaces = false; // This should be configurable
-    
+
     layoutManager.init();
     keyboard.init();
     overview.init();
@@ -477,7 +475,7 @@ function start() {
         let module = eval('imports.perf.' + perfModuleName + ';');
         Scripting.runPerfScript(module, perfOutput);
     }
-    
+
     wmSettings = new Gio.Settings({schema_id: "org.cinnamon.desktop.wm.preferences"})
     workspace_names = wmSettings.get_strv("workspace-names");
 
@@ -489,56 +487,56 @@ function start() {
 
     _nWorkspacesChanged();
 
-    startTime = new Date().getTime();
-    AppletManager.init();
-    global.log('AppletManager.init() started in %d ms'.format(new Date().getTime() - startTime));
+    Promise.all([
+        AppletManager.init(new Date().getTime()),
+        ExtensionSystem.init(),
+        DeskletManager.init(),
+        SearchProviderManager.init()
+    ]).then(function() {
+        createLookingGlass();
 
-    DeskletManager.init();
-    SearchProviderManager.init();
+        a11yHandler = new Accessibility.A11yHandler();
 
-    createLookingGlass();
+        if (software_rendering && !GLib.getenv('CINNAMON_2D')) {
+            notifyCinnamon2d();
+        }
 
-    a11yHandler = new Accessibility.A11yHandler();
+        if (xlet_startup_error)
+            Mainloop.timeout_add_seconds(3, notifyXletStartupError);
 
-    if (software_rendering && !GLib.getenv('CINNAMON_2D')) {
-        notifyCinnamon2d();
-    }
+        let sound_settings = new Gio.Settings( {schema_id: "org.cinnamon.sounds"} );
+        let do_login_sound = sound_settings.get_boolean("login-enabled");
 
-    if (xlet_startup_error)
-        Mainloop.timeout_add_seconds(3, notifyXletStartupError);
+        // We're mostly prepared for the startup animation
+        // now, but since a lot is going on asynchronously
+        // during startup, let's defer the startup animation
+        // until the event loop is uncontended and idle.
+        // This helps to prevent us from running the animation
+        // when the system is bogged down
+        if (do_animation) {
+            let id = GLib.idle_add(GLib.PRIORITY_LOW, Lang.bind(this, function() {
+                if (do_login_sound)
+                    soundManager.play_once_per_session('login');
+                layoutManager._startupAnimation();
+                return GLib.SOURCE_REMOVE;
+            }));
+        } else {
+            global.background_actor.show();
+            setRunState(RunState.RUNNING);
 
-    let sound_settings = new Gio.Settings( {schema_id: "org.cinnamon.sounds"} );
-    let do_login_sound = sound_settings.get_boolean("login-enabled");
-
-    // We're mostly prepared for the startup animation
-    // now, but since a lot is going on asynchronously
-    // during startup, let's defer the startup animation
-    // until the event loop is uncontended and idle.
-    // This helps to prevent us from running the animation
-    // when the system is bogged down
-    if (do_animation) {
-        let id = GLib.idle_add(GLib.PRIORITY_LOW, Lang.bind(this, function() {
             if (do_login_sound)
                 soundManager.play_once_per_session('login');
-            layoutManager._startupAnimation();
-            return GLib.SOURCE_REMOVE;
-        }));
-    } else {
-        global.background_actor.show();
-        setRunState(RunState.RUNNING);
+        }
 
-        if (do_login_sound)
-            soundManager.play_once_per_session('login');
-    }
+        // Disable panel edit mode when Cinnamon starts
+        if (global.settings.get_boolean("panel-edit-mode")) {
+            global.settings.set_boolean("panel-edit-mode", false);
+        }
 
-    // Disable panel edit mode when Cinnamon starts
-    if (global.settings.get_boolean("panel-edit-mode")) {
-        global.settings.set_boolean("panel-edit-mode", false);
-    }
+        global.connect('shutdown', do_shutdown_sequence);
 
-    global.connect('shutdown', do_shutdown_sequence);
-
-    global.log('Cinnamon took %d ms to start'.format(new Date().getTime() - cinnamonStartTime));
+        global.log('Cinnamon took %d ms to start'.format(new Date().getTime() - cinnamonStartTime));
+    });
 }
 
 function notifyCinnamon2d() {
@@ -1071,9 +1069,9 @@ function _log(category = 'info', msg = '') {
 /**
  * isError:
  * @obj (Object): the object to be tested
- * 
+ *
  * Tests whether @obj is an error object
- * 
+ *
  * Returns (boolean): whether @obj is an error object
  */
 function isError(obj) {
@@ -1099,7 +1097,7 @@ function isError(obj) {
 /**
  * _LogTraceFormatted:
  * @stack (string): the stack trace
- * 
+ *
  * Prints the stack trace to the LookingGlass
  * error stream in a predefined format
  */
@@ -1159,13 +1157,13 @@ function _logWarning(msg) {
  * _logError:
  * @msg (string): (optional) The message string
  * @error (Error): (optional) The error object
- * 
+ *
  * Logs the following (if present) to the
  * LookingGlass error stream:
  * - The message from the error object
  * - The stack trace of the error object
  * - The message @msg
- * 
+ *
  * It can be called in the form of either _logError(msg),
  * _logError(error) or _logError(msg, error).
  */
@@ -1186,9 +1184,9 @@ function _logError(msg, error) {
 /**
  * _logInfo:
  * @msg (Error/string): The error object or the message string
- * 
+ *
  * Logs the message to the LookingGlass
- * error stream. If @msg is an Error object, 
+ * error stream. If @msg is an Error object,
  * its stack trace will also be printed
  */
 
@@ -1219,7 +1217,7 @@ function formatTime(d) {
 /**
  * renderLogLine:
  * @line (dictionary): a log line
- * 
+ *
  * Converts a log line object into a string
  *
  * Returns (string): line in the format CATEGORY t=TIME MESSAGE
@@ -1312,7 +1310,7 @@ function _stageEventHandler(actor, event) {
         expo.hide();
         return true;
     }
-       
+
     if (action == Meta.KeyBindingAction.SWITCH_PANELS) {
         //Used to call the ctrlalttabmanager in Gnome Shell
         return true;
@@ -1329,8 +1327,8 @@ function _stageEventHandler(actor, event) {
              wm.actionMoveWorkspaceRight();
              return true;
         case Meta.KeyBindingAction.WORKSPACE_UP:
-            overview.hide();   
-            expo.hide();                  
+            overview.hide();
+            expo.hide();
             return true;
         case Meta.KeyBindingAction.WORKSPACE_DOWN:
             overview.hide();
@@ -1375,7 +1373,7 @@ function _findModal(actor) {
  * @timestamp is optionally used to associate the call with a specific user
  * initiated event.  If not provided then the value of
  * global.get_current_time() is assumed.
- * 
+ *
  * Returns (boolean): true iff we successfully acquired a grab or already had one
  */
 function pushModal(actor, timestamp, options) {
@@ -1670,7 +1668,7 @@ function isInteresting(metaWindow) {
     if (tracker.get_window_app(metaWindow)) {
         // orphans don't have an app!
         return false;
-    }    
+    }
     let type = metaWindow.get_window_type();
     return type === Meta.WindowType.DIALOG || type === Meta.WindowType.MODAL_DIALOG;
 }

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -488,7 +488,7 @@ function start() {
     _nWorkspacesChanged();
 
     Promise.all([
-        AppletManager.init(new Date().getTime()),
+        AppletManager.init(),
         ExtensionSystem.init(),
         DeskletManager.init(),
         SearchProviderManager.init()

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -1621,10 +1621,10 @@ PanelContextMenu.prototype = {
         this.addPanelItem.setSensitive(Main.panelManager.canAdd);
         this.pasteAppletItem.setSensitive(AppletManager.clipboard.length != 0);
 
-        let defs = AppletManager.enabledAppletDefinitions.idMap;
+        let {definitions} = AppletManager;
         let nonEmpty = false;
-        for (let i = 0, len = defs.length; i < len; i++) {
-            if (defs[i] && defs[i].panelId == this.panelId) {
+        for (let i = 0, len = definitions.length; i < len; i++) {
+            if (definitions[i] && definitions[i].panelId === this.panelId) {
                 nonEmpty = true;
                 break;
             }

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -1563,7 +1563,7 @@ function populateSettingsMenu(menu, panelId) {
         let dialog = new ModalDialog.ConfirmDialog(
                 _("Are you sure you want to clear all applets on this panel?") + "\n\n",
                 Lang.bind(this, function() {
-                    AppletManager.clearAppletConfiguration(this.panelId);
+                    AppletManager.clearAppletConfiguration(this.panelId, true);
                 }));
         dialog.open();
     });

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -2131,7 +2131,7 @@ Panel.prototype = {
                                    // the destroy process can test it
 
         this._clearPanelBarriers();
-        AppletManager.unloadAppletsOnPanel(this);
+        AppletManager.unloadAppletsOnPanel(this.panelId);
         this._context_menu.close();
         this._context_menu.destroy();
 

--- a/js/ui/searchProviderManager.js
+++ b/js/ui/searchProviderManager.js
@@ -3,7 +3,6 @@
 const Extension = imports.ui.extension;
 const {getModuleByIndex} = imports.misc.fileUtils;
 const GLib = imports.gi.GLib;
-const Gio = imports.gi.Gio;
 const Lang = imports.lang;
 
 // Maps uuid -> importer object (extension directory tree)

--- a/js/ui/searchProviderManager.js
+++ b/js/ui/searchProviderManager.js
@@ -57,6 +57,7 @@ function unloadRemovedSearchProviders() {
 }
 
 function init() {
+    let startTime = new Date().getTime();
     try {
         extensions = imports.search_providers;
     } catch (e) {
@@ -67,6 +68,7 @@ function init() {
 
     return initEnabledSearchProviders().then(function() {
         global.settings.connect('changed::' + ENABLED_SEARCH_PROVIDERS_KEY, onEnabledSearchProvidersChanged);
+        global.log(`SearchProviderManager started in ${new Date().getTime() - startTime} ms`);
     });
 }
 

--- a/js/ui/searchProviderManager.js
+++ b/js/ui/searchProviderManager.js
@@ -3,18 +3,17 @@
 const Extension = imports.ui.extension;
 const {getModuleByIndex} = imports.misc.fileUtils;
 const GLib = imports.gi.GLib;
-const Lang = imports.lang;
 
 // Maps uuid -> importer object (extension directory tree)
-let extensions;
+var extensions;
 // Kept for compatibility
-let extensionMeta;
+var extensionMeta;
 // Maps uuid -> extension state object (returned from init())
-const searchProviderObj = {};
+var searchProviderObj = {};
 // Arrays of uuids
-let enabledSearchProviders;
-let promises = [];
-const ENABLED_SEARCH_PROVIDERS_KEY = 'enabled-search-providers';
+var enabledSearchProviders;
+var promises = [];
+var ENABLED_SEARCH_PROVIDERS_KEY = 'enabled-search-providers';
 
 // Callback for extension.js
 function prepareExtensionUnload(extension) {

--- a/js/ui/searchProviderManager.js
+++ b/js/ui/searchProviderManager.js
@@ -43,7 +43,9 @@ function initEnabledSearchProviders() {
 }
 
 function unloadRemovedSearchProviders() {
-    let uuidList = Extension.extensions;
+    let uuidList = Extension.extensions.filter(function(extension) {
+        return extension.lowerType === 'search_provider';
+    });
     for (let i = 0; i < enabledSearchProviders.length; i++) {
         if (enabledSearchProviders.indexOf(uuidList[i].uuid) === -1) {
             promises.push(Extension.unloadExtension(uuidList[i].uuid, Extension.Type.SEARCH_PROVIDER));

--- a/js/ui/searchProviderManager.js
+++ b/js/ui/searchProviderManager.js
@@ -1,7 +1,7 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
 const Extension = imports.ui.extension;
-const FileUtils = imports.misc.fileUtils;
+const {getModuleByIndex} = imports.misc.fileUtils;
 const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
 const Lang = imports.lang;
@@ -24,7 +24,7 @@ function prepareExtensionUnload(extension) {
 
 // Callback for extension.js
 function finishExtensionLoad(extension) {
-    searchProviderObj[extension.uuid] = FileUtils.LoadedModules[extension.moduleIndex].module;
+    searchProviderObj[extension.uuid] = getModuleByIndex(extension.moduleIndex);
     return true;
 }
 

--- a/js/ui/searchProviderManager.js
+++ b/js/ui/searchProviderManager.js
@@ -51,7 +51,6 @@ function unloadRemovedSearchProviders() {
     }
     return Promise.all(promises).then(function() {
         promises = [];
-        resolve();
     });
 }
 

--- a/js/ui/searchProviderManager.js
+++ b/js/ui/searchProviderManager.js
@@ -21,7 +21,8 @@ function prepareExtensionUnload(extension) {
 }
 
 // Callback for extension.js
-function finishExtensionLoad(extension) {
+function finishExtensionLoad(extensionIndex) {
+    let extension = Extension.extensions[extensionIndex];
     searchProviderObj[extension.uuid] = getModuleByIndex(extension.moduleIndex);
     return true;
 }

--- a/js/ui/searchProviderManager.js
+++ b/js/ui/searchProviderManager.js
@@ -1,6 +1,7 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
 const Extension = imports.ui.extension;
+const FileUtils = imports.misc.fileUtils;
 const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
 const Lang = imports.lang;
@@ -23,7 +24,7 @@ function prepareExtensionUnload(extension) {
 
 // Callback for extension.js
 function finishExtensionLoad(extension) {
-    searchProviderObj[extension.uuid] = extension.module;
+    searchProviderObj[extension.uuid] = FileUtils.LoadedModules[extension.moduleIndex].module;
     return true;
 }
 

--- a/js/ui/searchProviderManager.js
+++ b/js/ui/searchProviderManager.js
@@ -57,7 +57,11 @@ function unloadRemovedSearchProviders() {
 }
 
 function init() {
-    extensions = imports.search_providers;
+    try {
+        extensions = imports.search_providers;
+    } catch (e) {
+        extensions = {};
+    }
 
     enabledSearchProviders = global.settings.get_strv(ENABLED_SEARCH_PROVIDERS_KEY);
 

--- a/js/ui/searchProviderManager.js
+++ b/js/ui/searchProviderManager.js
@@ -34,42 +34,34 @@ function onEnabledSearchProvidersChanged() {
 }
 
 function initEnabledSearchProviders() {
-    return new Promise(function(resolve) {
-        for (let i = 0; i < enabledSearchProviders.length; i++) {
-            promises.push(Extension.loadExtension(enabledSearchProviders[i], Extension.Type.SEARCH_PROVIDER))
-        }
-        Promise.all(promises).then(function() {
-            promises = [];
-            resolve();
-        });
+    for (let i = 0; i < enabledSearchProviders.length; i++) {
+        promises.push(Extension.loadExtension(enabledSearchProviders[i], Extension.Type.SEARCH_PROVIDER))
+    }
+    return Promise.all(promises).then(function() {
+        promises = [];
     });
 }
 
 function unloadRemovedSearchProviders() {
-    return new Promise(function(resolve) {
-        let uuidList = Extension.extensions;
-        for (let i = 0; i < enabledSearchProviders.length; i++) {
-            if (enabledSearchProviders.indexOf(uuidList[i].uuid) === -1) {
-                promises.push(Extension.unloadExtension(uuidList[i].uuid, Extension.Type.SEARCH_PROVIDER));
-            }
+    let uuidList = Extension.extensions;
+    for (let i = 0; i < enabledSearchProviders.length; i++) {
+        if (enabledSearchProviders.indexOf(uuidList[i].uuid) === -1) {
+            promises.push(Extension.unloadExtension(uuidList[i].uuid, Extension.Type.SEARCH_PROVIDER));
         }
-        Promise.all(promises).then(function() {
-            promises = [];
-            resolve();
-        });
+    }
+    return Promise.all(promises).then(function() {
+        promises = [];
+        resolve();
     });
 }
 
 function init() {
-    return new Promise(function(resolve) {
-        extensions = imports.search_providers;
+    extensions = imports.search_providers;
 
-        enabledSearchProviders = global.settings.get_strv(ENABLED_SEARCH_PROVIDERS_KEY);
+    enabledSearchProviders = global.settings.get_strv(ENABLED_SEARCH_PROVIDERS_KEY);
 
-        initEnabledSearchProviders().then(function() {
-            global.settings.connect('changed::' + ENABLED_SEARCH_PROVIDERS_KEY, onEnabledSearchProvidersChanged);
-            resolve();
-        });
+    return initEnabledSearchProviders().then(function() {
+        global.settings.connect('changed::' + ENABLED_SEARCH_PROVIDERS_KEY, onEnabledSearchProvidersChanged);
     });
 }
 

--- a/js/ui/settings.js
+++ b/js/ui/settings.js
@@ -12,7 +12,6 @@ const Cinnamon = imports.gi.Cinnamon;
 const Main = imports.ui.main;
 const Signals = imports.signals;
 const Extension = imports.ui.extension;
-const Mainloop = imports.mainloop;
 
 /**
  * ENUM:BindingDirection
@@ -31,7 +30,7 @@ const Mainloop = imports.mainloop;
  * Deprecated since 3.2: Binding direction is no longer meaningful. Please do not
  * use in new code.
  */
-const BindingDirection = {
+var BindingDirection = {
     IN : 1,
     OUT : 2,
     BIDIRECTIONAL : 3

--- a/js/ui/settings.js
+++ b/js/ui/settings.js
@@ -601,7 +601,7 @@ XletSettingsBase.prototype = {
         if (!configDir.query_exists(null)) configDir.make_directory_with_parents(null);
         this.file = configDir.get_child(this.instanceId + ".json");
         this.monitor = this.file.monitor_file(Gio.FileMonitorFlags.NONE, null);
-        let xletDir = this.ext_type.maps.dirs[this.uuid];
+        let xletDir = Extension.getExtension(this.uuid).dir;
         let templateFile = xletDir.get_child("settings-schema.json");
 
         // If the settings have already been installed previously we need to check if the schema
@@ -788,12 +788,11 @@ AppletSettings.prototype = {
      * @instanceId (int): instance id of the applet
      */
     _init: function (xlet, uuid, instanceId) {
-        this.ext_type = Extension.Type.APPLET;
         XletSettingsBase.prototype._init.call(this, xlet, uuid, instanceId, "Applet");
     },
 
     _get_is_multi_instance_xlet: function(uuid) {
-        return Extension.get_max_instances(uuid, this.ext_type) != 1;
+        return Extension.get_max_instances(uuid) != 1;
     },
 };
 
@@ -817,12 +816,11 @@ DeskletSettings.prototype = {
      * @instanceId (int): instance id of the desklet
      */
     _init: function (xlet, uuid, instanceId) {
-        this.ext_type = Extension.Type.DESKLET;
         XletSettingsBase.prototype._init.call(this, xlet, uuid, instanceId, "Desklet");
     },
 
     _get_is_multi_instance_xlet: function(uuid) {
-        return Extension.get_max_instances(uuid, this.ext_type) > 1;
+        return Extension.get_max_instances(uuid) > 1;
     }
 };
 
@@ -845,7 +843,6 @@ ExtensionSettings.prototype = {
      * @uuid (string): uuid of the extension
      */
     _init: function (xlet, uuid) {
-        this.ext_type = Extension.Type.EXTENSION;
         XletSettingsBase.prototype._init.call(this, xlet, uuid, null, "Extension");
     },
 

--- a/tests/interactive/urgentwindow.py
+++ b/tests/interactive/urgentwindow.py
@@ -1,6 +1,7 @@
-#!/usr/bin/python2
-from gi.repository import Gtk
-import glib
+#!/usr/bin/python3
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk, GLib
 
 class MessageDialogWindow(Gtk.Window):
     counter = 0
@@ -12,7 +13,7 @@ class MessageDialogWindow(Gtk.Window):
         self.set_urgency_hint(self.counter%2 == 0)
         self.counter = self.counter + 1
         if self.counter < 10:
-            glib.timeout_add(1000 * (self.counter % 7), self.show_urgent)
+            GLib.timeout_add(1000 * (self.counter % 7), self.show_urgent)
         else:
             self.set_urgency_hint(1==1)
 
@@ -20,5 +21,5 @@ class MessageDialogWindow(Gtk.Window):
 win = MessageDialogWindow()
 win.connect("delete-event", Gtk.main_quit)
 win.show_all()
-glib.timeout_add(3000, win.show_urgent)
+GLib.timeout_add(3000, win.show_urgent)
 Gtk.main()

--- a/tools/check-for-missing.py
+++ b/tools/check-for-missing.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 #
 # This is a simple script that we use to check for files in git
 # and not in the distribution. It was previously written in cinnamon
@@ -16,10 +16,10 @@ os.chdir(srcdir)
 
 status=0
 for f in subprocess.Popen(["git", "ls-files"], stdout=subprocess.PIPE).stdout:
-    f = f.strip()
+    f = f.decode('utf-8').strip()
     if (not os.path.exists(os.path.join(distdir, f)) and
             not any((fnmatch.fnmatch(f, p) for p in excludes))):
-        print "File missing from distribution:", f
+        print("File missing from distribution:", f)
         status=1
 
 sys.exit(status)


### PR DESCRIPTION
Depends on: https://github.com/linuxmint/cjs/pull/54

This cleans up some cyclical references and moves state from nested objects to an array of objects in extension.js. Global properties were made read-only, in the unlikely event they are re-assigned and crash Cinnamon. This also restructures the extension code for asynchronous loading using [Promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). 

The main advantage of loading extensions asynchronously is non-blocking I/O. Currently, when an extension is loaded, the UI locks up until the extension is finished loading. Worse, this can cause Cinnamon to freeze up entirely if a mistake is made in the xlet's code. It also opens up the possibility of off-loading smaller tasks to dedicated worker threads, such as reading files.

A new module importer is added that brings fixes for xlets not getting fully removed from the JS context when removed from the panel, or reloaded, and brings closer compatibility to libraries written for node. 

Example usage of the module importer from inside an xlet:

```js
const Cinnamon = require('gi.Cinnamon');
const DND = require('ui.dnd');
const gettext = require('gettext');
const myModuleA = require('./myModuleA.js');
```
Node conventions such as ```require```, ```module.exports```, ```__dirname```, and ```__filename``` only exist in the extension context.

No breaking changes to the API are introduced with this PR outside of the internal extension utilities.