### PR TITLE
[gtk3.22] cinnamon-settings: Remove some broken and hardcoded theming

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/ExtensionCore.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/ExtensionCore.py
@@ -396,16 +396,6 @@ class ManageSpicesPage(SettingsPage):
         toolbar.add(title_holder)
         main_box.add(toolbar)
 
-        toolbar_separator = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
-        main_box.add(toolbar_separator)
-        separator_context = toolbar_separator.get_style_context()
-        frame_color = frame_style.get_border_color(Gtk.StateFlags.NORMAL).to_string()
-        css_provider = Gtk.CssProvider()
-        css_provider.load_from_data('.separator { -GtkWidget-wide-separators: 0; \
-                                                   color: %s;                    \
-                                                }' % frame_color)
-        separator_context.add_provider(css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
-
         scw = Gtk.ScrolledWindow()
         scw.expand = True
         scw.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
@@ -778,16 +768,6 @@ class DownloadSpicesPage(SettingsPage):
         title_holder.add(label)
         toolbar.add(title_holder)
         main_box.add(toolbar)
-
-        toolbar_separator = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
-        main_box.add(toolbar_separator)
-        separator_context = toolbar_separator.get_style_context()
-        frame_color = frame_style.get_border_color(Gtk.StateFlags.NORMAL).to_string()
-        css_provider = Gtk.CssProvider()
-        css_provider.load_from_data('.separator { -GtkWidget-wide-separators: 0; \
-                                                   color: %s;                    \
-                                                }' % frame_color)
-        separator_context.add_provider(css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
 
         scw = Gtk.ScrolledWindow()
         scw.expand = True

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
@@ -380,21 +380,6 @@ class SettingsBox(Gtk.Frame):
         toolbar.add(title_holder)
         self.box.add(toolbar)
 
-        toolbar_separator = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
-        self.box.add(toolbar_separator)
-        separator_context = toolbar_separator.get_style_context()
-        frame_color = frame_style.get_border_color(Gtk.StateFlags.NORMAL).to_string()
-        css_provider = Gtk.CssProvider()
-        css_data = ".separator { -GtkWidget-wide-separators: 0; \
-                                   color: %s;                    \
-                               }" % frame_color
-        try:
-            css_provider.load_from_data(css_data)
-        except:
-            # we must be using python 3
-            css_provider.load_from_data(str.encode(css_data))
-        separator_context.add_provider(css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
-
         self.need_separator = False
 
     def add_row(self, widget):

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_screensaver.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_screensaver.py
@@ -203,16 +203,6 @@ class ScreensaverBox(Gtk.Box):
         toolbar.add(title_holder)
         self.main_box.add(toolbar)
 
-        toolbar_separator = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
-        self.main_box.add(toolbar_separator)
-        separator_context = toolbar_separator.get_style_context()
-        frame_color = frame_style.get_border_color(Gtk.StateFlags.NORMAL).to_string()
-        css_provider = Gtk.CssProvider()
-        css_provider.load_from_data(".separator { -GtkWidget-wide-separators: 0; \
-                                                   color: %s;                    \
-                                                }" % frame_color)
-        separator_context.add_provider(css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
-
         self.preview_stack = Gtk.Stack()
         self.preview_stack.set_border_width(30)
         self.preview_stack.set_size_request(-1, 300)

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_sound.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_sound.py
@@ -68,16 +68,6 @@ class SoundBox(Gtk.Box):
         toolbar.add(title_holder)
         main_box.add(toolbar)
 
-        toolbar_separator = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
-        main_box.add(toolbar_separator)
-        separator_context = toolbar_separator.get_style_context()
-        frame_color = frame_style.get_border_color(Gtk.StateFlags.NORMAL).to_string()
-        css_provider = Gtk.CssProvider()
-        css_provider.load_from_data(".separator { -GtkWidget-wide-separators: 0; \
-                                                   color: %s;                    \
-                                                }" % frame_color)
-        separator_context.add_provider(css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
-
         scw = Gtk.ScrolledWindow()
         scw.expand = True
         scw.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_startup.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_startup.py
@@ -373,16 +373,6 @@ class AutostartBox(Gtk.Box):
         toolbar.add(title_holder)
         main_box.add(toolbar)
 
-        toolbar_separator = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
-        main_box.add(toolbar_separator)
-        separator_context = toolbar_separator.get_style_context()
-        frame_color = frame_style.get_border_color(Gtk.StateFlags.NORMAL).to_string()
-        css_provider = Gtk.CssProvider()
-        css_provider.load_from_data(".separator { -GtkWidget-wide-separators: 0; \
-                                                   color: %s;                    \
-                                                }" % frame_color)
-        separator_context.add_provider(css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
-
         scw = Gtk.ScrolledWindow()
         scw.expand = True
         scw.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)


### PR DESCRIPTION
This setup no longer even works in gtk3.20+ and is the source of a bunch of
build spam. Just remove it and let themes handle it. Since it already isn't
working it won't make any difference in themes that don't.