### PR TITLE
popupMenu: Prevent warning of this._triangle

### DIFF
--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -2863,9 +2863,9 @@ PopupSubMenuMenuItem.prototype = {
     _init: function(text) {
         PopupBaseMenuItem.prototype._init.call(this);
 
-        // This check allows PopupSubMenu to be used as a generic scrollable container. PopupSubMenu
-        // already checks for the truthiness of this._triangle (passed as sourceArrow) before using
-        // it, so we can leave it undefined.
+        this._triangle = null;
+
+        // This check allows PopupSubMenu to be used as a generic scrollable container.
         if (typeof text === 'string') {
             this.actor.add_style_class_name('popup-submenu-menu-item');
 


### PR DESCRIPTION
Leaving sourceArrow undefined shouldn't have an adverse effect on Cinnamon since a check was added for sourceArrow in PopupSubMenu.prototype._init, but silencing the warning for cleaner log files.