### PR TITLE
Don't clear notifications when an app becomes focused

### DIFF
--- a/js/ui/notificationDaemon.js
+++ b/js/ui/notificationDaemon.js
@@ -121,11 +121,6 @@ NotificationDaemon.prototype = {
         }
         setting(this, this.settings, "boolean", "removeOld", "remove-old");
         setting(this, this.settings, "int", "timeout", "timeout");
-
-        Cinnamon.WindowTracker.get_default().connect('notify::focus-app',
-            Lang.bind(this, this._onFocusAppChanged));
-        Main.overview.connect('hidden',
-            Lang.bind(this, this._onFocusAppChanged));
     },
 
    // Create an icon for a notification from icon string/path.
@@ -523,20 +518,6 @@ NotificationDaemon.prototype = {
             Config.PACKAGE_VERSION,
             '1.2'
         ];
-    },
-
-    _onFocusAppChanged: function() {
-        let tracker = Cinnamon.WindowTracker.get_default();
-        if (!tracker.focus_app)
-            return;
-
-        for (let i = 0; i < this._sources.length; i++) {
-            let source = this._sources[i];
-            if (source.app == tracker.focus_app) {
-                source.destroyNonResidentNotifications();
-                return;
-            }
-        }
     },
 
     _emitNotificationClosed: function(id, reason) {


### PR DESCRIPTION
Apps like Chromium and Firefox create notifications with a reasonable
expectation that the user should see them before they disappear.  The
old behavior was to clear notifications when the app became focused.
If the user was away when notifications were generated, they would be
stored in the message tray.  If the user then focuses the app, all of the
notifications would disappear (even if the notifications had critical
urgency), never giving the user a chance to see them.

This behavior is not intuitive and can lead to loss of important notifications,
so this CL removes this behavior altogether.  Users can still use the "clear
all notifications" button in the tray.