### PR TITLE
st: Drop vfuncs from StThemeNodeTransition

### DIFF
--- a/src/st/st-theme-node-transition.c
+++ b/src/st/st-theme-node-transition.c
@@ -444,15 +444,13 @@ st_theme_node_transition_class_init (StThemeNodeTransitionClass *klass)
     g_signal_new ("completed",
                   G_TYPE_FROM_CLASS (klass),
                   G_SIGNAL_RUN_LAST,
-                  G_STRUCT_OFFSET (StThemeNodeTransitionClass, completed),
-                  NULL, NULL, NULL,
+                  0, NULL, NULL, NULL,
                   G_TYPE_NONE, 0);
 
   signals[NEW_FRAME] =
     g_signal_new ("new-frame",
                   G_TYPE_FROM_CLASS (klass),
                   G_SIGNAL_RUN_LAST,
-                  G_STRUCT_OFFSET (StThemeNodeTransitionClass, new_frame),
-                  NULL, NULL, NULL,
+                  0, NULL, NULL, NULL,
                   G_TYPE_NONE, 0);
 }

--- a/src/st/st-theme-node-transition.h
+++ b/src/st/st-theme-node-transition.h
@@ -47,9 +47,6 @@ struct _StThemeNodeTransition {
 
 struct _StThemeNodeTransitionClass {
   GObjectClass parent_class;
-
-  void (*completed) (StThemeNodeTransition *transition);
-  void (*new_frame) (StThemeNodeTransition *transition);
 };
 
 GType st_theme_node_transition_get_type (void) G_GNUC_CONST;


### PR DESCRIPTION
https://github.com/GNOME/gnome-shell/commit/2f88a7a1e15032bb91a2a732ee2eaad9e70fe3d2#diff-b948bb195b709c61ce7275142a2fbdfd