### PR TITLE
cinanmon-settings: don't rely on the presence of cinnamon-control-center

### DIFF
--- a/files/usr/bin/cinnamon-settings
+++ b/files/usr/bin/cinnamon-settings
@@ -7,6 +7,7 @@ Usage:  cinnamon-settings [optional module name]
 
 import os
 import sys
+import sysconfig
 
 if len(sys.argv) > 1:
     module = sys.argv[1]
@@ -14,7 +15,7 @@ if len(sys.argv) > 1:
         os.execvp("/usr/share/cinnamon/cinnamon-settings/xlet-settings.py", (" ", module[0:-1]) + tuple(sys.argv[2:]))
     if os.path.exists("/usr/share/cinnamon/cinnamon-settings/modules/cs_%s.py" % module):
         os.execvp("/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py", (" ",) + tuple(sys.argv[1:]))
-    elif os.path.exists("/usr/bin/cinnamon-control-center"):
+    elif os.path.exists(os.path.join(sysconfig.get_config_var("LIBDIR"), "cinnamon-control-center-1/panels/lib%s.so" % module)):
         os.execvp("/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py", (" ",) + tuple(sys.argv[1:]))
     elif os.path.exists("/usr/bin/gnome-control-center"):
         print ("Unknown module %s, calling gnome-control-center" % module)


### PR DESCRIPTION
The existence of the cinnamon-control-center binary does not even tell us what control center libraries are available. So instead, do the same thing we did for cinnamon-settings modules, and check if the library exists.

AFAICT this doesn't even affect anything except whether cinnamon-settings prints "Unknown module %s" and possibly first tries to proxy out to gnome before running cinnamon-settings anyway...

It seems incongruous to simply accept absolutely anything just because the control center was installed. Also I'm not entirely sure what the control center binary actually does, as it seems to just be an inferior version of cinnamon-settings and its desktop file says not to display it... Is there any reason to actually install it? The previous Arch maintainer stripped it out and I'm not sure whether I should add it back in.