### PR TITLE
Xlets: Fix shown info for overwritten xlets.

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
@@ -158,7 +158,7 @@ class Spice_Harvester(GObject.Object):
             if self.collection_type == 'extension':
                 self.spices_directories = (self.install_folder, )
             else:
-                self.spices_directories = (self.install_folder, '/usr/share/cinnamon/%ss/' % self.collection_type)
+                self.spices_directories = ('/usr/share/cinnamon/%ss/' % self.collection_type, self.install_folder)
 
         self._load_metadata()
 


### PR DESCRIPTION
If a system xlet is overwritten in `~/.local/share/cinnamon/xlets`, the local xlet is used, but the system metadata info is shown.
Fix to show local metadata, when local xlet is used