### PR TITLE
 Fix custom format not working and add tooltip 

### DIFF
--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
@@ -133,14 +133,15 @@ MyApplet.prototype = {
         let label_string = this.clock.get_clock();
         let in_vertical_panel = (this.orientation == St.Side.LEFT || this.orientation == St.Side.RIGHT);
 
-        if (!this.use_custom_format && !in_vertical_panel) {
+        if (!this.use_custom_format) {
             label_string = label_string.capitalize();
-        }
-        else {
-            let vertical_format = this.clock.get_default_time_format();
-            /* First removes the date, then changes single splits 24hr mode, then removes "AM/PM" in 12hr mode, finaly replacing : with a newline */
-            vertical_format = vertical_format.replace('%A %B %e, ', '').replace('%R', '%H%n%M').replace(' %p', '').replace(new RegExp(":", 'g'), "%n");
-            label_string = this.clock.get_clock_for_format(vertical_format);
+    
+            if (in_vertical_panel) {
+                let vertical_format = this.clock.get_default_time_format();
+                /* First removes the date, then changes single splits 24hr mode, then removes "AM/PM" in 12hr mode, finaly replacing : with a newline */
+                vertical_format = vertical_format.replace('%A %B %e, ', '').replace('%R', '%H%n%M').replace(' %p', '').replace(new RegExp(":", 'g'), "%n");
+                label_string = this.clock.get_clock_for_format(vertical_format);
+            }
         }
 
         this.set_applet_label(label_string);

--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/settings-schema.json
@@ -21,7 +21,7 @@
         "description" : "Date format",
         "indent": true,
         "dependency" : "use-custom-format",
-        "tooltip" : "Set your custom format here."
+        "tooltip" : "Set your custom format here. \nNote: if you have a vertical panel, use '%n' to create a newline"
     },
     "format-button" : {
         "type" : "button",


### PR DESCRIPTION
Fixes
 "NEWLY INTRODUCED BUG:
After updating to Cinnamon 3.6.3 a new bug is introduced that screws up the calendar’s time and date appearance if it is set to “use a custom date format.” I’ve had the same result after running the updates on two different computers and also in a virtual box hosted in the first of the two. I always set my time and date format to %a %e %b %Y @ %H:%M:%S. It displayed fine on both machines and in the vbox before I ran the update."