### PR TITLE
Fix blurry switches in the default theme

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -226,7 +226,7 @@ StScrollBar StButton#vhandle:hover {
 }
 /* Switches (to be used in menus) */
 .toggle-switch {
-    width: 65px;
+    width: 64px;
     height: 22px;
 }
 .toggle-switch-us {


### PR DESCRIPTION
The images are 22x64 not 22x65.