### PR TITLE
Fix blurry and off-centered arrow in popup submenus

### DIFF
--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -2881,7 +2881,7 @@ PopupSubMenuMenuItem.prototype = {
                                                align: St.Align.END });
 
             this._triangle = arrowIcon(St.Side.RIGHT);
-            this._triangle.pivot_point = new Clutter.Point({ x: 0.5, y: 0.6 });
+            this._triangle.pivot_point = new Clutter.Point({ x: 0.5, y: 0.5 });
             this._triangleBin.child = this._triangle;
         }
 


### PR DESCRIPTION
Placing the pivot point not in the center shifts the arrow a little bit down when rotated and it becomes **vertically off-centered** and **blurry** because it is in a subpixel position.

See the screenshot (view it at 100% zoom):
![screenshot from 2017-11-05 15-16-26](https://user-images.githubusercontent.com/10391266/32416572-a6857d64-c24b-11e7-8384-77edbffc070d.png)
_Before vs after._