### PR TITLE
Fix resident notifications not displaying

### DIFF
--- a/js/ui/notificationDaemon.js
+++ b/js/ui/notificationDaemon.js
@@ -611,10 +611,7 @@ Source.prototype = {
             this._setSummaryIcon(icon);
 
         let tracker = Cinnamon.WindowTracker.get_default();
-        if (notification.resident && this.app && tracker.focus_app == this.app)
-            this.pushNotification(notification);
-        else
-            this.notify(notification);
+        this.notify(notification);
     },
 
     handleSummaryClick: function() {

--- a/js/ui/notificationDaemon.js
+++ b/js/ui/notificationDaemon.js
@@ -610,7 +610,6 @@ Source.prototype = {
         if (!this.app && icon)
             this._setSummaryIcon(icon);
 
-        let tracker = Cinnamon.WindowTracker.get_default();
         this.notify(notification);
     },
 


### PR DESCRIPTION
processNotification() used to call pushNotification() if the
notification was resident and the app had focus.  This CL changes it
to always call notify() instead.

The only difference is that notify() additionally emits the 'notify'
signal which hooks into _onNotify(), the function that actually puts
the notification into the queue.  Without this, the notification would
never get displayed.