### PR TITLE
Sound: Make maximum sound volume configurable

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -34,6 +34,9 @@ const VOLUME_ADJUSTMENT_STEP = 0.05; /* Volume adjustment step in % */
 
 const ICON_SIZE = 28;
 
+const CINNAMON_DESKTOP_SOUNDS = "org.cinnamon.desktop.sound";
+const MAXIMUM_VOLUME_KEY = "maximum-volume";
+
 function ControlButton() {
     this._init.apply(this, arguments);
 }
@@ -156,8 +159,15 @@ VolumeSlider.prototype = {
     },
 
     _update: function(){
-        let value = (!this.stream || this.stream.is_muted)? 0 : this.stream.volume / this.applet._volumeMax;
-        let percentage = Math.round(value * 100) + "%";
+        let value = (!this.stream || this.stream.is_muted)? 0 : this.stream.volume / this.applet._volumeMax; // percentage of volume_max (set as value in the widget)
+        let visible_value = (!this.stream || this.stream.is_muted)? 0 : this.stream.volume / this.applet._volumeNorm; // percentage of volume_norm (shown to the user)
+        let delta = VOLUME_ADJUSTMENT_STEP;
+        if (visible_value > 1 - delta/2 && visible_value < 1 + delta/2) {
+            visible_value = 1; // 100% is magnetic
+            value = this.applet._volumeNorm / this.applet._volumeMax;
+        }
+
+        let percentage = Math.round(visible_value * 100) + "%";
 
         this.tooltip.set_text(this.tooltipText + percentage);
         let iconName = this._volumeToIcon(value);
@@ -914,7 +924,10 @@ MyApplet.prototype = {
             this._control.connect('stream-added', Lang.bind(this, this._onStreamAdded));
             this._control.connect('stream-removed', Lang.bind(this, this._onStreamRemoved));
 
-            this._volumeMax = 1*this._control.get_vol_max_norm(); // previously was 1.5*this._control.get_vol_max_norm();, but we'd need a little mark on the slider to make it obvious to the user we're going over 100%..
+            this._sound_settings = new Gio.Settings({ schema_id: CINNAMON_DESKTOP_SOUNDS });
+            this._volumeMax = this._sound_settings.get_int(MAXIMUM_VOLUME_KEY) / 100 * this._control.get_vol_max_norm();
+            this._volumeNorm = this._control.get_vol_max_norm();
+
             this._streams = [];
             this._devices = [];
             this._recordingAppsNum = 0;
@@ -972,10 +985,18 @@ MyApplet.prototype = {
 
             let appsys = Cinnamon.AppSystem.get_default();
             appsys.connect("installed-changed", Lang.bind(this, this._updateLaunchPlayer));
+
+
+            this._outputVolumeSection.set_mark(this._volumeNorm / this._volumeMax);
+            this._sound_settings.connect("changed::" + MAXIMUM_VOLUME_KEY, Lang.bind(this, this._on_sound_settings_change));
         }
         catch (e) {
             global.logError(e);
         }
+    },
+
+    _on_sound_settings_change : function() {
+        this._volumeMax = this._sound_settings.get_int(MAXIMUM_VOLUME_KEY) / 100 * this._control.get_vol_max_norm();
     },
 
     on_settings_changed : function() {
@@ -1030,7 +1051,7 @@ MyApplet.prototype = {
 
         if (direction == Clutter.ScrollDirection.DOWN) {
             let prev_muted = this._output.is_muted;
-            this._output.volume = Math.max(0, currentVolume - this._volumeMax * VOLUME_ADJUSTMENT_STEP);
+            this._output.volume = Math.max(0, currentVolume - this._volumeNorm * VOLUME_ADJUSTMENT_STEP);
             if (this._output.volume < 1) {
                 this._output.volume = 0;
                 if (!prev_muted)
@@ -1039,7 +1060,7 @@ MyApplet.prototype = {
             this._output.push_volume();
         }
         else if (direction == Clutter.ScrollDirection.UP) {
-            this._output.volume = Math.min(this._volumeMax, currentVolume + this._volumeMax * VOLUME_ADJUSTMENT_STEP);
+            this._output.volume = Math.min(this._volumeMax, currentVolume + this._volumeNorm * VOLUME_ADJUSTMENT_STEP);
             this._output.push_volume();
             this._output.change_is_muted(false);
         }

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_sound.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_sound.py
@@ -9,6 +9,8 @@ import dbus
 
 CINNAMON_SOUNDS = "org.cinnamon.sounds"
 CINNAMON_DESKTOP_SOUNDS = "org.cinnamon.desktop.sound"
+MAXIMUM_VOLUME_KEY = "maximum-volume"
+
 DECAY_STEP = .15
 
 EFFECT_LIST = [
@@ -159,10 +161,8 @@ class Slider(SettingsWidget):
         self.slider.add_mark(val, Gtk.PositionType.TOP, "")
 
 class VolumeBar(Slider):
-    def __init__(self, normVolume, maxVolume, title=_("Volume: "), gicon=None, sizeGroup=None):
+    def __init__(self, normVolume, maxPercent, title=_("Volume: "), gicon=None, sizeGroup=None):
         self.normVolume = normVolume
-        self.maxVolume = maxVolume
-        self.maxPercent = 100*maxVolume/normVolume
         self.volume = 0
         self.isMuted = False
         self.baseTitle = title
@@ -172,7 +172,7 @@ class VolumeBar(Slider):
         self.mutedHandlerId = 0
         self.volumeHandlerId = 0
 
-        super(VolumeBar, self).__init__(title, _("Softer"), _("Louder"), 0, self.maxPercent, sizeGroup, 1, 5, 0, gicon)
+        super(VolumeBar, self).__init__(title, _("Softer"), _("Louder"), 0, maxPercent, sizeGroup, 1, 5, 0, gicon)
         self.set_spacing(0)
         self.set_border_width(2)
         self.set_margin_left(23)
@@ -188,7 +188,7 @@ class VolumeBar(Slider):
 
         self.leftBox.pack_start(self.muteSwitch, False, False, 0)
 
-        if maxVolume > normVolume:
+        if maxPercent > 100:
             self.setMark(100)
 
         self.muteSwitchHandlerId = self.muteSwitch.connect("clicked", self.toggleMute)
@@ -502,6 +502,7 @@ class Module:
     def __init__(self, content_box):
         keywords = _("sound, media, music, speakers, audio")
         self.sidePage = SidePage(_("Sound"), "cs-sound", keywords, content_box, module=self)
+        self.sound_settings = Gio.Settings(CINNAMON_DESKTOP_SOUNDS)
 
     def on_module_selected(self):
         if not self.loaded:
@@ -548,7 +549,8 @@ class Module:
         sizeGroup = Gtk.SizeGroup.new(Gtk.SizeGroupMode.HORIZONTAL)
 
         # ouput volume
-        self.outVolume = VolumeBar(self.controller.get_vol_max_norm(), self.controller.get_vol_max_amplified(), sizeGroup=sizeGroup)
+        max_volume = self.sound_settings.get_int(MAXIMUM_VOLUME_KEY)
+        self.outVolume = VolumeBar(self.controller.get_vol_max_norm(), max_volume, sizeGroup=sizeGroup)
         devSettings.add_row(self.outVolume)
 
         # balance
@@ -578,7 +580,7 @@ class Module:
         sizeGroup = Gtk.SizeGroup.new(Gtk.SizeGroupMode.HORIZONTAL)
 
         # input volume
-        self.inVolume = VolumeBar(self.controller.get_vol_max_norm(), self.controller.get_vol_max_amplified(), sizeGroup=sizeGroup)
+        self.inVolume = VolumeBar(self.controller.get_vol_max_norm(), max_volume, sizeGroup=sizeGroup)
         devSettings.add_row(self.inVolume)
 
         # input level
@@ -603,7 +605,7 @@ class Module:
         self.sidePage.stack.add_titled(page, "effects", _("Sound Effects"))
 
         effectsVolumeSection = page.add_section(_("Effects Volume"))
-        self.effectsVolume = VolumeBar(self.controller.get_vol_max_norm(), self.controller.get_vol_max_norm())
+        self.effectsVolume = VolumeBar(self.controller.get_vol_max_norm(), 100)
         effectsVolumeSection.add_row(self.effectsVolume)
 
         effectsSection = SoundBox(_("Effects"))
@@ -634,6 +636,25 @@ class Module:
         box.pack_start(label, False, False, 0)
         noAppsMessage.pack_start(box, True, True, 0)
         self.appStack.add_named(noAppsMessage, "noAppsMessage")
+
+        ## Settings page
+        page = SettingsPage()
+        self.sidePage.stack.add_titled(page, "settings", _("Settings"))
+
+        amplificationSection = page.add_section(_("Amplification"))
+        self.maxVolume = Slider(_("Maximum volume: %d") % max_volume + "%", _("Reduced"), _("Amplified"), 1, 150, sizeGroup, step=1, page=10, value=max_volume, gicon=None, iconName=None)
+        self.maxVolume.adjustment.connect("value-changed", self.onMaxVolumeChanged)
+        self.maxVolume.setMark(100)
+        amplificationSection.add_row(self.maxVolume)
+
+    def onMaxVolumeChanged(self, adjustment):
+        newValue = int(round(adjustment.get_value()))
+        self.sound_settings.set_int(MAXIMUM_VOLUME_KEY, newValue)
+        self.maxVolume.label.set_label(_("Maximum volume: %d") % newValue + "%")
+        self.outVolume.adjustment.set_upper(newValue)
+        self.outVolume.slider.clear_marks()
+        if (newValue > 100):
+            self.outVolume.setMark(100)
 
     def inializeController(self):
         self.controller = Cvc.MixerControl(name = "cinnamon")
@@ -761,7 +782,7 @@ class Module:
         stream = self.controller.lookup_stream_id(id)
 
         if stream in self.controller.get_sink_inputs():
-            self.appList[id] = VolumeBar(self.controller.get_vol_max_norm(), self.controller.get_vol_max_norm(), stream.props.name + ": ", stream.get_gicon())
+            self.appList[id] = VolumeBar(self.controller.get_vol_max_norm(), 100, stream.props.name + ": ", stream.get_gicon())
             self.appList[id].setStream(stream)
             self.appSettings.add_row(self.appList[id])
             self.appSettings.list_box.invalidate_headers()

--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -651,6 +651,7 @@ PopupSliderMenuItem.prototype = {
 
         this._releaseId = this._motionId = 0;
         this._dragging = false;
+        this._mark_position = 0; // 0 means no mark
     },
 
     setValue: function(value) {
@@ -710,6 +711,16 @@ PopupSliderMenuItem.prototype = {
         Clutter.cairo_set_source_color(cr, color);
         cr.arc(handleX, handleY, handleRadius, 0, 2 * Math.PI);
         cr.fill();
+
+        // Draw a mark to indicate a certain value
+        if (this._mark_position > 0) {
+            let markWidth = 2;
+            let markHeight = sliderHeight + 4;
+            let xMark = sliderWidth * this._mark_position + markWidth / 2;
+            let yMark = height / 2 - markHeight / 2;
+            cr.rectangle(xMark, yMark, markWidth, markHeight);
+            cr.fill();
+        }
 
         cr.$dispose();
     },
@@ -782,6 +793,7 @@ PopupSliderMenuItem.prototype = {
             newvalue = 1;
         else
             newvalue = (relX - handleRadius) / (width - 2 * handleRadius);
+
         this._value = newvalue;
         this._slider.queue_repaint();
         this.emit('value-changed', this._value);
@@ -789,6 +801,10 @@ PopupSliderMenuItem.prototype = {
 
     get value() {
         return this._value;
+    },
+
+    set_mark: function (value) {
+        this._mark_position = value;
     },
 
     _onKeyPressEvent: function (actor, event) {


### PR DESCRIPTION
Credits to claudiux and https://github.com/linuxmint/Cinnamon/pull/7187 for the initial design and implementation.

This commit makes it possible to configure the maximum sound volume in the sound settings and modifies
the settings module and sound applet appropriately.

Depends on https://github.com/linuxmint/cinnamon-desktop/commit/d35987157f5d35c3b19db9d5f5adc19633f49589.

CSD change: https://github.com/linuxmint/cinnamon-settings-daemon/pull/215.