### PR TITLE
Power applet: truly hide label when there are no devices

### DIFF
--- a/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
@@ -421,9 +421,6 @@ MyApplet.prototype = {
                 C_("time of battery remaining", "%d:%02d").format(hours,minutes) + ")";
         }
         this.set_applet_label(labelText);
-        if (this.labelinfo != "nothing") {
-            this._applet_label.set_margin_left(1.0);
-        }
 
         if (icon) {
             if(this.panel_icon_name != icon) {
@@ -550,6 +547,7 @@ MyApplet.prototype = {
                 }
                 else {
                     // If there are no battery devices, show brightness info or disable the applet
+                    this.set_applet_label("");
                     if (this.brightness.actor.visible) {
                         // Show the brightness info
                         this.set_applet_tooltip(_("Brightness"));


### PR DESCRIPTION
* Setting label text to empty hides it, so that it doesn't take up any space when using paddings, margins or spacings.

* Also removed the fixed margin to separate the label from the icon as themes now have the ability to do that.

A visual example:
![screenshot from 2018-02-02 00-39-36](https://user-images.githubusercontent.com/10391266/35709212-dc743b4e-07b1-11e8-99e6-afb6d26477f2.png)

> **NOTE**: This only takes place when there are no devices, because when there are the label is set to empty correctly if "nothing" is selected.