### PR TITLE
appletManager.js: fix getRunningInstancesForUuid()

### DIFF
--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -781,9 +781,14 @@ function pasteAppletConfiguration(panelId) {
 }
 
 function getRunningInstancesForUuid(uuid) {
-    return filterDefinitionsByUUID(uuid).map(function(definition) {
-        return definition.applet;
-    });
+    let definitions = filterDefinitionsByUUID(uuid);
+    let result = [];
+    for (let i = 0; i < definitions.length; i++) {
+        if (definitions[i].applet != null) {
+            result.push(definitions[i].applet);
+        }
+    }
+    return result;
 }
 
 function callAppletInstancesChanged(uuid) {


### PR DESCRIPTION
Since we removed the discrete instances object appletObj and merged
instances into the definition object, we now have null instances.
This occurs during startup, for definitions that are on removed panels,
and likely for applets that fail to load.

To return the previous behavior we just need to filter instances that
aren't actually running at the moment, aka null.