### PR TITLE
st-private: Update shadow APIs for Cogl deprecations

### DIFF
--- a/src/st/st-cogl-wrapper.c
+++ b/src/st/st-cogl-wrapper.c
@@ -15,8 +15,8 @@ hardware_supports_npot_sizes (void)
     if (cogl_context != NULL)
         return supports_npot;
 
-    supports_npot = cogl_has_feature (st_get_cogl_context(),
-                                      COGL_FEATURE_ID_TEXTURE_NPOT);
+    cogl_context = st_get_cogl_context();
+    supports_npot = cogl_has_feature (cogl_context, COGL_FEATURE_ID_TEXTURE_NPOT);
 
     g_message ("cogl npot texture sizes %s", supports_npot ? "SUPPORTED" : "NOT supported");
 
@@ -26,12 +26,7 @@ hardware_supports_npot_sizes (void)
 CoglContext *
 st_get_cogl_context (void)
 {
-    if (cogl_context != NULL)
-        return cogl_context;
-
-    cogl_context = clutter_backend_get_cogl_context (clutter_get_default_backend ());
-
-    return cogl_context;
+    return clutter_backend_get_cogl_context (clutter_get_default_backend ());
 }
 
 /**

--- a/src/st/st-cogl-wrapper.c
+++ b/src/st/st-cogl-wrapper.c
@@ -12,18 +12,26 @@ static gboolean supports_npot = FALSE;
 inline static gboolean
 hardware_supports_npot_sizes (void)
 {
-  ClutterBackend *backend;
-
     if (cogl_context != NULL)
         return supports_npot;
 
-    backend = clutter_get_default_backend ();
-    cogl_context = clutter_backend_get_cogl_context (backend);
-    supports_npot = cogl_has_feature (cogl_context, COGL_FEATURE_ID_TEXTURE_NPOT);
+    supports_npot = cogl_has_feature (st_get_cogl_context(),
+                                      COGL_FEATURE_ID_TEXTURE_NPOT);
 
     g_message ("cogl npot texture sizes %s", supports_npot ? "SUPPORTED" : "NOT supported");
 
     return supports_npot;
+}
+
+CoglContext *
+st_get_cogl_context (void)
+{
+    if (cogl_context != NULL)
+        return cogl_context;
+
+    cogl_context = clutter_backend_get_cogl_context (clutter_get_default_backend ());
+
+    return cogl_context;
 }
 
 /**

--- a/src/st/st-cogl-wrapper.h
+++ b/src/st/st-cogl-wrapper.h
@@ -11,6 +11,8 @@
 
 G_BEGIN_DECLS
 
+CoglContext * st_get_cogl_context(void);
+
 CoglTexture * st_cogl_texture_new_from_data_wrapper                (int  width,
                                                                     int  height,
                                                        CoglTextureFlags  flags,

--- a/src/st/st-icon.c
+++ b/src/st/st-icon.c
@@ -61,7 +61,7 @@ struct _StIconPrivate
   gint          icon_size;       /* icon size we are using */
   gint          icon_scale;
 
-  CoglHandle    shadow_material;
+  CoglPipeline  *shadow_pipeline;
   float         shadow_width;
   float         shadow_height;
   StShadow     *shadow_spec;
@@ -155,23 +155,11 @@ st_icon_dispose (GObject *gobject)
       priv->pending_texture = NULL;
     }
 
-  if (priv->gicon)
-    {
-      g_object_unref (priv->gicon);
-      priv->gicon = NULL;
-    }
+  g_clear_object (&priv->gicon);
 
-  if (priv->shadow_material)
-    {
-      cogl_handle_unref (priv->shadow_material);
-      priv->shadow_material = COGL_INVALID_HANDLE;
-    }
+  g_clear_pointer (&priv->shadow_pipeline, cogl_object_unref);
 
-  if (priv->shadow_spec)
-    {
-      st_shadow_unref (priv->shadow_spec);
-      priv->shadow_spec = NULL;
-    }
+  g_clear_pointer (&priv->shadow_spec, st_shadow_unref);
 
   G_OBJECT_CLASS (st_icon_parent_class)->dispose (gobject);
 }
@@ -199,7 +187,7 @@ st_icon_paint (ClutterActor *actor)
 
   if (priv->icon_texture)
     {
-      if (priv->shadow_material)
+      if (priv->shadow_pipeline)
         {
           ClutterActorBox allocation;
           float width, height;
@@ -208,7 +196,7 @@ st_icon_paint (ClutterActor *actor)
           clutter_actor_box_get_size (&allocation, &width, &height);
 
           _st_paint_shadow_with_opacity (priv->shadow_spec,
-                                         priv->shadow_material,
+                                         priv->shadow_pipeline,
                                          &allocation,
                                          clutter_actor_get_paint_opacity (priv->icon_texture));
         }
@@ -224,17 +212,8 @@ st_icon_style_changed (StWidget *widget)
   StThemeNode *theme_node = st_widget_get_theme_node (widget);
   StIconPrivate *priv = self->priv;
 
-  if (priv->shadow_spec)
-    {
-      st_shadow_unref (priv->shadow_spec);
-      priv->shadow_spec = NULL;
-    }
-
-  if (priv->shadow_material)
-    {
-      cogl_handle_unref (priv->shadow_material);
-      priv->shadow_material = COGL_INVALID_HANDLE;
-    }
+  g_clear_pointer (&priv->shadow_pipeline, cogl_object_unref);
+  g_clear_pointer (&priv->shadow_spec, st_shadow_unref);
 
   priv->shadow_spec = st_theme_node_get_shadow (theme_node, "icon-shadow");
 
@@ -314,34 +293,27 @@ st_icon_init (StIcon *self)
   self->priv->prop_icon_size = -1;
   self->priv->icon_type = DEFAULT_ICON_TYPE;
 
-  self->priv->shadow_material = COGL_INVALID_HANDLE;
+  self->priv->shadow_pipeline = NULL;
   self->priv->shadow_width = -1;
   self->priv->shadow_height = -1;
   self->priv->icon_scale = 1;
 }
 
 static void
-st_icon_update_shadow_material (StIcon *icon)
+st_icon_update_shadow_pipeline (StIcon *icon)
 {
   StIconPrivate *priv = icon->priv;
 
-  if (priv->shadow_material)
-    {
-      cogl_handle_unref (priv->shadow_material);
-      priv->shadow_material = COGL_INVALID_HANDLE;
-    }
+  g_clear_pointer (&priv->shadow_pipeline, cogl_object_unref);
 
   if (priv->shadow_spec)
    {
-     CoglHandle material;
      gint width, height;
 
      clutter_texture_get_base_size (CLUTTER_TEXTURE (priv->icon_texture),
                                     &width, &height);
 
-     material = _st_create_shadow_material_from_actor (priv->shadow_spec,
-                                                       priv->icon_texture);
-     priv->shadow_material = material;
+     priv->shadow_pipeline = _st_create_shadow_pipeline_from_actor (priv->shadow_spec, priv->icon_texture);
      priv->shadow_width = width;
      priv->shadow_height = height;
    }
@@ -351,7 +323,7 @@ static void
 on_pixbuf_changed (ClutterTexture *texture,
                    StIcon         *icon)
 {
-  st_icon_update_shadow_material (icon);
+  st_icon_update_shadow_pipeline (icon);
 }
 
 static void
@@ -376,7 +348,7 @@ st_icon_finish_update (StIcon *icon)
       /* Remove the temporary ref we added */
       g_object_unref (priv->icon_texture);
 
-      st_icon_update_shadow_material (icon);
+      st_icon_update_shadow_pipeline (icon);
 
       /* "pixbuf-change" is actually a misnomer for "texture-changed" */
       g_signal_connect (priv->icon_texture, "pixbuf-change",

--- a/src/st/st-private.h
+++ b/src/st/st-private.h
@@ -64,18 +64,18 @@ void _st_actor_get_preferred_height (ClutterActor *actor,
 void _st_set_text_from_style (ClutterText *text,
                               StThemeNode *theme_node);
 
-CoglHandle _st_create_texture_material (CoglHandle src_texture);
+CoglPipeline * _st_create_texture_pipeline (CoglTexture *src_texture);
 
 /* Helper for widgets which need to draw additional shadows */
-CoglHandle _st_create_shadow_material (StShadow   *shadow_spec,
-                                       CoglHandle  src_texture);
-CoglHandle _st_create_shadow_material_from_actor (StShadow     *shadow_spec,
-                                                  ClutterActor *actor);
-cairo_pattern_t *_st_create_shadow_cairo_pattern (StShadow        *shadow_spec,
-                                                  cairo_pattern_t *src_pattern);
+CoglPipeline * _st_create_shadow_pipeline (StShadow    *shadow_spec,
+                                           CoglTexture *src_texture);
+CoglPipeline * _st_create_shadow_pipeline_from_actor (StShadow     *shadow_spec,
+                                                      ClutterActor *actor);
+cairo_pattern_t * _st_create_shadow_cairo_pattern (StShadow        *shadow_spec,
+                                                   cairo_pattern_t *src_pattern);
 
 void _st_paint_shadow_with_opacity (StShadow        *shadow_spec,
-                                    CoglHandle       shadow_material,
+                                    CoglPipeline    *shadow_pipeline,
                                     ClutterActorBox *box,
                                     guint8           paint_opacity);
 

--- a/src/st/st-theme-node-drawing.c
+++ b/src/st/st-theme-node-drawing.c
@@ -390,7 +390,7 @@ st_theme_node_lookup_corner (StThemeNode    *node,
 
   key = corner_to_string (&corner);
   texture = st_texture_cache_load (cache, key, ST_TEXTURE_CACHE_POLICY_NONE, load_corner, &corner, NULL);
-  material = _st_create_texture_material (texture);
+  material = _st_create_texture_pipeline (texture);
   cogl_handle_unref (texture);
 
   g_free (key);
@@ -1410,7 +1410,7 @@ st_theme_node_render_resources (StThemeNode   *node,
     }
 
   if (node->border_slices_texture)
-    node->border_slices_material = _st_create_texture_material (node->border_slices_texture);
+    node->border_slices_material = _st_create_texture_pipeline (node->border_slices_texture);
   else
     node->border_slices_material = COGL_INVALID_HANDLE;
 
@@ -1439,17 +1439,17 @@ st_theme_node_render_resources (StThemeNode   *node,
     node->prerendered_texture = st_theme_node_prerender_background (node);
 
   if (node->prerendered_texture)
-    node->prerendered_material = _st_create_texture_material (node->prerendered_texture);
+    node->prerendered_material = _st_create_texture_pipeline (node->prerendered_texture);
   else
     node->prerendered_material = COGL_INVALID_HANDLE;
 
   if (box_shadow_spec && !has_inset_box_shadow)
     {
       if (node->border_slices_texture != COGL_INVALID_HANDLE)
-        node->box_shadow_material = _st_create_shadow_material (box_shadow_spec,
+        node->box_shadow_material = _st_create_shadow_pipeline (box_shadow_spec,
                                                                 node->border_slices_texture);
       else if (node->prerendered_texture != COGL_INVALID_HANDLE)
-        node->box_shadow_material = _st_create_shadow_material (box_shadow_spec,
+        node->box_shadow_material = _st_create_shadow_pipeline (box_shadow_spec,
                                                                 node->prerendered_texture);
       else if (node->background_color.alpha > 0 || has_border)
         {
@@ -1478,7 +1478,7 @@ st_theme_node_render_resources (StThemeNode   *node,
               cogl_pop_framebuffer ();
               cogl_handle_unref (offscreen);
 
-              node->box_shadow_material = _st_create_shadow_material (box_shadow_spec,
+              node->box_shadow_material = _st_create_shadow_pipeline (box_shadow_spec,
                                                                       buffer);
             }
           cogl_handle_unref (buffer);
@@ -1489,14 +1489,14 @@ st_theme_node_render_resources (StThemeNode   *node,
   if (background_image != NULL && !has_border && !has_border_radius)
     {
       node->background_texture = st_texture_cache_load_file_to_cogl_texture (texture_cache, background_image);
-      node->background_material = _st_create_texture_material (node->background_texture);
+      node->background_material = _st_create_texture_pipeline (node->background_texture);
 
       if (node->background_repeat)
         cogl_material_set_layer_wrap_mode (node->background_material, 0, COGL_MATERIAL_WRAP_MODE_REPEAT);
 
       if (background_image_shadow_spec)
         {
-          node->background_shadow_material = _st_create_shadow_material (background_image_shadow_spec,
+          node->background_shadow_material = _st_create_shadow_pipeline (background_image_shadow_spec,
                                                                          node->background_texture);
         }
     }


### PR DESCRIPTION
https://github.com/GNOME/gnome-shell/commit/1c1f63a7d7a5f0be5a796679d029a6b0c600b838#diff-578ccc5ce70c4a11d7f30e3f38002f0bR168
also
st: Adapt the mutter implementation for create_texture_material
https://github.com/GNOME/gnome-shell/commit/05f9f991d8d5796b77def6c096a36786b5307351#diff-578ccc5ce70c4a11d7f30e3f38002f0b
This was adapted to make use of the static cogl context in st-cogl-wrapper

No regressions that I can see.
Presumably for Cinnamon 3.8 at this stage in the cycle
