### PR TITLE
Fix panel applet clearing

### DIFF
--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -741,17 +741,14 @@ function copyAppletConfiguration(panelId) {
 
 function clearAppletConfiguration(panelId) {
     rawDefinitions = global.settings.get_strv("enabled-applets");
-    let removedDefinitions = [];
+    let rawDefinitionsCopy = rawDefinitions.slice();
     for (let i = 0; i < rawDefinitions.length; i++) {
         let rawDefinition = rawDefinitions[i].split(':');
         if (parseInt(rawDefinition[0].split('panel')[1]) === panelId) {
-            removedDefinitions.push(i);
+            rawDefinitionsCopy.splice(rawDefinitionsCopy.indexOf(rawDefinitions[i]), 1);
         }
     }
-    for (var i = 0; i < removedDefinitions.length; i++) {
-        rawDefinitions.splice(removedDefinitions[i], 1);
-    }
-    global.settings.set_strv("enabled-applets", rawDefinitions);
+    global.settings.set_strv("enabled-applets", rawDefinitionsCopy);
 }
 
 function pasteAppletConfiguration(panelId) {

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -1563,7 +1563,7 @@ function populateSettingsMenu(menu, panelId) {
         let dialog = new ModalDialog.ConfirmDialog(
                 _("Are you sure you want to clear all applets on this panel?") + "\n\n",
                 Lang.bind(this, function() {
-                    AppletManager.clearAppletConfiguration(this.panelId, true);
+                    AppletManager.clearAppletConfiguration(this.panelId);
                 }));
         dialog.open();
     });


### PR DESCRIPTION
This wasn't working because when an item from `rawDefinitions` is removed, the array re-indexes and the following cached indexes become incorrect.