### PR TITLE
panel-launchers: Set the default icon size to 22

### DIFF
--- a/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
@@ -14,7 +14,7 @@ const Util = imports.misc.util;
 const Settings = imports.ui.settings;
 const Signals = imports.signals;
 
-const DEFAULT_ICON_SIZE = 20;
+const DEFAULT_ICON_SIZE = 22;
 const ICON_HEIGHT_FACTOR = 0.8;
 
 const PANEL_EDIT_MODE_KEY = 'panel-edit-mode';


### PR DESCRIPTION
This allows us to use a non-scaled icon in the panel which looks nicer than the
slightly blurred version we get when scaling 20px.