### PR TITLE
xlet-settings: translate title in list widget

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/xlet-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/xlet-settings.py
@@ -262,6 +262,10 @@ class MainWindow(object):
                                     continue
                                 new_opt_data[translate(self.uuid, option)] = opt_data[option]
                             settings_map[setting][key] = new_opt_data
+                        elif key in "columns":
+                            columns_data = settings_map[setting][key]
+                            for column in columns_data:
+                                column["title"] = translate(self.uuid, column["title"])
             finally:
                 # if a layout is not explicitly defined, generate the settings
                 # widgets based on the order they occur


### PR DESCRIPTION
The title in the list widget, which has been introduced with Cinnamon 3.4, is not translated.
Gotta catch (and translate) 'em all.