### PR TITLE
Speed up windows mapping

### DIFF
--- a/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
@@ -239,20 +239,18 @@ PanelAppLauncher.prototype = {
     },
 
     launch: function() {
-        let allocation = this._iconBox.get_allocation_box();
-        this._iconBox.width = allocation.x2 - allocation.x1;
-        this._iconBox.height = allocation.y2 - allocation.y1;
+        if (this.isCustom()) {
+            this.appinfo.launch([], null);
+        }
+        else {
+            this.app.open_new_window(-1);
+        }
         this._animateIcon(0);
-        if (this.isCustom()) this.appinfo.launch([], null);
-        else this.app.open_new_window(-1);
     },
 
     launchAction: function(name) {
-        let allocation = this._iconBox.get_allocation_box();
-        this._iconBox.width = allocation.x2 - allocation.x1;
-        this._iconBox.height = allocation.y2 - allocation.y1;
-        this._animateIcon(0);
         this.getAppInfo().launch_action(name, null);
+        this._animateIcon(0);
     },
 
     getId: function() {

--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -1033,7 +1033,7 @@ MyApplet.prototype = {
         this.settings.bind("buttons-use-entire-space", "buttonsUseEntireSpace", this._refreshAllItems);
         this.settings.bind("window-preview", "usePreview", this._onPreviewChanged);
 
-        this.signals.connect(global.screen, 'window-added', this._onWindowAdded, this);
+        this.signals.connect(global.screen, 'window-added', this._onWindowAddedAsync, this);
         this.signals.connect(global.screen, 'window-monitor-changed', this._onWindowMonitorChanged, this);
         this.signals.connect(global.screen, 'window-workspace-changed', this._onWindowWorkspaceChanged, this);
         this.signals.connect(global.screen, 'window-skip-taskbar-changed', this._onWindowSkipTaskbarChanged, this);
@@ -1124,9 +1124,13 @@ MyApplet.prototype = {
         this.manager.set_spacing(spacing * global.ui_scale);
     },
 
+    _onWindowAddedAsync: function(screen, metaWindow, monitor) {
+        Mainloop.timeout_add(20, Lang.bind(this, this._onWindowAdded, screen, metaWindow, monitor));
+    },
+
     _onWindowAdded: function(screen, metaWindow, monitor) {
         if (this._shouldAdd(metaWindow))
-            this._addWindow_async(metaWindow, false);
+            this._addWindow(metaWindow, false);
     },
 
     _onWindowMonitorChanged: function(screen, metaWindow, monitor) {
@@ -1263,10 +1267,6 @@ MyApplet.prototype = {
             else
                 this._removeWindow(window);
         }
-    },
-
-    _addWindow_async: function(metaWindow, alert) {
-        Mainloop.timeout_add(20, Lang.bind(this, this._addWindow, metaWindow, alert));
     },
 
     _addWindow: function(metaWindow, alert) {

--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -353,12 +353,12 @@ AppMenuButton.prototype = {
         if (this.alert)
             this.getAttention();
 
-        this.window_signals.connect(metaWindow, 'notify::title', this.setDisplayTitle, this);
-        this.window_signals.connect(metaWindow, "notify::minimized", this.setDisplayTitle, this);
-        this.window_signals.connect(metaWindow, "notify::tile-type", this.setDisplayTitle, this);
-        this.window_signals.connect(metaWindow, "notify::icon", this.setIcon, this);
-        this.window_signals.connect(metaWindow, "notify::appears-focused", this.onFocus, this);
-        this.window_signals.connect(metaWindow, "unmanaged", this.onUnmanaged, this);
+        this.window_signals.connect(this.metaWindow, 'notify::title', this.setDisplayTitle, this);
+        this.window_signals.connect(this.metaWindow, "notify::minimized", this.setDisplayTitle, this);
+        this.window_signals.connect(this.metaWindow, "notify::tile-type", this.setDisplayTitle, this);
+        this.window_signals.connect(this.metaWindow, "notify::icon", this.setIcon, this);
+        this.window_signals.connect(this.metaWindow, "notify::appears-focused", this.onFocus, this);
+        this.window_signals.connect(this.metaWindow, "unmanaged", this.onUnmanaged, this);
     },
 
     onUnmanaged: function() {
@@ -1126,7 +1126,7 @@ MyApplet.prototype = {
 
     _onWindowAdded: function(screen, metaWindow, monitor) {
         if (this._shouldAdd(metaWindow))
-            this._addWindow(metaWindow, false);
+            this._addWindow_async(metaWindow, false);
     },
 
     _onWindowMonitorChanged: function(screen, metaWindow, monitor) {
@@ -1263,6 +1263,10 @@ MyApplet.prototype = {
             else
                 this._removeWindow(window);
         }
+    },
+
+    _addWindow_async: function(metaWindow, alert) {
+        Mainloop.timeout_add(20, Lang.bind(this, this._addWindow, metaWindow, alert));
     },
 
     _addWindow: function(metaWindow, alert) {

--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -257,6 +257,7 @@ AppMenuButton.prototype = {
         this.metaWindow = metaWindow;
         this.alert = alert;
         this.labelVisible = false;
+        this.window_signals = new SignalManager.SignalManager(null);
 
         if (this._applet.orientation == St.Side.TOP)
             this.actor.add_style_class_name('top');
@@ -295,13 +296,6 @@ AppMenuButton.prototype = {
 
         this._iconBottomClip = 0;
         this._visible = true;
-
-        this._updateCaptionId = this.metaWindow.connect('notify::title',
-                Lang.bind(this, this.setDisplayTitle));
-        this._updateTileTypeId = this.metaWindow.connect('notify::tile-type',
-                Lang.bind(this, this.setDisplayTitle));
-        this._updateIconId = this.metaWindow.connect('notify::icon',
-                Lang.bind(this, this.setIcon));
 
         this._progress = 0;
 
@@ -347,6 +341,7 @@ AppMenuButton.prototype = {
         global.settings.connect('changed::panel-edit-mode', Lang.bind(this, this.onPanelEditModeChanged));
 
         this._windows = this._applet._windows;
+
         this.scrollConnector = null;
         this.onScrollModeChanged();
         this._needsAttention = false;
@@ -357,6 +352,18 @@ AppMenuButton.prototype = {
 
         if (this.alert)
             this.getAttention();
+
+        this.window_signals.connect(metaWindow, 'notify::title', this.setDisplayTitle, this);
+        this.window_signals.connect(metaWindow, "notify::minimized", this.setDisplayTitle, this);
+        this.window_signals.connect(metaWindow, "notify::tile-type", this.setDisplayTitle, this);
+        this.window_signals.connect(metaWindow, "notify::icon", this.setIcon, this);
+        this.window_signals.connect(metaWindow, "notify::appears-focused", this.onFocus, this);
+        this.window_signals.connect(metaWindow, "unmanaged", this.onUnmanaged, this);
+    },
+
+    onUnmanaged: function() {
+        this.destroy();
+        this._windows.splice(this._windows.indexOf(this), 1);
     },
 
     onPreviewChanged: function() {
@@ -510,9 +517,7 @@ AppMenuButton.prototype = {
     },
 
     destroy: function() {
-        this.metaWindow.disconnect(this._updateCaptionId);
-        this.metaWindow.disconnect(this._updateTileTypeId);
-        this.metaWindow.disconnect(this._updateIconId);
+        this.window_signals.disconnectAllSignals();
         this._tooltip.destroy();
         if (this.rightClickMenu) {
             this.rightClickMenu.destroy();
@@ -987,6 +992,8 @@ MyApplet.prototype = {
     _init: function(orientation, panel_height, instance_id) {
         Applet.Applet.prototype._init.call(this, orientation, panel_height, instance_id);
 
+        this.signals = new SignalManager.SignalManager(null);
+
         this.setAllowedLayout(Applet.AllowedLayout.BOTH);
 
         this.actor.set_track_hover(false);
@@ -1026,23 +1033,12 @@ MyApplet.prototype = {
         this.settings.bind("buttons-use-entire-space", "buttonsUseEntireSpace", this._refreshAllItems);
         this.settings.bind("window-preview", "usePreview", this._onPreviewChanged);
 
-        this.signals = new SignalManager.SignalManager(null);
-
-        let tracker = Cinnamon.WindowTracker.get_default();
-        this.signals.connect(tracker, "notify::focus-app", this._onFocus, this);
         this.signals.connect(global.screen, 'window-added', this._onWindowAdded, this);
-        this.signals.connect(global.screen, 'window-removed', this._onWindowRemoved, this);
         this.signals.connect(global.screen, 'window-monitor-changed', this._onWindowMonitorChanged, this);
         this.signals.connect(global.screen, 'window-workspace-changed', this._onWindowWorkspaceChanged, this);
         this.signals.connect(global.screen, 'window-skip-taskbar-changed', this._onWindowSkipTaskbarChanged, this);
         this.signals.connect(global.screen, 'monitors-changed', this._updateWatchedMonitors, this);
         this.signals.connect(global.window_manager, 'switch-workspace', this._refreshAllItems, this);
-
-        this.signals.connect(global.window_manager, 'minimize', this._onWindowStateChange, this);
-        this.signals.connect(global.window_manager, 'maximize', this._onWindowStateChange, this);
-        this.signals.connect(global.window_manager, 'unmaximize', this._onWindowStateChange, this);
-        this.signals.connect(global.window_manager, 'map', this._onWindowStateChange, this);
-        this.signals.connect(global.window_manager, 'tile', this._onWindowStateChange, this);
 
         this.actor.connect('style-changed', Lang.bind(this, this._updateSpacing));
 
@@ -1133,10 +1129,6 @@ MyApplet.prototype = {
             this._addWindow(metaWindow, false);
     },
 
-    _onWindowRemoved: function(screen, metaWindow) {
-        this._removeWindow(metaWindow);
-    },
-
     _onWindowMonitorChanged: function(screen, metaWindow, monitor) {
         if (this._shouldAdd(metaWindow))
             this._addWindow(metaWindow, false);
@@ -1199,11 +1191,6 @@ MyApplet.prototype = {
             this._addWindow(window, true);
     },
 
-    _onFocus: function() {
-        for (let window of this._windows)
-            window.onFocus();
-    },
-
     _refreshItem: function(window) {
         window.actor.visible =
             (window.metaWindow.get_workspace() == global.screen.get_active_workspace()) ||
@@ -1222,28 +1209,12 @@ MyApplet.prototype = {
         for (let window of this._windows) {
             this._refreshItem(window);
         }
-        this._onFocus();
     },
 
     _reTitleItems: function() {
         for (let window of this._windows) {
             window.setDisplayTitle();
         }
-    },
-
-    _onWindowStateChange: function(cinnamonwm, actor) {
-        for (let window of this._windows)
-            if (window.metaWindow == actor.metaWindow)
-                window.setDisplayTitle();
-    },
-
-    // Used by windowManager for traditional minimize and map effect
-    getOriginFromWindow: function(metaWindow) {
-        for (let window of this._windows)
-            if (window.metaWindow == metaWindow)
-                return window.actor;
-
-        return false;
     },
 
     _updateWatchedMonitors: function() {
@@ -1304,6 +1275,7 @@ MyApplet.prototype = {
         this.manager_container.add_actor(appButton.actor);
 
         this._windows.push(appButton);
+
         /* We want to make the AppMenuButtons look like they are ordered by
          * workspace. So if we add an AppMenuButton for a window in another
          * workspace, put it in the right position. It is at the end by

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -1657,6 +1657,9 @@ function queueDeferredWork(workId) {
  */
 function isInteresting(metaWindow) {
 
+    if (metaWindow.get_title() == "JavaEmbeddedFrame")
+        return false;
+
     // Include any window the tracker finds interesting
     if (tracker.is_window_interesting(metaWindow)) {
         return true;

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -1656,21 +1656,19 @@ function queueDeferredWork(workId) {
  * Returns (boolean): whether the window is interesting
  */
 function isInteresting(metaWindow) {
-    if (metaWindow.get_title() == "JavaEmbeddedFrame")
-        return false;
 
+    // Include any window the tracker finds interesting
     if (tracker.is_window_interesting(metaWindow)) {
-        // The nominal case.
         return true;
     }
-    // The rest of this function is devoted to discovering "orphan" windows
-    // (dialogs without an associated app, e.g., the Logout dialog).
-    if (tracker.get_window_app(metaWindow)) {
-        // orphans don't have an app!
-        return false;
-    }
+
+    // Include app-less dialogs
     let type = metaWindow.get_window_type();
-    return type === Meta.WindowType.DIALOG || type === Meta.WindowType.MODAL_DIALOG;
+    if (!tracker.get_window_app(metaWindow) && (type === Meta.WindowType.DIALOG || type === Meta.WindowType.MODAL_DIALOG)) {
+        return true;
+    }
+
+    return false;
 }
 
 /**


### PR DESCRIPTION
The goal of this PR is to make it faster for Cinnamon to open windows.

Using the following test script:

```
#!/usr/bin/python3

import gi
gi.require_version('Gtk', '3.0')
from gi.repository import Gtk, GObject

import time, threading

# Used as a decorator to time functions
def print_timing(func):
    def wrapper(*arg):
        t1 = time.time()
        res = func(*arg)
        t2 = time.time()
        print('%s took %0.3f ms' % (func.__name__, (t2 - t1) * 1000.0))
        return res
    return wrapper

# Used as a decorator to run things in the background
def async(func):
    def wrapper(*args, **kwargs):
        thread = threading.Thread(target=func, args=args, kwargs=kwargs)
        thread.daemon = True
        thread.start()
        return thread
    return wrapper

# Used as a decorator to run things in the main loop, from another thread
def idle(func):
    def wrapper(*args):
        GObject.idle_add(func, *args)
    return wrapper

class MyApp ():

    def __init__(self):
        self.windows = []
        mainwindow = Gtk.Window()
        box = Gtk.Box()
        button = Gtk.Button()
        button.set_label("Open windows")
        button.connect("clicked", self.make_windows)
        box.pack_start(button, False, False, 0)
        button = Gtk.Button()
        button.set_label("Close windows")
        button.connect("clicked", self.close_windows)
        box.pack_start(button, False, False, 0)
        mainwindow.add(box)
        mainwindow.show_all()
        mainwindow.connect("destroy", Gtk.main_quit)

    @print_timing
    def make_windows(self, widget):
        for i in range(200):
            window = Gtk.Window()
            self.windows.append(window)
            window.show()

    @print_timing
    def close_windows(self, widget):
        for window in self.windows:
            window.destroy()
        self.windows = []


MyApp()
Gtk.main()
```

We look at the reported figures in the output and measure the time it takes (with a stopwatch) for the main window to defocus and the 200 windows to map themselves completely.

We observe a significant difference in performance in Cinnamon compared to other DEs.

Typical values: 

cinnamon: 4s and 22s
cinnamon without window-list: 2,7s and 10,5s
muffin: 1,3s and 10s
marco: 1s and 28s
metacity: 1s and 6s

The goal is to reduce both numbers as much as possible.

The first commit stops checking the window title and reduces the defocus time a bit.. from 22s to 20s.

The second commit simplifies the window list and reduces the defocus time from 20s to 12s.
