### PR TITLE
shell-embedded-window: change realize to map

### DIFF
--- a/src/cinnamon-embedded-window-private.h
+++ b/src/cinnamon-embedded-window-private.h
@@ -14,7 +14,7 @@ void _cinnamon_embedded_window_allocate (CinnamonEmbeddedWindow *window,
 				      int                  width,
 				      int                  height);
 
-void _cinnamon_embedded_window_realize   (CinnamonEmbeddedWindow *window);
-void _cinnamon_embedded_window_unrealize (CinnamonEmbeddedWindow *window);
+void _cinnamon_embedded_window_map   (CinnamonEmbeddedWindow *window);
+void _cinnamon_embedded_window_unmap (CinnamonEmbeddedWindow *window);
 
 #endif /* __CINNAMON_EMBEDDED_WINDOW_PRIVATE_H__ */

--- a/src/cinnamon-embedded-window.c
+++ b/src/cinnamon-embedded-window.c
@@ -19,20 +19,11 @@
  *  - CinnamonGtkEmbed is created for the CinnamonEmbeddedWindow
  *  - actor is added to a stage
  *
- * Ideally, the way it would work is that the GtkWindow is mapped
- * if and only if both:
+ * The GtkWindow is mapped if and only if both:
  *
- * - GTK_WIDGET_VISIBLE (window) [widget has been shown]
+ * - gtk_window_visible (window) [widget has been shown]
  * - Actor is mapped [actor and all parents visible, actor in stage]
  *
- * Implementing this perfectly is not currently possible, due to problems
- * in Clutter, see:
- *
- * http://bugzilla.openedhand.com/show_bug.cgi?id=1138
- *
- * So until that is fixed we use the "realized" state of the ClutterActor
- * as a stand-in for the ideal mapped state, this will work as long
- * as the ClutterActor and all its parents are in fact visible.
  */
 
 G_DEFINE_TYPE (CinnamonEmbeddedWindow, cinnamon_embedded_window, GTK_TYPE_WINDOW);
@@ -230,7 +221,7 @@ _cinnamon_embedded_window_set_actor (CinnamonEmbeddedWindow  *window,
   window->priv->actor = actor;
 
   if (actor &&
-      clutter_actor_is_realized (CLUTTER_ACTOR (actor)) &&
+      clutter_actor_is_mapped (CLUTTER_ACTOR (actor)) &&
       gtk_widget_get_visible (GTK_WIDGET (window)))
     gtk_widget_map (GTK_WIDGET (window));
 }
@@ -270,7 +261,7 @@ _cinnamon_embedded_window_allocate (CinnamonEmbeddedWindow *window,
 }
 
 void
-_cinnamon_embedded_window_realize (CinnamonEmbeddedWindow *window)
+_cinnamon_embedded_window_map (CinnamonEmbeddedWindow *window)
 {
   g_return_if_fail (CINNAMON_IS_EMBEDDED_WINDOW (window));
 
@@ -279,7 +270,7 @@ _cinnamon_embedded_window_realize (CinnamonEmbeddedWindow *window)
 }
 
 void
-_cinnamon_embedded_window_unrealize (CinnamonEmbeddedWindow *window)
+_cinnamon_embedded_window_unmap (CinnamonEmbeddedWindow *window)
 {
   g_return_if_fail (CINNAMON_IS_EMBEDDED_WINDOW (window));
 

--- a/src/cinnamon-gtk-embed.c
+++ b/src/cinnamon-gtk-embed.c
@@ -199,24 +199,24 @@ cinnamon_gtk_embed_allocate (ClutterActor          *actor,
 }
 
 static void
-cinnamon_gtk_embed_realize (ClutterActor *actor)
+cinnamon_gtk_embed_map (ClutterActor *actor)
 {
   CinnamonGtkEmbed *embed = CINNAMON_GTK_EMBED (actor);
 
-  _cinnamon_embedded_window_realize (embed->priv->window);
+  _cinnamon_embedded_window_map (embed->priv->window);
 
-  CLUTTER_ACTOR_CLASS (cinnamon_gtk_embed_parent_class)->realize (actor);
+  CLUTTER_ACTOR_CLASS (cinnamon_gtk_embed_parent_class)->map (actor);
 }
 
 static void
-cinnamon_gtk_embed_unrealize (ClutterActor *actor)
+cinnamon_gtk_embed_unmap (ClutterActor *actor)
 {
   CinnamonGtkEmbed *embed = CINNAMON_GTK_EMBED (actor);
-  
-  if (embed->priv->window)
-    _cinnamon_embedded_window_unrealize (embed->priv->window);
 
-  CLUTTER_ACTOR_CLASS (cinnamon_gtk_embed_parent_class)->unrealize (actor);
+  if (embed->priv->window)
+    _cinnamon_embedded_window_unmap (embed->priv->window);
+
+  CLUTTER_ACTOR_CLASS (cinnamon_gtk_embed_parent_class)->unmap (actor);
 }
 
 static void
@@ -244,8 +244,8 @@ cinnamon_gtk_embed_class_init (CinnamonGtkEmbedClass *klass)
   actor_class->get_preferred_width = cinnamon_gtk_embed_get_preferred_width;
   actor_class->get_preferred_height = cinnamon_gtk_embed_get_preferred_height;
   actor_class->allocate = cinnamon_gtk_embed_allocate;
-  actor_class->realize = cinnamon_gtk_embed_realize;
-  actor_class->unrealize = cinnamon_gtk_embed_unrealize;
+  actor_class->map = cinnamon_gtk_embed_map;
+  actor_class->unmap = cinnamon_gtk_embed_unmap;
 
   g_object_class_install_property (object_class,
                                    PROP_WINDOW,


### PR DESCRIPTION
https://github.com/GNOME/gnome-shell/commit/d212d574669ef842cb39a0a0f7a7fa066656528c
see issue #5573
thanks to @lestcape for pointing this out.

Can't see any regressions, but also can't check against the collapsible systray applet that generated the issue, as it has some problems. Hence suggest that this fix can wait for 3.8