### PR TITLE
initialise applet position to avoid drag and drop errors in edit mode

### DIFF
--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -1763,7 +1763,7 @@ PanelZoneDNDHandler.prototype = {
 
         let children = this._panelZone.get_children();
         let curAppletPos = 0;
-        let insertAppletPos = null;
+        let insertAppletPos = 0;
 
         for (let i = 0, len = children.length; i < len; i++) {
             if (children[i]._delegate instanceof Applet.Applet){


### PR DESCRIPTION
occasionally the null applet position was being carried through to the writing of the new applet
causing apparent drop failures, and to the disappearance of the highlighted drop box.  Much visible
weirdness with a very simple solution