### PR TITLE
sound applet middle click mute refinement

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -1055,8 +1055,7 @@ MyApplet.prototype = {
             if (this.middleClickAction === "mute") {
                 this._toggle_out_mute();
                 this._toggle_in_mute();
-            }
-            else if (this.middleClickAction === "out_mute")
+            } else if (this.middleClickAction === "out_mute")
                 this._toggle_out_mute();
             else if (this.middleClickAction === "in_mute")
                 this._toggle_in_mute();

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -1052,8 +1052,14 @@ MyApplet.prototype = {
 
         //mute or play / pause players on middle click
         if (buttonId === 2) {
-            if (this.middleClickAction === "mute")
+            if (this.middleClickAction === "mute") {
                 this._toggle_out_mute();
+                this._toggle_in_mute();
+            }
+            else if (this.middleClickAction === "out_mute")
+                this._toggle_out_mute();
+            else if (this.middleClickAction === "in_mute")
+                this._toggle_in_mute();
             else if (this.middleClickAction === "player")
                 this._players[this._activePlayer]._mediaServerPlayer.PlayPauseRemote();
         } else if (buttonId === 8) { // previous and next track on mouse buttons 4 and 5 (8 and 9 by X11 numbering)

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/settings-schema.json
@@ -45,6 +45,8 @@
         "default": "mute",
         "options": {
             "Toggle Mute": "mute",
+            "Toggle Mute output": "out_mute",
+            "Toggle Mute input": "in_mute",
             "Toggle Play / Pause": "player"
         },
         "description": "Action on middle click"


### PR DESCRIPTION
Change the default behaviour of toggle mute from output only to input and output. Add two new options to toggle mute for output only or input only.