### PR TITLE
st-icon: remove unused fields

### DIFF
--- a/src/st/st-icon.c
+++ b/src/st/st-icon.c
@@ -62,8 +62,6 @@ struct _StIconPrivate
   gint          icon_scale;
 
   CoglHandle    shadow_material;
-  float         shadow_width;
-  float         shadow_height;
   StShadow     *shadow_spec;
 };
 
@@ -315,8 +313,6 @@ st_icon_init (StIcon *self)
   self->priv->icon_type = DEFAULT_ICON_TYPE;
 
   self->priv->shadow_material = COGL_INVALID_HANDLE;
-  self->priv->shadow_width = -1;
-  self->priv->shadow_height = -1;
   self->priv->icon_scale = 1;
 }
 
@@ -332,19 +328,8 @@ st_icon_update_shadow_material (StIcon *icon)
     }
 
   if (priv->shadow_spec)
-   {
-     CoglHandle material;
-     gint width, height;
-
-     clutter_texture_get_base_size (CLUTTER_TEXTURE (priv->icon_texture),
-                                    &width, &height);
-
-     material = _st_create_shadow_material_from_actor (priv->shadow_spec,
-                                                       priv->icon_texture);
-     priv->shadow_material = material;
-     priv->shadow_width = width;
-     priv->shadow_height = height;
-   }
+     priv->shadow_material = _st_create_shadow_material_from_actor (priv->shadow_spec,
+                                                                    priv->icon_texture);
 }
 
 static void


### PR DESCRIPTION
github.com/GNOME/gnome-shell/commit/60e7db71260ed2f8e22760c52bcf6288e1bfe6ba#diff-b948bb195b709c61ce7275142a2fbdfd
and
GNOME/gnome-shell@7f381dd#diff-b948bb195b709c61ce7275142a2fbdfd