### PR TITLE
SettingsWidgets.py: TextView widget - fix focus-stealing bug

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
@@ -378,7 +378,7 @@ class SettingsBox(Gtk.Frame):
             vbox.add(Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL))
         list_box = Gtk.ListBox()
         list_box.set_selection_mode(Gtk.SelectionMode.NONE)
-        row = Gtk.ListBoxRow()
+        row = Gtk.ListBoxRow(can_focus=False)
         row.add(widget)
         if isinstance(widget, Switch):
             list_box.connect("row-activated", widget.clicked)
@@ -394,7 +394,7 @@ class SettingsBox(Gtk.Frame):
             vbox.add(Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL))
         list_box = Gtk.ListBox()
         list_box.set_selection_mode(Gtk.SelectionMode.NONE)
-        row = Gtk.ListBoxRow()
+        row = Gtk.ListBoxRow(can_focus=False)
         row.add(widget)
         if isinstance(widget, Switch):
             list_box.connect("row-activated", widget.clicked)


### PR DESCRIPTION
The problem was caused by the ListBox trying to select the ListboxRow that's wrapped around the Textview widget, even though it was set to SelectionType.None. This caused the Textview to lose focus as soon as the mouse button was released, which in turn rendered the Textview almost unusable. This pull request explicitly forbids the ListboxRow from receiving focus, which it shouldn't have anyway, as the Listbox is only there for cosmetic reasons anyway.