### PR TITLE
tooltips.js - base #PanelTooltip position on panel width / height

### DIFF
--- a/js/ui/tooltips.js
+++ b/js/ui/tooltips.js
@@ -327,16 +327,16 @@ PanelItemTooltip.prototype = {
             if (!panel.getIsVisible()) continue;
             switch (panel.panelPosition) {
                 case PanelLoc.top:
-                    panelTop = panel.actor.height + 1;
+                    panelTop = panel.actor.height;
                     break;
                 case PanelLoc.bottom:
-                    panelBottom = panel.actor.height + 1;
+                    panelBottom = panel.actor.height;
                     break;
                 case PanelLoc.left:
-                    panelLeft = panel.actor.width + 1;
+                    panelLeft = panel.actor.width;
                     break;
                 case PanelLoc.right:
-                    panelRight = panel.actor.width + 1;
+                    panelRight = panel.actor.width;
                     break;
             }
         }

--- a/js/ui/tooltips.js
+++ b/js/ui/tooltips.js
@@ -315,59 +315,39 @@ PanelItemTooltip.prototype = {
         let tooltipWidth = this._tooltip.get_allocation_box().x2 - this._tooltip.get_allocation_box().x1;
 
         let monitor = Main.layoutManager.findMonitorForActor(this._panelItem.actor);
-        
-        let panels = Main.panelManager.getPanelsInMonitor(Main.layoutManager.monitors.indexOf(monitor));
-        
-        let panelTop = 0;
-        let panelBottom = 0;
-        let panelLeft = 0;
-        let panelRight = 0;       
-        
-        for (let panel of panels) {
-            if (!panel.getIsVisible()) continue;
-            switch (panel.panelPosition) {
-                case PanelLoc.top:
-                    panelTop = panel.actor.height;
-                    break;
-                case PanelLoc.bottom:
-                    panelBottom = panel.actor.height;
-                    break;
-                case PanelLoc.left:
-                    panelLeft = panel.actor.width;
-                    break;
-                case PanelLoc.right:
-                    panelRight = panel.actor.width;
-                    break;
-            }
-        }
-        
+
         let tooltipTop = 0;
         let tooltipLeft = 0;
+        let panel = 0;
 
         switch (this.orientation) {
             case St.Side.BOTTOM:
-                tooltipTop = monitor.height - tooltipHeight - panelBottom;
+                panel = Main.panelManager.getPanel(Main.layoutManager.monitors.indexOf(monitor), PanelLoc.bottom);
+                tooltipTop = monitor.height - tooltipHeight - panel.actor.height;
                 tooltipLeft = this.mousePosition[0] - Math.round(tooltipWidth / 2);
                 tooltipLeft = Math.max(tooltipLeft, monitor.x);
                 tooltipLeft = Math.min(tooltipLeft, monitor.x + monitor.width - tooltipWidth);
                 break;
             case St.Side.TOP:
-                tooltipTop =  panelTop;
+                panel = Main.panelManager.getPanel(Main.layoutManager.monitors.indexOf(monitor), PanelLoc.top);
+                tooltipTop =  panel.actor.height;
                 tooltipLeft = this.mousePosition[0] - Math.round(tooltipWidth / 2);
                 tooltipLeft = Math.max(tooltipLeft, monitor.x);
                 tooltipLeft = Math.min(tooltipLeft, monitor.x + monitor.width - tooltipWidth);
                 break;
             case St.Side.LEFT:
+                panel = Main.panelManager.getPanel(Main.layoutManager.monitors.indexOf(monitor), PanelLoc.left);
                 tooltipTop = this._panelItem.actor.get_transformed_position()[1];
                 tooltipTop = tooltipTop + Math.round((this._panelItem.actor.get_allocation_box().y2 -
                     this._panelItem.actor.get_allocation_box().y1) / 2) - Math.round(tooltipHeight / 2);
-                tooltipLeft = panelLeft;
+                tooltipLeft = panel.actor.width;
                 break;
             case St.Side.RIGHT:
+                panel = Main.panelManager.getPanel(Main.layoutManager.monitors.indexOf(monitor), PanelLoc.right);
                 tooltipTop = this._panelItem.actor.get_transformed_position()[1];
                 tooltipTop = tooltipTop + Math.round((this._panelItem.actor.get_allocation_box().y2 -
                     this._panelItem.actor.get_allocation_box().y1) / 2) - Math.round(tooltipHeight / 2);
-                tooltipLeft = monitor.width - tooltipWidth - panelRight;
+                tooltipLeft = monitor.width - tooltipWidth - panel.actor.width;
                 break;
             default:
                 break;

--- a/js/ui/tooltips.js
+++ b/js/ui/tooltips.js
@@ -9,6 +9,12 @@ const Tweener = imports.ui.tweener;
 const Gio = imports.gi.Gio;
 const DESKTOP_SCHEMA = 'org.cinnamon.desktop.interface';
 const CURSOR_SIZE_KEY = 'cursor-size';
+const PanelLoc = {
+    top : 0,
+    bottom : 1,
+    left : 2,
+    right : 3
+};
 /**
  * #TooltipBase
  * @item (Clutter.Actor): The object owning the tooltip.
@@ -309,34 +315,59 @@ PanelItemTooltip.prototype = {
         let tooltipWidth = this._tooltip.get_allocation_box().x2 - this._tooltip.get_allocation_box().x1;
 
         let monitor = Main.layoutManager.findMonitorForActor(this._panelItem.actor);
+        
+        let panels = Main.panelManager.getPanelsInMonitor(Main.layoutManager.monitors.indexOf(monitor));
+        
+        let panelTop = 0;
+        let panelBottom = 0;
+        let panelLeft = 0;
+        let panelRight = 0;       
+        
+        for (let panel of panels) {
+            if (!panel.getIsVisible()) continue;
+            switch (panel.panelPosition) {
+                case PanelLoc.top:
+                    panelTop = panel.actor.height + 1;
+                    break;
+                case PanelLoc.bottom:
+                    panelBottom = panel.actor.height + 1;
+                    break;
+                case PanelLoc.left:
+                    panelLeft = panel.actor.width + 1;
+                    break;
+                case PanelLoc.right:
+                    panelRight = panel.actor.width + 1;
+                    break;
+            }
+        }
+        
         let tooltipTop = 0;
         let tooltipLeft = 0;
 
         switch (this.orientation) {
             case St.Side.BOTTOM:
-                tooltipTop = this.item.get_transformed_position()[1] - tooltipHeight;
+                tooltipTop = monitor.height - tooltipHeight - panelBottom;
                 tooltipLeft = this.mousePosition[0] - Math.round(tooltipWidth / 2);
                 tooltipLeft = Math.max(tooltipLeft, monitor.x);
                 tooltipLeft = Math.min(tooltipLeft, monitor.x + monitor.width - tooltipWidth);
                 break;
             case St.Side.TOP:
-                tooltipTop = this.item.get_transformed_position()[1] + this.item.get_transformed_size()[1];
+                tooltipTop =  panelTop;
                 tooltipLeft = this.mousePosition[0] - Math.round(tooltipWidth / 2);
                 tooltipLeft = Math.max(tooltipLeft, monitor.x);
                 tooltipLeft = Math.min(tooltipLeft, monitor.x + monitor.width - tooltipWidth);
                 break;
             case St.Side.LEFT:
-                [tooltipLeft, tooltipTop] = this._panelItem.actor.get_transformed_position();
+                tooltipTop = this._panelItem.actor.get_transformed_position()[1];
                 tooltipTop = tooltipTop + Math.round((this._panelItem.actor.get_allocation_box().y2 -
                     this._panelItem.actor.get_allocation_box().y1) / 2) - Math.round(tooltipHeight / 2);
-                tooltipLeft = tooltipLeft + this._panelItem.actor.get_allocation_box().x2 -
-                    this._panelItem.actor.get_allocation_box().x1;
+                tooltipLeft = panelLeft;
                 break;
             case St.Side.RIGHT:
-                [tooltipLeft, tooltipTop] = this._panelItem.actor.get_transformed_position();
+                tooltipTop = this._panelItem.actor.get_transformed_position()[1];
                 tooltipTop = tooltipTop + Math.round((this._panelItem.actor.get_allocation_box().y2 -
                     this._panelItem.actor.get_allocation_box().y1) / 2) - Math.round(tooltipHeight / 2);
-                tooltipLeft = tooltipLeft - tooltipWidth;
+                tooltipLeft = monitor.width - tooltipWidth - panelRight;
                 break;
             default:
                 break;


### PR DESCRIPTION
Hi,

Fixes #7267 & #7266 
Complements #7325

A similar problem to that addressed in #7325 affects tooltip positions in panels with a border.
e.g. 
![screenshot from 2018-03-23 10-55-55](https://user-images.githubusercontent.com/29017677/37826295-b8a0fc16-2e8a-11e8-9441-fe9cfbc57b84.png)

This commit changes the calculation of the tooltip vertical position to be based on the panel height for horizontal panels, and panel width for vertical panels. A one pixel buffer is added to ensure that there is some separation between a panel with borders and a tooltip with borders.

After - 
![screenshot from 2018-03-23 10-56-56](https://user-images.githubusercontent.com/29017677/37826384-21c32b7e-2e8b-11e8-9a31-3e05c2fe9807.png)

Please be gentle if I've done anything really stupid in the JS - it's been a number of years since I've done any JS work and I am an amateur by any definition of the word.