### PR TITLE
dnd: Fix scope warning

### DIFF
--- a/js/ui/dnd.js
+++ b/js/ui/dnd.js
@@ -74,7 +74,7 @@ function isDragging() {
     return currentDraggable != null;
 }
 
-const _Draggable = new Lang.Class({
+var _Draggable = new Lang.Class({
     Name: 'Draggable',
 
     _init : function(actor, params, target) {


### PR DESCRIPTION
Prevents the following warning:

```
(cinnamon:3026): Cjs-WARNING **: Some code accessed the property '_Draggable' on the module 'dnd'. That property was defined with 'let' or 'const' inside the module. This was previously supported, but is not correct according to the ES6 standard. Any symbols to be exported from a module must be defined with 'var'. The property access will work as previously for the time being, but please fix your code anyway.
```