### PR TITLE
tray: avoid deprecation warning by dropping use of gdk_display_suppor…

### DIFF
--- a/src/tray/na-tray-child.c
+++ b/src/tray/na-tray-child.c
@@ -283,8 +283,7 @@ na_tray_child_new (GdkScreen *screen,
   depth = gdk_visual_get_depth (visual);
 
   visual_has_alpha = red_prec + blue_prec + green_prec < depth;
-  child->has_alpha = (visual_has_alpha &&
-                      gdk_display_supports_composite (gdk_screen_get_display (screen)));
+  child->has_alpha = visual_has_alpha;
 
   child->composited = child->has_alpha;
 

--- a/src/tray/na-tray-manager.c
+++ b/src/tray/na-tray-manager.c
@@ -651,8 +651,7 @@ na_tray_manager_set_visual_property (NaTrayManager *manager)
   visual_atom = gdk_x11_get_xatom_by_name_for_display (display,
 						       "_NET_SYSTEM_TRAY_VISUAL");
 
-  if (gdk_screen_get_rgba_visual (manager->screen) != NULL &&
-      gdk_display_supports_composite (display))
+  if (gdk_screen_get_rgba_visual (manager->screen) != NULL)
     xvisual = GDK_VISUAL_XVISUAL (gdk_screen_get_rgba_visual (manager->screen));
   else
     {


### PR DESCRIPTION
…ts_composite

as it isn't needed with mutter/muffin
https://github.com/GNOME/gnome-shell/commit/731d64e0e4c7b8974f6299ae02ff441afbac6e7e#diff-ce7ed307675c0793350595d93693da22