### PR TITLE
Spices description: Do not cut off the letter `n`

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/ExtensionCore.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/ExtensionCore.py
@@ -128,7 +128,7 @@ def sanitize_html(string):
     parser = MyHTMLParser()
     parser.feed(string)
     text = parser.get_text()
-    return text.strip('\\n ').strip('\\n').replace('\\n', ' ').replace('  ', ' ').replace('\\', '')
+    return text.strip('\n ').strip('\n').replace('\n', ' ').replace('  ', ' ').replace('\\', '')
 
 
 class ManageSpicesRow(Gtk.ListBoxRow):


### PR DESCRIPTION
The letter `n` is cut off, if it appears at the end of a description.

Fixes https://github.com/linuxmint/Cinnamon/issues/7096