### PR TITLE
sound@cinnamon.org: Volume control up to 150% of nominal volume. 

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -204,32 +204,6 @@ VolumeSlider.prototype = {
         this.emit('value-changed', this._value);
     },
 
-    _moveHandle: function(absX, absY) {
-        let relX, relY, sliderX, sliderY;
-        [sliderX, sliderY] = this._slider.get_transformed_position();
-        relX = absX - sliderX;
-        relY = absY - sliderY;
-
-        let width = this._slider.width;
-        let handleRadius = this._slider.get_theme_node().get_length('-slider-handle-radius');
-
-        let newvalue;
-        if (relX < handleRadius)
-            newvalue = 0;
-        else if (relX > width - handleRadius)
-            newvalue = 1;
-        else
-            newvalue = (relX - handleRadius) / (width - 2 * handleRadius);
-        this._value = newvalue;
-        
-        this._slider.queue_repaint();
-        this.emit('value-changed', this._value);
-    },
-
-    get value() {
-        return this._value;
-    },
-
     _onKeyPressEvent: function (actor, event) {
         let key = event.get_key_symbol();
         if (key == Clutter.KEY_Right || key == Clutter.KEY_Left) {

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -85,16 +85,10 @@ function VolumeSlider(){
 VolumeSlider.prototype = {
     __proto__: PopupMenu.PopupSliderMenuItem.prototype,
 
-    _init: function(applet, stream, tooltip, app_icon, is_master){
+    _init: function(applet, stream, tooltip, app_icon){
         PopupMenu.PopupSliderMenuItem.prototype._init.call(this, 0);
         this.applet = applet;
         
-        if (is_master == null || is_master == undefined) {
-            this.is_master = false
-        } else {
-            this.is_master = is_master
-        }
-
         if(tooltip)
             this.tooltipText = tooltip + ": ";
         else
@@ -118,6 +112,10 @@ VolumeSlider.prototype = {
         this.addActor(this._slider, {span: -1, expand: true});
 
         this.connectWithStream(stream);
+    },
+    
+    set_master: function(is_master) {
+        this.is_master = is_master
     },
 
     connectWithStream: function(stream){
@@ -285,7 +283,8 @@ StreamMenuSection.prototype = {
             iconName = "audio-x-generic";
         }
 
-        let slider = new VolumeSlider(applet, stream, name, iconName, false);
+        let slider = new VolumeSlider(applet, stream, name, iconName);
+        slider.set_master(false);
         this.addMenuItem(slider);
     }
 };
@@ -1020,7 +1019,8 @@ MyApplet.prototype = {
             this._selectOutputDeviceItem.actor.hide();
 
             this._inputSection = new PopupMenu.PopupMenuSection();
-            this._inputVolumeSection = new VolumeSlider(this, null, _("Microphone"), null, false);
+            this._inputVolumeSection = new VolumeSlider(this, null, _("Microphone"), null);
+            this._inputVolumeSection.set_master(false);
             this._inputVolumeSection.connect("values-changed", Lang.bind(this, this._inputValuesChanged));
             this._selectInputDeviceItem = new PopupMenu.PopupSubMenuMenuItem(_("Input device"));
             this._inputSection.addMenuItem(this._inputVolumeSection);
@@ -1343,7 +1343,8 @@ MyApplet.prototype = {
 
         //between these two separators will be the player MenuSection (position 3)
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-        this._outputVolumeSection = new VolumeSlider(this, null, _("Volume"), null, true);
+        this._outputVolumeSection = new VolumeSlider(this, null, _("Volume"), null);
+        this._outputVolumeSection.set_master(true);
         this._outputVolumeSection.connect("values-changed", Lang.bind(this, this._outputValuesChanged));
 
         this.menu.addMenuItem(this._outputVolumeSection);

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/settings-schema.json
@@ -59,5 +59,20 @@
         "type" : "switch",
         "description" : "Hide system tray icons for compatible players",
         "default": true
+    },
+    "section3": {
+        "type": "section",
+        "description" : "Sound Settings"
+    },
+    "percentMaxVolume": {
+        "type": "spinbutton",
+        "default": 100,
+        "min": 10,
+        "max": 150,
+        "units": "% of nominal volume",
+        "step": 5,
+        "description": "Maximum volume control",
+        "tooltip": "You can try to increase the volume of your sound card up to 150% of its nominal value. Use with caution. You can also set a value less than 100%, for example on a child's computer."
     }
+    
 }

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/settings-schema.json
@@ -67,7 +67,7 @@
     "percentMaxVolume": {
         "type": "spinbutton",
         "default": 100,
-        "min": 10,
+        "min": 30,
         "max": 150,
         "units": "% of nominal volume",
         "step": 5,

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/stylesheet.css
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/stylesheet.css
@@ -1,0 +1,24 @@
+/* 
+Style sheet for the Sound Applet.
+*/
+
+.sound-normal {
+
+background-color: transparent;
+color: white;
+}
+
+.sound-veryhigh {
+background-color: transparent;
+color: yellow;
+}
+
+.sound-superhigh {
+background-color: transparent;
+color: orange;
+}
+
+.sound-extrahigh {
+background-color: transparent;
+color: red;
+}


### PR DESCRIPTION
Hi,

I propose an improvement of the sound@cinnamon.org applet.

An option allows you to control the volume up to 150% of its nominal value.

The icon and the slider are coloured according to the volume when it is greater than 100%. I added the stylesheet.css file for that.

New option in Settings:
![sound-settings](https://user-images.githubusercontent.com/33965039/34783927-24a98d06-f62d-11e7-9dda-3871916e5faa.png)

From 0 to 100%: standard icons.
![sound_100](https://user-images.githubusercontent.com/33965039/34783979-4bd45910-f62d-11e7-82ea-3185a0d0bb56.png)

From 101 to 115%: yellow icon.
![sound_115](https://user-images.githubusercontent.com/33965039/34783980-4bf322b4-f62d-11e7-8eb8-e71afe0b2b53.png)

From 116 to 130%: orange icon.
![sound_130](https://user-images.githubusercontent.com/33965039/34783982-4c0c8c04-f62d-11e7-8a49-1c4e11262673.png)

From 131 to 150%: red icon.
![sound_150](https://user-images.githubusercontent.com/33965039/34783983-4c2f13e6-f62d-11e7-85d0-d75055d64a3c.png)

Best regards,

Claudiux