### PR TITLE
windows-quick-list: Fix icon allocation warnings

### DIFF
--- a/files/usr/share/cinnamon/applets/windows-quick-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/windows-quick-list@cinnamon.org/applet.js
@@ -116,7 +116,7 @@ MyApplet.prototype = {
 
     activateWindow: function(metaWorkspace, metaWindow) {
         if (this._menu.isOpen) {
-            this._menu.toggle();
+            this._menu.toggle_with_options(false);
         }
         this.menu.toggle();
         if(!metaWindow.is_on_all_workspaces()) { metaWorkspace.activate(global.get_current_time()); }
@@ -127,7 +127,7 @@ MyApplet.prototype = {
     on_applet_clicked: function(event) {
         this.updateMenu();
         if (!this._menu.isOpen) {
-            this._menu.toggle();
+            this._menu.toggle_with_options(false);
         }
         this.menu.toggle();
     }


### PR DESCRIPTION
Fixes the following warning when animations are enabled:

```sh
(cinnamon:3968): Clutter-WARNING **: clutter-actor.c:10033: Actor 'StIcon' tried to allocate a size of -30.00 x 24.00
```