### PR TITLE
indicatorManager.js: add support for appindicator SecondaryActivate

### DIFF
--- a/js/ui/indicatorManager.js
+++ b/js/ui/indicatorManager.js
@@ -581,6 +581,16 @@ AppIndicator.prototype = {
         }
     },
 
+    secondaryActivate: function() {
+        if (this._proxy) {
+            let test = this._proxy.call({
+                name: 'SecondaryActivate',
+                paramTypes: 'ii',
+                paramValues: [0, 0]
+            });
+        }
+    },
+
     scroll: function(dx, dy) {
         if (this._proxy) {
             if (dx != 0) {
@@ -1108,9 +1118,13 @@ IndicatorActor.prototype = {
             } else if (event.get_button() == 1) {
                 this.menu.close();
                 this._indicator.open();
+            }else if (event.get_button() == 2) {
+                this._indicator.secondaryActivate();
             }
         } else if ((event.get_button() == 1) && this.menu) {
             this.menu.toggle();
+        } else if ((event.get_button() == 2) && this.menu) {
+            this._indicator.secondaryActivate();
         }
         return false;
     },


### PR DESCRIPTION
Adds support for triggering the SecondaryActivate function on an appindicator by clicking the middle mouse button on the icon. This is the same behaviour as in Unity on Ubuntu, and since middle mouse clicking does nothing in Cinnamon currently I thought it might be nice to have.

More info:
https://bugs.launchpad.net/unity/+bug/812933
https://developer.ubuntu.com/api/devel/ubuntu-13.10/c/AppIndicator3-0.1.html