### PR TITLE
Use a style class name for the new window list progress indicator

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -1268,7 +1268,7 @@ StScrollBar StButton#vhandle:hover {
     background-gradient-end: rgba(255,144,144,0.5);
 }
 
-.window-list-item-box:progress {
+.window-list-item-box .progress {
     background-gradient-direction: vertical;
     background-gradient-start: rgba(255,52,52,0.5);
     background-gradient-end: rgba(255,144,144,0.5);

--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -280,8 +280,7 @@ AppMenuButton.prototype = {
                 Lang.bind(this, this._getPreferredHeight));
         this.actor.connect('allocate', Lang.bind(this, this._allocate));
 
-        this.progressOverlay = new St.Widget({ style_class: "window-list-item-box", reactive: false, important: true  });
-        this.progressOverlay.add_style_pseudo_class("progress");
+        this.progressOverlay = new St.Widget({ style_class: "progress", reactive: false, important: true  });
 
         this.actor.add_actor(this.progressOverlay);
 


### PR DESCRIPTION
This allows themes a bit more flexibility with theming the new progress
indicator. It also allows our 'important' property to work for themes that don't
yet have specific support.