### PR TITLE
appletManager, deskletManager: Fix change handlers

### DIFF
--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -48,11 +48,8 @@ function initEnabledApplets() {
 
 function unloadRemovedApplets(removedApplets) {
     for (let i = 0; i < removedApplets.length; i++) {
-         promises.push(Extension.unloadExtension(removedApplets[i], Extension.Type.APPLET));
+        Extension.unloadExtension(removedApplets[i], Extension.Type.APPLET);
     }
-    return Promise.all(promises).then(function() {
-        promises = [];
-    });
 }
 
 function init() {
@@ -138,21 +135,16 @@ function createAppletDefinition(definition) {
     let elements = definition.split(":");
     if (elements.length > 4) {
         let panelId = parseInt(elements[0].split('panel')[1]);
-        // Its important we check if the definition object already exists before creating a new object, otherwise we are
-        // creating duplicate references that could cause memory leaks.
-        let existingDefinition = getAppletDefinition({
-            uuid: elements[3],
-            applet_id: elements[4],
-            location_label: elements[1],
-            panelId
-        });
-        if (existingDefinition) {
-            return existingDefinition;
-        }
         let panel = Main.panelManager.panels[panelId];
+        let center = elements[1] === 'center';
         let orientation;
         let order;
-        try { order = parseInt(elements[2]); } catch(e) { order = 0; }
+
+        try {
+            order = parseInt(elements[2]);
+        } catch(e) {
+            order = 0;
+        }
 
         // Panel might not exist. Still keep definition for future use.
         if (panel) {
@@ -160,15 +152,24 @@ function createAppletDefinition(definition) {
         }
 
         let appletDefinition = {
-            panelId: panelId,
-            orientation: orientation,
+            panelId,
+            orientation,
             location_label: elements[1],
-            center: elements[1] == "center",
-            order: order,
+            center,
+            order,
             uuid: elements[3],
-            applet_id: elements[4],
-            applet: null
+            applet_id: elements[4]
         };
+
+        // Its important we check if the definition object already exists before creating a new object, otherwise we are
+        // creating duplicate references that could cause memory leaks.
+        let existingDefinition = getAppletDefinition(appletDefinition);
+
+        if (existingDefinition) {
+            return existingDefinition;
+        }
+
+        appletDefinition.applet = null;
 
         if (elements.length > 5) appletDefinition.overrides = elements[5].split(',');
         return appletDefinition;
@@ -237,57 +238,60 @@ function checkForUpgrade(newEnabledApplets) {
 }
 
 function appletDefinitionsEqual(a, b) {
-    return (a.panelId === b.panelId
+    return (a != null && b != null
+        && a.panelId === b.panelId
         && a.orientation === b.orientation
         && a.location_label === b.location_label
         && a.order === b.order);
 }
 
 function onEnabledAppletsChanged() {
-    try {
-        let oldDefinitions = definitions;
-        definitions = getDefinitions();
-        let removedApplets = [];
-        // Remove all applet instances that do not exist in the definition anymore.
-        for (let i = 0; i < oldDefinitions.length; i++) {
-            let {uuid, applet_id, location_label, panelId} = oldDefinitions[i];
-            let appletDefinition = getAppletDefinition({applet_id, uuid, location_label, panelId});
-            if (!appletDefinition) {
-                removeAppletFromPanels(
-                    oldDefinitions[i],
-                    Extension.get_max_instances(uuid, Extension.Type.APPLET) !== 1
-                );
-            }
-            let definitionByUUID = getAppletDefinition({uuid});
-            if (!definitionByUUID) {
-                oldDefinitions[i].applet = undefined;
-                removedApplets.push(uuid);
-            }
+    let oldDefinitions = definitions.slice();
+    definitions = getDefinitions();
+    let addedApplets = [];
+    let removedApplets = [];
+    let unChangedApplets = [];
+
+    for (let i = 0; i < definitions.length; i++) {
+        let {uuid} = definitions[i];
+        let oldDefinition = queryCollection(oldDefinitions, {uuid});
+
+        let isEqualToOldDefinition = appletDefinitionsEqual(definitions[i], oldDefinition);
+
+        if (oldDefinition && !isEqualToOldDefinition) {
+            removedApplets.push(oldDefinition);
         }
-        // Unload all applet extensions that do not exist in the definition anymore.
-        unloadRemovedApplets(removedApplets).then(function() {
-            // Add or move applet instances of already loaded applet extensions
-            for (let i = 0; i < definitions.length; i++) {
-                let {applet_id, uuid, panelId} = definitions[i];
-                let newDefinition = getAppletDefinition({applet_id, panelId});
-                let oldDefinition = queryCollection(oldDefinitions, {applet_id, panelId});
 
-                if (!oldDefinition || !appletDefinitionsEqual(newDefinition, oldDefinition)) {
-                    let extension = Extension.getExtension(uuid);
-                    if (extension) {
-                        addAppletToPanels(extension, newDefinition);
-                    }
-                }
-            }
+        if (!oldDefinition || !isEqualToOldDefinition) {
+            let extension = Extension.getExtension(uuid);
+            addedApplets.push({extension, definition: definitions[i]});
+            continue;
+        }
 
-            // Make sure all applet extensions are loaded.
-            // Once loaded, the applets will add themselves via finishExtensionLoad
-            initEnabledApplets();
-            Main.statusIconDispatcher.redisplay();
-        });
-    } catch (e) {
-        global.logError('Failed to refresh list of applets', e);
+        unChangedApplets.push(uuid);
     }
+    for (let i = 0; i < oldDefinitions.length; i++) {
+        if (unChangedApplets.indexOf(oldDefinitions[i].uuid) === -1) {
+            removedApplets.push(oldDefinitions[i]);
+        }
+    }
+    for (let i = 0; i < removedApplets.length; i++) {
+        let {uuid} = removedApplets[i];
+        removeAppletFromPanels(
+            removedApplets[i],
+            Extension.get_max_instances(uuid, Extension.Type.APPLET) !== 1
+        );
+        Extension.unloadExtension(uuid, Extension.Type.APPLET);
+    }
+    for (let i = 0; i < addedApplets.length; i++) {
+        let {extension, definition} = addedApplets[i];
+        addAppletToPanels(extension, definition);
+    }
+
+    // Make sure all applet extensions are loaded.
+    // Once loaded, the applets will add themselves via finishExtensionLoad
+    initEnabledApplets();
+    Main.statusIconDispatcher.redisplay();
 }
 
 function removeAppletFromPanels(appletDefinition, deleteConfig) {
@@ -384,7 +388,7 @@ function addAppletToPanels(extension, appletDefinition, panel = null) {
         removeAppletFromInappropriatePanel (extension, appletDefinition);
 
         return true;
-    } catch(e) {
+    } catch (e) {
         extension.unlockRole();
         Extension.logError('Failed to load applet: ' + appletDefinition.uuid + "/" + appletDefinition.applet_id, extension.uuid, e);
         return false;
@@ -560,7 +564,11 @@ function createApplet(extension, appletDefinition, panel = null) {
 
     let applet;
     try {
-        applet = getModuleByIndex(extension.moduleIndex).main(extension.meta, orientation, panel_height, applet_id);
+        let module = getModuleByIndex(extension.moduleIndex);
+        if (!module) {
+            return null;
+        }
+        applet = module.main(extension.meta, orientation, panel_height, applet_id);
     } catch (e) {
         Extension.logError(`Failed to evaluate 'main' function on applet: ${uuid}/${applet_id}`, uuid, e);
         return null;

--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -253,8 +253,8 @@ function onEnabledAppletsChanged() {
     let unChangedApplets = [];
 
     for (let i = 0; i < definitions.length; i++) {
-        let {uuid} = definitions[i];
-        let oldDefinition = queryCollection(oldDefinitions, {uuid});
+        let {uuid, applet_id} = definitions[i];
+        let oldDefinition = queryCollection(oldDefinitions, {uuid, applet_id});
 
         let isEqualToOldDefinition = appletDefinitionsEqual(definitions[i], oldDefinition);
 
@@ -268,10 +268,10 @@ function onEnabledAppletsChanged() {
             continue;
         }
 
-        unChangedApplets.push(uuid);
+        unChangedApplets.push(applet_id);
     }
     for (let i = 0; i < oldDefinitions.length; i++) {
-        if (unChangedApplets.indexOf(oldDefinitions[i].uuid) === -1) {
+        if (unChangedApplets.indexOf(oldDefinitions[i].applet_id) === -1) {
             removedApplets.push(oldDefinitions[i]);
         }
     }

--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -487,29 +487,26 @@ function loadExtension(uuid, type) {
  * @deleteConfig (bool): delete also config files, defaults to true
  */
 function unloadExtension(uuid, type, deleteConfig = true) {
-    return new Promise(function(resolve, reject) {
-        let extensionIndex = queryCollection(extensions, {uuid}, true);
-        if (extensionIndex > -1) {
-            let extension = extensions[extensionIndex];
-            extension.unlockRole();
+    let extensionIndex = queryCollection(extensions, {uuid}, true);
+    if (extensionIndex > -1) {
+        let extension = extensions[extensionIndex];
+        extension.unlockRole();
 
-            // Try to disable it -- if it's ERROR'd, we can't guarantee that,
-            // but it will be removed on next reboot, and hopefully nothing
-            // broke too much.
-            try {
-                Type[extension.upperType].callbacks.prepareExtensionUnload(extension, deleteConfig);
-            } catch(e) {
-                logError(`Error disabling ${extension.lowerType} ${extension.uuid}`, extension.uuid, e);
-            }
-            extension.unloadStylesheet();
-            extension.unloadIconDirectory();
-
-            Type[extension.upperType].emit('extension-unloaded', extension.uuid);
-
-            forgetExtension(extensionIndex, uuid, type, true);
-            resolve();
+        // Try to disable it -- if it's ERROR'd, we can't guarantee that,
+        // but it will be removed on next reboot, and hopefully nothing
+        // broke too much.
+        try {
+            Type[extension.upperType].callbacks.prepareExtensionUnload(extension, deleteConfig);
+        } catch (e) {
+            logError(`Error disabling ${extension.lowerType} ${extension.uuid}`, extension.uuid, e);
         }
-    });
+        extension.unloadStylesheet();
+        extension.unloadIconDirectory();
+
+        Type[extension.upperType].emit('extension-unloaded', extension.uuid);
+
+        forgetExtension(extensionIndex, uuid, type, true);
+    }
 }
 
 function forgetExtension(extensionIndex, uuid, type, forgetMeta) {
@@ -535,10 +532,9 @@ function forgetExtension(extensionIndex, uuid, type, forgetMeta) {
  */
 function reloadExtension(uuid, type) {
     if (getExtension(uuid)) {
-        unloadExtension(uuid, type, false).then(function() {
-            Main._addXletDirectoriesToSearchPath();
-            loadExtension(uuid, type);
-        });
+        unloadExtension(uuid, type, false);
+        Main._addXletDirectoriesToSearchPath();
+        loadExtension(uuid, type);
         return;
     }
 

--- a/js/ui/extensionSystem.js
+++ b/js/ui/extensionSystem.js
@@ -89,7 +89,8 @@ function get_object_for_uuid(uuid) {
 function onEnabledExtensionsChanged() {
     enabledExtensions = global.settings.get_strv(ENABLED_EXTENSIONS_KEY);
 
-    unloadRemovedExtensions().then(initEnabledExtensions);
+    unloadRemovedExtensions();
+    initEnabledExtensions();
 }
 
 function initEnabledExtensions() {
@@ -107,12 +108,9 @@ function unloadRemovedExtensions() {
     });
     for (let i = 0; i < uuidList.length; i++) {
         if (enabledExtensions.indexOf(uuidList[i].uuid) === -1) {
-            promises.push(Extension.unloadExtension(uuidList[i].uuid, Extension.Type.EXTENSION));
+            Extension.unloadExtension(uuidList[i].uuid, Extension.Type.EXTENSION);
         }
     }
-    return Promise.all(promises).then(function() {
-        promises = [];
-    });
 }
 
 function init() {

--- a/js/ui/searchProviderManager.js
+++ b/js/ui/searchProviderManager.js
@@ -30,7 +30,8 @@ function finishExtensionLoad(extensionIndex) {
 function onEnabledSearchProvidersChanged() {
     enabledSearchProviders = global.settings.get_strv(ENABLED_SEARCH_PROVIDERS_KEY);
 
-    unloadRemovedSearchProviders().then(initEnabledSearchProviders);
+    unloadRemovedSearchProviders();
+    initEnabledSearchProviders();
 }
 
 function initEnabledSearchProviders() {
@@ -48,12 +49,9 @@ function unloadRemovedSearchProviders() {
     });
     for (let i = 0; i < extensions.length; i++) {
         if (enabledSearchProviders.indexOf(extensions[i].uuid) === -1) {
-            promises.push(Extension.unloadExtension(extensions[i].uuid, Extension.Type.SEARCH_PROVIDER));
+            Extension.unloadExtension(extensions[i].uuid, Extension.Type.SEARCH_PROVIDER);
         }
     }
-    return Promise.all(promises).then(function() {
-        promises = [];
-    });
 }
 
 function init() {


### PR DESCRIPTION
1. Removes the promise for `unloadExtension` since nothing asynchronous is happening inside this function. 
2. Fixes applets being moved to new position within a panel location not being recognized as a change.
3. Unsure if this was occurring on master already, but deskletManager's change handler was updated so desklet removing worked correctly without a Cinnamon restart.