### PR TITLE
cinnamon-util: fix GFile leak

### DIFF
--- a/src/cinnamon-util.c
+++ b/src/cinnamon-util.c
@@ -91,6 +91,7 @@ cinnamon_util_get_file_display_for_common_files (GFile *file)
        * nemo */
       return g_strdup (_("Home"));
     }
+  g_object_unref (compare);
 
   compare = g_file_new_for_path ("/");
   if (g_file_equal (file, compare))
@@ -262,7 +263,7 @@ cinnamon_util_get_label_for_uri (const char *text_uri)
         label = cinnamon_util_get_file_description (file);
       if (!label)
         label = cinnamon_util_get_file_display_name (file, TRUE);
-        g_object_unref (file);
+      g_object_unref (file);
 
       return label;
     }

--- a/src/cinnamon-util.c
+++ b/src/cinnamon-util.c
@@ -71,6 +71,7 @@ cinnamon_util_get_file_display_name_if_mount (GFile *file)
       if (!ret && g_file_equal (file, compare))
         ret = g_mount_get_name (mount);
       g_object_unref (mount);
+      g_object_unref (compare);
     }
   g_list_free (mounts);
   g_object_unref (monitor);
@@ -180,6 +181,7 @@ cinnamon_util_get_file_icon_if_mount (GFile *file)
           ret = g_mount_get_icon (mount);
         }
       g_object_unref (mount);
+      g_object_unref (compare);
     }
   g_list_free (mounts);
   g_object_unref (monitor);
@@ -352,7 +354,10 @@ cinnamon_util_get_icon_for_uri (const char *text_uri)
 
   retval = cinnamon_util_get_file_icon_if_mount (file);
   if (retval)
-    return retval;
+    {
+      g_object_unref (file);
+      return retval;
+    }
 
   /* gvfs doesn't give us a nice icon for subfolders of the trash, so
    * overriding */


### PR DESCRIPTION
https://github.com/GNOME/gnome-shell/commit/447246da741da9126aadb41c98a9179290bbcd86#diff-e13d0669f81906a880112b462a031c53
also fix an instance of deceptive indentation

And then I found some similar leaks ...