### PR TITLE
SettingsWidgets: prevent toggling disabled switches

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
@@ -511,7 +511,8 @@ class Switch(SettingsWidget):
         self.set_tooltip_text(tooltip)
 
     def clicked(self, *args):
-        self.content_widget.set_active(not self.content_widget.get_active())
+        if self.is_sensitive():
+            self.content_widget.set_active(not self.content_widget.get_active())
 
 class SpinButton(SettingsWidget):
     bind_prop = "value"


### PR DESCRIPTION
For example when there's a dependency in an xlet's settings.


I forgot to mention that it happened only if one clicks on the row instead of the switch.