### PR TITLE
st-private: Fix offscreen leak if cogl_framebuffer_allocate fails

### DIFF
--- a/src/st/st-private.c
+++ b/src/st/st-private.c
@@ -502,6 +502,7 @@ _st_create_shadow_pipeline_from_actor (StShadow     *shadow_spec,
       if (!cogl_framebuffer_allocate (fb, &catch_error))
         {
           cogl_error_free (catch_error);
+          cogl_object_unref (offscreen);
           cogl_object_unref (buffer);
           return NULL;
         }


### PR DESCRIPTION
https://github.com/GNOME/gnome-shell/commit/941513b280433c269491572b7b1de2a7c5bab21b#diff-b948bb195b709c61ce7275142a2fbdfd