### PR TITLE
appletManager, deskletManager: Fix incorrect handling of adding/removing multiple xlets of the same UUID

### DIFF
--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -248,6 +248,7 @@ function appletDefinitionsEqual(a, b) {
 function onEnabledAppletsChanged() {
     let oldDefinitions = definitions.slice();
     definitions = getDefinitions();
+    let addedApplets = [];
     let removedApplets = [];
     let unChangedApplets = [];
 
@@ -262,6 +263,8 @@ function onEnabledAppletsChanged() {
         }
 
         if (!oldDefinition || !isEqualToOldDefinition) {
+            let extension = Extension.getExtension(uuid);
+            addedApplets.push({extension, definition: definitions[i]});
             continue;
         }
 
@@ -278,7 +281,10 @@ function onEnabledAppletsChanged() {
             removedApplets[i].definition,
             Extension.get_max_instances(uuid, Extension.Type.APPLET) !== 1 && !removedApplets[i].changed
         );
-        Extension.unloadExtension(uuid, Extension.Type.APPLET);
+    }
+    for (let i = 0; i < addedApplets.length; i++) {
+        let {extension, definition} = addedApplets[i];
+        addAppletToPanels(extension, definition);
     }
 
     // Make sure all applet extensions are loaded.

--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -587,18 +587,11 @@ function createApplet(extension, appletDefinition, panel = null) {
 }
 
 function _removeAppletFromPanel(uuid, applet_id) {
-
-    for (let i=0; i < rawDefinitions.length; i++) {
-        let appletDefinition = createAppletDefinition(rawDefinitions[i]);
-        if (appletDefinition) {
-            if (uuid == appletDefinition.uuid && applet_id == appletDefinition.applet_id) {
-                let newEnabledApplets = rawDefinitions.slice(0);
-                newEnabledApplets.splice(i, 1);
-                global.settings.set_strv('enabled-applets', newEnabledApplets);
-                break;
-            }
-        }
+    let definition = queryCollection(definitions, {uuid, applet_id});
+    if (!definition) {
+        return false;
     }
+    removeApplet(definition);
 }
 
 function saveAppletsPositions() {

--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -284,6 +284,9 @@ function onEnabledAppletsChanged() {
     }
     for (let i = 0; i < addedApplets.length; i++) {
         let {extension, definition} = addedApplets[i];
+        if (!extension) {
+            continue;
+        }
         addAppletToPanels(extension, definition);
     }
 

--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -314,7 +314,7 @@ Extension.prototype = {
                 if(fatal)
                     throw logError(msg, this.uuid);
                 else
-                    global.logWarning(this.formatError(this.name, this.uuid, msg));
+                    global.logWarning(formatError(this.uuid, msg));
             }
         }
     },


### PR DESCRIPTION
- Removes the call to unloadExtension in `onEnabledAppletsChanged`. It was calling a function that can only remove by UUID. In cases where multiple applets of the same UUID are on the panel, and only one instance needs to be removed, this prevents all of them from being removed.
- Re-added addAppletToPanels in `onEnabledAppletsChanged`. `initEnabledApplets` will try to initialize enabled applets, but the `Extension` constructor checks its cache and resolves true if an xlet of the same UUID is already loaded. This is ideal normally because instances are tracked in appletManager, but it skips the actual panel loading event.
- Fixes incorrect invocation of `formatError`, caught by @Odyseus 
- `_onEnabledDeskletsChanged` no longer gets called when desklets are dragged