### PR TITLE
Add ability to raise desklets above windows

### DIFF
--- a/files/usr/share/cinnamon/applets/show-desklets@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/show-desklets@cinnamon.org/applet.js
@@ -1,0 +1,62 @@
+const Applet = imports.ui.applet;
+const Panel = imports.ui.panel;
+const Main = imports.ui.main;
+const Settings = imports.ui.settings;
+
+// ES2015 class syntax can be used for Cinnamon 3.8+
+class MyApplet extends Applet.IconApplet {
+    _init(orientation, panel_height, instance_id) {
+        super._init(orientation, panel_height, instance_id);
+
+        this.set_applet_icon_name('cs-desklets');
+        this.set_applet_tooltip(_('Show Desklets'));
+        this._applet_context_menu.addMenuItem(
+            new Panel.SettingsLauncher(_('Add Desklets'), 'desklets', 'list-add')
+        )
+
+        this.state = {};
+        this.settings = new Settings.AppletSettings(this.state, __meta.uuid, instance_id);
+        this.settings.bind('showKey', 'showKey', () => {
+            this.unbindShowKey();
+            this.bindShowKey();
+        });
+
+        global.settings.connect('changed::panel-edit-mode', () => this.onPanelEditModeChanged());
+        this.bindShowKey();
+    }
+
+    bindShowKey() {
+        Main.keybindingManager.addHotKey('show-desklet-key', this.state.showKey, () => this.on_applet_clicked());
+    }
+
+    unbindShowKey() {
+        Main.keybindingManager.removeHotKey('show-desklet-key');
+    }
+
+    onPanelEditModeChanged() {
+        if (global.settings.get_boolean('panel-edit-mode')
+            && Main.deskletContainer.isModal) {
+            Main.deskletContainer.lower();
+        }
+    }
+
+    on_applet_clicked() {
+        if (Main.deskletContainer.isModal) {
+            Main.deskletContainer.lower();
+        } else {
+            Main.deskletContainer.raise();
+        }
+    }
+
+    on_applet_removed_from_panel() {
+        if (Main.deskletContainer.isModal) {
+            Main.deskletContainer.lower();
+        }
+        this.unbindShowKey();
+        this.settings.finalize();
+    }
+}
+
+function main(metadata, orientation, panel_height, instance_id) {
+    return new MyApplet(orientation, panel_height, instance_id);
+}

--- a/files/usr/share/cinnamon/applets/show-desklets@cinnamon.org/metadata.json
+++ b/files/usr/share/cinnamon/applets/show-desklets@cinnamon.org/metadata.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "show-desklets@cinnamon.org",
+    "name": "Show Desklets",
+    "description": "Raises desklets above windows",
+    "icon": "cs-desklets",
+    "max-instances": -1
+}

--- a/files/usr/share/cinnamon/applets/show-desklets@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/show-desklets@cinnamon.org/settings-schema.json
@@ -1,0 +1,7 @@
+{
+    "showKey": {
+        "type": "keybinding",
+        "description": "Show desklets shortcut",
+        "default": "<Super>Tab::"
+    }
+}


### PR DESCRIPTION
- Modified `DeskletContainer` to enable raising its actor above and below the window group, based on code @collinss wrote for the sticky notes applet.
  - When clicking outside of a desklet, the desklet container is lowered and input is released.
  - Tested all desklets on Spices, and they seem to behave the same when raised and input is grabbed.
- Added a companion stock applet, "Show Desklets" which toggles desklet visibility when clicked.
  - Added a context menu shortcut to add desklets
  - Added a keybinding shortcut option, which defaults to Super + Tab. I didn't see this conflicting with anything, but could be wrong. If so I can change it.
  - Written using ES2015 class syntax. I think it looks cleaner than the constructor style. While there is a specific syntax for [GObject classes in GJS](https://github.com/linuxmint/cjs/blob/master/NEWS#L75), this isn't necessary (or work) with extending normal JS objects like the applet prototype APIs. MDN has some [good info](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes) on these if unfamiliar.
  - Depends on #7306 so `__meta` could be used.