### PR TITLE
Applets: fix linter warnings

### DIFF
--- a/files/usr/share/cinnamon/applets/a11y@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/a11y@cinnamon.org/applet.js
@@ -1,4 +1,3 @@
-const St = imports.gi.St;
 const PopupMenu = imports.ui.popupMenu;
 const Gio = imports.gi.Gio;
 const Lang = imports.lang;
@@ -14,12 +13,7 @@ const KEY_MOUSE_KEYS_ENABLED  = 'mousekeys-enable';
 
 const APPLICATIONS_SCHEMA = 'org.cinnamon.desktop.a11y.applications';
 
-const DPI_LOW_REASONABLE_VALUE  = 50;
-const DPI_HIGH_REASONABLE_VALUE = 500;
-
 const DPI_FACTOR_LARGE   = 1.25;
-const DPI_FACTOR_LARGER  = 1.5;
-const DPI_FACTOR_LARGEST = 2.0;
 
 const DESKTOP_INTERFACE_SCHEMA = 'org.cinnamon.desktop.interface';
 const KEY_GTK_THEME      = 'gtk-theme';

--- a/files/usr/share/cinnamon/applets/expo@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/expo@cinnamon.org/applet.js
@@ -18,7 +18,7 @@ MyApplet.prototype = {
             this.set_applet_tooltip(_("Expo"));
             this._hover_activates = false;
 
-            this.settings = new Settings.AppletSettings(this, metadata["uuid"], this.instance_id);
+            this.settings = new Settings.AppletSettings(this, metadata.uuid, this.instance_id);
 
             this.settings.bind("activate-on-hover", "_hover_activates");
 

--- a/files/usr/share/cinnamon/applets/inhibit@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/inhibit@cinnamon.org/applet.js
@@ -43,8 +43,8 @@ InhibitSwitch.prototype = {
 
         this.sessionProxy = null;
         this.sessionCookie = null;
-        this.sigAddedId = 0
-        this.sigRemovedId = 0
+        this.sigAddedId = 0;
+        this.sigRemovedId = 0;
 
         GnomeSession.SessionManager(Lang.bind(this, function(proxy, error) {
             if (error)
@@ -141,9 +141,9 @@ MyApplet.prototype = {
         this.menu.addMenuItem(this.inhibitSwitch);
 
         this.set_applet_icon_symbolic_name('inhibit');
-        this.set_applet_tooltip(_("Inhibit applet"))
+        this.set_applet_tooltip(_("Inhibit applet"));
 
-        this.notif_settings = new Gio.Settings({ schema_id: "org.cinnamon.desktop.notifications" })
+        this.notif_settings = new Gio.Settings({ schema_id: "org.cinnamon.desktop.notifications" });
         this.notificationsSwitch = new PopupMenu.PopupSwitchMenuItem(_("Notifications"), this.notif_settings.get_boolean("display-notifications"));
 
         this.notif_settings.connect('changed::display-notifications', Lang.bind(this, function() {

--- a/files/usr/share/cinnamon/applets/keyboard@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/keyboard@cinnamon.org/applet.js
@@ -1,14 +1,10 @@
 const Applet = imports.ui.applet;
 const XApp = imports.gi.XApp;
 const Lang = imports.lang;
-const Cinnamon = imports.gi.Cinnamon;
-const Clutter = imports.gi.Clutter;
 const St = imports.gi.St;
-const Gtk = imports.gi.Gtk;
 const Main = imports.ui.main;
 const PopupMenu = imports.ui.popupMenu;
 const Util = imports.misc.util;
-const Settings = imports.ui.settings;
 const Mainloop = imports.mainloop;
 const Gio = imports.gi.Gio;
 const Cairo = imports.cairo;
@@ -40,7 +36,7 @@ EmblemedIcon.prototype = {
         let cr = actor.get_context();
         let [w, h] = actor.get_surface_size();
 
-        cr.save()
+        cr.save();
 
         let surf = St.TextureCache.get_default().load_file_to_cairo_surface(this.path);
 
@@ -71,7 +67,7 @@ EmblemedIcon.prototype = {
 
         cr.paint();
 
-        cr.restore()
+        cr.restore();
 
         XApp.KbdLayoutController.render_cairo_subscript(cr,
                                                         true_x_offset + (true_width / 2),
@@ -98,7 +94,7 @@ EmblemedIcon.prototype = {
     set_style_class_name: function(name) {
         return;
     }
-}
+};
 
 function LayoutMenuItem() {
     this._init.apply(this, arguments);
@@ -251,7 +247,7 @@ MyApplet.prototype = {
                 }
 
                 name = this.use_upper ? name.toUpperCase() : name;
-                actor = new St.Label({ text: name })
+                actor = new St.Label({ text: name });
             }
 
             let item = new LayoutMenuItem(this._config, i, actor, groups[i]);
@@ -307,8 +303,8 @@ MyApplet.prototype = {
 
             name = this.use_upper ? name.toUpperCase() : name;
 
-            this.set_applet_label(name)
-            this.hide_applet_icon()
+            this.set_applet_label(name);
+            this.hide_applet_icon();
         }
     },
 

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -12,12 +12,10 @@ const AppFavorites = imports.ui.appFavorites;
 const Gtk = imports.gi.Gtk;
 const Atk = imports.gi.Atk;
 const Gio = imports.gi.Gio;
-const Signals = imports.signals;
 const GnomeSession = imports.misc.gnomeSession;
 const ScreenSaver = imports.misc.screenSaver;
 const FileUtils = imports.misc.fileUtils;
 const Util = imports.misc.util;
-const Tweener = imports.ui.tweener;
 const DND = imports.ui.dnd;
 const Meta = imports.gi.Meta;
 const DocInfo = imports.misc.docInfo;
@@ -26,7 +24,6 @@ const Settings = imports.ui.settings;
 const Pango = imports.gi.Pango;
 const SearchProviderManager = imports.ui.searchProviderManager;
 
-const ICON_SIZE = 16;
 const MAX_FAV_ICON_SIZE = 32;
 const CATEGORY_ICON_SIZE = 22;
 const APPLICATION_ICON_SIZE = 22;
@@ -132,7 +129,7 @@ ApplicationContextMenuItem.prototype = {
 
     activate: function (event) {
         switch (this._action){
-            case "add_to_panel":
+            case "add_to_panel": {
                 if (!Main.AppletManager.get_role_provider_exists(Main.AppletManager.Roles.PANEL_LAUNCHER)) {
                     let new_applet_id = global.settings.get_int("next-applet-id");
                     global.settings.set_int("next-applet-id", (new_applet_id + 1));
@@ -146,7 +143,7 @@ ApplicationContextMenuItem.prototype = {
 
                 this._appButton.toggleMenu();
                 break;
-            case "add_to_desktop":
+            } case "add_to_desktop": {
                 let file = Gio.file_new_for_path(this._appButton.app.get_app_info().get_filename());
                 let destFile = Gio.file_new_for_path(USER_DESKTOP_PATH+"/"+this._appButton.app.get_id());
                 try{
@@ -157,22 +154,23 @@ ApplicationContextMenuItem.prototype = {
                 }
                 this._appButton.toggleMenu();
                 break;
-            case "add_to_favorites":
+            } case "add_to_favorites": {
                 AppFavorites.getAppFavorites().addFavorite(this._appButton.app.get_id());
                 this._appButton.toggleMenu();
                 break;
-            case "remove_from_favorites":
+            } case "remove_from_favorites": {
                 AppFavorites.getAppFavorites().removeFavorite(this._appButton.app.get_id());
                 this._appButton.toggleMenu();
                 break;
-            case "uninstall":
+            } case "uninstall": {
                 Util.spawnCommandLine("gksu -m '" + _("Please provide your password to uninstall this application") + "' /usr/bin/cinnamon-remove-application '" + this._appButton.app.get_app_info().get_filename() + "'");
                 this._appButton.appsMenuButton.menu.close();
                 break;
-            case "run_with_nvidia_gpu":
+            } case "run_with_nvidia_gpu": {
                 Util.spawnCommandLine("optirun gtk-launch " + this._appButton.app.get_id());
                 this._appButton.appsMenuButton.menu.close();
                 break;
+            }
         }
         return false;
     }
@@ -299,7 +297,7 @@ GenericApplicationButton.prototype = {
 
         PopupMenu.PopupBaseMenuItem.prototype.destroy.call(this);
     }
-}
+};
 
 function TransientButton(appsMenuButton, pathOrCommand) {
     this._init(appsMenuButton, pathOrCommand);
@@ -351,13 +349,10 @@ TransientButton.prototype = {
 
 
 
-        let iconBox = new St.Bin();
         this.file = Gio.file_new_for_path(this.pathOrCommand);
 
         try {
             this.handler = this.file.query_default_handler(null);
-            let icon_uri = this.file.get_uri();
-            let fileInfo = this.file.query_info(Gio.FILE_ATTRIBUTE_STANDARD_TYPE, Gio.FileQueryInfoFlags.NONE, null);
             let contentType = Gio.content_type_guess(this.pathOrCommand, null);
             let themedIcon = Gio.content_type_get_icon(contentType[0]);
             this.icon = new St.Icon({gicon: themedIcon, icon_size: APPLICATION_ICON_SIZE, icon_type: St.IconType.FULLCOLOR });
@@ -388,11 +383,11 @@ TransientButton.prototype = {
 
     activate: function(event) {
         if (this.handler != null) {
-            this.handler.launch([this.file], null)
+            this.handler.launch([this.file], null);
         } else {
             // Try anyway, even though we probably shouldn't.
             try {
-                Util.spawn(['gvfs-open', this.file.get_uri()])
+                Util.spawn(['gvfs-open', this.file.get_uri()]);
             } catch (e) {
                 global.logError("No handler available to open " + this.file.get_uri());
             }
@@ -401,7 +396,7 @@ TransientButton.prototype = {
 
         this.appsMenuButton.menu.close();
     }
-}
+};
 
 function ApplicationButton(appsMenuButton, app, showIcon) {
     this._init(appsMenuButton, app, showIcon);
@@ -412,11 +407,11 @@ ApplicationButton.prototype = {
 
     _init: function(appsMenuButton, app, showIcon) {
         GenericApplicationButton.prototype._init.call(this, appsMenuButton, app, true);
-        this.category = new Array();
+        this.category = [];
         this.actor.set_style_class_name('menu-application-button');
 
         if (showIcon) {
-            this.icon = this.app.create_icon_texture(APPLICATION_ICON_SIZE)
+            this.icon = this.app.create_icon_texture(APPLICATION_ICON_SIZE);
             this.addActor(this.icon);
         }
         this.name = this.app.get_name();
@@ -532,7 +527,7 @@ SearchProviderResultButton.prototype = {
             global.logError(e);
         }
     }
-}
+};
 
 function PlaceButton(appsMenuButton, place, button_name, showIcon) {
     this._init(appsMenuButton, place, button_name, showIcon);
@@ -597,7 +592,7 @@ RecentContextMenuItem.prototype = {
     },
 
     activate: function (event) {
-        this._callback()
+        this._callback();
         return false;
     }
 };
@@ -722,7 +717,7 @@ RecentButton.prototype = {
                 menu.addMenuItem(menuItem);
             }
 
-            let infos = Gio.AppInfo.get_all_for_type(this.mimeType)
+            let infos = Gio.AppInfo.get_all_for_type(this.mimeType);
 
             for (let i = 0; i < infos.length; i++) {
                 let info = infos[i];
@@ -810,7 +805,7 @@ NoRecentDocsButton.prototype = {
             this.callback();
         }
     }
-}
+};
 
 function RecentClearButton(appsMenuButton) {
     this._init(appsMenuButton);
@@ -926,7 +921,7 @@ RecentCategoryButton.prototype = {
         if (showIcon) {
             this.icon = new St.Icon({icon_name: "folder-recent", icon_size: CATEGORY_ICON_SIZE, icon_type: St.IconType.FULLCOLOR});
             this.addActor(this.icon);
-            this.icon.realize()
+            this.icon.realize();
         } else {
             this.icon = null;
         }
@@ -949,7 +944,7 @@ FavoritesButton.prototype = {
         let icon_size = 0.6 * real_size / global.ui_scale;
         if (icon_size > MAX_FAV_ICON_SIZE)
             icon_size = MAX_FAV_ICON_SIZE;
-        this.actor.style = "padding-top: "+(icon_size / 3)+"px;padding-bottom: "+(icon_size / 3)+"px;"
+        this.actor.style = "padding-top: "+(icon_size / 3)+"px;padding-bottom: "+(icon_size / 3)+"px;";
 
         this.actor.add_style_class_name('menu-favorites-button');
         let icon = app.create_icon_texture(icon_size);
@@ -999,12 +994,12 @@ SystemButton.prototype = {
         let icon_size = 0.6 * real_size / global.ui_scale;
         if (icon_size > MAX_FAV_ICON_SIZE)
             icon_size = MAX_FAV_ICON_SIZE;
-        this.actor.style = "padding-top: "+(icon_size / 3)+"px;padding-bottom: "+(icon_size / 3)+"px;"
+        this.actor.style = "padding-top: "+(icon_size / 3)+"px;padding-bottom: "+(icon_size / 3)+"px;";
         this.actor.add_style_class_name('menu-favorites-button');
 
         let iconObj = new St.Icon({icon_name: icon, icon_size: icon_size, icon_type: St.IconType.FULLCOLOR});
         this.addActor(iconObj);
-        iconObj.realize()
+        iconObj.realize();
     },
 
     _onButtonReleaseEvent: function(actor, event) {
@@ -1040,7 +1035,7 @@ CategoriesApplicationsBox.prototype = {
 
         return DND.DragMotionResult.CONTINUE;
     }
-}
+};
 
 function FavoritesBox() {
     this._init();
@@ -1179,7 +1174,7 @@ FavoritesBox.prototype = {
 
         return true;
     }
-}
+};
 
 function MyApplet(orientation, panel_height, instance_id) {
     this._init(orientation, panel_height, instance_id);
@@ -1239,15 +1234,15 @@ MyApplet.prototype = {
             icon_name: 'edit-clear',
             icon_type: St.IconType.SYMBOLIC });
         this._searchIconClickedId = 0;
-        this._applicationsButtons = new Array();
-        this._applicationsButtonFromApp = new Object();
-        this._favoritesButtons = new Array();
-        this._placesButtons = new Array();
-        this._transientButtons = new Array();
+        this._applicationsButtons = [];
+        this._applicationsButtonFromApp = {};
+        this._favoritesButtons = [];
+        this._placesButtons = [];
+        this._transientButtons = [];
         this.recentButton = null;
-        this._recentButtons = new Array();
-        this._categoryButtons = new Array();
-        this._searchProviderButtons = new Array();
+        this._recentButtons = [];
+        this._categoryButtons = [];
+        this._searchProviderButtons = [];
         this._selectedItemIndex = null;
         this._previousSelectedActor = null;
         this._previousVisibleIndex = null;
@@ -1256,7 +1251,7 @@ MyApplet.prototype = {
         this._activeActor = null;
         this._applicationsBoxWidth = 0;
         this.menuIsOpening = false;
-        this._knownApps = new Array(); // Used to keep track of apps that are already installed, so we can highlight newly installed ones
+        this._knownApps = []; // Used to keep track of apps that are already installed, so we can highlight newly installed ones
         this._appsWereRefreshed = false;
         this._canUninstallApps = GLib.file_test("/usr/bin/cinnamon-remove-application", GLib.FileTest.EXISTS);
         this._isBumblebeeInstalled = GLib.file_test("/usr/bin/optirun", GLib.FileTest.EXISTS);
@@ -1274,7 +1269,7 @@ MyApplet.prototype = {
         this._fileFolderAccessActive = false;
         this._pathCompleter = new Gio.FilenameCompleter();
         this._pathCompleter.set_dirs_only(false);
-        this.lastAcResults = new Array();
+        this.lastAcResults = [];
         this.settings.bind("search-filesystem", "searchFilesystem");
         this.refreshing = false; // used as a flag to know if we're currently refreshing (so we don't do it more than once concurrently)
 
@@ -1394,7 +1389,7 @@ MyApplet.prototype = {
     },
 
     on_applet_removed_from_panel: function () {
-        Main.keybindingManager.removeHotKey("overlay-key-" + this.instance_id)
+        Main.keybindingManager.removeHotKey("overlay-key-" + this.instance_id);
     },
 
     _launch_editor: function() {
@@ -2105,8 +2100,6 @@ MyApplet.prototype = {
         let [mx, my, mask] = global.get_pointer();
         let [bx, by] = this.categoriesApplicationsBox.actor.get_transformed_position();
         let [bw, bh] = this.categoriesApplicationsBox.actor.get_transformed_size();
-        let [aw, ah] = actor.get_transformed_size();
-        let [ax, ay] = actor.get_transformed_position();
         let [appbox_x, appbox_y] = this.applicationsBox.get_transformed_position();
 
         let right_x = appbox_x - bx;
@@ -2340,7 +2333,7 @@ MyApplet.prototype = {
                         this.selectedAppTitle.set_text("");
                         this.selectedAppDescription.set_text("");
                     });
-                }
+                };
 
                 let handleNewButton = (id) => {
                     let uri = this.RecentManager._infosByTimestamp[id].uri;
@@ -2359,7 +2352,7 @@ MyApplet.prototype = {
                         handleEnterEvent(button);
                         handleLeaveEvent(button);
 
-                        new_button = button
+                        new_button = button;
                     }
 
                     new_recents.push(new_button);
@@ -2491,7 +2484,7 @@ MyApplet.prototype = {
     },
 
     _refreshApps : function() {
-        /* iterate in reverse, so multiple splices will not upset 
+        /* iterate in reverse, so multiple splices will not upset
          * the remaining elements */
         for (let i = this._categoryButtons.length - 1; i > -1; i--) {
             if (this._categoryButtons[i] instanceof CategoryButton) {
@@ -2502,13 +2495,13 @@ MyApplet.prototype = {
 
         this._applicationsButtons.forEach(Lang.bind(this, function(button) {
             button.destroy();
-        }))
+        }));
 
-        this._applicationsButtons = new Array();
+        this._applicationsButtons = [];
         // this.applicationsBox.destroy_all_children();
 
-        this._transientButtons = new Array();
-        this._applicationsButtonFromApp = new Object();
+        this._transientButtons = [];
+        this._applicationsButtonFromApp = {};
         this._applicationsBoxWidth = 0;
 
         this._allAppsCategoryButton = new CategoryButton(null);
@@ -2660,10 +2653,9 @@ MyApplet.prototype = {
         this.favoritesBox.destroy_all_children();
 
         //Load favorites again
-        this._favoritesButtons = new Array();
+        this._favoritesButtons = [];
         let launchers = global.settings.get_strv('favorite-apps');
         let appSys = Cinnamon.AppSystem.get_default();
-        let j = 0;
         for ( let i = 0; i < launchers.length; ++i ) {
             let app = appSys.lookup_app(launchers[i]);
             if (app) {
@@ -2673,8 +2665,6 @@ MyApplet.prototype = {
 
                 this._addEnterEvent(button, Lang.bind(this, this._favEnterEvent, button));
                 button.actor.connect('leave-event', Lang.bind(this, this._favLeaveEvent, button));
-
-                ++j;
             }
         }
 
@@ -2758,7 +2748,7 @@ MyApplet.prototype = {
                     var app = appsys.lookup_app_by_tree_entry(entry);
                     if (!app)
                         app = appsys.lookup_settings_app_by_tree_entry(entry);
-                    var app_key = app.get_id()
+                    var app_key = app.get_id();
                     if (app_key == null) {
                         app_key = app.get_name() + ":" +
                             app.get_description();
@@ -3113,7 +3103,7 @@ MyApplet.prototype = {
             this._transientButtons.forEach( function (item, index) {
                 item.actor.destroy();
             });
-            this._transientButtons = new Array();
+            this._transientButtons = [];
 
             for (let i = 0; i < autocompletes.length; i++) {
                 let button = new TransientButton(this, autocompletes[i]);
@@ -3199,7 +3189,7 @@ MyApplet.prototype = {
 
     _listBookmarks: function(pattern){
        let bookmarks = Main.placesManager.getBookmarks();
-       var res = new Array();
+       var res = [];
        for (let id = 0; id < bookmarks.length; id++) {
           if (!pattern || bookmarks[id].name.toLowerCase().indexOf(pattern)!=-1) res.push(bookmarks[id]);
        }
@@ -3208,7 +3198,7 @@ MyApplet.prototype = {
 
     _listDevices: function(pattern){
        let devices = Main.placesManager.getMounts();
-       var res = new Array();
+       var res = [];
        for (let id = 0; id < devices.length; id++) {
           if (!pattern || devices[id].name.toLowerCase().indexOf(pattern)!=-1) res.push(devices[id]);
        }
@@ -3216,7 +3206,7 @@ MyApplet.prototype = {
     },
 
     _listApplications: function(category_menu_id, pattern){
-        var applist = new Array();
+        var applist = [];
         if (category_menu_id) {
             applist = category_menu_id;
         } else {
@@ -3224,7 +3214,7 @@ MyApplet.prototype = {
         }
         let res;
         if (pattern){
-            res = new Array();
+            res = [];
             for (var i in this._applicationsButtons) {
                 let app = this._applicationsButtons[i].app;
                 if (Util.latinise(app.get_name().toLowerCase()).indexOf(pattern)!=-1 ||
@@ -3257,20 +3247,20 @@ MyApplet.prototype = {
         }
 
         var appResults = this._listApplications(null, pattern);
-        var placesResults = new Array();
+        var placesResults = [];
         var bookmarks = this._listBookmarks(pattern);
-        for (var i in bookmarks)
+        for (let i in bookmarks)
             placesResults.push(bookmarks[i].name);
         var devices = this._listDevices(pattern);
-        for (var i in devices)
+        for (let i in devices)
             placesResults.push(devices[i].name);
-        var recentResults = new Array();
+        var recentResults = [];
         for (let i = 0; i < this._recentButtons.length; i++) {
             if (!(this._recentButtons[i] instanceof RecentClearButton) && this._recentButtons[i].button_name.toLowerCase().indexOf(pattern) != -1)
                 recentResults.push(this._recentButtons[i].button_name);
         }
 
-        var acResults = new Array(); // search box autocompletion results
+        var acResults = []; // search box autocompletion results
         if (this.searchFilesystem) {
             // Don't use the pattern here, as filesystem is case sensitive
             acResults = this._getCompletions(this.searchEntryText.get_text());
@@ -3326,13 +3316,11 @@ MyApplet.prototype = {
         if (text.indexOf('/') != -1) {
             return this._pathCompleter.get_completions(text);
         } else {
-            return new Array();
+            return [];
         }
     },
 
     _run : function(input) {
-        let command = input;
-
         this._commandError = false;
         if (input) {
             let path = null;

--- a/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
@@ -43,20 +43,6 @@ const NM80211ApSecurityFlags = NetworkManager['80211ApSecurityFlags'];
 // (the remaining are placed into More...)
 const NUM_VISIBLE_NETWORKS = 5;
 
-function macToArray(string) {
-    return string.split(':').map(function(el) {
-        return parseInt(el, 16);
-    });
-}
-
-function macCompare(one, two) {
-    for (let i = 0; i < 6; i++) {
-        if (one[i] != two[i])
-            return false;
-    }
-    return true;
-}
-
 function ssidCompare(one, two) {
     if (!one || !two)
         return false;
@@ -116,7 +102,7 @@ NMNetworkMenuItem.prototype = {
 
         this._label = new St.Label({ text: title });
         this.addActor(this._label);
-        let strStrengh = new String(this.bestAP.strength);
+        let strStrengh = String(this.bestAP.strength);
         strStrengh = strStrengh + '%';
         this._labelStrength = new St.Label({ text: strStrengh });
         this.addActor(this._labelStrength, { align: St.Align.END });
@@ -151,7 +137,7 @@ NMNetworkMenuItem.prototype = {
             this.bestAP = ap;
 
         this._signalIcon.icon_name = this._getIcon();
-        let strStrengh = new String(this.bestAP.strength);
+        let strStrengh = String(this.bestAP.strength);
         strStrengh = strStrengh + '%';
         this._labelStrength.set_text(strStrengh);
     },
@@ -923,9 +909,9 @@ NMDeviceBluetooth.prototype = {
     },
 
     _createAutomaticConnection: function() {
-        let connection = new NetworkManager.Connection;
+        let connection = new NetworkManager.Connection();
         connection._uuid = NetworkManager.utils_uuid_generate();
-        connection.add_setting(new NetworkManager.SettingBluetooth);
+        connection.add_setting(new NetworkManager.SettingBluetooth());
         connection.add_setting(new NetworkManager.SettingConnection({
             uuid: connection._uuid,
             id: this._autoConnectionName,
@@ -1186,14 +1172,14 @@ NMDeviceWireless.prototype = {
         if (rsn_flags != NM80211ApSecurityFlags.NONE) {
             /* RSN check first so that WPA+WPA2 APs are treated as RSN/WPA2 */
             if (rsn_flags & NM80211ApSecurityFlags.KEY_MGMT_802_1X)
-	        type = NMAccessPointSecurity.WPA2_ENT;
-	    else if (rsn_flags & NM80211ApSecurityFlags.KEY_MGMT_PSK)
-	        type = NMAccessPointSecurity.WPA2_PSK;
+                type = NMAccessPointSecurity.WPA2_ENT;
+            else if (rsn_flags & NM80211ApSecurityFlags.KEY_MGMT_PSK)
+                type = NMAccessPointSecurity.WPA2_PSK;
         } else if (wpa_flags != NM80211ApSecurityFlags.NONE) {
             if (wpa_flags & NM80211ApSecurityFlags.KEY_MGMT_802_1X)
                 type = NMAccessPointSecurity.WPA_ENT;
             else if (wpa_flags & NM80211ApSecurityFlags.KEY_MGMT_PSK)
-	        type = NMAccessPointSecurity.WPA_PSK;
+                type = NMAccessPointSecurity.WPA_PSK;
         } else {
             if (flags & NM80211ApFlags.PRIVACY)
                 type = NMAccessPointSecurity.WEP;
@@ -1427,7 +1413,6 @@ NMDeviceWireless.prototype = {
             return;
         }
 
-        let obj = this._connections[pos];
         this._connections.splice(pos, 1);
 
         let anyauto = false, forceupdate = false;
@@ -1510,7 +1495,6 @@ NMDeviceWireless.prototype = {
     },
 
     _createActiveConnectionItem: function() {
-        let icon, title;
         if (this._activeConnection._connection) {
             let connection = this._activeConnection._connection;
             if (!this._activeNetwork) {
@@ -1531,7 +1515,6 @@ NMDeviceWireless.prototype = {
                 this._activeConnectionItem = new PopupMenu.PopupImageMenuItem(connection._name, 'network-wireless-connected', { reactive: false });
         } else {
             // We cannot read the connection (due to ACL, or API incompatibility), but we still show signal if we have it
-            let menuItem;
             if (this._activeNetwork)
                 this._activeConnectionItem = new NMNetworkMenuItem(this._activeNetwork.accessPoints, undefined,
                                                                    { reactive: false });
@@ -1582,15 +1565,15 @@ NMDeviceWireless.prototype = {
             apObj.item = new NMNetworkMenuItem(apObj.accessPoints);
             apObj.item.connect('activate', Lang.bind(this, function() {
                 let accessPoints = sortAccessPoints(apObj.accessPoints);
-                if (   (accessPoints[0]._secType == NMAccessPointSecurity.WPA2_ENT)
-                    || (accessPoints[0]._secType == NMAccessPointSecurity.WPA_ENT)) {
+                if ((accessPoints[0]._secType == NMAccessPointSecurity.WPA2_ENT) ||
+                    (accessPoints[0]._secType == NMAccessPointSecurity.WPA_ENT)) {
                     // 802.1x-enabled APs require further configuration, so they're
                     // handled in cinnamon-settings
                     Util.spawn(['cinnamon-settings', 'network', 'connect-8021x-wifi',
                                 this.device.get_path(), accessPoints[0].dbus_path]);
                 } else {
                     let connection = this._createAutomaticConnection(apObj);
-                    this._client.add_and_activate_connection(connection, this.device, accessPoints[0].dbus_path, null)
+                    this._client.add_and_activate_connection(connection, this.device, accessPoints[0].dbus_path, null);
                 }
             }));
         }
@@ -1973,7 +1956,7 @@ MyApplet.prototype = {
         let pos = devices.indexOf(wrapper);
         devices.splice(pos, 1);
 
-        this._syncSectionTitle(wrapper.category)
+        this._syncSectionTitle(wrapper.category);
     },
 
     _syncActiveConnections: function() {
@@ -2081,15 +2064,15 @@ MyApplet.prototype = {
                         }
                     }
                 } else
-                    a._primaryDevice = this._devices.vpn.device
+                    a._primaryDevice = this._devices.vpn.device;
 
                 if (a._primaryDevice)
                     a._primaryDevice.setActiveConnection(a);
 
-                if (a.state == NetworkManager.ActiveConnectionState.ACTIVATED
-                    && a._primaryDevice && a._primaryDevice._notification) {
-                    a._primaryDevice._notification.destroy();
-                    a._primaryDevice._notification = null;
+                if (a.state == NetworkManager.ActiveConnectionState.ACTIVATED &&
+                    a._primaryDevice && a._primaryDevice._notification) {
+                        a._primaryDevice._notification.destroy();
+                        a._primaryDevice._notification = null;
                 }
             }
         }
@@ -2098,10 +2081,10 @@ MyApplet.prototype = {
     },
 
     _notifyActivated: function(activeConnection) {
-        if (activeConnection.state == NetworkManager.ActiveConnectionState.ACTIVATED
-            && activeConnection._primaryDevice && activeConnection._primaryDevice._notification) {
-            activeConnection._primaryDevice._notification.destroy();
-            activeConnection._primaryDevice._notification = null;
+        if (activeConnection.state == NetworkManager.ActiveConnectionState.ACTIVATED &&
+            activeConnection._primaryDevice && activeConnection._primaryDevice._notification) {
+                activeConnection._primaryDevice._notification.destroy();
+                activeConnection._primaryDevice._notification = null;
         }
 
         this._updateIcon();
@@ -2232,8 +2215,6 @@ MyApplet.prototype = {
             this._updateFrequencySeconds = DEFAULT_PERIODIC_UPDATE_FREQUENCY_SECONDS;
             this._syncActiveConnections();
             let mc = this._mainConnection;
-            let hasApIcon = false;
-            let hasMobileIcon = false;
 
             if (!mc) {
                 this._setIcon('network-offline');
@@ -2281,13 +2262,11 @@ MyApplet.prototype = {
                         } else {
                             this._setIcon('network-wireless-signal-' + signalToIcon(ap.strength));
                             this.set_applet_tooltip(_("Wireless connection") + ": " + ap.get_ssid() + " ("+ ap.strength +"%)");
-                            hasApIcon = true;
                         }
-                        break;
                     } else {
                         log('Active connection with no primary device?');
-                        break;
                     }
+                    break;
                 case NMConnectionCategory.WIRED:
                     this._setIcon('network-wired');
                     this.set_applet_tooltip(_("Connected to the wired network"));
@@ -2307,7 +2286,6 @@ MyApplet.prototype = {
 
                     this._setIcon('network-cellular-signal-' + signalToIcon(dev.mobileDevice.signal_quality));
                     this.set_applet_tooltip(_("Connected to the cellular network"));
-                    hasMobileIcon = true;
                     break;
                 case NMConnectionCategory.VPN:
                     this._setIcon('network-vpn');

--- a/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
@@ -5,9 +5,7 @@ const Gtk = imports.gi.Gtk;
 const Gio = imports.gi.Gio;
 const PopupMenu = imports.ui.popupMenu;
 const St = imports.gi.St;
-const Clutter = imports.gi.Clutter;
 const Mainloop = imports.mainloop;
-const MessageTray = imports.ui.messageTray;
 const Urgency = imports.ui.messageTray.Urgency;
 const NotificationDestroyedReason = imports.ui.messageTray.NotificationDestroyedReason;
 const Settings = imports.ui.settings;
@@ -140,7 +138,7 @@ MyApplet.prototype = {
         this.notifications.push(notification);
         // Steal the notication panel.
         notification.expand();
-        this._notificationbin.add(notification.actor)
+        this._notificationbin.add(notification.actor);
         notification.actor._parent_container = this._notificationbin;
         notification.actor.add_style_class_name('notification-applet-padding');
         // Register for destruction.
@@ -259,7 +257,6 @@ MyApplet.prototype = {
     },
 
     _update_timestamp: function () {
-        let dateFormat = _("%l:%M %p");
         let actors = this._notificationbin.get_children();
         if (actors) {
             for (let i = 0; i < actors.length; i++) {
@@ -318,16 +315,17 @@ function timeify(orig_time) {
         str = orig_time.toLocaleFormat('%r');
     }
     switch (true) {
-        case (diff <= 15):
+        case (diff <= 15): {
             str += _(" (Just now)");
             break;
-        case (diff > 15 && diff <= 59):
+        } case (diff > 15 && diff <= 59): {
             str += Gettext.ngettext(" (%d second ago)", " (%d seconds ago)", diff).format(diff);
             break;
-        case (diff > 59 && diff <= 3540):
-            diff_minutes = Math.floor(diff / 60);
+        } case (diff > 59 && diff <= 3540): {
+            let diff_minutes = Math.floor(diff / 60);
             str += Gettext.ngettext(" (%d minute ago)", " (%d minutes ago)", diff_minutes).format(diff_minutes);
             break;
+        }
     }
     return str;
 }

--- a/files/usr/share/cinnamon/applets/on-screen-keyboard@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/on-screen-keyboard@cinnamon.org/applet.js
@@ -1,18 +1,7 @@
 const Applet = imports.ui.applet;
-const Mainloop = imports.mainloop;
 const Gio = imports.gi.Gio;
-const Interfaces = imports.misc.interfaces;
-const Util = imports.misc.util;
 const Lang = imports.lang;
-const Cinnamon = imports.gi.Cinnamon;
-const Clutter = imports.gi.Clutter;
-const St = imports.gi.St;
-const PopupMenu = imports.ui.popupMenu;
-const GLib = imports.gi.GLib;
-const Pango = imports.gi.Pango;
-const Tooltips = imports.ui.tooltips;
 const Main = imports.ui.main;
-const Settings = imports.ui.settings;
 
 function MyApplet(metadata, orientation, panel_height, instanceId) {
     this._init(metadata, orientation, panel_height, instanceId);

--- a/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
@@ -1,13 +1,11 @@
 const Applet = imports.ui.applet;
 const AppletManager = imports.ui.appletManager;
 
-const Clutter = imports.gi.Clutter;
 const St = imports.gi.St;
 const Cinnamon = imports.gi.Cinnamon;
 const Lang = imports.lang;
 const Gio = imports.gi.Gio;
 const PopupMenu = imports.ui.popupMenu;
-const Main = imports.ui.main;
 const GLib = imports.gi.GLib;
 const Tooltips = imports.ui.tooltips;
 const DND = imports.ui.dnd;
@@ -17,11 +15,10 @@ const Settings = imports.ui.settings;
 const Signals = imports.signals;
 
 const DEFAULT_ICON_SIZE = 20;
-const ICON_HEIGHT_FACTOR = .8;
+const ICON_HEIGHT_FACTOR = 0.8;
 
 const PANEL_EDIT_MODE_KEY = 'panel-edit-mode';
 const PANEL_LAUNCHERS_KEY = 'panel-launchers';
-const PANEL_LAUNCHERS_DRAGGABLE_KEY = 'panel-launchers-draggable';
 
 const CUSTOM_LAUNCHERS_PATH = GLib.get_home_dir() + '/.cinnamon/panel-launchers';
 
@@ -80,7 +77,7 @@ PanelAppLauncherMenu.prototype = {
         item.connect('activate', Lang.bind(this._launcher._applet, this._launcher._applet.configureApplet));
         subMenu.menu.addMenuItem(item);
 
-        item = new PopupMenu.PopupIconMenuItem(_("Remove 'Panel launchers'"), "edit-delete", St.IconType.SYMBOLIC);
+        item = new PopupMenu.PopupIconMenuItem(_("Remove '%s'").format(_("Panel launchers")), "edit-delete", St.IconType.SYMBOLIC);
         item.connect('activate', Lang.bind(this, function() {
             AppletManager._removeAppletFromPanel(this._launcher._applet._uuid, this._launcher._applet.instance_id);
         }));
@@ -108,7 +105,7 @@ PanelAppLauncherMenu.prototype = {
     _launchAction: function(event, name) {
         this._launcher.launchAction(name);
     }
-}
+};
 
 function PanelAppLauncher(launchersBox, app, appinfo, orientation, panel_height, scale) {
     this._init(launchersBox, app, appinfo, orientation, panel_height, scale);
@@ -322,7 +319,7 @@ PanelAppLauncher.prototype = {
         }
         return null;
     }
-}
+};
 
 function MyApplet(metadata, orientation, panel_height, instance_id) {
     this._init(metadata, orientation, panel_height, instance_id);
@@ -351,8 +348,8 @@ MyApplet.prototype = {
 
         this.uuid = metadata.uuid;
 
-        this._settings_proxy = new Array();
-        this._launchers = new Array();
+        this._settings_proxy = [];
+        this._launchers = [];
 
         this.actor.add(this.myactor);
         this.actor.reactive = global.settings.get_boolean(PANEL_EDIT_MODE_KEY);
@@ -435,7 +432,7 @@ MyApplet.prototype = {
         let appinfo = null;
         if (!app)
             appinfo = Gio.DesktopAppInfo.new_from_filename(CUSTOM_LAUNCHERS_PATH+"/"+path);
-        return [app, appinfo]
+        return [app, appinfo];
     },
 
     on_panel_height_changed: function() {
@@ -460,8 +457,8 @@ MyApplet.prototype = {
 
     reload: function() {
         this.myactor.destroy_all_children();
-        this._launchers = new Array();
-        this._settings_proxy = new Array();
+        this._launchers = [];
+        this._settings_proxy = [];
 
         for (let file of this.launcherList) {
             let [app, appinfo] = this.loadSingleApp(file);
@@ -647,7 +644,6 @@ MyApplet.prototype = {
                 children[i] == this._dragPlaceholder.actor)
                 continue;
 
-            let childId = children[i]._delegate.getId();
             if (source === children[i]._delegate)
                 continue;
             launcherPos++;

--- a/files/usr/share/cinnamon/applets/removable-drives@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/removable-drives@cinnamon.org/applet.js
@@ -22,8 +22,8 @@ DriveMenuItem.prototype = {
         this.addActor(this.label);
 
         let ejectIcon = new St.Icon({ icon_name: 'media-eject',
-				      icon_type: St.IconType.SYMBOLIC,
-				      style_class: 'popup-menu-icon ' });
+                      icon_type: St.IconType.SYMBOLIC,
+                      style_class: 'popup-menu-icon ' });
         let ejectButton = new St.Button({ child: ejectIcon });
         ejectButton.connect('clicked', Lang.bind(this, this._eject));
         this.addActor(ejectButton);
@@ -46,17 +46,17 @@ function MyApplet(orientation, panel_height, instance_id) {
 MyApplet.prototype = {
     __proto__: Applet.IconApplet.prototype,
 
-    _init: function(orientation, panel_height, instance_id) {        
+    _init: function(orientation, panel_height, instance_id) {
         Applet.IconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
-        
-        try {        
+
+        try {
             this.set_applet_icon_symbolic_name("drive-harddisk");
             this.set_applet_tooltip(_("Removable drives"));
-            
+
             this.menuManager = new PopupMenu.PopupMenuManager(this);
             this.menu = new Applet.AppletPopupMenu(this, orientation);
-            this.menuManager.addMenu(this.menu);            
-                                            
+            this.menuManager.addMenu(this.menu);
+
             this._contentSection = new PopupMenu.PopupMenuSection();
             this.menu.addMenuItem(this._contentSection);
 
@@ -67,19 +67,19 @@ MyApplet.prototype = {
                 let homeFile = Gio.file_new_for_path(GLib.get_home_dir());
                 let homeUri = homeFile.get_uri();
                 Gio.app_info_launch_default_for_uri(homeUri, null);
-            });     
-            
+            });
+
             Main.placesManager.connect('mounts-updated', Lang.bind(this, this._update));
         }
         catch (e) {
             global.logError(e);
         }
     },
-    
+
     on_applet_clicked: function(event) {
-        this.menu.toggle();        
+        this.menu.toggle();
     },
-    
+
     _update: function() {
         this._contentSection.removeAll();
 
@@ -94,10 +94,10 @@ MyApplet.prototype = {
 
         this.actor.visible = any;
     }
-    
+
 };
 
-function main(metadata, orientation, panel_height, instance_id) {  
+function main(metadata, orientation, panel_height, instance_id) {
     let myApplet = new MyApplet(orientation, panel_height, instance_id);
-    return myApplet;      
+    return myApplet;
 }

--- a/files/usr/share/cinnamon/applets/scale@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/scale@cinnamon.org/applet.js
@@ -13,12 +13,12 @@ MyApplet.prototype = {
     _init: function(metadata, orientation, panel_height, instance_id) {
         Applet.IconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
 
-        try {            
+        try {
             this.set_applet_icon_symbolic_name("cinnamon-scale");
-            this.set_applet_tooltip(_("Scale"));            
-            this._hover_activates = false;            
+            this.set_applet_tooltip(_("Scale"));
+            this._hover_activates = false;
 
-            this.settings = new Settings.AppletSettings(this, metadata["uuid"], this.instance_id);
+            this.settings = new Settings.AppletSettings(this, metadata.uuid, this.instance_id);
 
             this.settings.bind("activate-on-hover", "_hover_activates");
 

--- a/files/usr/share/cinnamon/applets/separator@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/separator@cinnamon.org/applet.js
@@ -45,7 +45,7 @@ MyApplet.prototype = {
             this._line.set_width((this._panelHeight - 8));
         }
     },
-}; 
+};
 
 function main(metadata, orientation, panel_height, instance_id) {
     let myApplet = new MyApplet(orientation, panel_height, instance_id);

--- a/files/usr/share/cinnamon/applets/settings-example@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/settings-example@cinnamon.org/applet.js
@@ -65,16 +65,16 @@ MyApplet.prototype = {
 
     on_settings_changed: function() {
         if (this.use_custom) {
-            this.set_applet_label(this.custom_label)
+            this.set_applet_label(this.custom_label);
         } else {
             this.set_applet_label(_("Hi there!"));
         }
 
         let icon_file = Gio.File.new_for_path(this.icon_name);
         if (icon_file.query_exists(null)) {
-            this.set_applet_icon_path(this.icon_name)
+            this.set_applet_icon_path(this.icon_name);
         } else {
-            this.set_applet_icon_name(this.icon_name)
+            this.set_applet_icon_name(this.icon_name);
         }
 
         this.spinner_val_demo.label.clutter_text.set_text("Spinner value is: " + this.spinner_number);
@@ -109,12 +109,12 @@ MyApplet.prototype = {
         //animate icon
         Tweener.addTween(this._applet_icon, {
             margin_left: 10,
-            time: .5,
+            time: 0.5,
             transition: this.tween_function,
             onComplete: function(){
                 Tweener.addTween(this._applet_icon, {
                     margin_left: 0,
-                    time: .5,
+                    time: 0.5,
                     transition: this.tween_function
                 });
             },

--- a/files/usr/share/cinnamon/applets/settings@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/settings@cinnamon.org/applet.js
@@ -1,17 +1,6 @@
-const Lang = imports.lang;
-const St = imports.gi.St;
-const Cinnamon = imports.gi.Cinnamon;
 const Applet = imports.ui.applet;
 const Panel = imports.ui.panel;
-const Main = imports.ui.main;
 const PopupMenu = imports.ui.popupMenu;
-const Util = imports.misc.util;
-const GLib = imports.gi.GLib;
-const Gio = imports.gi.Gio;
-
-function ConfirmDialog(){
-    this._init();
-}
 
 function MyApplet(orientation, panel_height, instance_id) {
     this._init(orientation, panel_height, instance_id);
@@ -20,40 +9,40 @@ function MyApplet(orientation, panel_height, instance_id) {
 MyApplet.prototype = {
     __proto__: Applet.IconApplet.prototype,
 
-    _init: function(orientation, panel_height, instance_id) {        
+    _init: function(orientation, panel_height, instance_id) {
         Applet.IconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
-        
-        try {        
+
+        try {
             this.set_applet_icon_symbolic_name("go-up");
-            this.set_applet_tooltip(_("Settings"));                            
+            this.set_applet_tooltip(_("Settings"));
             this.menuManager = new PopupMenu.PopupMenuManager(this);
             this._buildMenu(orientation);
-                        
+
         }
         catch (e) {
             global.logError(e);
         }
     },
-    
+
     on_applet_clicked: function(event) {
-        this.menu.toggle();        
+        this.menu.toggle();
     },
-    
+
     _buildMenu: function(orientation) {
         this.menu = new Applet.AppletPopupMenu(this, orientation);
-        this.menuManager.addMenu(this.menu);        
+        this.menuManager.addMenu(this.menu);
         Panel.populateSettingsMenu(this.menu);
     },
-    
+
     on_orientation_changed: function(orientation){
         this.menu.destroy();
         this._buildMenu(orientation);
     }
-        
-    
+
+
 };
 
-function main(metadata, orientation, panel_height, instance_id) {  
+function main(metadata, orientation, panel_height, instance_id) {
     let myApplet = new MyApplet(orientation, panel_height, instance_id);
-    return myApplet;      
+    return myApplet;
 }

--- a/files/usr/share/cinnamon/applets/show-desktop@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/show-desktop@cinnamon.org/applet.js
@@ -1,6 +1,5 @@
 const Applet = imports.ui.applet;
 const Settings = imports.ui.settings;  // Needed for settings API
-const Main = imports.ui.main;
 const Mainloop = imports.mainloop;
 const Tweener = imports.ui.tweener;
 const Clutter = imports.gi.Clutter;
@@ -64,16 +63,15 @@ MyApplet.prototype = {
             }
 
             this._peek_timeout_id = Mainloop.timeout_add(this.peek_delay, Lang.bind(this, function() {
-                if (this.actor.hover
-                    && !this._applet_context_menu.isOpen
-                    && !global.settings.get_boolean("panel-edit-mode")) {
+                if (this.actor.hover &&
+                    !this._applet_context_menu.isOpen &&
+                    !global.settings.get_boolean("panel-edit-mode")) {
 
                     Tweener.addTween(global.window_group,
                                      {opacity: this.peek_opacity, time: 0.275, transition: "easeInSine"});
 
                     let windows = global.get_window_actors();
                     for (let i = 0; i < windows.length; i++) {
-                        let window = windows[i].meta_window;
                         let compositor = windows[i];
 
                         if (this.peek_blur) {

--- a/files/usr/share/cinnamon/applets/slideshow@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/slideshow@cinnamon.org/applet.js
@@ -53,7 +53,7 @@ MyApplet.prototype = {
                     "preferences-desktop-wallpaper",
                     St.IconType.SYMBOLIC);
             this.open_settings_context_menu_item.connect('activate', Lang.bind(this, function() {
-                Util.spawnCommandLine("cinnamon-settings backgrounds")
+                Util.spawnCommandLine("cinnamon-settings backgrounds");
             }));
             this._applet_context_menu.addMenuItem(this.open_settings_context_menu_item);
         }

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -10,7 +10,6 @@ const St = imports.gi.St;
 const PopupMenu = imports.ui.popupMenu;
 const GLib = imports.gi.GLib;
 const Cvc = imports.gi.Cvc;
-const Pango = imports.gi.Pango;
 const Tooltips = imports.ui.tooltips;
 const Main = imports.ui.main;
 const Settings = imports.ui.settings;
@@ -77,7 +76,7 @@ ControlButton.prototype = {
         this.button.can_focus = status;
         this.button.reactive = status;
     }
-}
+};
 
 function VolumeSlider(){
     this._init.apply(this, arguments);
@@ -140,7 +139,7 @@ VolumeSlider.prototype = {
 
         let volume = this._value * this.applet._volumeMax, muted;
 
-        if(this._value < .005){
+        if(this._value < 0.005){
             volume = 0;
             muted = true;
         } else {
@@ -172,7 +171,7 @@ VolumeSlider.prototype = {
     },
 
     _volumeToIcon: function(value){
-        if(value < .005)
+        if(value < 0.005)
             return this.isMic? "microphone-sensitivity-none" : "audio-volume-muted";
         let n = Math.floor(3 * value), icon;
         if(n < 1)
@@ -184,7 +183,7 @@ VolumeSlider.prototype = {
 
         return this.isMic? "microphone-sensitivity-" + icon : "audio-volume-" + icon;
     }
-}
+};
 
 function StreamMenuSection(){
     this._init.apply(this, arguments);
@@ -227,7 +226,7 @@ StreamMenuSection.prototype = {
         let slider = new VolumeSlider(applet, stream, name, iconName);
         this.addMenuItem(slider);
     }
-}
+};
 
 function Player() {
     this._init.apply(this, arguments);
@@ -283,7 +282,7 @@ Player.prototype = {
         if (!this._prop || !this._mediaServerPlayer || !this._mediaServer)
             return;
 
-        let mainBox = new PopupMenu.PopupMenuSection;
+        let mainBox = new PopupMenu.PopupMenuSection();
         this.addMenuItem(mainBox);
 
         this.vertBox = new St.BoxLayout({ style_class: "sound-player", important: true, vertical: true });
@@ -495,7 +494,7 @@ Player.prototype = {
         this._canSeek = this._getCanSeek();
 
         if (this._songLength == 0 || position == false)
-            this._canSeek = false
+            this._canSeek = false;
     },
 
     _setPosition: function(value) {
@@ -610,7 +609,6 @@ Player.prototype = {
                 let cover_path = "";
                 if (this._trackCoverFile.match(/^http/)) {
                     this._hideCover();
-                    let cover = Gio.file_new_for_uri(decodeURIComponent(this._trackCoverFile));
                     this._trackCoverFileTmp = Gio.file_new_tmp('XXXXXX.mediaplayer-cover')[0];
                     Util.spawn_async(['wget', this._trackCoverFile, '-O', this._trackCoverFileTmp.get_path()], Lang.bind(this, this._onDownloadedCover));
                 }
@@ -797,7 +795,7 @@ Player.prototype = {
         PopupMenu.PopupMenuSection.prototype.destroy.call(this);
     }
 
-}
+};
 
 function MediaPlayerLauncher(app, menu) {
     this._init(app, menu);
@@ -939,7 +937,7 @@ MyApplet.prototype = {
             this._applet_context_menu.addMenuItem(this.mute_out_switch);
             this._applet_context_menu.addMenuItem(this.mute_in_switch);
 
-            this._applet_context_menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem);
+            this._applet_context_menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
             this._outputApplicationsMenu = new PopupMenu.PopupSubMenuMenuItem(_("Applications"));
             this._selectOutputDeviceItem = new PopupMenu.PopupSubMenuMenuItem(_("Output device"));
@@ -948,7 +946,7 @@ MyApplet.prototype = {
             this._outputApplicationsMenu.actor.hide();
             this._selectOutputDeviceItem.actor.hide();
 
-            this._inputSection = new PopupMenu.PopupMenuSection;
+            this._inputSection = new PopupMenu.PopupMenuSection();
             this._inputVolumeSection = new VolumeSlider(this, null, _("Microphone"), null);
             this._inputVolumeSection.connect("values-changed", Lang.bind(this, this._inputValuesChanged));
             this._selectInputDeviceItem = new PopupMenu.PopupSubMenuMenuItem(_("Input device"));
@@ -959,7 +957,7 @@ MyApplet.prototype = {
             this._selectInputDeviceItem.actor.hide();
             this._inputSection.actor.hide();
 
-            this._applet_context_menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem);
+            this._applet_context_menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
             this.mute_out_switch.connect('toggled', Lang.bind(this, this._toggle_out_mute));
             this.mute_in_switch.connect('toggled', Lang.bind(this, this._toggle_in_mute));
@@ -1156,7 +1154,6 @@ MyApplet.prototype = {
     },
 
     _addPlayer: function(busName, owner) {
-        let position;
         if (this._players[owner]) {
             let prevName = this._players[owner]._busName;
             // HAVE: ADDING: ACTION:
@@ -1245,7 +1242,7 @@ MyApplet.prototype = {
         //do we know already this player?
         for (let i = 0, l = this._knownPlayers.length; i < l; ++i) {
             if (this._knownPlayers[i] === entry)
-                return
+                return;
         }
         //No, save it to _knownPlayers and update player list
         this._knownPlayers.push(entry);
@@ -1265,12 +1262,12 @@ MyApplet.prototype = {
         this._updateLaunchPlayer();
 
         //between these two separators will be the player MenuSection (position 3)
-        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem);
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
         this._outputVolumeSection = new VolumeSlider(this, null, _("Volume"), null);
         this._outputVolumeSection.connect("values-changed", Lang.bind(this, this._outputValuesChanged));
 
         this.menu.addMenuItem(this._outputVolumeSection);
-        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem);
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
         this.menu.addSettingsAction(_("Sound Settings"), 'sound');
     },

--- a/files/usr/share/cinnamon/applets/spacer@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/spacer@cinnamon.org/applet.js
@@ -31,7 +31,7 @@ MyApplet.prototype = {
         if (this.bin) {
             this.bin.destroy();
 
-            this.bin = new St.Bin;
+            this.bin = new St.Bin();
             this.actor.add(this.bin);
 
             this.width_changed();

--- a/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
@@ -8,7 +8,7 @@ const Main = imports.ui.main;
 const Mainloop = imports.mainloop;
 const SignalManager = imports.misc.signalManager;
 
-const ICON_SCALE_FACTOR = .8; // for custom panel heights, 20 (default icon size) / 25 (default panel height)
+const ICON_SCALE_FACTOR = 0.8; // for custom panel heights, 20 (default icon size) / 25 (default panel height)
 
 const DEFAULT_ICON_SIZE = 20;
 
@@ -251,7 +251,7 @@ MyApplet.prototype = {
             // child instanceof CinnamonTrayIcon.
             return (child.toString().indexOf("CinnamonTrayIcon") != -1);
         });
-        for (var i = 0; i < children.length; i++) {
+        for (let i = 0; i < children.length; i++) {
             children[i].destroy();
         }
     },

--- a/files/usr/share/cinnamon/applets/trash@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/trash@cinnamon.org/applet.js
@@ -1,9 +1,7 @@
 const St = imports.gi.St;
 const ModalDialog = imports.ui.modalDialog;
 const Gio = imports.gi.Gio;
-const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
-const Clutter = imports.gi.Clutter;
 const Applet = imports.ui.applet;
 const PopupMenu = imports.ui.popupMenu;
 const Mainloop = imports.mainloop;
@@ -95,7 +93,7 @@ MyApplet.prototype = {
     }
 };
 
-function main(metadata, orientation, panel_height, instance_id) {      
+function main(metadata, orientation, panel_height, instance_id) {
     let myApplet = new MyApplet(orientation, panel_height, instance_id);
-    return myApplet;      
+    return myApplet;
 }

--- a/files/usr/share/cinnamon/applets/user@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/user@cinnamon.org/applet.js
@@ -1,16 +1,13 @@
-const Cinnamon = imports.gi.Cinnamon;
 const Applet = imports.ui.applet;
 const Lang = imports.lang;
 const St = imports.gi.St;
 const PopupMenu = imports.ui.popupMenu;
 const Util = imports.misc.util;
 const GLib = imports.gi.GLib;
-const Gio = imports.gi.Gio
+const Gio = imports.gi.Gio;
 const AccountsService = imports.gi.AccountsService;
 const GnomeSession = imports.misc.gnomeSession;
 const ScreenSaver = imports.misc.screenSaver;
-const Main = imports.ui.main;
-const Panel = imports.ui.panel;
 const Settings = imports.ui.settings;
 
 

--- a/files/usr/share/cinnamon/applets/user@cinnamon.org/stylesheet.css
+++ b/files/usr/share/cinnamon/applets/user@cinnamon.org/stylesheet.css
@@ -1,9 +1,9 @@
 .user-box {
-  padding: .4em 1.75em;  
+  padding: .4em 1.75em;
   spacing: 6px;
 }
 
-.user-icon {  
+.user-icon {
   border-radius: 4px;
   border: 2px solid #a5a5a5;
 }

--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -57,18 +57,15 @@ const Applet = imports.ui.applet;
 const AppletManager = imports.ui.appletManager;
 const DND = imports.ui.dnd;
 const Main = imports.ui.main;
-const Panel = imports.ui.panel;
 const PopupMenu = imports.ui.popupMenu;
 const Settings = imports.ui.settings;
 const SignalManager = imports.misc.signalManager;
 const Tooltips = imports.ui.tooltips;
-const Tweener = imports.ui.tweener;
-const Util = imports.misc.util;
 
 const HORIZONTAL_ICON_SIZE = 16; // too bad this can't be defined in theme (cinnamon-app.create_icon_texture returns a clutter actor, not a themable object -
                                  // probably something that could be addressed
-const ICON_HEIGHT_FACTOR = .64;
-const VERTICAL_ICON_HEIGHT_FACTOR = .75;
+const ICON_HEIGHT_FACTOR = 0.64;
+const VERTICAL_ICON_HEIGHT_FACTOR = 0.75;
 const MAX_TEXT_LENGTH = 1000;
 const FLASH_INTERVAL = 500;
 
@@ -138,7 +135,7 @@ WindowPreview.prototype = {
 
     show: function() {
         if (!this.actor || this._applet._menuOpen)
-            return
+            return;
 
         this.muffinWindow = this.metaWindow.get_compositor_private();
         let windowTexture = this.muffinWindow.get_texture();
@@ -184,7 +181,7 @@ WindowPreview.prototype = {
         }
 
         let previewLeft;
-        if (this._applet.orientation == St.Side.BOTTOM || this._applet.orientation == St.Side.TOP) { 
+        if (this._applet.orientation == St.Side.BOTTOM || this._applet.orientation == St.Side.TOP) {
             // centre the applet on the window list item if window list is on the top or bottom panel
             previewLeft = this.item.get_transformed_position()[0] + this.item.get_transformed_size()[0]/2 - previewWidth/2;
         } else if (this._applet.orientation == St.Side.LEFT) {
@@ -240,7 +237,7 @@ WindowPreview.prototype = {
         }
         this.actor = null;
     }
-}
+};
 
 function AppMenuButton(applet, metaWindow, alert) {
     this._init(applet, metaWindow, alert);
@@ -319,7 +316,7 @@ AppMenuButton.prototype = {
                     this._progress = this.metaWindow.progress;
 
                     if (this._progress >0) {
-                        this.progressOverlay.show()
+                        this.progressOverlay.show();
                     } else {
                         this.progressOverlay.hide();
                     }
@@ -355,7 +352,7 @@ AppMenuButton.prototype = {
         this._needsAttention = false;
 
         this.setDisplayTitle();
-        this.onFocus()
+        this.onFocus();
         this.setIcon();
 
         if (this.alert)

--- a/files/usr/share/cinnamon/applets/windows-quick-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/windows-quick-list@cinnamon.org/applet.js
@@ -1,15 +1,13 @@
 const Applet = imports.ui.applet;
 const Cinnamon = imports.gi.Cinnamon;
-const GLib = imports.gi.GLib;
 const Lang = imports.lang;
-const Mainloop = imports.mainloop;
 const PopupMenu = imports.ui.popupMenu;
 const St = imports.gi.St;
 const Main = imports.ui.main;
 
 function MyApplet(metadata, orientation, panel_height, instance_id) {
     this._init(metadata, orientation, panel_height, instance_id);
-};
+}
 
 MyApplet.prototype = {
     __proto__: Applet.IconApplet.prototype,
@@ -108,7 +106,7 @@ MyApplet.prototype = {
             global.logError(e);
         }
         if (empty_menu) {
-            let item = new PopupMenu.PopupMenuItem(_("No open windows"))
+            let item = new PopupMenu.PopupMenuItem(_("No open windows"));
             item.actor.reactive = false;
             item.actor.can_focus = false;
             item.label.add_style_class_name('popup-subtitle-menu-item');

--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
@@ -114,11 +114,6 @@ WorkspaceGraph.prototype = {
             let cr = area.get_context();
             let [area_width, area_height] = area.get_surface_size();
 
-            let workspace_is_active = false;
-            if (this.index == global.screen.get_active_workspace_index()) {
-                workspace_is_active = true;
-            }
-
             // construct a list with all windows
             let windows = this.workspace.list_windows();
             windows = windows.filter( Main.isInteresting );

--- a/files/usr/share/cinnamon/applets/xrandr@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/xrandr@cinnamon.org/applet.js
@@ -8,19 +8,19 @@ const Lang = imports.lang;
 const Applet = imports.ui.applet;
 const PopupMenu = imports.ui.popupMenu;
 
-const N_ = function(e) { return e };
+const N_ = function(e) { return e; };
 
 const possibleRotations = [ CinnamonDesktop.RRRotation.ROTATION_0,
-			    CinnamonDesktop.RRRotation.ROTATION_90,
-			    CinnamonDesktop.RRRotation.ROTATION_180,
-			    CinnamonDesktop.RRRotation.ROTATION_270
-			  ];
+                CinnamonDesktop.RRRotation.ROTATION_90,
+                CinnamonDesktop.RRRotation.ROTATION_180,
+                CinnamonDesktop.RRRotation.ROTATION_270
+              ];
 
 let rotations = [ [ CinnamonDesktop.RRRotation.ROTATION_0, N_("Normal") ],
-		  [ CinnamonDesktop.RRRotation.ROTATION_90, N_("Left") ],
-		  [ CinnamonDesktop.RRRotation.ROTATION_270, N_("Right") ],
-		  [ CinnamonDesktop.RRRotation.ROTATION_180, N_("Upside-down") ]
-		];
+          [ CinnamonDesktop.RRRotation.ROTATION_90, N_("Left") ],
+          [ CinnamonDesktop.RRRotation.ROTATION_270, N_("Right") ],
+          [ CinnamonDesktop.RRRotation.ROTATION_180, N_("Upside-down") ]
+        ];
 
 function MyApplet(orientation, panel_height, instance_id) {
     this._init(orientation, panel_height, instance_id);
@@ -29,13 +29,13 @@ function MyApplet(orientation, panel_height, instance_id) {
 MyApplet.prototype = {
     __proto__: Applet.IconApplet.prototype,
 
-    _init: function(orientation, panel_height, instance_id) {        
+    _init: function(orientation, panel_height, instance_id) {
         Applet.IconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
-        
-        try {        
+
+        try {
             this.set_applet_icon_symbolic_name("preferences-desktop-display");
             this.set_applet_tooltip(_("Display"));
-            
+
             this.menuManager = new PopupMenu.PopupMenuManager(this);
             this.menu = new Applet.AppletPopupMenu(this, orientation);
             this.menuManager.addMenu(this.menu);
@@ -61,16 +61,16 @@ MyApplet.prototype = {
             global.logError(e);
         }
     },
-    
+
     on_applet_clicked: function(event) {
-        this.menu.toggle();        
+        this.menu.toggle();
     },
-    
+
     _randrEvent: function() {
         this.menu.removeAll();
         this._createMenu();
     },
-    
+
     _createMenu: function() {
         let config = CinnamonDesktop.RRConfig.new_current(this._screen);
         let outputs = config.get_outputs();
@@ -136,14 +136,11 @@ MyApplet.prototype = {
             retval = current;
         }
         return retval;
-    }    
-    
+    }
+
 };
 
-function main(metadata, orientation, panel_height, instance_id) {  
+function main(metadata, orientation, panel_height, instance_id) {
     let myApplet = new MyApplet(orientation, panel_height, instance_id);
-    return myApplet;      
+    return myApplet;
 }
-
-
-


### PR DESCRIPTION
Remove unused variables, add missing semicolons, use `[]` notation instead of `new Array()`, etc.

