### PR TITLE
Melange fixes

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-looking-glass/cinnamon-looking-glass.py
+++ b/files/usr/share/cinnamon/cinnamon-looking-glass/cinnamon-looking-glass.py
@@ -281,17 +281,6 @@ class ClosableTabLabel(Gtk.Box):
         button.set_focus_on_click(False)
         button.add(Gtk.Image.new_from_stock(Gtk.STOCK_CLOSE, Gtk.IconSize.MENU))
         button.connect("clicked", self.button_clicked)
-        data =  ".button {\n" \
-                "-GtkButton-default-border : 0px;\n" \
-                "-GtkButton-default-outside-border : 0px;\n" \
-                "-GtkButton-inner-border: 0px;\n" \
-                "-GtkWidget-focus-line-width : 0px;\n" \
-                "-GtkWidget-focus-padding : 0px;\n" \
-                "padding: 0px;\n" \
-                "}"
-        provider = Gtk.CssProvider()
-        provider.load_from_data(data)
-        button.get_style_context().add_provider(provider, 600)
         self.pack_start(button, False, False, 0)
 
         self.show_all()

--- a/files/usr/share/cinnamon/cinnamon-looking-glass/cinnamon-looking-glass.py
+++ b/files/usr/share/cinnamon/cinnamon-looking-glass/cinnamon-looking-glass.py
@@ -15,7 +15,7 @@ import os
 import pyinotify
 import gi
 gi.require_version('Gtk', '3.0')
-from gi.repository import Gio, Gtk, GObject, Gdk
+from gi.repository import Gio, Gtk, GObject, Gdk, GLib
 import dbus, dbus.service, dbus.glib
 import pageutils
 from lookingglass_proxy import LookingGlassProxy
@@ -229,6 +229,7 @@ class FileWatcherView(Gtk.ScrolledWindow):
 
         self.filename = filename
         self.changed = 0
+        self.updateId = 0
         self.set_shadow_type(Gtk.ShadowType.ETCHED_IN)
         self.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
 
@@ -261,8 +262,16 @@ class FileWatcherView(Gtk.ScrolledWindow):
             self.changed -= 1
 
     def getUpdates(self):
+        # only update 2 times per second max
+        # without this rate limiting, certain file modifications can cause a crash at Gtk.TextBuffer.set_text()
+        if self.updateId == 0:
+            self.updateId = GLib.timeout_add(500, self.update)
+
+    def update(self):
         self.changed = 2 # onSizeChanged will be called twice, but only the second time is final
         self.textbuffer.set_text(open(self.filename, 'r').read())
+        self.updateId = 0
+        return False
 
 class ClosableTabLabel(Gtk.Box):
     __gsignals__ = {


### PR DESCRIPTION
Removes some custom themeing which was used only for custom file watch tabs' close button, as it was broken during the python3 migration. Since it was broken, and it's also obsolete style properties that have no effect in gtk 3.20+ now seemed like a good time to remove it.

Fixes a crash with FileWatcherView when the watched file is updated in quick succession. The crash was 100% reproducible by adding a watcher for `~/.xsession-errors` and restarting cinnamon.

Stack trace:
```
Fatal Python error: Segmentation fault

Thread 0x00007f020f7fe700 (most recent call first):
  File "/usr/lib/python3.6/site-packages/gi/overrides/Gtk.py", line 725 in set_text
  File "/usr/share/cinnamon/cinnamon-looking-glass/cinnamon-looking-glass.py", line 276 in update
  File "/usr/share/cinnamon/cinnamon-looking-glass/cinnamon-looking-glass.py", line 268 in getUpdates
  File "/usr/share/cinnamon/cinnamon-looking-glass/cinnamon-looking-glass.py", line 225 in process_IN_MODIFY
  File "/usr/lib/python3.6/site-packages/pyinotify.py", line 630 in __call__
  File "/usr/lib/python3.6/site-packages/pyinotify.py", line 910 in __call__
  File "/usr/lib/python3.6/site-packages/pyinotify.py", line 1278 in process_events
  File "/usr/lib/python3.6/site-packages/pyinotify.py", line 1479 in loop
  File "/usr/lib/python3.6/site-packages/pyinotify.py", line 1491 in run
  File "/usr/lib/python3.6/threading.py", line 916 in _bootstrap_inner
  File "/usr/lib/python3.6/threading.py", line 884 in _bootstrap

Current thread 0x00007f0251a86540 (most recent call first):
  File "/usr/share/cinnamon/cinnamon-looking-glass/cinnamon-looking-glass.py", line 579 in <module>
Segmentation fault (core dumped)
```