### PR TITLE
Applets: when setting an icon, make sure it's actually an St.Icon. So…

### DIFF
--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -681,7 +681,7 @@ IconApplet.prototype = {
     },
 
     _ensureIcon: function() {
-        if (!this._applet_icon)
+        if (!this._applet_icon || !(this._applet_icon instanceof St.Icon))
             this._applet_icon = new St.Icon({ reactive: true, track_hover: true, style_class: 'applet-icon'});
 
         this._applet_icon_box.set_child(this._applet_icon);


### PR DESCRIPTION
…me applets (such as the keyboard applet) set _applet_icon to something other than an St.Icon, so it causes an error when trying to set the icon using one of the api functions. This was causing the keyboard applet not to show in panel edit mode after a keyboard layout was added and removed.