### PR TITLE
st: remove some cogl deprecations

### DIFF
--- a/src/st/st-theme-node-drawing.c
+++ b/src/st/st-theme-node-drawing.c
@@ -1322,6 +1322,7 @@ _st_theme_node_init_drawing_state (StThemeNode *node)
 }
 
 static void st_theme_node_paint_borders (StThemeNode           *node,
+                                         CoglFramebuffer       *framebuffer,
                                          const ClutterActorBox *box,
                                          guint8                 paint_opacity);
 
@@ -1471,9 +1472,7 @@ st_theme_node_render_resources (StThemeNode   *node,
                                      height, 0, 1.0);
               cogl_framebuffer_clear4f (offscreen, COGL_BUFFER_BIT_COLOR, 0, 0, 0, 0);
 
-              cogl_push_framebuffer (offscreen);
-              st_theme_node_paint_borders (node, &box, 0xFF);
-              cogl_pop_framebuffer ();
+              st_theme_node_paint_borders (node, offscreen, &box, 0xFF);
               cogl_handle_unref (offscreen);
 
               node->box_shadow_material = _st_create_shadow_pipeline (box_shadow_spec,
@@ -1522,10 +1521,10 @@ paint_material_with_opacity (CoglHandle       material,
 
 static void
 st_theme_node_paint_borders (StThemeNode           *node,
+                             CoglFramebuffer       *fb,
                              const ClutterActorBox *box,
                              guint8                 paint_opacity)
 {
-  CoglFramebuffer *fb = cogl_get_draw_framebuffer ();
   float width, height;
   guint border_width[4];
   guint border_radius[4];
@@ -1951,6 +1950,7 @@ st_theme_node_paint_outline (StThemeNode           *node,
 
 void
 st_theme_node_paint (StThemeNode           *node,
+                     CoglFramebuffer       *fb,
                      const ClutterActorBox *box,
                      guint8                 paint_opacity)
 {
@@ -2024,7 +2024,7 @@ st_theme_node_paint (StThemeNode           *node,
     }
   else
     {
-      st_theme_node_paint_borders (node, box, paint_opacity);
+      st_theme_node_paint_borders (node, fb, box, paint_opacity);
     }
 
   st_theme_node_paint_outline (node, box, paint_opacity);
@@ -2033,7 +2033,6 @@ st_theme_node_paint (StThemeNode           *node,
     {
       ClutterActorBox background_box;
       ClutterActorBox texture_coords;
-      CoglFramebuffer *fb = cogl_get_draw_framebuffer ();
       gboolean has_visible_outline;
 
       /* If the node doesn't have an opaque or repeating background or

--- a/src/st/st-theme-node-drawing.c
+++ b/src/st/st-theme-node-drawing.c
@@ -1501,11 +1501,11 @@ st_theme_node_render_resources (StThemeNode   *node,
 
 static void
 paint_material_with_opacity (CoglHandle       material,
+                             CoglFramebuffer  *fb,
                              ClutterActorBox *box,
                              ClutterActorBox *coords,
                              guint8           paint_opacity)
 {
-  CoglFramebuffer *fb = cogl_get_draw_framebuffer ();
   cogl_pipeline_set_color4ub (material,
                               paint_opacity, paint_opacity, paint_opacity, paint_opacity);
 
@@ -1799,10 +1799,10 @@ st_theme_node_paint_borders (StThemeNode           *node,
 
 static void
 st_theme_node_paint_sliced_border_image (StThemeNode           *node,
+                                         CoglFramebuffer       *fb,
                                          const ClutterActorBox *box,
                                          guint8                 paint_opacity)
 {
-  CoglFramebuffer *fb = cogl_get_draw_framebuffer ();
   gfloat ex, ey;
   gfloat tx1, ty1, tx2, ty2;
   gint border_left, border_right, border_top, border_bottom;
@@ -1891,6 +1891,7 @@ st_theme_node_paint_sliced_border_image (StThemeNode           *node,
 
 static void
 st_theme_node_paint_outline (StThemeNode           *node,
+                             CoglFramebuffer       *fb,
                              const ClutterActorBox *box,
                              guint8                 paint_opacity)
 
@@ -2014,20 +2015,21 @@ st_theme_node_paint (StThemeNode           *node,
                                                   &paint_box);
 
           paint_material_with_opacity (node->prerendered_material,
+                                       fb,
                                        &paint_box,
                                        NULL,
                                        paint_opacity);
         }
 
       if (node->border_slices_material != COGL_INVALID_HANDLE)
-        st_theme_node_paint_sliced_border_image (node, &allocation, paint_opacity);
+        st_theme_node_paint_sliced_border_image (node, fb, &allocation, paint_opacity);
     }
   else
     {
       st_theme_node_paint_borders (node, fb, box, paint_opacity);
     }
 
-  st_theme_node_paint_outline (node, box, paint_opacity);
+  st_theme_node_paint_outline (node, fb, box, paint_opacity);
 
   if (node->background_texture != COGL_INVALID_HANDLE)
     {
@@ -2069,6 +2071,7 @@ st_theme_node_paint (StThemeNode           *node,
                                        paint_opacity);
 
       paint_material_with_opacity (node->background_material,
+                                   fb,
                                    &background_box,
                                    &texture_coords,
                                    paint_opacity);

--- a/src/st/st-theme-node-private.h
+++ b/src/st/st-theme-node-private.h
@@ -115,6 +115,7 @@ struct _StThemeNode {
   CoglPipeline *border_slices_material;
   CoglPipeline *prerendered_texture;
   CoglPipeline *prerendered_material;
+  CoglPipeline *color_pipeline;
   CoglHandle corner_material[4];
 };
 

--- a/src/st/st-theme-node-transition.c
+++ b/src/st/st-theme-node-transition.c
@@ -298,13 +298,9 @@ setup_framebuffers (StThemeNodeTransition *transition,
                                  priv->offscreen_box.x2,
                                  priv->offscreen_box.y2, 0.0, 1.0);
 
-  cogl_push_framebuffer (priv->old_offscreen);
-  st_theme_node_paint (priv->old_theme_node, allocation, 255);
-  cogl_pop_framebuffer ();
+  st_theme_node_paint (priv->old_theme_node, priv->old_offscreen, allocation, 255);
 
-  cogl_push_framebuffer (priv->new_offscreen);
-  st_theme_node_paint (priv->new_theme_node, allocation, 255);
-  cogl_pop_framebuffer ();
+  st_theme_node_paint (priv->new_theme_node, priv->new_offscreen, allocation, 255);
 
   return TRUE;
 }

--- a/src/st/st-theme-node.h
+++ b/src/st/st-theme-node.h
@@ -242,8 +242,11 @@ gboolean st_theme_node_geometry_equal (StThemeNode *node,
                                        StThemeNode *other);
 gboolean st_theme_node_paint_equal    (StThemeNode *node,
                                        StThemeNode *other);
-
+/**
+ * st_theme_node_paint: (skip)
+ */
 void st_theme_node_paint (StThemeNode            *node,
+                          CoglFramebuffer        *framebuffer,
                           const ClutterActorBox  *box,
                           guint8                  paint_opacity);
 

--- a/src/st/st-widget.c
+++ b/src/st/st-widget.c
@@ -382,7 +382,7 @@ st_widget_paint_background (StWidget *widget)
                                     &allocation,
                                     opacity);
   else
-    st_theme_node_paint (theme_node, &allocation, opacity);
+    st_theme_node_paint (theme_node, cogl_get_draw_framebuffer (), &allocation, opacity);
 
   // ClutterEffect *effect = clutter_actor_get_effect (actor, "background-effect");
 


### PR DESCRIPTION
three linked upstream commits, one requiring some adaptation.  No obvious regressions, no new warning messages.