### PR TITLE
Improving a piece of code in cinnamon-settings.py

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
@@ -258,16 +258,7 @@ class MainWindow:
                 self.unsortedSidePages.append((samodule.sidePage, samodule.name, samodule.category))
 
         # sort the modules alphabetically according to the current locale
-        sidePageNamesToSort = map(lambda m: m[0].name, self.unsortedSidePages)
-        sortedSidePageNames = sorted(sidePageNamesToSort, key=cmp_to_key(locale.strcoll))
-        for sidePageName in sortedSidePageNames:
-            nextSidePage = None
-            for trySidePage in self.unsortedSidePages:
-                if(trySidePage[0].name == sidePageName):
-                    nextSidePage = trySidePage
-
-            self.sidePages.append(nextSidePage);
-
+        self.sidePages = sorted(self.unsortedSidePages, key=lambda m : (cmp_to_key(locale.strcoll))(m[0].name))
 
         # create the backing stores for the side nav-view.
         sidePagesIters = {}


### PR DESCRIPTION
Hello everybody. I just want to propose a small improvement of a piece of code.

The removed code sorts the array _unsortedSidePages_ using the name of the side pages as a key. To do so, he first extracts those names and stores them in a new array, sorts this array, and retrieves the elements from _unsortedSidePages_ (lines 263-267).

I propose to replace all of this by one line. This line sorts directly the elements of the original array by name, without extracting those names. It is smaller and more efficient.