### PR TITLE
Spices.py: Fix xlets not installing if a file without an extension is in the po directory

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
@@ -574,7 +574,7 @@ class Spice_Harvester(GObject.Object):
                 if 'po' in contents:
                     po_dir = os.path.join(uuidfolder, 'po')
                     for file in os.listdir(po_dir):
-                        if file.split(".")[1] == 'po':
+                        if file.endswith('.po'):
                             lang = file.split(".")[0]
                             locale_dir = os.path.join(locale_inst, lang, 'LC_MESSAGES')
                             rec_mkdir(locale_dir)


### PR DESCRIPTION
When uncommenting the try-except block wrapping the _install method, this stack trace was seen when trying to install `multicore-sys-monitor@ccadeptic23` (since patched on the xlet side). 

```sh
Exception in thread Thread-85:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 754, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/usr/share/cinnamon/cinnamon-settings/bin/Spices.py", line 283, in _process_job
    job['result'] = job['func'](job)
  File "/usr/share/cinnamon/cinnamon-settings/bin/Spices.py", line 577, in _install
    if file.split(".")[1] == 'po':
IndexError: list index out of range
```