### PR TITLE
Prevent users from editing locked settings

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/GSettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/GSettingsWidgets.py
@@ -265,6 +265,7 @@ class CSGSettingsBackend(object):
             self.settings.bind(self.key, bind_object, self.bind_prop, self.bind_dir)
         else:
             self.settings.connect("changed::"+self.key, self.on_setting_changed)
+            self.settings.bind_writable(self.key, bind_object, "sensitive", False)
             self.on_setting_changed()
             self.connect_widget_handlers()
 


### PR DESCRIPTION
Before this patch, settings widgets that did set bind_dir=None would not have their sensitivity set to false when the gsettings key is locked.