### PR TITLE
Update cs_power.py

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_power.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_power.py
@@ -40,6 +40,8 @@ SLEEP_DELAY_OPTIONS = [
     (1800, _("30 minutes")),
     (2700, _("45 minutes")),
     (3600, _("1 hour")),
+    (7200, _("2 hours")),
+    (10800, _("3 hours")),
     (0, _("Never"))
 ]
 


### PR DESCRIPTION
Allow for longer times till the system goes to sleep - added 2 and 3 hours. 
This is useful when listening to albums ( > 60 min) without having to move the mouse or watching movies. 
Maybe this could/should be fixed else where for all different media/video players and maybe browsers (html5 or flash) but given the simplicity of this solution I guess this is useful already - See feature request  #6185

I tested the "fix" (actually just additional options) but the **translation(s) for "hours" are missing** afterwards. 
**Where or how can I add translations?**