### PR TITLE
Fix bad allocation of panels with borders

### DIFF
--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -3041,11 +3041,9 @@ Panel.prototype = {
         let allocHeight  = box.y2 - box.y1;
         let allocWidth   = box.x2 - box.x1;
 
-        let childBox = new Clutter.ActorBox();
-        childBox.x1 = box.x1;
-        childBox.x2 = childBox.x1 + allocWidth;
-        childBox.y1 = box.y1;
-        childBox.y2 = childBox.y1 + allocHeight;
+        /* Panel left/center/bottom will fit inside this box, which is equivalent
+           to the CSS content-box (imaginary box inside borders and paddings) */
+        let childBox = box.copy();
 
         /* The boxes are layout managers, so they rubber-band around their contents and have a few
            characteristics that they enforce on their contents.  Of particular note is that the alignment
@@ -3059,6 +3057,8 @@ Panel.prototype = {
 
         if (this.panelPosition == PanelLoc.left || this.panelPosition == PanelLoc.right) {
 
+            /* Distribute sizes for the allocated height with points relative to
+               the children allocation box, inside borders and paddings. */
             let [leftBoundary, rightBoundary] = this._calcBoxSizes(allocHeight, allocWidth, true);
             leftBoundary += box.y1;
             rightBoundary += box.y1;
@@ -3115,6 +3115,8 @@ Panel.prototype = {
             }
         } else {           // horizontal panel
 
+            /* Distribute sizes for the allocated width with points relative to
+               the children allocation box, inside borders and paddings. */
             let [leftBoundary, rightBoundary] = this._calcBoxSizes(allocWidth, allocHeight, false);
             leftBoundary += box.x1;
             rightBoundary += box.x1;

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -3041,6 +3041,12 @@ Panel.prototype = {
         let allocHeight  = box.y2 - box.y1;
         let allocWidth   = box.x2 - box.x1;
 
+        let childBox = new Clutter.ActorBox();
+        childBox.x1 = box.x1;
+        childBox.x2 = childBox.x1 + allocWidth;
+        childBox.y1 = box.y1;
+        childBox.y2 = childBox.y1 + allocHeight;
+
         /* The boxes are layout managers, so they rubber-band around their contents and have a few
            characteristics that they enforce on their contents.  Of particular note is that the alignment
            - LEFT, CENTER, RIGHT - is not independent of the fill as it probably ought to be, and that there
@@ -3054,17 +3060,16 @@ Panel.prototype = {
         if (this.panelPosition == PanelLoc.left || this.panelPosition == PanelLoc.right) {
 
             let [leftBoundary, rightBoundary] = this._calcBoxSizes(allocHeight, allocWidth, true);
-            let childBox = new Clutter.ActorBox();
+            leftBoundary += box.y1;
+            rightBoundary += box.y1;
 
-            childBox.x1 = 0;
-            childBox.x2 = allocWidth;
-            this._setVertChildbox (childBox,0, leftBoundary);
+            this._setVertChildbox (childBox, box.y1, leftBoundary);
             this._leftBox.allocate(childBox, flags);
 
             this._setVertChildbox (childBox, leftBoundary, rightBoundary);
             this._centerBox.allocate(childBox, flags);
 
-            this._setVertChildbox (childBox, rightBoundary, allocHeight);
+            this._setVertChildbox (childBox, rightBoundary, box.y2);
             this._rightBox.allocate(childBox, flags);
 
             // Corners are in response to a bit of optional css and are about painting corners just outside the panels so as to create a seamless
@@ -3111,18 +3116,16 @@ Panel.prototype = {
         } else {           // horizontal panel
 
             let [leftBoundary, rightBoundary] = this._calcBoxSizes(allocWidth, allocHeight, false);
+            leftBoundary += box.x1;
+            rightBoundary += box.x1;
 
-            let childBox = new Clutter.ActorBox();
-
-            childBox.y1 = 0;
-            childBox.y2 = allocHeight;
-            this._setHorizChildbox (childBox,0,leftBoundary,leftBoundary, allocWidth);
+            this._setHorizChildbox (childBox, box.x1, leftBoundary, leftBoundary, box.x2);
             this._leftBox.allocate(childBox, flags);
 
-            this._setHorizChildbox (childBox,leftBoundary,rightBoundary,rightBoundary,leftBoundary);
+            this._setHorizChildbox (childBox, leftBoundary, rightBoundary, rightBoundary, leftBoundary);
             this._centerBox.allocate(childBox, flags);
 
-            this._setHorizChildbox (childBox,rightBoundary,allocWidth,0,rightBoundary);
+            this._setHorizChildbox (childBox, rightBoundary, box.x2, box.x1, rightBoundary);
             this._rightBox.allocate(childBox, flags);
 
             if (this.drawcorner[0]) {

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -2767,10 +2767,11 @@ Panel.prototype = {
     },
 
     _set_horizontal_panel_style: function() {
+        let rtl = this.actor.get_direction() === St.TextDirection.RTL;
 
         this._leftBox.remove_style_class_name('vertical');
         this._leftBox.set_vertical(false);
-        this._leftBox.set_x_align(Clutter.ActorAlign.START);
+        this._leftBox.set_x_align(rtl ? Clutter.ActorAlign.END : Clutter.ActorAlign.START);
         this._leftBox.set_y_align(Clutter.ActorAlign.FILL);
 
         this._centerBox.remove_style_class_name('vertical');
@@ -2780,7 +2781,7 @@ Panel.prototype = {
 
         this._rightBox.remove_style_class_name('vertical');
         this._rightBox.set_vertical(false);
-        this._rightBox.set_x_align(Clutter.ActorAlign.END);
+        this._rightBox.set_x_align(rtl ? Clutter.ActorAlign.START : Clutter.ActorAlign.END);
         this._rightBox.set_y_align(Clutter.ActorAlign.FILL);
     },
 
@@ -2996,9 +2997,9 @@ Panel.prototype = {
         leftBoundary  = Math.round(leftWidth);
         rightBoundary = Math.round(allocWidth - rightWidth);
 
-        if (!vertical && (this.actor.get_direction() == St.TextDirection.RTL)) {
-            leftBoundary  = allocWidth - leftWidth;
-            rightBoundary = rightWidth;
+        if (!vertical && (this.actor.get_direction() === St.TextDirection.RTL)) {
+            leftBoundary  = Math.round(allocWidth - leftWidth);
+            rightBoundary = Math.round(rightWidth);
         }
 
         return [leftBoundary, rightBoundary];
@@ -3041,7 +3042,7 @@ Panel.prototype = {
         let allocHeight  = box.y2 - box.y1;
         let allocWidth   = box.x2 - box.x1;
 
-        /* Left, center and right panel sections will fit inside this box, which is 
+        /* Left, center and right panel sections will fit inside this box, which is
            equivalent to the CSS content-box (imaginary box inside borders and paddings) */
         let childBox = box.copy();
 

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -3084,35 +3084,25 @@ Panel.prototype = {
             if (this.drawcorner[0]) {
                 [cornerMinWidth, cornerWidth]   = this._leftCorner.actor.get_preferred_width(-1);
                 [cornerMinHeight, cornerHeight] = this._leftCorner.actor.get_preferred_height(-1);
+                if (this.panelPosition === PanelLoc.left) { // left panel
+                    this._setCornerChildbox(childBox, box.x2, box.x2+cornerWidth, 0, cornerWidth);
+                } else { // right panel
+                    this._setCornerChildbox(childBox, box.x1-cornerWidth, box.x1, 0, cornerWidth);
+                }
+                this._leftCorner.actor.allocate(childBox, flags);
             }
 
             if (this.drawcorner[1]) {
                 [cornerMinWidth, cornerWidth]   = this._rightCorner.actor.get_preferred_width(-1);
                 [cornerMinHeight, cornerHeight] = this._rightCorner.actor.get_preferred_height(-1);
+                if (this.panelPosition === PanelLoc.left) { // left panel
+                    this._setCornerChildbox(childBox, box.x2, box.x2+cornerWidth, this.actor.height-cornerHeight, this.actor.height);
+                } else { // right panel
+                    this._setCornerChildbox(childBox, box.x1-cornerWidth, box.x1, this.actor.height-cornerHeight, this.actor.height);
+                }
+                this._rightCorner.actor.allocate(childBox, flags);
             }
 
-            if (this.panelPosition == PanelLoc.left) { // left panel
-                if (this.drawcorner[0]) {
-                    this._setCornerChildbox(childBox, box.x2, box.x2+cornerWidth, box.y1, box.y1+cornerWidth);
-                    this._leftCorner.actor.allocate(childBox, flags);
-                }
-
-                if (this.drawcorner[1]) {
-                    this._setCornerChildbox(childBox, box.x2, box.x2+cornerWidth, box.y2-cornerHeight, box.y2);
-                    this._rightCorner.actor.allocate(childBox, flags);
-                }
-            }
-            if (this.panelPosition == PanelLoc.right) {          // right panel
-                if (this.drawcorner[0]) {
-                    this._setCornerChildbox(childBox, box.x1-cornerWidth, box.x2, box.y1, box.y1+cornerWidth);
-                    this._leftCorner.actor.allocate(childBox, flags);
-                }
-
-                if (this.drawcorner[1]) {
-                    this._setCornerChildbox(childBox, box.x1-cornerWidth, box.x2, box.y2-cornerHeight, box.y2);
-                    this._rightCorner.actor.allocate(childBox, flags);
-                }
-            }
         } else {           // horizontal panel
 
             /* Distribute sizes for the allocated width with points relative to
@@ -3133,31 +3123,23 @@ Panel.prototype = {
             if (this.drawcorner[0]) {
                 [cornerMinWidth, cornerWidth]   = this._leftCorner.actor.get_preferred_width(-1);
                 [cornerMinHeight, cornerHeight] = this._leftCorner.actor.get_preferred_height(-1);
+                if (this.panelPosition === PanelLoc.top) { // top panel
+                    this._setCornerChildbox(childBox, 0, cornerWidth, box.y2, box.y2+cornerHeight);
+                } else { // bottom panel
+                    this._setCornerChildbox(childBox, 0, cornerWidth, box.y1-cornerHeight, box.y2);
+                }
+                this._leftCorner.actor.allocate(childBox, flags);
             }
 
             if (this.drawcorner[1]) {
                 [cornerMinWidth, cornerWidth]   = this._rightCorner.actor.get_preferred_width(-1);
                 [cornerMinHeight, cornerHeight] = this._rightCorner.actor.get_preferred_height(-1);
-            }
-
-            if (this.panelPosition == PanelLoc.top) { // top panel
-                if (this.drawcorner[0]) {
-                    this._setCornerChildbox(childBox, 0, cornerWidth, allocHeight,allocHeight + cornerHeight );
-                    this._leftCorner.actor.allocate(childBox, flags);
+                if (this.panelPosition === PanelLoc.top) { // top panel
+                  this._setCornerChildbox(childBox, this.actor.width-cornerWidth, this.actor.width, box.y2, box.y2+cornerHeight);
+                } else { // bottom panel
+                  this._setCornerChildbox(childBox, this.actor.width-cornerWidth, this.actor.width, box.y1-cornerHeight, box.y1);
                 }
-                if (this.drawcorner[1]) {
-                    this._setCornerChildbox(childBox, allocWidth - cornerWidth, allocWidth, allocHeight,allocHeight + cornerHeight );
-                    this._rightCorner.actor.allocate(childBox, flags);
-                }
-            } else { // bottom
-                if (this.drawcorner[0]) {
-                    this._setCornerChildbox(childBox, 0,cornerWidth, box.y1 - cornerHeight, box.y2);
-                    this._leftCorner.actor.allocate(childBox, flags);
-                }
-                if (this.drawcorner[1]) {
-                    this._setCornerChildbox(childBox, allocWidth - cornerWidth, allocWidth, box.y1 - cornerHeight,box.y2 );
-                    this._rightCorner.actor.allocate(childBox, flags);
-                }
+                this._rightCorner.actor.allocate(childBox, flags);
             }
         }
     },

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -3041,8 +3041,8 @@ Panel.prototype = {
         let allocHeight  = box.y2 - box.y1;
         let allocWidth   = box.x2 - box.x1;
 
-        /* Panel left/center/bottom will fit inside this box, which is equivalent
-           to the CSS content-box (imaginary box inside borders and paddings) */
+        /* Left, center and right panel sections will fit inside this box, which is 
+           equivalent to the CSS content-box (imaginary box inside borders and paddings) */
         let childBox = box.copy();
 
         /* The boxes are layout managers, so they rubber-band around their contents and have a few

--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -2547,14 +2547,14 @@ PopupMenu.prototype = {
                 else if (xPos + natWidth > x2) xPos = x2 - natWidth;
 
                 // now we calculate the x postion based on the orientation
-                if (this._orientation == St.Side.BOTTOM) {
+                if (this._orientation === St.Side.BOTTOM) {
                     this.sideFlipped = true;
-                    yPos = sourceBox.y1 - natHeight;
+                    yPos = Math.min(y2, sourceBox.y1) - natHeight;
                     styleClasses.push("bottom");
                 }
                 else {
                     this.sideFlipped = false;
-                    yPos = sourceBox.y2;
+                    yPos = Math.max(sourceBox.y2, y1);
                     styleClasses.push("top");
                 }
                 break;
@@ -2569,14 +2569,14 @@ PopupMenu.prototype = {
 
                 // now we calculate the x postion based on the orientation
                 // if the menu opens to the right, we also need to make sure we have room for it on that side
-                if (this._orientation == St.Side.RIGHT || x2 - sourceBox.x2 < natWidth) {
+                if (this._orientation === St.Side.RIGHT || x2 - sourceBox.x2 < natWidth) {
                     this.sideFlipped = true;
-                    xPos = sourceBox.x1 - natWidth;
+                    xPos = Math.min(sourceBox.x1, x2) - natWidth;
                     styleClasses.push("right");
                 }
                 else {
                     this.sideFlipped = false;
-                    xPos = sourceBox.x2;
+                    xPos = Math.max(sourceBox.x2, x1);
                     styleClasses.push("left");
                 }
                 break;


### PR DESCRIPTION
Children were allocated at 0 over the top-left borders and paddings, leading to dead zones in the opposite side.

Fixes #6440

Visual explanation:
![screenshot from 2018-03-04 19-45-12](https://user-images.githubusercontent.com/10391266/36950534-91a84138-1ff7-11e8-8029-3f5ff467d5b8.png)

```css
.panel-bottom {
    background: red;
    border-top: 8px solid blue;
}
```
**I need to test it in RTL mode**. I did my best but I could not find a way to enable it. If you tell me how to do it I'll check if it works with that (it should).