### PR TITLE
Fix issues related to Cinnamon running with cjs/mozjs52

### DIFF
--- a/js/misc/config.js.in
+++ b/js/misc/config.js.in
@@ -1,12 +1,12 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
 /* The name of this package (not localized) */
-const PACKAGE_NAME = '@PACKAGE_NAME@';
+var PACKAGE_NAME = '@PACKAGE_NAME@';
 /* The version of this package */
-const PACKAGE_VERSION = '@PACKAGE_VERSION@';
+var PACKAGE_VERSION = '@PACKAGE_VERSION@';
 /* The version of GJS we're linking to */
-const GJS_VERSION = '@GJS_VERSION@';
+var GJS_VERSION = '@GJS_VERSION@';
 /* 1 if gnome-bluetooth is available, 0 otherwise */
-const HAVE_BLUETOOTH = @HAVE_BLUETOOTH@;
+var HAVE_BLUETOOTH = @HAVE_BLUETOOTH@;
 /* The system TLS CA list */
-const CINNAMON_SYSTEM_CA_FILE = '@CINNAMON_SYSTEM_CA_FILE@';
+var CINNAMON_SYSTEM_CA_FILE = '@CINNAMON_SYSTEM_CA_FILE@';

--- a/js/misc/fileDialog.js
+++ b/js/misc/fileDialog.js
@@ -17,9 +17,9 @@ function _launchDialog(type, callback, params) {
 	let args = ["cinnamon-file-dialog"];
 	if (params.selectMultiple) type += 3; //add 3 to use the select-multiple version
 	args.push(String(type));
-	if (params.path) args.push("-p", params.path.replace("~", GLib.get_home_dir()));
+	if (params.path) args.push("-p", params.path.replace(/~/, GLib.get_home_dir()));
 	if (params.name) args.push("-n", params.name);
-	if (params.directory) args.push("-d", params.directory.replace("~", GLib.get_home_dir()));
+	if (params.directory) args.push("-d", params.directory.replace(/~/, GLib.get_home_dir()));
 	if (params.filters) {
 		let filterList = [];
 		for (let i = 0; i < params.filters.length; i++) {

--- a/js/misc/fileUtils.js
+++ b/js/misc/fileUtils.js
@@ -71,7 +71,7 @@ function getUserDesktopDir() {
                 }
             }
             if (dataDic["XDG_DESKTOP_DIR"])
-                path = dataDic["XDG_DESKTOP_DIR"].substring(1, dataDic["XDG_DESKTOP_DIR"].length-1).replace("$HOME", GLib.get_home_dir());
+                path = dataDic["XDG_DESKTOP_DIR"].substring(1, dataDic["XDG_DESKTOP_DIR"].length-1).replace(/\$HOME/, GLib.get_home_dir());
             else
                 path = GLib.get_home_dir() + '/Desktop';
         }catch(e){

--- a/js/misc/gnomeSession.js
+++ b/js/misc/gnomeSession.js
@@ -1,10 +1,8 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
 const Gio = imports.gi.Gio;
-const Lang = imports.lang;
-const Signals = imports.signals;
 
-const PresenceIface = '\
+var PresenceIface = '\
 <node> \
     <interface name="org.gnome.SessionManager.Presence"> \
         <method name="SetStatus"> \
@@ -17,7 +15,7 @@ const PresenceIface = '\
     </interface> \
 </node>';
 
-const PresenceStatus = {
+var PresenceStatus = {
     AVAILABLE: 0,
     INVISIBLE: 1,
     BUSY: 2,
@@ -30,7 +28,7 @@ function Presence(initCallback, cancellable) {
                              '/org/gnome/SessionManager/Presence', initCallback, cancellable);
 }
 
-const InhibitorIface = ' \
+var InhibitorIface = ' \
 <node> \
     <interface name="org.gnome.SessionManager.Inhibitor"> \
         <property name="app_id" type="s" access="read" /> \
@@ -47,7 +45,7 @@ function Inhibitor(objectPath, initCallback, cancellable) {
     return new InhibitorProxy(Gio.DBus.session, 'org.gnome.SessionManager', objectPath, initCallback, cancellable);
 }
 
-const SessionManagerIface = '\
+var SessionManagerIface = '\
 <node> \
     <interface name="org.gnome.SessionManager"> \
         <method name="Logout"> \

--- a/js/ui/dnd.js
+++ b/js/ui/dnd.js
@@ -5,7 +5,6 @@ const GLib = imports.gi.GLib;
 const Gtk = imports.gi.Gtk;
 const St = imports.gi.St;
 const Lang = imports.lang;
-const Meta = imports.gi.Meta;
 const Cinnamon = imports.gi.Cinnamon;
 const Signals = imports.signals;
 const Tweener = imports.ui.tweener;
@@ -13,37 +12,37 @@ const Main = imports.ui.main;
 
 const Params = imports.misc.params;
 
-const DND_ANIMATION_TIME = 0.2;
+var DND_ANIMATION_TIME = 0.2;
 // Time to scale down to maxDragActorSize
-const SCALE_ANIMATION_TIME = 0.25;
+var SCALE_ANIMATION_TIME = 0.25;
 // Time to animate to original position on cancel
-const SNAP_BACK_ANIMATION_TIME = 0.25;
+var SNAP_BACK_ANIMATION_TIME = 0.25;
 // Time to animate to original position on success
-const REVERT_ANIMATION_TIME = 0.75;
+var REVERT_ANIMATION_TIME = 0.75;
 
-const DragMotionResult = {
+var DragMotionResult = {
     NO_DROP:   0,
     COPY_DROP: 1,
     MOVE_DROP: 2,
     CONTINUE:  3
 };
 
-const DRAG_CURSOR_MAP = {
+var DRAG_CURSOR_MAP = {
     0: Cinnamon.Cursor.DND_UNSUPPORTED_TARGET,
     1: Cinnamon.Cursor.DND_COPY,
     2: Cinnamon.Cursor.DND_MOVE
 };
 
-const DragDropResult = {
+var DragDropResult = {
     FAILURE:  0,
     SUCCESS:  1,
     CONTINUE: 2
 };
 
-let eventHandlerActor = null;
-let currentDraggable = null;
-let dragMonitors = [];
-let targetMonitors = [];
+var eventHandlerActor = null;
+var currentDraggable = null;
+var dragMonitors = [];
+var targetMonitors = [];
 
 function _getEventHandlerActor() {
     if (!eventHandlerActor) {

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -119,74 +119,74 @@ const Settings = imports.ui.settings;
 const Systray = imports.ui.systray;
 const Accessibility = imports.ui.accessibility;
 
-const LAYOUT_TRADITIONAL = "traditional";
-const LAYOUT_FLIPPED = "flipped";
-const LAYOUT_CLASSIC = "classic";
+var LAYOUT_TRADITIONAL = "traditional";
+var LAYOUT_FLIPPED = "flipped";
+var LAYOUT_CLASSIC = "classic";
 
-const CIN_LOG_FOLDER = GLib.get_home_dir() + '/.cinnamon/';
+var CIN_LOG_FOLDER = GLib.get_home_dir() + '/.cinnamon/';
 
-let DEFAULT_BACKGROUND_COLOR = Clutter.Color.from_pixel(0x000000ff);
+var DEFAULT_BACKGROUND_COLOR = Clutter.Color.from_pixel(0x000000ff);
 
-let panel = null;
-let soundManager = null;
-let backgroundManager = null;
-let slideshowManager = null;
-let placesManager = null;
-let panelManager = null;
-let osdWindowManager = null;
-let overview = null;
-let expo = null;
-let runDialog = null;
-let lookingGlass = null;
-let wm = null;
-let a11yHandler = null;
-let messageTray = null;
-let indicatorManager = null;
-let notificationDaemon = null;
-let windowAttentionHandler = null;
-let recorder = null;
-let cinnamonDBusService = null;
-let modalCount = 0;
-let modalActorFocusStack = [];
-let uiGroup = null;
-let magnifier = null;
-let xdndHandler = null;
-let statusIconDispatcher = null;
-let keyboard = null;
-let layoutManager = null;
-let themeManager = null;
-let keybindingManager = null;
-let _errorLogStack = [];
-let _startDate;
-let _defaultCssStylesheet = null;
-let _cssStylesheet = null;
-let dynamicWorkspaces = null;
-let tracker = null;
-let settingsManager = null;
-let systrayManager = null;
-let wmSettings = null;
+var panel = null;
+var soundManager = null;
+var backgroundManager = null;
+var slideshowManager = null;
+var placesManager = null;
+var panelManager = null;
+var osdWindowManager = null;
+var overview = null;
+var expo = null;
+var runDialog = null;
+var lookingGlass = null;
+var wm = null;
+var a11yHandler = null;
+var messageTray = null;
+var indicatorManager = null;
+var notificationDaemon = null;
+var windowAttentionHandler = null;
+var recorder = null;
+var cinnamonDBusService = null;
+var modalCount = 0;
+var modalActorFocusStack = [];
+var uiGroup = null;
+var magnifier = null;
+var xdndHandler = null;
+var statusIconDispatcher = null;
+var keyboard = null;
+var layoutManager = null;
+var themeManager = null;
+var keybindingManager = null;
+var _errorLogStack = [];
+var _startDate;
+var _defaultCssStylesheet = null;
+var _cssStylesheet = null;
+var dynamicWorkspaces = null;
+var tracker = null;
+var settingsManager = null;
+var systrayManager = null;
+var wmSettings = null;
 
-let workspace_names = [];
+var workspace_names = [];
 
-let applet_side = St.Side.TOP; // Kept to maintain compatibility. Doesn't seem to be used anywhere
-let deskletContainer = null;
+var applet_side = St.Side.TOP; // Kept to maintain compatibility. Doesn't seem to be used anywhere
+var deskletContainer = null;
 
-let software_rendering = false;
+var software_rendering = false;
 
-let lg_log_file;
-let can_log = false;
+var lg_log_file;
+var can_log = false;
 
-let popup_rendering_actor = null;
+var popup_rendering_actor = null;
 
-let xlet_startup_error = false;
+var xlet_startup_error = false;
 
-const RunState = {
+var RunState = {
     INIT : 0,
     STARTUP : 1,
     RUNNING : 2
 }
 
-let runState = RunState.INIT;
+var runState = RunState.INIT;
 
 // Override Gettext localization
 const Gettext = imports.gettext;

--- a/js/ui/messageTray.js
+++ b/js/ui/messageTray.js
@@ -21,23 +21,23 @@ const Tweener = imports.ui.tweener;
 const Util = imports.misc.util;
 const AppletManager = imports.ui.appletManager;
 
-const ANIMATION_TIME = .2;
-const NOTIFICATION_TIMEOUT = 4;
-const NOTIFICATION_CRITICAL_TIMEOUT_WITH_APPLET = 10;
-const SUMMARY_TIMEOUT = 1;
-const LONGER_SUMMARY_TIMEOUT = 4;
+var ANIMATION_TIME = .2;
+var NOTIFICATION_TIMEOUT = 4;
+var NOTIFICATION_CRITICAL_TIMEOUT_WITH_APPLET = 10;
+var SUMMARY_TIMEOUT = 1;
+var LONGER_SUMMARY_TIMEOUT = 4;
 
-const HIDE_TIMEOUT = 0.2;
-const LONGER_HIDE_TIMEOUT = 0.6;
+var HIDE_TIMEOUT = 0.2;
+var LONGER_HIDE_TIMEOUT = 0.6;
 
-const MAX_SOURCE_TITLE_WIDTH = 180;
+var MAX_SOURCE_TITLE_WIDTH = 180;
 
 
 // We delay hiding of the tray if the mouse is within MOUSE_LEFT_ACTOR_THRESHOLD
 // range from the point where it left the tray.
-const MOUSE_LEFT_ACTOR_THRESHOLD = 20;
+var MOUSE_LEFT_ACTOR_THRESHOLD = 20;
 
-const State = {
+var State = {
     HIDDEN:  0,
     SHOWING: 1,
     SHOWN:   2,
@@ -49,7 +49,7 @@ const State = {
 // user did not interact with, DISMISSED for all other notifications that were
 // destroyed as a result of a user action, and SOURCE_CLOSED for the notifications
 // that were requested to be destroyed by the associated source.
-const NotificationDestroyedReason = {
+var NotificationDestroyedReason = {
     EXPIRED: 1,
     DISMISSED: 2,
     SOURCE_CLOSED: 3
@@ -59,7 +59,7 @@ const NotificationDestroyedReason = {
 // urgency values map to the corresponding values for the notifications received
 // through the notification daemon. HIGH urgency value is used for chats received
 // through the Telepathy client.
-const Urgency = {
+var Urgency = {
     LOW: 0,
     NORMAL: 1,
     HIGH: 2,

--- a/js/ui/overrides.js
+++ b/js/ui/overrides.js
@@ -142,6 +142,10 @@ function overrideJS() {
         return this.charAt(0).toUpperCase();
     }
 
+    if (!String.prototype.includes) {
+        String.prototype.includes = String.prototype.contains;
+    }
+
     Number.prototype.clamp = function(min, max) {
         return Math.min(Math.max(this, min), max);
     };

--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -21,23 +21,23 @@ const RadioButton = imports.ui.radioButton;
 const Params = imports.misc.params;
 const Util = imports.misc.util;
 
-const SLIDER_SCROLL_STEP = 0.05; /* Slider scrolling step in % */
+var SLIDER_SCROLL_STEP = 0.05; /* Slider scrolling step in % */
 
-const PanelLoc = {
+var PanelLoc = {
     top : 0,
     bottom : 1,
     left : 2,
     right : 3
 };
 
-const OrnamentType = {
+var OrnamentType = {
     NONE: 0,
     CHECK: 1,
     DOT: 2,
     ICON: 3
 };
 
-const FactoryClassTypes = {
+var FactoryClassTypes = {
     'RootMenuClass'            : "RootMenuClass",
     'MenuItemClass'            : "MenuItemClass",
     'SubMenuMenuItemClass'     : "SubMenuMenuItemClass",
@@ -45,7 +45,7 @@ const FactoryClassTypes = {
     'SeparatorMenuItemClass'   : "SeparatorMenuItemClass"
 };
 
-const FactoryEventTypes = {
+var FactoryEventTypes = {
     'opened'    : "opened",
     'closed'    : "closed",
     'clicked'   : "clicked"

--- a/js/ui/search.js
+++ b/js/ui/search.js
@@ -292,9 +292,9 @@ OpenSearchSystem.prototype = {
     activateResult: function(id, params) {
         let searchTerms = this._terms.join(' ');
 
-        let url = this._providers[id].url.replace('{searchTerms}', encodeURIComponent(searchTerms));
-        if (url.match('{language}'))
-            url = url.replace('{language}', this._providers[id].lang);
+        let url = this._providers[id].url.replace(/{searchTerms}/g, encodeURIComponent(searchTerms));
+        if (url.match(/{language}/g))
+            url = url.replace(/{language}/g, this._providers[id].lang);
 
         try {
             Gio.app_info_launch_default_for_uri(url, global.create_app_launch_context());

--- a/js/ui/windowAttentionHandler.js
+++ b/js/ui/windowAttentionHandler.js
@@ -35,7 +35,7 @@ WindowAttentionHandler.prototype = {
             let ignored_classes = global.settings.get_strv("demands-attention-ignored-wm-classes");
 
             for (let i = 0; i < ignored_classes.length; i++) {
-                if (wmclass.toLowerCase().contains(ignored_classes[i].toLowerCase())) {
+                if (wmclass.toLowerCase().includes(ignored_classes[i].toLowerCase())) {
                     return;
                 }
             }

--- a/js/ui/workspacesView.js
+++ b/js/ui/workspacesView.js
@@ -2,7 +2,6 @@
 
 const Clutter = imports.gi.Clutter;
 const Lang = imports.lang;
-const Meta = imports.gi.Meta;
 const Cinnamon = imports.gi.Cinnamon;
 const St = imports.gi.St;
 const Signals = imports.signals;
@@ -11,15 +10,15 @@ const Main = imports.ui.main;
 const Tweener = imports.ui.tweener;
 const Workspace = imports.ui.workspace;
 
-const WORKSPACE_SWITCH_TIME = 0.25;
+var WORKSPACE_SWITCH_TIME = 0.25;
 
-const SwipeScrollDirection = {
+var SwipeScrollDirection = {
     NONE: 0,
     HORIZONTAL: 1,
     VERTICAL: 2
 };
 
-const SwipeScrollResult = {
+var SwipeScrollResult = {
     CANCEL: 0,
     SWIPE: 1,
     CLICK: 2


### PR DESCRIPTION
Depends on: https://github.com/linuxmint/cjs/pull/61

This fixes some of the mozjs52 related warnings occurring in the logs except for extension related modules, which will be handled in #6878.

This also fixes a few string.replace calls so they only use regex, the old way of only passing strings to `replace` was not on a standards track and will break in JS.

Some unused imports were also cleaned up.