### PR TITLE
[WIP] applet: set full colour icon size from theme if not in scale mode

### DIFF
--- a/files/usr/share/cinnamon/applets/keyboard@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/keyboard@cinnamon.org/applet.js
@@ -88,7 +88,9 @@ EmblemedIcon.prototype = {
     },
 
     set_icon_size: function(size) {
-        this.actor.width = this.actor.height = size;
+        if (size > 0) {  /* note that -1 is a valid value, meaning to take the theme default */
+            this.actor.width = this.actor.height = size;
+        }
     },
 
     set_style_class_name: function(name) {

--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -21,7 +21,6 @@ const COLOR_ICON_HEIGHT_FACTOR = .875;  // Panel height factor for normal color 
 const PANEL_FONT_DEFAULT_HEIGHT = 11.5; // px
 const PANEL_SYMBOLIC_ICON_DEFAULT_HEIGHT = 1.14 * PANEL_FONT_DEFAULT_HEIGHT; // ems conversion
 const DEFAULT_PANEL_HEIGHT = 25;
-const DEFAULT_ICON_HEIGHT = 22;
 const FALLBACK_ICON_HEIGHT = 22;
 
 const AllowedLayout = {  // the panel layout that an applet is suitable for
@@ -697,20 +696,16 @@ IconApplet.prototype = {
             case St.IconType.FULLCOLOR:
                 this._applet_icon.set_icon_size(this._scaleMode ?
                                                 fullcolor_scaleup :
-                                                DEFAULT_ICON_HEIGHT);
+                                                -1);
                 this._applet_icon.set_style_class_name('applet-icon');
             break;
             case St.IconType.SYMBOLIC:
+            default:
                 this._applet_icon.set_icon_size(this._scaleMode ?
                                                 symb_scaleup :
                                                 -1);
                 this._applet_icon.set_style_class_name('system-status-icon');
             break;
-            default:
-                this._applet_icon.set_icon_size(this._scaleMode ?
-                                                symb_scaleup :
-                                                -1);
-                                                this._applet_icon.set_style_class_name('system-status-icon');
         }
     },
 


### PR DESCRIPTION
At the moment turning scale mode off on panels should let sizes be fixed by the theme.  This isn't the case for full colour icons, which use a fixed default.  This change lets these icons use the theme default.  Further work will be needed on two applets which similarly use hard-coded defaults, panel-launchers and systray.  That could well be in a later PR once I've worked out how best to address that hard-coding.