### PR TITLE
st-entry:don't possibly allocate actors a negative size

### DIFF
--- a/src/st/st-entry.c
+++ b/src/st/st-entry.c
@@ -421,7 +421,7 @@ st_entry_allocate (ClutterActor          *actor,
                               flags);
 
       /* reduce the size for the entry */
-      child_box.x1 += icon_w + priv->spacing;
+      child_box.x1 = MIN (child_box.x2, child_box.x1 + icon_w + priv->spacing);
     }
 
   if (priv->secondary_icon)
@@ -442,7 +442,7 @@ st_entry_allocate (ClutterActor          *actor,
                               flags);
 
       /* reduce the size for the entry */
-      child_box.x2 -= icon_w + priv->spacing;
+       child_box.x2 = MAX (child_box.x1, child_box.x2 - icon_w - priv->spacing);
     }
 
   clutter_actor_get_preferred_height (priv->entry, child_box.x2 - child_box.x1,


### PR DESCRIPTION
https://github.com/GNOME/gnome-shell/commit/4e07d0b0737fd557538c7452d4a00d58e0f626c2#diff-b948bb195b709c61ce7275142a2fbdfd