### PR TITLE
Improve label settings widget

### DIFF
--- a/files/usr/share/cinnamon/applets/settings-example@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/settings-example@cinnamon.org/settings-schema.json
@@ -5,7 +5,7 @@
         "page1": {
             "type": "page",
             "title": "Visible settings",
-            "sections": ["section1", "section2"]
+            "sections": ["section0", "section1", "section2"]
         },
         "page2": {
             "type": "page",
@@ -21,6 +21,11 @@
             "type": "page",
             "title": "Editable list settings",
             "sections": ["section7"]
+        },
+        "section0": {
+            "type": "section",
+            "title": "Info",
+            "keys": ["label-info"]
         },
         "section1": {
             "type": "section",
@@ -57,6 +62,10 @@
             "title": "My list",
             "keys": ["tree"]
         }
+    },
+    "label-info" : {
+        "type" : "label",
+        "description" : "Play with these widgets and see the automatic reaction in the panel applet.\n\nThis is a label, and the content can't be modified nor accessed. You may want to use a label to show aditional hints or instructions, for example."
     },
     "icon-name": {
         "type": "iconfilechooser",

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
@@ -1191,5 +1191,16 @@ class Text(SettingsWidget):
         super(Text, self).__init__()
         self.label = label
 
-        self.content_widget = Gtk.Label(label=label, halign=align)
+        if align == Gtk.Align.END:
+            xalign = 1.0
+            justification = Gtk.Justification.RIGHT
+        elif align == Gtk.Align.CENTER:
+            xalign = 0.5
+            justification = Gtk.Justification.CENTER
+        else: # START and FILL align left
+            xalign = 0
+            justification = Gtk.Justification.LEFT
+
+        self.content_widget = Gtk.Label(label, halign=align, xalign=xalign, justify=justification)
+        self.content_widget.set_line_wrap(True)
         self.pack_start(self.content_widget, True, True, 0)


### PR DESCRIPTION
Enable text wrapping for the label widget because one typically wants more than one line in there.

Also added it to the settings example so that new xlet creators know that it exists and how to use it.