### PR TITLE
popupMenu.js: PopupSubMenu: add prototype method closeAfterUnmap

### DIFF
--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -1950,8 +1950,13 @@ PopupMenuBase.prototype = {
             this._connectSubMenuSignals(menuItem, menuItem.menu);
             this._connectItemSignals(menuItem);
             this._signals.connect(this, 'open-state-changed', function(self, open) {
-                if (!open)
-                    menuItem.menu.close(false);
+                if (!open && menuItem.menu.isOpen) {
+                    if (this.animating) {
+                        menuItem.menu.closeAfterUnmap();
+                    } else {
+                        menuItem.menu.close(false);
+                    }
+                }
             }, this);
         } else if (menuItem instanceof PopupSeparatorMenuItem) {
             this._connectItemSignals(menuItem);
@@ -2641,6 +2646,7 @@ PopupSubMenu.prototype = {
      */
     _init: function(sourceActor, sourceArrow) {
         PopupMenuBase.prototype._init.call(this, sourceActor);
+        this.unmapId = 0;
 
         if (sourceArrow) {
             this._arrow = sourceArrow;
@@ -2802,6 +2808,22 @@ PopupSubMenu.prototype = {
                 this.isOpen = false;
                 this.emit('open-state-changed', false);
             }
+    },
+
+    //Closes the submenu after it has been unmapped. Used to prevent size changes
+    //when the parent is closing at the same time and may be tweening.
+    closeAfterUnmap: function() {
+        if (this.isOpen && this.actor.mapped) {
+            if (!this.unmapId) {
+                this.unmapId = this.actor.connect("notify::mapped", Lang.bind(this, function() {
+                    this.actor.disconnect(this.unmapId);
+                    this.unmapId = 0;
+                    this.close(false);
+                }));
+            }
+        } else {
+            this.close(false);
+        }
     },
 
     _onKeyPressEvent: function(actor, event) {


### PR DESCRIPTION
and use it when the menu is closing due to a parent open-state-changed
notification during parent animation.

This prevents PopupMenus from changing size/position during the close
tween when they contain open PopupSubMenus.

Before:
![popup-before](https://user-images.githubusercontent.com/11601860/34808683-5477ca4e-f645-11e7-9b34-75f2ab2fcbc2.gif)

After:
![popup-after](https://user-images.githubusercontent.com/11601860/34808684-569ac8bc-f645-11e7-8e7a-2a69909d93f9.gif)
