### PR TITLE
Fix multi-version xlets loading twice, address metadata availability

### DIFF
--- a/js/misc/fileUtils.js
+++ b/js/misc/fileUtils.js
@@ -140,7 +140,7 @@ function unloadModule(index) {
     }
 }
 
-function createExports({path, dir, type, file, size, JS, returnIndex, reject}) {
+function createExports({path, dir, meta, type, file, size, JS, returnIndex, reject}) {
     // Import data is stored in an array of objects and the module index is looked up by path.
     let importerData = {
         size,
@@ -211,6 +211,7 @@ function createExports({path, dir, type, file, size, JS, returnIndex, reject}) {
             'require',
             'exports',
             'module',
+            '__meta',
             '__dirname',
             '__filename',
             JS
@@ -221,6 +222,7 @@ function createExports({path, dir, type, file, size, JS, returnIndex, reject}) {
             },
             exports,
             module,
+            meta,
             dir,
             file.get_basename()
         );
@@ -235,7 +237,7 @@ function createExports({path, dir, type, file, size, JS, returnIndex, reject}) {
     }
 }
 
-function requireModule(path, dir, type, async = false, returnIndex = false) {
+function requireModule(path, dir, meta, type, async = false, returnIndex = false) {
     // Allow passing through native bindings, e.g. const Cinnamon = require('gi.Cinnamon');
     // Check if this is a GI import
     if (path.substr(0, 3) === 'gi.') {
@@ -274,7 +276,7 @@ function requireModule(path, dir, type, async = false, returnIndex = false) {
         if (!success) {
             throw new Error(fileLoadErrorMessage);
         }
-        return createExports({path, dir, file, size: JS.length, JS, returnIndex});
+        return createExports({path, dir, meta, type, file, size: JS.length, JS, returnIndex});
     }
     return new Promise(function(resolve, reject) {
         file.load_contents_async(null, function(object, result) {
@@ -283,7 +285,7 @@ function requireModule(path, dir, type, async = false, returnIndex = false) {
                 if (!success) {
                     throw new Error(fileLoadErrorMessage);
                 }
-                resolve(createExports({path, dir, type, file, size: JS.length, JS, returnIndex, reject}));
+                resolve(createExports({path, dir, meta, type, file, size: JS.length, JS, returnIndex, reject}));
             } catch (e) {
                 reject(e);
             }

--- a/js/misc/fileUtils.js
+++ b/js/misc/fileUtils.js
@@ -218,7 +218,7 @@ function createExports({path, dir, meta, type, file, size, JS, returnIndex, reje
         ).call(
             exports,
             function require(path) {
-                return requireModule(path, dir);
+                return requireModule(path, dir, meta, type);
             },
             exports,
             module,

--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -244,7 +244,7 @@ Extension.prototype = {
             extensions.push(this);
 
             if(!type.callbacks.finishExtensionLoad(extensions.length - 1)) {
-                throw new Error(`${type.name} ${uuid}: Could not create applet object.`);
+                throw new Error(`${type.name} ${uuid}: Could not create ${this.lowerType} object.`);
             }
             this.finalize();
             Main.cinnamonDBusService.EmitXletAddedComplete(true, uuid);

--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -223,11 +223,6 @@ Extension.prototype = {
                 return findExtensionSubdirectory(this.dir).then((dir) => {
                     this.dir = dir;
                     this.meta.path = this.dir.get_path();
-                    let pathSections = this.meta.path.split('/');
-                    let version = pathSections[pathSections.length - 1];
-                    try {
-                        imports[type.folder][this.uuid] = imports[type.folder][this.uuid][version];
-                    } catch (e) {/* Extension was reloaded */}
                     return finishLoad();
                 });
             }

--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -196,6 +196,7 @@ Extension.prototype = {
             return requireModule(
                 `${this.meta.path}/${this.lowerType}.js`, // path
                 this.meta.path, // dir,
+                this.meta, // meta
                 this.lowerType, // type
                 true, // async
                 true // returnIndex

--- a/js/ui/extensionSystem.js
+++ b/js/ui/extensionSystem.js
@@ -36,7 +36,6 @@ function prepareExtensionUnload(extension) {
     } catch (e) {
         Extension.logError('Failed to evaluate \'disable\' function on extension: ' + extension.uuid, e);
     }
-    extensionMeta = Extension.Type.EXTENSION.legacyMeta;
     let runningExtensionIndex = runningExtensions.findIndex(function(uuid) {
         return extension.uuid === uuid;
     });
@@ -123,6 +122,7 @@ function init() {
     } catch (e) {
         extensions = {};
     }
+    extensionMeta = Extension.Type.EXTENSION.legacyMeta;
     ExtensionState = Extension.State;
 
     enabledExtensions = global.settings.get_strv(ENABLED_EXTENSIONS_KEY);

--- a/js/ui/extensionSystem.js
+++ b/js/ui/extensionSystem.js
@@ -5,6 +5,8 @@ const {getModuleByIndex} = imports.misc.fileUtils;
 
 // Maps uuid -> importer object (extension directory tree)
 var extensions;
+// Kept for compatibility
+var extensionMeta;
 // Lists extension uuid's that are currently active;
 var runningExtensions = [];
 // Arrays of uuids
@@ -34,6 +36,7 @@ function prepareExtensionUnload(extension) {
     } catch (e) {
         Extension.logError('Failed to evaluate \'disable\' function on extension: ' + extension.uuid, e);
     }
+    extensionMeta = Extension.Type.EXTENSION.legacyMeta;
     let runningExtensionIndex = runningExtensions.findIndex(function(uuid) {
         return extension.uuid === uuid;
     });


### PR DESCRIPTION
- Removes left over code that imported multi-version xlets with the cjs importer
- Re-added `extensionMeta`
- Made the meta object available to the xlet scope with the variable `__meta`