### PR TITLE
window-manager: Show the workspace OSD even when effects are disabled

### DIFF
--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -725,6 +725,7 @@ WindowManager.prototype = {
 
     _switchWorkspace : function(cinnamonwm, from, to, direction) {
         if (!this._shouldAnimate()) {
+            this.showWorkspaceOSD();
             cinnamonwm.completed_switch_workspace();
             return;
         }


### PR DESCRIPTION
Users find the useful and there is no reason to hide it just because effects
are disabled

Fixes https://github.com/linuxmint/Cinnamon/issues/6942