### PR TITLE
notifications: close button and no fade on mouseover

### DIFF
--- a/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
@@ -107,17 +107,6 @@ MyApplet.prototype = {
             return;
         }
 
-        if (notification.enter_id > 0) {
-            notification.actor.disconnect(notification.enter_id);
-            notification.enter_id = 0;
-        }
-        if (notification.leave_id > 0) {
-            notification.actor.disconnect(notification.leave_id);
-            notification.leave_id = 0;
-        }
-
-        notification.actor.opacity = (notification._table.get_theme_node().get_length('opacity') / global.ui_scale) || 255;
-
         notification.actor.unparent();
         let existing_index = this.notifications.indexOf(notification);
         if (existing_index != -1) {	// This notification is already listed.

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_notifications.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_notifications.py
@@ -58,21 +58,8 @@ class Module:
         switch = GSettingsSwitch(_("Remove notifications after their timeout is reached"), "org.cinnamon.desktop.notifications", "remove-old")
         settings.add_reveal_row(switch, "org.cinnamon.desktop.notifications", "display-notifications")
 
-        switch = GSettingsSwitch(_("Have notifications fade out when hovered over"), "org.cinnamon.desktop.notifications", "fade-on-mouseover")
-        settings.add_reveal_row(switch, "org.cinnamon.desktop.notifications", "display-notifications")
-
         switch = GSettingsSwitch(_("Show notifications on the bottom side of the screen"), "org.cinnamon.desktop.notifications", "bottom-notifications")
         settings.add_reveal_row(switch, "org.cinnamon.desktop.notifications", "display-notifications")
-
-        spin = GSettingsSpinButton(_("Hover opacity"), "org.cinnamon.desktop.notifications", "fade-opacity", _("%"), 0, 100)
-        settings.add_reveal_row(spin)
-        spin.revealer.settings = Gio.Settings.new("org.cinnamon.desktop.notifications")
-
-        def on_settings_changed(*args):
-            spin.revealer.set_reveal_child(spin.revealer.settings["fade-on-mouseover"] and spin.revealer.settings["display-notifications"])
-        spin.revealer.settings.connect("changed::fade-on-mouseover", on_settings_changed)
-        spin.revealer.settings.connect("changed::display-notifications", on_settings_changed)
-        on_settings_changed()
 
         button = Button(_("Display a test notification"), self.send_test)
         settings.add_row(button)

--- a/js/ui/messageTray.js
+++ b/js/ui/messageTray.js
@@ -494,6 +494,21 @@ Notification.prototype = {
                                         col: 2,
                                         y_expand: false,
                                         y_fill: false });
+
+        // notification dismiss button
+        let icon = new St.Icon({ icon_name: 'window-close',
+                                 icon_type: St.IconType.SYMBOLIC,
+                                 icon_size: 16 });
+        let closeButton = new St.Button({ child: icon, opacity: 128 });
+        closeButton.connect('clicked', Lang.bind(this, this.destroy));
+        closeButton.connect('notify::hover', function() { closeButton.opacity = closeButton.hover ? 255 : 128; });
+        this._table.add(closeButton, { row: 0,
+                                       col: 3,
+                                       x_expand: false,
+                                       y_expand: false,
+                                       y_fill: false,
+                                       y_align: St.Align.START });
+
         this._timeLabel = new St.Label();
         this._titleLabel = new St.Label();
         this._bannerBox.add_actor(this._titleLabel);
@@ -738,10 +753,10 @@ Notification.prototype = {
     _updateLastColumnSettings: function() {
         if (this._scrollArea)
             this._table.child_set(this._scrollArea, { col: this._imageBin ? 2 : 1,
-                                                      col_span: this._imageBin ? 1 : 2 });
+                                                      col_span: this._imageBin ? 2 : 3 });
         if (this._actionArea)
             this._table.child_set(this._actionArea, { col: this._imageBin ? 2 : 1,
-                                                      col_span: this._imageBin ? 1 : 2 });
+                                                      col_span: this._imageBin ? 2 : 3 });
     },
 
     setImage: function(image) {


### PR DESCRIPTION
This adds a simple close button to all notifications that can be used to dismiss them individually without
activating the associated action.

Additionally, this removes the "fade on mouseover" feature for notifications as it makes closing the notification harder. Currently we disable this feature for notifications that have action buttons. Extending this behavior to all notifications so the close button is easier to use will effectively disable the feature anyway.