### PR TITLE
panel: ensure rightbox has something to drag into in edit mode when e…

### DIFF
--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -1749,14 +1749,41 @@ PanelZoneDNDHandler.prototype = {
                 curAppletPos++;
             }
         }
+
         source.actor._applet._newOrder = insertAppletPos;
         source.actor._applet._newPanelLocation = this._panelZone;
         source.actor._applet._zoneString = this._zoneString;
         source.actor._applet._newPanelId = this._panelId;
 
+        let sourcebox = source.actor._applet._panelLocation; /* this is the panel box providing the applet */
+
         this._clearDragPlaceholder();
         actor.destroy();
         AppletManager.saveAppletsPositions();
+
+        /* this._panelZone is the panel box being dropped into. Note that the style class name will
+           be something like 'panelLeft' or 'panelLeft vertical'*/
+
+        if (this._panelZone.has_style_class_name("panelRight") || this._panelZone.has_style_class_name("panelLeft")) {
+          this._panelZone.set_size(-1, -1);  /* kludge pt 2 - if the box being dropped into
+                                               has been set a fixed size then we need to let it adjust. */
+
+        }
+
+        if (sourcebox.has_style_class_name("panelRight") || sourcebox.has_style_class_name("panelLeft")) {
+          children = sourcebox.get_children();
+          if (children.length == 0) {         /* put back some minimum space if the source box is now empty */
+            if (sourcebox.get_parent()._delegate.is_vertical) {
+               let height = sourcebox.get_height();
+             if (height < EDIT_MODE_MIN_BOX_SIZE * global.ui_scale)
+                 sourcebox.set_height(EDIT_MODE_MIN_BOX_SIZE * global.ui_scale);
+            } else {
+              let width = sourcebox.get_width();
+              if (width < EDIT_MODE_MIN_BOX_SIZE * global.ui_scale)
+                 sourcebox.set_width(EDIT_MODE_MIN_BOX_SIZE * global.ui_scale);
+            }
+          }
+        }
 
         return true;
     },
@@ -2289,6 +2316,38 @@ Panel.prototype = {
         this._centerBox.change_style_pseudo_class('dnd', this._panelEditMode);
         this._rightBox.change_style_pseudo_class('dnd', this._panelEditMode);
 
+        /* this next section is a bit of a kludge and should be reworked when
+           someone can find a better way. The issue is that boxlayout left and right
+           align can show no visible box when containing no applets.  This puts a
+           fixed min size in to permit a drop to happen in edit mode, it turns on
+           when selecting edit mode, and off when leaving.
+
+           Note that setting up to use the full width does not work, it gets
+           left alignment which doesn't seem to be able to be over-ridden,
+           and the applet gets a whole box fill effect which is weird when dragging
+           - perhaps x_fill etc. is turned on elsewhere  */
+
+        if (this._panelEditMode) {
+          if (this.is_vertical) {
+            let height = this._rightBox.get_height();
+            if (height < EDIT_MODE_MIN_BOX_SIZE * global.ui_scale)
+                this._rightBox.set_height(EDIT_MODE_MIN_BOX_SIZE * global.ui_scale);
+            height = this._leftBox.get_height();
+            if (height < EDIT_MODE_MIN_BOX_SIZE * global.ui_scale)
+                this._leftBox.set_height(EDIT_MODE_MIN_BOX_SIZE * global.ui_scale);
+          } else {
+            let width = this._rightBox.get_width();
+            if (width < EDIT_MODE_MIN_BOX_SIZE * global.ui_scale)
+                this._rightBox.set_width(EDIT_MODE_MIN_BOX_SIZE * global.ui_scale);
+            width = this._leftBox.get_width();
+            if (width < EDIT_MODE_MIN_BOX_SIZE * global.ui_scale)
+                this._leftBox.set_width(EDIT_MODE_MIN_BOX_SIZE * global.ui_scale);
+          }
+        } else {
+            this._rightBox.set_size(-1, -1);
+            this._leftBox.set_size(-1, -1);
+        }
+
         if (old_mode != this._panelEditMode) {
             this._updatePanelVisibility();
         }
@@ -2658,27 +2717,24 @@ Panel.prototype = {
     },
 
     _set_vertical_panel_style: function() {
-        this._rightBox.add_style_class_name('vertical');
-        this._rightBox.set_vertical(true);
-        this._rightBox.set_x_align(Clutter.ActorAlign.FILL);
-        this._rightBox.set_y_align(Clutter.ActorAlign.END);
 
         this._leftBox.add_style_class_name('vertical');
         this._leftBox.set_vertical(true);
         this._leftBox.set_x_align(Clutter.ActorAlign.FILL);
-        this._leftBox.set_y_align(Clutter.ActorAlign.FILL);
+        this._leftBox.set_y_align(Clutter.ActorAlign.START);
 
         this._centerBox.add_style_class_name('vertical');
         this._centerBox.set_vertical(true);
         this._centerBox.set_x_align(Clutter.ActorAlign.FILL);
         this._centerBox.set_y_align(Clutter.ActorAlign.FILL);
+
+        this._rightBox.add_style_class_name('vertical');
+        this._rightBox.set_vertical(true);
+        this._rightBox.set_x_align(Clutter.ActorAlign.FILL);
+        this._rightBox.set_y_align(Clutter.ActorAlign.END);
     },
 
     _set_horizontal_panel_style: function() {
-        this._rightBox.remove_style_class_name('vertical');
-        this._rightBox.set_vertical(false);
-        this._rightBox.set_x_align(Clutter.ActorAlign.END);
-        this._rightBox.set_y_align(Clutter.ActorAlign.FILL);
 
         this._leftBox.remove_style_class_name('vertical');
         this._leftBox.set_vertical(false);
@@ -2689,6 +2745,11 @@ Panel.prototype = {
         this._centerBox.set_vertical(false);
         this._centerBox.set_x_align(Clutter.ActorAlign.FILL);
         this._centerBox.set_y_align(Clutter.ActorAlign.FILL);
+
+        this._rightBox.remove_style_class_name('vertical');
+        this._rightBox.set_vertical(false);
+        this._rightBox.set_x_align(Clutter.ActorAlign.END);
+        this._rightBox.set_y_align(Clutter.ActorAlign.FILL);
     },
 
     _setFont: function(panelHeight) {
@@ -2806,11 +2867,12 @@ Panel.prototype = {
         let centerBoxOccupied = this._centerBox.get_n_children() > 0;
 
         /* If panel edit mode, pretend central box is occupied and give it at
-         * least width 25 so that things can be dropped into it */
+         * least a minimum width so that things can be dropped into it.
+           Note that this has to be combined with the box being given Clutter.ActorAlign.FILL */
         if (this._panelEditMode) {
             centerBoxOccupied  = true;
-            centerMinWidth     = Math.max(centerMinWidth, EDIT_MODE_MIN_BOX_SIZE);
-            centerNaturalWidth = Math.max(centerNaturalWidth, EDIT_MODE_MIN_BOX_SIZE);
+            centerMinWidth     = Math.max(centerMinWidth, EDIT_MODE_MIN_BOX_SIZE * global.ui_scale);
+            centerNaturalWidth = Math.max(centerNaturalWidth, EDIT_MODE_MIN_BOX_SIZE * global.ui_scale);
         }
 
         let totalMinWidth             = leftMinWidth + centerMinWidth + rightMinWidth;
@@ -2946,6 +3008,16 @@ Panel.prototype = {
 
         let allocHeight  = box.y2 - box.y1;
         let allocWidth   = box.x2 - box.x1;
+
+        /* The boxes are layout managers, so they rubber-band around their contents and have a few
+           characteristics that they enforce on their contents.  Of particular note is that the alignment
+           - LEFT, CENTER, RIGHT - is not independent of the fill as it probably ought to be, and that there
+           is this hybrid FILL alignment that also comes with implied left alignment (probably locale dependent).
+           Which is not a great problem when there is something in the box, but if there is nothing in the box and
+           something other than FILL alignment is chosen, then the boxes will have no size allocated.
+           Which is a bit of a bummer if you need to drag something into an empty box. So we need to work
+           around this. That's a manual size set when turning on edit mode, combined with adjustments after drop.
+           Note also that settings such as x_fill and y_fill only apply to the children of the box, not to the box itself */
 
         if (this.panelPosition == PanelLoc.left || this.panelPosition == PanelLoc.right) {
 


### PR DESCRIPTION
…mpty

rightbox is coming up with no size to drop into in edit mode after changes to boxlayout.  This ensures that there is something there to drop into, and that things are visually consistent across other boxes.  I'll look and see if reinventing align_end is compatible with the new code, meanwhile this appears to work OK. If the right box is resized to the full size (explicit sizing, or by using constraints) then applets are always left aligned, and there are fill artefacts on drag, that's why I've used only small blank drag zones