### PR TITLE
theme-node: Fix font family formatting

### DIFF
--- a/src/st/st-theme-node.c
+++ b/src/st/st-theme-node.c
@@ -2406,7 +2406,7 @@ font_family_from_terms (CRTerm *term,
           if (term->the_operator == NO_OP)
             g_string_append (family_string, " ");
           else
-            g_string_append (family_string, ", ");
+            g_string_append (family_string, ",");
         }
       else
         {


### PR DESCRIPTION
https://github.com/GNOME/gnome-shell/commit/6fc5b0477ba1c77b6bcdd23e07254fbe97c92b83#diff-b948bb195b709c61ce7275142a2fbdfd