### PR TITLE
cinnamon-settings-info: Make some labels selectable

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
@@ -159,6 +159,7 @@ class Module:
                 widget.pack_start(labelKey, False, False, 0)
                 labelKey.get_style_context().add_class("dim-label")
                 labelValue = Gtk.Label.new(value)
+                labelValue.set_selectable(True)
                 widget.pack_end(labelValue, False, False, 0)
                 settings.add_row(widget)
 


### PR DESCRIPTION
This makes them easy to copy/paste the information.

Closes: https://github.com/linuxmint/Cinnamon/issues/7174