### PR TITLE
Online Accounts: Use translations

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_online_accounts.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_online_accounts.py
@@ -38,6 +38,7 @@ class Module:
     def on_button_clicked(self, button):
         gladefile = "/usr/share/cinnamon/cinnamon-settings/cinnamon-online-accounts-info.ui"
         self.builder = Gtk.Builder()
+        self.builder.set_translation_domain('cinnamon')
         self.builder.add_from_file(gladefile)
         self.window = self.builder.get_object("main_window")
         self.window.set_title(_("Online Accounts"))


### PR DESCRIPTION
The help dialog of Cinnamon Online Accounts was translated, but it is not used currently.
Tell the gladefile, where to look for translations.

Fixes https://github.com/linuxmint/Cinnamon/issues/7076