### PR TITLE
Bring back xlet meta data

### DIFF
--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -181,7 +181,7 @@ Extension.prototype = {
 
         const finishLoad = () => {
             // Many xlets still use appletMeta/deskletMeta to get the path
-            type.legacyMeta[uuid] = {path: this.meta.path};
+            type.legacyMeta[uuid] = Object.assign({}, this.meta);
 
             ensureFileExists(this.dir.get_child(`${this.lowerType}.js`));
             this.loadStylesheet(this.dir.get_child('stylesheet.css'));

--- a/js/ui/extensionSystem.js
+++ b/js/ui/extensionSystem.js
@@ -5,6 +5,8 @@ const {getModuleByIndex} = imports.misc.fileUtils;
 
 // Maps uuid -> importer object (extension directory tree)
 var extensions;
+// Kept for compatibility
+var extensionMeta;
 // Lists extension uuid's that are currently active;
 var runningExtensions = [];
 // Arrays of uuids
@@ -120,6 +122,7 @@ function init() {
     } catch (e) {
         extensions = {};
     }
+    extensionMeta = Extension.Type.EXTENSION.legacyMeta;
     ExtensionState = Extension.State;
 
     enabledExtensions = global.settings.get_strv(ENABLED_EXTENSIONS_KEY);


### PR DESCRIPTION
This PR brings back the xlets meta data object that was removed with the #6878 PR.

An in-depth discussion can be read in the previously linked PR about this change.