### PR TITLE
Revert to using the native importer

### DIFF
--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
@@ -7,7 +7,7 @@ const Util = imports.misc.util;
 const PopupMenu = imports.ui.popupMenu;
 const UPowerGlib = imports.gi.UPowerGlib;
 const Settings = imports.ui.settings;
-const Calendar = imports.applets['calendar@cinnamon.org'].calendar;
+const Calendar = require('./calendar');
 const CinnamonDesktop = imports.gi.CinnamonDesktop;
 
 String.prototype.capitalize = function() {

--- a/js/misc/fileUtils.js
+++ b/js/misc/fileUtils.js
@@ -226,8 +226,6 @@ function requireModule(path, dir, meta, async = false, returnIndex = false) {
     // Check the file extension
     if (fileName.substr(-3) === '.js') {
         fileName = fileName.substr(0, fileName.length - 3);
-    } else {
-        path += '.js';
     }
     // Check relative paths
     if (fileName[0] === '.' || path[0] !== '/') {

--- a/js/misc/fileUtils.js
+++ b/js/misc/fileUtils.js
@@ -2,6 +2,7 @@
 
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
+var getExtension = null;
 
 var importNames = [
     'mainloop',
@@ -23,13 +24,7 @@ var cinnamonImportNames = [
     'misc',
     'perf'
 ];
-var giImportNames = imports.gi.GIRepository.Repository
-    .get_default()
-    .get_loaded_namespaces();
 var LoadedModules = [];
-var FunctionConstructor = Symbol();
-var Symbols = {};
-Symbols[FunctionConstructor] = 0..constructor.constructor;
 
 function listDirAsync(file, callback) {
     let allFiles = [];
@@ -131,103 +126,47 @@ function unloadModule(index) {
     let indexes = [];
     for (let i = 0; i < LoadedModules.length; i++) {
         if (LoadedModules[i] && LoadedModules[i].dir === LoadedModules[index].dir) {
-            indexes.push(i);
+            LoadedModules[i].module = undefined;
+            delete LoadedModules[i].module;
+            LoadedModules.splice(LoadedModules.findIndex(module => module.dir === LoadedModules[i].dir), 1);
         }
-    }
-    for (var i = 0; i < indexes.length; i++) {
-        LoadedModules[indexes[i]].module = undefined;
-        LoadedModules[indexes[i]].size = -1;
     }
 }
 
-function createExports({path, dir, meta, type, file, size, JS, returnIndex, reject}) {
+function getModuleFromImports(importerData, dir, fileName) {
+    try {
+        // Make sure the file is removed from the importer. This should propagate and finalize
+        // the GjsModule object, so xlets can be fully reloaded.
+        delete imports[fileName];
+    } catch (e) {/* Not imported yet */}
+
+    let oldSearchPath = imports.searchPath.slice();
+    imports.searchPath = [dir];
+    importerData.module = imports[fileName];
+    imports.searchPath = oldSearchPath;
+
+    return importerData;
+}
+
+function createExports({path, dir, fileName, meta, returnIndex, reject}) {
     // Import data is stored in an array of objects and the module index is looked up by path.
     let importerData = {
-        size,
         path,
         dir,
         module: null
-    };
-    // module.exports as an object holding a module's namespaces is a node convention, and is intended
-    // to help interop with other libraries.
-    const exports = {};
-    const module = {
-        exports: exports
     };
 
     // Storing by array index that other extension classes can look up.
     let moduleIndex = findModuleIndex(path);
     if (moduleIndex > -1) {
-        // Module already exists, check if its been updated
-        if (size === LoadedModules[moduleIndex].size
-            && LoadedModules[moduleIndex].module != null) {
-            // Return the cache
-            return returnIndex ? moduleIndex : LoadedModules[moduleIndex].module;
-        }
-        // Module has been updated
-        LoadedModules[moduleIndex] = importerData;
+        importerData = LoadedModules[moduleIndex];
     } else {
         LoadedModules.push(importerData);
         moduleIndex = LoadedModules.length - 1;
     }
 
-    JS = `'use strict';${JS};`;
-    // Regex matches the top level variable names, and appends them to the module.exports object,
-    // mimicking the native CJS importer.
-    const exportsRegex = /^(module\.exports(.?([A-Za-z_$]*))) = ([A-Za-z_;]*)$/gm;
-    const varRegex = /^(const|var|let|function{1,}) ([a-zA-Z_$]*)/gm;
-    let match;
-
-    if (!JS.match(exportsRegex)) {
-        while ((match = varRegex.exec(JS)) != null) {
-            if (match.index === varRegex.lastIndex) {
-                varRegex.lastIndex++;
-            }
-            // Don't modularize native imports
-            if (match[2]
-                && importNames.indexOf(match[2].toLowerCase()) === -1
-                && giImportNames.indexOf(match[2]) === -1) {
-                JS += `exports.${match[2]} = typeof ${match[2]} !== 'undefined' ? ${match[2]} : null;`;
-            }
-        }
-    }
-
-    // send_results is overridden in SearchProviderManager, so we need to make sure the send_results
-    // function on the exports object, what SearchProviderManager actually has access to outside the
-    // module scope, is called.
-    if (type === 'search_provider') {
-        JS += 'var send_results = function() {exports.send_results.apply(this, arguments)};' +
-            'var get_locale_string = function() {return exports.get_locale_string.apply(this, arguments)};';
-    }
-
-    // Return the exports object containing all of our top level namespaces, and include the sourceURL so
-    // Spidermonkey includes the file names in stack traces.
-    JS += `return exports;//# sourceURL=${path}`;
-
     try {
-        // Create the function returning module.exports and return it to Extension so it can be called by the
-        // appropriate manager.
-        importerData.module = Symbols[FunctionConstructor](
-            'require',
-            'exports',
-            'module',
-            '__meta',
-            '__dirname',
-            '__filename',
-            JS
-        ).call(
-            exports,
-            function require(path) {
-                return requireModule(path, dir, meta, type);
-            },
-            exports,
-            module,
-            meta,
-            dir,
-            file.get_basename()
-        );
-
-        return returnIndex ? moduleIndex : importerData.module;
+        importerData = getModuleFromImports(importerData, dir, fileName);
     } catch (e) {
         if (reject) {
             reject(e);
@@ -235,9 +174,35 @@ function createExports({path, dir, meta, type, file, size, JS, returnIndex, reje
         }
         throw e;
     }
+    importerData.module.__meta = meta;
+    importerData.module.__dirname = dir;
+    importerData.module.__filename = fileName;
+
+    return returnIndex ? moduleIndex : importerData.module;
 }
 
-function requireModule(path, dir, meta, type, async = false, returnIndex = false) {
+function requireModule(path, dir, meta, async = false, returnIndex = false) {
+    if (!meta) {
+        // If require is being called from within an xlet, we need to look backwards into the
+        // stack, pick out the UUID, and then fetch the associated extension object.
+        let callStack = new Error().stack.split('\n');
+        let uuid = null;
+        for (let i = 0; i < callStack.length; i++) {
+            uuid = callStack[i].match(/(\w|-|\.|_)+@(\w|-|\.|_)+/g);
+            if (uuid) {
+                uuid = uuid[0];
+                break;
+            }
+        }
+        // fileUtils.js loads before the global object is created, so need to load it on first
+        // invocation once.
+        if (!getExtension) {
+            getExtension = imports.ui.extension.getExtension;
+        }
+        let extension = getExtension(uuid);
+        meta = extension.meta;
+        dir = meta.path;
+    }
     // Allow passing through native bindings, e.g. const Cinnamon = require('gi.Cinnamon');
     // Check if this is a GI import
     if (path.substr(0, 3) === 'gi.') {
@@ -253,42 +218,37 @@ function requireModule(path, dir, meta, type, async = false, returnIndex = false
     if (importNames.indexOf(path) > -1) {
         return imports[path];
     }
+
+    let pathSections = path.split('/');
+    let fileName = pathSections[pathSections.length - 1];
+
     // Check the file extension
-    if (path.substr(-3) !== '.js') {
+    if (fileName.substr(-3) === '.js') {
+        fileName = fileName.substr(0, fileName.length - 3);
+    } else {
         path += '.js';
     }
     // Check relative paths
-    if (path[0] === '.' || path[0] !== '/') {
+    if (fileName[0] === '.' || path[0] !== '/') {
         path = path.replace(/\.\//g, '');
         if (dir) {
             path = `${dir}/${path}`;
         }
     }
-    let success, JS;
+
     let file = Gio.File.new_for_commandline_arg(path);
-    let fileLoadErrorMessage = '[requireModule] Unable to load file contents.';
     if (!file.query_exists(null)) {
         throw new Error(`[requireModule] Path does not exist.\n${path}`);
     }
 
     if (!async) {
-        [success, JS] = file.load_contents(null);
-        if (!success) {
-            throw new Error(fileLoadErrorMessage);
-        }
-        return createExports({path, dir, meta, type, file, size: JS.length, JS, returnIndex});
+        return createExports({path, dir, fileName, meta, returnIndex});
     }
     return new Promise(function(resolve, reject) {
-        file.load_contents_async(null, function(object, result) {
-            try {
-                [success, JS] = file.load_contents_finish(result);
-                if (!success) {
-                    throw new Error(fileLoadErrorMessage);
-                }
-                resolve(createExports({path, dir, meta, type, file, size: JS.length, JS, returnIndex, reject}));
-            } catch (e) {
-                reject(e);
-            }
-        });
+        try {
+            resolve(createExports({path, dir, fileName, meta, returnIndex, reject}));
+        } catch (e) {
+            reject(e);
+        }
     });
 }

--- a/js/misc/fileUtils.js
+++ b/js/misc/fileUtils.js
@@ -123,7 +123,6 @@ function unloadModule(index) {
     if (!LoadedModules[index]) {
         return;
     }
-    let indexes = [];
     for (let i = 0; i < LoadedModules.length; i++) {
         if (LoadedModules[i] && LoadedModules[i].dir === LoadedModules[index].dir) {
             LoadedModules[i].module = undefined;
@@ -174,9 +173,11 @@ function createExports({path, dir, fileName, meta, returnIndex, reject}) {
         }
         throw e;
     }
-    importerData.module.__meta = meta;
-    importerData.module.__dirname = dir;
-    importerData.module.__filename = fileName;
+    try {
+        importerData.module.__meta = meta;
+        importerData.module.__dirname = dir;
+        importerData.module.__filename = fileName;
+    } catch (e) {/* Directory import */}
 
     return returnIndex ? moduleIndex : importerData.module;
 }
@@ -234,11 +235,6 @@ function requireModule(path, dir, meta, async = false, returnIndex = false) {
         if (dir) {
             path = `${dir}/${path}`;
         }
-    }
-
-    let file = Gio.File.new_for_commandline_arg(path);
-    if (!file.query_exists(null)) {
-        throw new Error(`[requireModule] Path does not exist.\n${path}`);
     }
 
     if (!async) {

--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -83,9 +83,8 @@ function filterDefinitionsByUUID(uuid) {
 }
 
 // Callback for extension.js
-function finishExtensionLoad(extensionIndex) {
+function finishExtensionLoad(extension) {
     // Add all applet instances for this extension
-    let extension = Extension.extensions[extensionIndex];
     for (let i = 0; i < definitions.length; i++) {
         if (definitions[i].uuid !== extension.uuid
             || definitions[i].applet != null) {

--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -12,8 +12,6 @@ const {getModuleByIndex} = imports.misc.fileUtils;
 const {queryCollection} = imports.misc.util;
 const Gettext = imports.gettext;
 
-// Maps uuid -> importer object (applet directory tree)
-var applets;
 // Kept for compatibility
 var appletMeta;
 // Maps applet_id -> applet objects
@@ -54,11 +52,6 @@ function unloadRemovedApplets(removedApplets) {
 
 function init() {
     let startTime = new Date().getTime();
-    try {
-        applets = imports.applets;
-    } catch (e) {
-        applets = {};
-    }
     appletMeta = Extension.Type.APPLET.legacyMeta;
     appletsLoaded = false;
 

--- a/js/ui/deskletManager.js
+++ b/js/ui/deskletManager.js
@@ -162,9 +162,8 @@ function getDefinitions() {
 }
 
 // Callback for extension.js
-function finishExtensionLoad(extensionIndex) {
+function finishExtensionLoad(extension) {
     // Add all desklet instances for this extension
-    let extension = Extension.extensions[extensionIndex];
     for (let i = 0; i < definitions.length; i++) {
         if (definitions[i].uuid !== extension.uuid) {
             continue;

--- a/js/ui/deskletManager.js
+++ b/js/ui/deskletManager.js
@@ -13,8 +13,6 @@ const Main = imports.ui.main;
 const {getModuleByIndex} = imports.misc.fileUtils;
 const {queryCollection} = imports.misc.util;
 
-// Maps uuid -> importer object (desklet directory tree)
-var desklets;
 // Kept for compatibility
 var deskletMeta;
 
@@ -57,11 +55,6 @@ function unloadRemovedDesklets(removedDeskletUUIDs) {
  */
 function init(){
     let startTime = new Date().getTime();
-    try {
-        desklets = imports.desklets;
-    } catch (e) {
-        desklets = {};
-    }
     deskletMeta = Extension.Type.DESKLET.legacyMeta;
     deskletsLoaded = false
 

--- a/js/ui/environment.js
+++ b/js/ui/environment.js
@@ -13,6 +13,7 @@ const Gtk = imports.gi.Gtk;
 const Cinnamon = imports.gi.Cinnamon;
 const St = imports.gi.St;
 const Overrides = imports.ui.overrides;
+const {requireModule} = imports.misc.fileUtils;
 
 // We can't import cinnamon JS modules yet, because they may have
 // variable initializations, etc, that depend on init() already having
@@ -89,6 +90,7 @@ function init() {
         configurable: false,
         enumerable: false
     });
+    window.require = requireModule;
 
     // Set the default direction for St widgets (this needs to be done before any use of St)
     if (Gtk.Widget.get_default_direction() == Gtk.TextDirection.RTL) {

--- a/js/ui/environment.js
+++ b/js/ui/environment.js
@@ -90,7 +90,16 @@ function init() {
         configurable: false,
         enumerable: false
     });
-    window.require = requireModule;
+    Object.defineProperty(window, 'require', {
+        get: function() {
+            return requireModule;
+        },
+        set: function() {
+            readOnlyError('require');
+        },
+        configurable: false,
+        enumerable: false
+    });
 
     // Set the default direction for St widgets (this needs to be done before any use of St)
     if (Gtk.Widget.get_default_direction() == Gtk.TextDirection.RTL) {

--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -481,9 +481,8 @@ function loadExtension(uuid, type) {
  * @deleteConfig (bool): delete also config files, defaults to true
  */
 function unloadExtension(uuid, type, deleteConfig = true) {
-    let extensionIndex = queryCollection(extensions, {uuid}, true);
-    if (extensionIndex > -1) {
-        let extension = extensions[extensionIndex];
+    let extension = getExtension(uuid);
+    if (extension) {
         extension.unlockRole();
 
         // Try to disable it -- if it's ERROR'd, we can't guarantee that,

--- a/js/ui/extensionSystem.js
+++ b/js/ui/extensionSystem.js
@@ -46,8 +46,7 @@ function prepareExtensionUnload(extension) {
 }
 
 // Callback for extension.js
-function finishExtensionLoad(extensionIndex) {
-    let extension = Extension.extensions[extensionIndex];
+function finishExtensionLoad(extension) {
     if (!extension.lockRole(getModuleByIndex(extension.moduleIndex))) {
         return false;
     }

--- a/js/ui/extensionSystem.js
+++ b/js/ui/extensionSystem.js
@@ -3,8 +3,6 @@
 const Extension = imports.ui.extension;
 const {getModuleByIndex} = imports.misc.fileUtils;
 
-// Maps uuid -> importer object (extension directory tree)
-var extensions;
 // Kept for compatibility
 var extensionMeta;
 // Lists extension uuid's that are currently active;
@@ -116,11 +114,6 @@ function unloadRemovedExtensions() {
 
 function init() {
     let startTime = new Date().getTime();
-    try {
-        extensions = imports.extensions;
-    } catch (e) {
-        extensions = {};
-    }
     extensionMeta = Extension.Type.EXTENSION.legacyMeta;
     ExtensionState = Extension.State;
 

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -223,26 +223,6 @@ function _initRecorder() {
     });
 }
 
-function _addXletDirectoriesToSearchPath() {
-    imports.searchPath.unshift(global.datadir);
-    imports.searchPath.unshift(global.userdatadir);
-    // Including the system data directory also includes unnecessary system utilities,
-    // so we are making sure they are removed.
-    let types = ['applets', 'desklets', 'extensions', 'search_providers'];
-    let importsCache = {};
-    for (let i = 0; i < types.length; i++) {
-        // Cache our existing xlet GJS importer objects
-        importsCache[types[i]] = imports[types[i]];
-    }
-    // Remove the two paths we added to the beginning of the array.
-    imports.searchPath.splice(0, 2);
-    for (let i = 0; i < types.length; i++) {
-        // Re-add cached xlet objects
-        imports[types[i]] = importsCache[types[i]];
-        importsCache[types[i]] = undefined;
-    }
-}
-
 function _initUserSession() {
     _initRecorder();
 
@@ -427,7 +407,6 @@ function start() {
     overview.init();
     expo.init();
 
-    _addXletDirectoriesToSearchPath();
     _initUserSession();
 
     // Provide the bus object for gnome-session to

--- a/js/ui/searchProviderManager.js
+++ b/js/ui/searchProviderManager.js
@@ -4,8 +4,6 @@ const Extension = imports.ui.extension;
 const {getModuleByIndex} = imports.misc.fileUtils;
 const GLib = imports.gi.GLib;
 
-// Maps uuid -> importer object (extension directory tree)
-var extensions;
 // Kept for compatibility
 var extensionMeta;
 // Maps uuid -> extension state object (returned from init())
@@ -55,11 +53,6 @@ function unloadRemovedSearchProviders() {
 
 function init() {
     let startTime = new Date().getTime();
-    try {
-        extensions = imports.search_providers;
-    } catch (e) {
-        extensions = {};
-    }
     extensionMeta = Extension.Type.SEARCH_PROVIDER.legacyMeta;
 
     enabledSearchProviders = global.settings.get_strv(ENABLED_SEARCH_PROVIDERS_KEY);

--- a/js/ui/searchProviderManager.js
+++ b/js/ui/searchProviderManager.js
@@ -21,8 +21,7 @@ function prepareExtensionUnload(extension) {
 }
 
 // Callback for extension.js
-function finishExtensionLoad(extensionIndex) {
-    let extension = Extension.extensions[extensionIndex];
+function finishExtensionLoad(extension) {
     searchProviderObj[extension.uuid] = getModuleByIndex(extension.moduleIndex);
     return true;
 }

--- a/js/ui/settings.js
+++ b/js/ui/settings.js
@@ -600,7 +600,11 @@ XletSettingsBase.prototype = {
         if (!configDir.query_exists(null)) configDir.make_directory_with_parents(null);
         this.file = configDir.get_child(this.instanceId + ".json");
         this.monitor = this.file.monitor_file(Gio.FileMonitorFlags.NONE, null);
-        let xletDir = Extension.getExtension(this.uuid).dir;
+        let xlet = Extension.getExtension(this.uuid);
+        if (!xlet) {
+            return;
+        }
+        let xletDir = xlet.dir;
         let templateFile = xletDir.get_child("settings-schema.json");
 
         // If the settings have already been installed previously we need to check if the schema


### PR DESCRIPTION
This reverts to using the native importer and retains asynchronous loading of extensions, and the `require` API. It works differently than it used to though, now it will only import exact files as needed, this prevents CJS from loading every xlet on disk into memory.

This was done to allow complete stack traces, since xlets creation with the function constructor all appear as `Function`, making debugging much harder.

Todo:
  - ~Update desklets and extensions~

Depends on https://github.com/linuxmint/cjs/pull/66