### PR TITLE
window-list: unique style class and new preview options

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -1274,6 +1274,17 @@ StScrollBar StButton#vhandle:hover {
     background-gradient-end: rgba(255,144,144,0.5);
 }
 
+.window-list-preview {
+    background: rgba(80,80,80,0.8);
+    border: 2px solid #a5a5a5;
+    border-radius: 8px;
+    font-size: 9pt;
+    color: white;
+    text-shadow: black 0px 0px 2px;
+    padding: 8px;
+    spacing: 4px;
+}
+
 /* ===================================================================
  * Sound Applet (sound@cinnamon.org)
  * ===================================================================*/

--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/settings-schema.json
@@ -42,5 +42,23 @@
       "type": "switch",
       "default": true,
       "description": "Show window thumbnails on hover"
+  },
+  "window-preview-show-label": {
+      "type": "switch",
+      "default": true,
+      "description": "Show title above thumbnail",
+      "dependency": "window-preview"
+  },
+  "window-preview-scale": {
+      "type": "radiogroup",
+      "default": 1,
+      "description": "Thumbnail size",
+      "options": {
+          "Small": 0.75,
+          "Medium": 1,
+          "Large": 1.25,
+          "Largest": 1.5
+      },
+      "dependency": "window-preview"
   }
 }


### PR DESCRIPTION
We now use the the "window-list-preview" style class for the preview
in order to allow fine grained control instead of sharing the window
switcher's style class.

Adds support for user to disable the preview label and to change the
thumbnail size from 75% to 150% of default.

<s>The thumbnail may have some aspect ratio issues right now, and the default theme may need a few tweaks, but this is the basic idea.</s>

Support will need to be added to all existing themes. Until then the default theme as shown <s>here</s> below will be displayed.