### PR TITLE
Performance: Avoid caching `this` context in SignalManager instances

### DIFF
--- a/files/usr/share/cinnamon/applets/show-desktop@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/show-desktop@cinnamon.org/applet.js
@@ -24,10 +24,10 @@ MyApplet.prototype = {
         this.settings.bindProperty(Settings.BindingDirection.IN, "peek-opacity", "peek_opacity", null, null);
         this.settings.bindProperty(Settings.BindingDirection.IN, "peek-blur", "peek_blur", null, null);
 
-        this.signals = new SignalManager.SignalManager(this);
+        this.signals = new SignalManager.SignalManager(null);
         this.actor.connect('enter-event', Lang.bind(this, this._on_enter));
         this.actor.connect('leave-event', Lang.bind(this, this._on_leave));
-        this.signals.connect(global.stage, 'notify::key-focus', this._on_leave);
+        this.signals.connect(global.stage, 'notify::key-focus', this._on_leave, this);
 
         this._did_peek = false;
         this._peek_timeout_id = 0;

--- a/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
@@ -58,7 +58,7 @@ MyApplet.prototype = {
         this.actor.set_style_class_name('systray');
         this.actor.set_important(true);  // ensure we get class details from the default theme if not present
 
-        this._signalManager = new SignalManager.SignalManager(this);
+        this._signalManager = new SignalManager.SignalManager(null);
         let manager;
 
         this.orientation = orientation;
@@ -133,9 +133,9 @@ MyApplet.prototype = {
             indicatorActor._applet = this;
 
             this._shellIndicators[appIndicator.id] = indicatorActor;
-            this._signalManager.connect(indicatorActor.actor, 'destroy', this._onIndicatorIconDestroy);
-            this._signalManager.connect(indicatorActor.actor, 'enter-event', this._onEnterEvent);
-            this._signalManager.connect(indicatorActor.actor, 'leave-event', this._onLeaveEvent);
+            this._signalManager.connect(indicatorActor.actor, 'destroy', this._onIndicatorIconDestroy, this);
+            this._signalManager.connect(indicatorActor.actor, 'enter-event', this._onEnterEvent, this);
+            this._signalManager.connect(indicatorActor.actor, 'leave-event', this._onLeaveEvent, this);
 
             this.manager_container.add_actor(indicatorActor.actor);
 
@@ -218,9 +218,9 @@ MyApplet.prototype = {
     on_applet_added_to_panel: function() {
         Main.statusIconDispatcher.start(this.actor.get_parent().get_parent());
 
-        this._signalManager.connect(Main.statusIconDispatcher, 'status-icon-added', this._onTrayIconAdded);
-        this._signalManager.connect(Main.statusIconDispatcher, 'status-icon-removed', this._onTrayIconRemoved);
-        this._signalManager.connect(Main.statusIconDispatcher, 'before-redisplay', this._onBeforeRedisplay);
+        this._signalManager.connect(Main.statusIconDispatcher, 'status-icon-added', this._onTrayIconAdded, this);
+        this._signalManager.connect(Main.statusIconDispatcher, 'status-icon-removed', this._onTrayIconRemoved, this);
+        this._signalManager.connect(Main.statusIconDispatcher, 'before-redisplay', this._onBeforeRedisplay, this);
         this._signalManager.connect(Main.systrayManager, "changed", Main.statusIconDispatcher.redisplay, Main.statusIconDispatcher);
         this._addIndicatorSupport();
     },

--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -1028,23 +1028,23 @@ MyApplet.prototype = {
         this.settings.bind("buttons-use-entire-space", "buttonsUseEntireSpace", this._refreshAllItems);
         this.settings.bind("window-preview", "usePreview", this._onPreviewChanged);
 
-        this.signals = new SignalManager.SignalManager(this);
+        this.signals = new SignalManager.SignalManager(null);
 
         let tracker = Cinnamon.WindowTracker.get_default();
-        this.signals.connect(tracker, "notify::focus-app", this._onFocus);
-        this.signals.connect(global.screen, 'window-added', this._onWindowAdded);
-        this.signals.connect(global.screen, 'window-removed', this._onWindowRemoved);
-        this.signals.connect(global.screen, 'window-monitor-changed', this._onWindowMonitorChanged);
-        this.signals.connect(global.screen, 'window-workspace-changed', this._onWindowWorkspaceChanged);
-        this.signals.connect(global.screen, 'window-skip-taskbar-changed', this._onWindowSkipTaskbarChanged);
-        this.signals.connect(global.screen, 'monitors-changed', this._updateWatchedMonitors);
-        this.signals.connect(global.window_manager, 'switch-workspace', this._refreshAllItems);
+        this.signals.connect(tracker, "notify::focus-app", this._onFocus, this);
+        this.signals.connect(global.screen, 'window-added', this._onWindowAdded, this);
+        this.signals.connect(global.screen, 'window-removed', this._onWindowRemoved, this);
+        this.signals.connect(global.screen, 'window-monitor-changed', this._onWindowMonitorChanged, this);
+        this.signals.connect(global.screen, 'window-workspace-changed', this._onWindowWorkspaceChanged, this);
+        this.signals.connect(global.screen, 'window-skip-taskbar-changed', this._onWindowSkipTaskbarChanged, this);
+        this.signals.connect(global.screen, 'monitors-changed', this._updateWatchedMonitors, this);
+        this.signals.connect(global.window_manager, 'switch-workspace', this._refreshAllItems, this);
 
-        this.signals.connect(global.window_manager, 'minimize', this._onWindowStateChange);
-        this.signals.connect(global.window_manager, 'maximize', this._onWindowStateChange);
-        this.signals.connect(global.window_manager, 'unmaximize', this._onWindowStateChange);
-        this.signals.connect(global.window_manager, 'map', this._onWindowStateChange);
-        this.signals.connect(global.window_manager, 'tile', this._onWindowStateChange);
+        this.signals.connect(global.window_manager, 'minimize', this._onWindowStateChange, this);
+        this.signals.connect(global.window_manager, 'maximize', this._onWindowStateChange, this);
+        this.signals.connect(global.window_manager, 'unmaximize', this._onWindowStateChange, this);
+        this.signals.connect(global.window_manager, 'map', this._onWindowStateChange, this);
+        this.signals.connect(global.window_manager, 'tile', this._onWindowStateChange, this);
 
         this.actor.connect('style-changed', Lang.bind(this, this._updateSpacing));
 
@@ -1166,8 +1166,8 @@ MyApplet.prototype = {
 
     _updateAttentionGrabber: function() {
         if (this.enableAlerts) {
-            this.signals.connect(global.display, "window-marked-urgent", this._onWindowDemandsAttention);
-            this.signals.connect(global.display, "window-demands-attention", this._onWindowDemandsAttention);
+            this.signals.connect(global.display, "window-marked-urgent", this._onWindowDemandsAttention, this);
+            this.signals.connect(global.display, "window-demands-attention", this._onWindowDemandsAttention, this);
         } else {
             this.signals.disconnect("window-marked-urgent");
             this.signals.disconnect("window-demands-attention");

--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
@@ -24,10 +24,10 @@ WorkspaceButton.prototype = {
         this.workspace_name = Main.getWorkspaceName(index);
         this.actor = null; // defined in subclass
 
-        this.ws_signals = new SignalManager.SignalManager(this);
+        this.ws_signals = new SignalManager.SignalManager(null);
 
-        this.ws_signals.connect(this.workspace, "window-added", this.update);
-        this.ws_signals.connect(this.workspace, "window-removed", this.update);
+        this.ws_signals.connect(this.workspace, "window-added", this.update, this);
+        this.ws_signals.connect(this.workspace, "window-removed", this.update, this);
     },
 
     show : function() {
@@ -221,7 +221,7 @@ MyApplet.prototype = {
         try {
             this.orientation = orientation;
             this.panel_height = panel_height;
-            this.signals = new SignalManager.SignalManager(this);
+            this.signals = new SignalManager.SignalManager(null);
             this.buttons = [];
             this._last_switch = 0;
             this._last_switch_direction = 0;
@@ -385,7 +385,7 @@ MyApplet.prototype = {
         this.signals.disconnectAllSignals();
         if (this.display_type == "visual" && !suppress_graph) {
             // In visual mode, keep track of window events to represent them
-            this.signals.connect(global.display, "notify::focus-window", this._onFocusChanged);
+            this.signals.connect(global.display, "notify::focus-window", this._onFocusChanged, this);
             this._onFocusChanged();
         }
     },
@@ -402,8 +402,8 @@ MyApplet.prototype = {
             return;
 
         this._focusWindow = global.display.focus_window.get_compositor_private();
-        this.signals.connect(this._focusWindow, "position-changed", Lang.bind(this, this._onPositionChanged));
-        this.signals.connect(this._focusWindow, "size-changed", Lang.bind(this, this._onPositionChanged));
+        this.signals.connect(this._focusWindow, "position-changed", Lang.bind(this, this._onPositionChanged), this);
+        this.signals.connect(this._focusWindow, "size-changed", Lang.bind(this, this._onPositionChanged), this);
         this._onPositionChanged();
     },
 

--- a/js/ui/accessibility.js
+++ b/js/ui/accessibility.js
@@ -21,7 +21,7 @@ A11yHandler.prototype = {
         this.a11y_keyboard_settings = new Gio.Settings( { schema_id: "org.cinnamon.desktop.a11y.keyboard" });
         this.wm_settings = new Gio.Settings( { schema_id: "org.cinnamon.desktop.wm.preferences" });
 
-        this._signalManager = new SignalManager.SignalManager(this);
+        this._signalManager = new SignalManager.SignalManager(null);
 
         /* Feature toggles */
         this._toggle_keys_osd = false;

--- a/js/ui/expoThumbnail.js
+++ b/js/ui/expoThumbnail.js
@@ -50,12 +50,12 @@ ExpoWindowClone.prototype = {
         this.realWindow = realWindow;
         this.metaWindow = realWindow.meta_window;
         this.refreshClone();
-        this._signalManager = new SignalManager.SignalManager(this);
+        this._signalManager = new SignalManager.SignalManager(null);
 
-        this._signalManager.connect(this.realWindow, 'size-changed', this.onSizeChanged);
+        this._signalManager.connect(this.realWindow, 'size-changed', this.onSizeChanged, this);
         this._signalManager.connect(this.metaWindow, 'workspace-changed', function(w, oldws) {
             this.emit('workspace-changed', oldws);
-        })
+        }, this);
 
         this.onPositionChanged();
         this.onSizeChanged();

--- a/js/ui/indicatorManager.js
+++ b/js/ui/indicatorManager.js
@@ -975,9 +975,9 @@ IndicatorActor.prototype = {
         this._updatedLabel();
         this._updatedStatus();
 
-        this._signalManager = new SignalManager.SignalManager(this);
-        this._signalManager.connect(this.actor, 'scroll-event', this._handleScrollEvent);
-        this._signalManager.connect(Gtk.IconTheme.get_default(), 'changed', this._invalidateIcon);
+        this._signalManager = new SignalManager.SignalManager(null);
+        this._signalManager.connect(this.actor, 'scroll-event', this._handleScrollEvent, this);
+        this._signalManager.connect(Gtk.IconTheme.get_default(), 'changed', this._invalidateIcon, this);
         //this._signalManager.connect(this._indicator, 'icon', this._updateIcon);
         //this._signalManager.connect(this._indicator, 'overlay-icon', this._updateOverlayIcon);
         //this._signalManager.connect(this._indicator, 'ready', this._invalidateIcon);

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -1887,7 +1887,7 @@ Panel.prototype = {
         this._destroyed = false;
         this._positionChanged = false;
         this._monitorsChanged = false;
-        this._signalManager = new SignalManager.SignalManager(this);
+        this._signalManager = new SignalManager.SignalManager(null);
         this.margin_top = 0;
         this.margin_bottom = 0;
         this.margin_left = 0;
@@ -1942,12 +1942,12 @@ Panel.prototype = {
         this.actor.connect('get-preferred-height', Lang.bind(this, this._getPreferredHeight));
         this.actor.connect('allocate', Lang.bind(this, this._allocate));
 
-        this._signalManager.connect(global.settings, "changed::" + PANEL_AUTOHIDE_KEY, this._processPanelAutoHide);
-        this._signalManager.connect(global.settings, "changed::" + PANEL_HEIGHT_KEY, this._moveResizePanel);
-        this._signalManager.connect(global.settings, "changed::" + PANEL_RESIZABLE_KEY, this._moveResizePanel);
-        this._signalManager.connect(global.settings, "changed::" + PANEL_SCALE_TEXT_ICONS_KEY, this._onScaleTextIconsChanged);
-        this._signalManager.connect(global.settings, "changed::panel-edit-mode", this._onPanelEditModeChanged);
-        this._signalManager.connect(global.settings, "changed::no-adjacent-panel-barriers", this._updatePanelBarriers);
+        this._signalManager.connect(global.settings, "changed::" + PANEL_AUTOHIDE_KEY, this._processPanelAutoHide, this);
+        this._signalManager.connect(global.settings, "changed::" + PANEL_HEIGHT_KEY, this._moveResizePanel, this);
+        this._signalManager.connect(global.settings, "changed::" + PANEL_RESIZABLE_KEY, this._moveResizePanel, this);
+        this._signalManager.connect(global.settings, "changed::" + PANEL_SCALE_TEXT_ICONS_KEY, this._onScaleTextIconsChanged, this);
+        this._signalManager.connect(global.settings, "changed::panel-edit-mode", this._onPanelEditModeChanged, this);
+        this._signalManager.connect(global.settings, "changed::no-adjacent-panel-barriers", this._updatePanelBarriers, this);
     },
 
     drawCorners: function(drawcorner)
@@ -2436,8 +2436,8 @@ Panel.prototype = {
             return;
 
         this._focusWindow = global.display.focus_window.get_compositor_private();
-        this._signalManager.connect(this._focusWindow, "position-changed", this._updatePanelVisibility);
-        this._signalManager.connect(this._focusWindow, "size-changed", this._updatePanelVisibility);
+        this._signalManager.connect(this._focusWindow, "position-changed", this._updatePanelVisibility, this);
+        this._signalManager.connect(this._focusWindow, "size-changed", this._updatePanelVisibility, this);
         this._updatePanelVisibility();
     },
 
@@ -2445,13 +2445,13 @@ Panel.prototype = {
         this._autohideSettings = this._getProperty(PANEL_AUTOHIDE_KEY, "s");
 
         if (this._autohideSettings == "intel") {
-            this._signalManager.connect(global.display, "notify::focus-window", this._onFocusChanged);
+            this._signalManager.connect(global.display, "notify::focus-window", this._onFocusChanged, this);
             /* focus-window signal is emitted when the workspace change
              * animation starts. When the animation ends, we do the position
              * check again because the windows have moved. We cannot use
              * _onFocusChanged because _onFocusChanged does nothing when there
              * is no actual focus change. */
-            this._signalManager.connect(global.window_manager, "switch-workspace-complete", this._updatePanelVisibility);
+            this._signalManager.connect(global.window_manager, "switch-workspace-complete", this._updatePanelVisibility, this);
             this._onFocusChanged();
         } else {
             this._signalManager.disconnect("notify::focus-window");

--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -105,7 +105,7 @@ PopupBaseMenuItem.prototype = {
                                          style_class: null,
                                          focusOnHover: true
                                        });
-        this._signals = new SignalManager.SignalManager(this);
+        this._signals = new SignalManager.SignalManager(null);
         this.actor = new Cinnamon.GenericContainer({ style_class: 'popup-menu-item',
                                                   reactive: params.reactive,
                                                   track_hover: params.reactive,
@@ -1681,7 +1681,7 @@ PopupMenuBase.prototype = {
     _init: function(sourceActor, styleClass) {
         this.sourceActor = sourceActor;
 
-        this._signals = new SignalManager.SignalManager(this);
+        this._signals = new SignalManager.SignalManager(null);
         if (styleClass !== undefined) {
             this.box = new St.BoxLayout({ style_class: styleClass,
                                           vertical: true });
@@ -1952,7 +1952,7 @@ PopupMenuBase.prototype = {
             this._signals.connect(this, 'open-state-changed', function(self, open) {
                 if (!open)
                     menuItem.menu.close(false);
-            });
+            }, this);
         } else if (menuItem instanceof PopupSeparatorMenuItem) {
             this._connectItemSignals(menuItem);
 
@@ -3403,20 +3403,20 @@ PopupMenuManager.prototype = {
         this._menuStack = [];
         this._preGrabInputMode = null;
         this._grabbedFromKeynav = false;
-        this._signals = new SignalManager.SignalManager(this);
+        this._signals = new SignalManager.SignalManager(null);
     },
 
     addMenu: function(menu, position) {
-        this._signals.connect(menu, 'open-state-changed', this._onMenuOpenState);
-        this._signals.connect(menu, 'child-menu-added', this._onChildMenuAdded);
-        this._signals.connect(menu, 'child-menu-removed', this._onChildMenuRemoved);
-        this._signals.connect(menu, 'destroy', this._onMenuDestroy);
+        this._signals.connect(menu, 'open-state-changed', this._onMenuOpenState, this);
+        this._signals.connect(menu, 'child-menu-added', this._onChildMenuAdded, this);
+        this._signals.connect(menu, 'child-menu-removed', this._onChildMenuRemoved, this);
+        this._signals.connect(menu, 'destroy', this._onMenuDestroy, this);
 
         let source = menu.sourceActor;
 
         if (source) {
-            this._signals.connect(source, 'enter-event', function() { this._onMenuSourceEnter(menu); });
-            this._signals.connect(source, 'key-focus-in', function() { this._onMenuSourceEnter(menu); });
+            this._signals.connect(source, 'enter-event', function() { this._onMenuSourceEnter(menu); }, this);
+            this._signals.connect(source, 'key-focus-in', function() { this._onMenuSourceEnter(menu); }, this);
         }
 
         if (position == undefined)
@@ -3446,11 +3446,11 @@ PopupMenuManager.prototype = {
         if (!Main.pushModal(this._owner.actor)) {
             return;
         }
-        this._signals.connect(global.stage, 'captured-event', this._onEventCapture);
+        this._signals.connect(global.stage, 'captured-event', this._onEventCapture, this);
         // captured-event doesn't see enter/leave events
-        this._signals.connect(global.stage, 'enter-event', this._onEventCapture);
-        this._signals.connect(global.stage, 'leave-event', this._onEventCapture);
-        this._signals.connect(global.stage, 'notify::key-focus', this._onKeyFocusChanged);
+        this._signals.connect(global.stage, 'enter-event', this._onEventCapture, this);
+        this._signals.connect(global.stage, 'leave-event', this._onEventCapture, this);
+        this._signals.connect(global.stage, 'notify::key-focus', this._onKeyFocusChanged, this);
 
         this.grabbed = true;
     },

--- a/js/ui/tooltips.js
+++ b/js/ui/tooltips.js
@@ -55,22 +55,22 @@ function TooltipBase(item) {
 
 TooltipBase.prototype = {
     _init: function(item) {
-        this.signals = new SignalManager.SignalManager(this);
+        this.signals = new SignalManager.SignalManager(null);
 
-        this.signals.connect(global.stage, 'notify::key-focus', this._hide);
-        this.signals.connect(item, 'enter-event', this._onEnterEvent);
-        this.signals.connect(item, 'motion-event', this._onMotionEvent);
-        this.signals.connect(item, 'leave-event', this._hide);
-        this.signals.connect(item, 'button-press-event', this._hide);
-        this.signals.connect(item, 'button-release-event', this._hide);
-        this.signals.connect(item, 'destroy', this.destroy);
+        this.signals.connect(global.stage, 'notify::key-focus', this._hide, this);
+        this.signals.connect(item, 'enter-event', this._onEnterEvent, this);
+        this.signals.connect(item, 'motion-event', this._onMotionEvent, this);
+        this.signals.connect(item, 'leave-event', this._hide, this);
+        this.signals.connect(item, 'button-press-event', this._hide, this);
+        this.signals.connect(item, 'button-release-event', this._hide, this);
+        this.signals.connect(item, 'destroy', this.destroy, this);
         this.signals.connect(item, 'allocation-changed', function() {
             // An allocation change could mean that the actor has moved,
             // so hide, but wait until after the allocation cycle.
             Mainloop.idle_add(Lang.bind(this, function() {
                 this._hide();
             }));
-        });
+        }, this);
 
         this._showTimer = null;
         this.visible = false;


### PR DESCRIPTION
This passes null so SignalManager doesn't cache the context, which it uses for binding callbacks. This can be replaced by SignalManager.connect's fourth parameter, bind.

Since the manager is a property of its callee, re-referencing `this` inside each SignalManager instance will create a circular reference, and while they are not inherently bad, it forces the engine to check more objects. Spidermonkey in particular counts circular references as part of an object's reference count, which makes it more likely an object will exist after its needed, and it will continue to consume memory.