### PR TITLE
on-screen-keyboard applet: change icon to keyboard

### DIFF
--- a/files/usr/share/cinnamon/applets/on-screen-keyboard@cinnamon.org/metadata.json
+++ b/files/usr/share/cinnamon/applets/on-screen-keyboard@cinnamon.org/metadata.json
@@ -1,6 +1,6 @@
 {
  "uuid": "on-screen-keyboard@cinnamon.org",
  "name": "On-Screen keyboard",
- "icon": "input-keyboard",
+ "icon": "keyboard",
  "description": "A Cinnamon applet to launch the on-screen keyboard"
 }


### PR DESCRIPTION
Use the same icon for the applet, which is used for the application