### PR TITLE
Systray: remove the resize delay in scale mode

### DIFF
--- a/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
@@ -349,10 +349,7 @@ MyApplet.prototype = {
         icon._rolePosition = position;
 
         if (this._scaleMode) {
-            let timerId = Mainloop.timeout_add(500, Lang.bind(this, function() {
-                this._resizeStatusItem(role, icon);
-                Mainloop.source_remove(timerId);
-            }));
+            this._resizeStatusItem(role, icon);
         } else {
             icon.set_pivot_point(0.5, 0.5);
             icon.set_scale((DEFAULT_ICON_SIZE * global.ui_scale) / icon.width,


### PR DESCRIPTION
This causes a strange two stage display sequence for the user. Precautionary delay for the application to load is already baked in before this.

It's not clear to me why there would be a timing difference between scale mode (which has this extra delay) and having the icon size set by default/theme (no additional delay).  There's already a 1 sec initial delay for most applications which I presume is precautionary to give them time to load, so the current code gives a 1 second delay in most cases before an unscaled icon shows- and then there is a re-scaling of the icon to the expected size half a second later.  That's a bit weird, and gives an unhelpful impression of Cinnamon being slow and laggy.  Unless someone knows of a really good reason why the half second additional delay is in there, I propose removing it.