### PR TITLE
dnd: avoid use of deprecated reparent

### DIFF
--- a/js/ui/dnd.js
+++ b/js/ui/dnd.js
@@ -261,7 +261,7 @@ const _Draggable = new Lang.Class({
 
         if (this.actor._delegate && this.actor._delegate.getDragActor) {
             this._dragActor = this.actor._delegate.getDragActor();
-            this._dragActor.reparent(Main.uiGroup);
+            global.reparentActor(this._dragActor, Main.uiGroup);
             this._dragActor.raise_top();
             Cinnamon.util_set_hidden_from_pick(this._dragActor, true);
 
@@ -310,7 +310,7 @@ const _Draggable = new Lang.Class({
             this._dragOffsetX = actorStageX - this._dragStartX;
             this._dragOffsetY = actorStageY - this._dragStartY;
 
-            this._dragActor.reparent(Main.uiGroup);
+            global.reparentActor(this._dragActor, Main.uiGroup);
             this._dragActor.raise_top();
             Cinnamon.util_set_hidden_from_pick(this._dragActor, true);
         }
@@ -615,7 +615,7 @@ const _Draggable = new Lang.Class({
 
     _onAnimationComplete : function (dragActor, eventTime) {
         if (this._dragOrigParent) {
-            dragActor.reparent(this._dragOrigParent);
+            global.reparentActor (dragActor, this._dragOrigParent);
             dragActor.set_scale(this._dragOrigScale, this._dragOrigScale);
             dragActor.set_position(this._dragOrigX, this._dragOrigY);
         } else {


### PR DESCRIPTION
Can't see any regressions. I did see this at one time in the log, but could not reproduce, so it could be coming from somewhere else

(cinnamon:21731): Clutter-CRITICAL **: clutter_layout_manager_allocate: assertion 'CLUTTER_IS_LAYOUT_MANAGER (manager)' failed