### PR TITLE
Guard against failure of cairo_pattern_get_surface()

### DIFF
--- a/src/st/st-private.c
+++ b/src/st/st-private.c
@@ -561,7 +561,12 @@ _st_create_shadow_cairo_pattern (StShadow        *shadow_spec,
   g_return_val_if_fail (shadow_spec != NULL, NULL);
   g_return_val_if_fail (src_pattern != NULL, NULL);
 
-  cairo_pattern_get_surface (src_pattern, &src_surface);
+  if (cairo_pattern_get_surface (src_pattern, &src_surface) != CAIRO_STATUS_SUCCESS)
+    /* The most likely reason we can't get the pattern is that sizing went hairwire
+     * and the caller tried to create a surface too big for memory, leaving us with
+     * a pattern in an error state; we return a transparent pattern for the shadow.
+     */
+    return cairo_pattern_create_rgba(1.0, 1.0, 1.0, 0.0);
 
   width_in  = cairo_image_surface_get_width  (src_surface);
   height_in = cairo_image_surface_get_height (src_surface);

--- a/src/st/st-theme-node-drawing.c
+++ b/src/st/st-theme-node-drawing.c
@@ -729,7 +729,9 @@ paint_shadow_pattern_to_cairo_context (StShadow *shadow_spec,
       /* Then subtract out the bounds of the surface in the surface
        * pattern; we transform the context by the inverse of the
        * pattern matrix to get to surface coordinates */
-      cairo_pattern_get_surface (pattern, &surface);
+      if (cairo_pattern_get_surface (pattern, &surface) != CAIRO_STATUS_SUCCESS)
+        /* Something went wrong previously */
+        goto no_surface;
       width = cairo_image_surface_get_width  (surface);
       height = cairo_image_surface_get_height (surface);
 
@@ -744,6 +746,7 @@ paint_shadow_pattern_to_cairo_context (StShadow *shadow_spec,
     }
 
   cairo_mask (cr, pattern);
+no_surface:
   cairo_restore (cr);
 }
 


### PR DESCRIPTION
https://github.com/GNOME/gnome-shell/commit/6d22670307928dfdce75a7536598486fa25d51d7#diff-8a01b40c2c1be22ef97916811be0ab65

Stops a potential fault condition causing a crash.