### PR TITLE
Sound: reuse cover temp file

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -619,7 +619,8 @@ Player.prototype = {
                 let cover_path = "";
                 if (this._trackCoverFile.match(/^http/)) {
                     this._hideCover();
-                    this._trackCoverFileTmp = Gio.file_new_tmp('XXXXXX.mediaplayer-cover')[0];
+                    if(!this._trackCoverFileTmp)
+                        this._trackCoverFileTmp = Gio.file_new_tmp('XXXXXX.mediaplayer-cover')[0];
                     Util.spawn_async(['wget', this._trackCoverFile, '-O', this._trackCoverFileTmp.get_path()], Lang.bind(this, this._onDownloadedCover));
                 }
                 else {


### PR DESCRIPTION
This small change makes the sound applet reuse the same temp file for
downloading cover files. Previously, a new file was created in /tmp/ for every
song, cluttering /tmp/ with cover images.

This should not affect behaviour of the applet in any other way as wget is used to download the covers, so if the file is accidentally removed by the user, it will simply be recreated when new cover is downloaded. showCover is called after the download finishes, so there is no risk of showing the cover for the previous song.