### PR TITLE
Applets, desklets: switch to class syntax, remove try-catch blocks

### DIFF
--- a/files/usr/share/cinnamon/applets/a11y@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/a11y@cinnamon.org/applet.js
@@ -24,11 +24,11 @@ const HIGH_CONTRAST_THEME = 'HighContrast';
 
 const Keymap = Gdk.Keymap.get_default();
 
-function MyApplet(metadata, orientation, panel_height, applet_id) {
+function CinnamonA11YApplet(metadata, orientation, panel_height, applet_id) {
     this._init(metadata, orientation, panel_height, applet_id);
 }
 
-MyApplet.prototype = {
+CinnamonA11YApplet.prototype = {
     __proto__: Applet.TextIconApplet.prototype,
 
     _init: function(metadata, orientation, panel_height, instance_id) {
@@ -229,6 +229,5 @@ MyApplet.prototype = {
 };
 
 function main(metadata, orientation, panel_height, instance_id) {
-    let myApplet = new MyApplet(metadata, orientation, panel_height, instance_id);
-    return myApplet;
+    return new CinnamonA11YApplet(metadata, orientation, panel_height, instance_id);
 }

--- a/files/usr/share/cinnamon/applets/a11y@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/a11y@cinnamon.org/applet.js
@@ -24,15 +24,9 @@ const HIGH_CONTRAST_THEME = 'HighContrast';
 
 const Keymap = Gdk.Keymap.get_default();
 
-function CinnamonA11YApplet(metadata, orientation, panel_height, applet_id) {
-    this._init(metadata, orientation, panel_height, applet_id);
-}
-
-CinnamonA11YApplet.prototype = {
-    __proto__: Applet.TextIconApplet.prototype,
-
-    _init: function(metadata, orientation, panel_height, instance_id) {
-        Applet.TextIconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
+class CinnamonA11YApplet extends Applet.TextIconApplet {
+    constructor(metadata, orientation, panel_height, instance_id) {
+        super(orientation, panel_height, instance_id);
 
         this.setAllowedLayout(Applet.AllowedLayout.BOTH);
 
@@ -90,9 +84,9 @@ CinnamonA11YApplet.prototype = {
         catch (e) {
             global.logError(e);
         }
-    },
+    }
 
-    _handleStateChange: function(actor, event) {
+    _handleStateChange(actor, event) {
         if (this.a11y_settings.get_boolean(KEY_STICKY_KEYS_ENABLED)) {
             let state = Keymap.get_modifier_state();
             let modifiers = [];
@@ -126,18 +120,18 @@ CinnamonA11YApplet.prototype = {
         } else {
             this.reset_tooltip();
         }
-    },
+    }
 
-    on_applet_clicked: function(event) {
+    on_applet_clicked(event) {
         this.menu.toggle();
-    },
+    }
 
-    reset_tooltip: function () {
+    reset_tooltip () {
         this.set_applet_tooltip(_("Accessibility"));
         this._applet_tooltip.hide();
-    },
+    }
 
-    _buildItemExtended: function(string, initial_value, writable, on_set) {
+    _buildItemExtended(string, initial_value, writable, on_set) {
         let widget = new PopupMenu.PopupSwitchMenuItem(string, initial_value);
         if (!writable)
             widget.actor.reactive = false;
@@ -146,9 +140,9 @@ CinnamonA11YApplet.prototype = {
                 on_set(item.state);
             });
         return widget;
-    },
+    }
 
-    _buildItem: function(string, schema, key) {
+    _buildItem(string, schema, key) {
         let settings = new Gio.Settings({ schema_id: schema });
         let widget = this._buildItemExtended(string,
             settings.get_boolean(key),
@@ -160,9 +154,9 @@ CinnamonA11YApplet.prototype = {
             widget.setToggleState(settings.get_boolean(key));
         });
         return widget;
-    },
+    }
 
-    _buildHCItem: function() {
+    _buildHCItem() {
         let settings = new Gio.Settings({ schema_id: DESKTOP_INTERFACE_SCHEMA });
         let gtkTheme = settings.get_string(KEY_GTK_THEME);
         let iconTheme = settings.get_string(KEY_ICON_THEME);
@@ -198,9 +192,9 @@ CinnamonA11YApplet.prototype = {
                 iconTheme = value;
         });
         return highContrast;
-    },
+    }
 
-    _buildFontItem: function() {
+    _buildFontItem() {
         let settings = new Gio.Settings({ schema_id: DESKTOP_INTERFACE_SCHEMA });
 
         let factor = settings.get_double(KEY_TEXT_SCALING_FACTOR);
@@ -221,12 +215,12 @@ CinnamonA11YApplet.prototype = {
             widget.setToggleState(active);
         });
         return widget;
-    },
+    }
 
-    on_applet_removed_from_panel: function() {
+    on_applet_removed_from_panel() {
         Main.systrayManager.unregisterRole("a11y", this.metadata.uuid);
     }
-};
+}
 
 function main(metadata, orientation, panel_height, instance_id) {
     return new CinnamonA11YApplet(metadata, orientation, panel_height, instance_id);

--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
@@ -32,11 +32,11 @@ function _onVertSepRepaint (area)
     cr.$dispose();
 };
 
-function MyApplet(orientation, panel_height, instance_id) {
+function CinnamonCalendarApplet(orientation, panel_height, instance_id) {
     this._init(orientation, panel_height, instance_id);
 }
 
-MyApplet.prototype = {
+CinnamonCalendarApplet.prototype = {
     __proto__: Applet.TextApplet.prototype,
 
     _init: function(orientation, panel_height, instance_id) {
@@ -214,6 +214,5 @@ MyApplet.prototype = {
 };
 
 function main(metadata, orientation, panel_height, instance_id) {
-    let myApplet = new MyApplet(orientation, panel_height, instance_id);
-    return myApplet;
+    return new CinnamonCalendarApplet(orientation, panel_height, instance_id);
 }

--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
@@ -7,7 +7,7 @@ const Util = imports.misc.util;
 const PopupMenu = imports.ui.popupMenu;
 const UPowerGlib = imports.gi.UPowerGlib;
 const Settings = imports.ui.settings;
-const Calendar = imports.applets['calendar@cinnamon.org'].calendar;
+const Calendar = require('./calendar');
 const CinnamonDesktop = imports.gi.CinnamonDesktop;
 
 String.prototype.capitalize = function() {
@@ -32,15 +32,9 @@ function _onVertSepRepaint (area)
     cr.$dispose();
 };
 
-function CinnamonCalendarApplet(orientation, panel_height, instance_id) {
-    this._init(orientation, panel_height, instance_id);
-}
-
-CinnamonCalendarApplet.prototype = {
-    __proto__: Applet.TextApplet.prototype,
-
-    _init: function(orientation, panel_height, instance_id) {
-        Applet.TextApplet.prototype._init.call(this, orientation, panel_height, instance_id);
+class CinnamonCalendarApplet extends Applet.TextApplet {
+    constructor(orientation, panel_height, instance_id) {
+        super(orientation, panel_height, instance_id);
 
         this.setAllowedLayout(Applet.AllowedLayout.BOTH);
 
@@ -98,31 +92,31 @@ CinnamonCalendarApplet.prototype = {
         catch (e) {
             global.logError(e);
         }
-    },
+    }
 
-    _clockNotify: function(obj, pspec, data) {
+    _clockNotify(obj, pspec, data) {
         this._updateClockAndDate();
-    },
+    }
 
-    on_applet_clicked: function(event) {
+    on_applet_clicked(event) {
         this.menu.toggle();
-    },
+    }
 
-    _onSettingsChanged: function() {
+    _onSettingsChanged() {
         this._updateFormatString();
         this._updateClockAndDate();
-    },
+    }
 
-    on_custom_format_button_pressed: function() {
+    on_custom_format_button_pressed() {
         Util.spawnCommandLine("xdg-open http://www.foragoodstrftime.com/");
-    },
+    }
 
-    _onLaunchSettings: function() {
+    _onLaunchSettings() {
         this.menu.close();
         Util.spawnCommandLine("cinnamon-settings calendar");
-    },
+    }
 
-    _updateFormatString: function() {
+    _updateFormatString() {
         let in_vertical_panel = (this.orientation == St.Side.LEFT || this.orientation == St.Side.RIGHT);
 
         if (this.use_custom_format) {
@@ -150,9 +144,9 @@ CinnamonCalendarApplet.prototype = {
         } else {
             this.clock.set_format_string(null);
         }
-    },
+    }
 
-    _updateClockAndDate: function() {
+    _updateClockAndDate() {
         let label_string = this.clock.get_clock();
 
         if (!this.use_custom_format) {
@@ -167,9 +161,9 @@ CinnamonCalendarApplet.prototype = {
 
         this._date.set_text(dateFormattedFull);
         this.set_applet_tooltip(dateFormattedFull);
-    },
+    }
 
-    on_applet_added_to_panel: function() {
+    on_applet_added_to_panel() {
         this._onSettingsChanged();
 
         if (this.clock_notify_id == 0) {
@@ -178,16 +172,16 @@ CinnamonCalendarApplet.prototype = {
 
         /* Populates the calendar so our menu allocation is correct for animation */
         this._updateCalendar();
-    },
+    }
 
-    on_applet_removed_from_panel: function() {
+    on_applet_removed_from_panel() {
         if (this.clock_notify_id > 0) {
             this.clock.disconnect(this.clock_notify_id);
             this.clock_notify_id = 0;
         }
-    },
+    }
 
-    _initContextMenu: function () {
+    _initContextMenu () {
         this.menu = new Applet.AppletPopupMenu(this, this.orientation);
         this.menuManager.addMenu(this.menu);
 
@@ -197,21 +191,20 @@ CinnamonCalendarApplet.prototype = {
                 this._updateCalendar();
             }
         }));
-    },
+    }
 
-    _updateCalendar: function () {
+    _updateCalendar () {
         let now = new Date();
 
         this._calendar.setDate(now, true);
-    },
+    }
 
-    on_orientation_changed: function (orientation) {
+    on_orientation_changed (orientation) {
         this.orientation = orientation;
         this.menu.setOrientation(orientation);
         this._onSettingsChanged();
     }
-
-};
+}
 
 function main(metadata, orientation, panel_height, instance_id) {
     return new CinnamonCalendarApplet(orientation, panel_height, instance_id);

--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/calendar.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/calendar.js
@@ -109,18 +109,14 @@ function _getCalendarDayAbbreviation(dayNumber) {
 
 // Abstraction for an appointment/event in a calendar
 
-function CalendarEvent(date, end, summary, allDay) {
-    this._init(date, end, summary, allDay);
-}
-
-CalendarEvent.prototype = {
-    _init: function(date, end, summary, allDay) {
+class CalendarEvent {
+    constructor(date, end, summary, allDay) {
         this.date = date;
         this.end = end;
         this.summary = summary;
         this.allDay = allDay;
     }
-};
+}
 
 function _datesEqual(a, b) {
     if (a < b)
@@ -140,12 +136,8 @@ function _dateIntervalsOverlap(a0, a1, b0, b1)
         return true;
 }
 
-function Calendar(settings) {
-    this._init(settings);
-}
-
-Calendar.prototype = {
-    _init: function(settings) {
+class Calendar {
+    constructor(settings) {
         this._weekStart = Cinnamon.util_get_week_start();
         this._weekdate = NaN;
         this._digitWidth = NaN;
@@ -182,16 +174,16 @@ Calendar.prototype = {
                            Lang.bind(this, this._onScroll));
 
         this._buildHeader ();
-    },
+    }
 
-    _onSettingsChange: function(object, key, old_val, new_val) {
+    _onSettingsChange(object, key, old_val, new_val) {
         if (key == FIRST_WEEKDAY_KEY) this._weekStart = Cinnamon.util_get_week_start();
         this._buildHeader();
         this._update(false);
-    },
+    }
 
     // Sets the calendar to show a specific date
-    setDate: function(date, forceReload) {
+    setDate(date, forceReload) {
         if (!_sameDay(date, this._selectedDate)) {
             this._selectedDate = date;
             this._update(forceReload);
@@ -200,9 +192,9 @@ Calendar.prototype = {
             if (forceReload)
                 this._update(forceReload);
         }
-    },
+    }
 
-    _buildHeader: function() {
+    _buildHeader() {
         let offsetCols = this.show_week_numbers ? 1 : 0;
         this.actor.destroy_all_children();
 
@@ -269,21 +261,21 @@ Calendar.prototype = {
 
         // All the children after this are days, and get removed when we update the calendar
         this._firstDayIndex = this.actor.get_n_children();
-    },
+    }
 
-    _onStyleChange: function(actor, event) {
+    _onStyleChange(actor, event) {
         // width of a digit in pango units
         this._digitWidth = _getDigitWidth(this.actor) / Pango.SCALE;
         this._setWeekdateHeaderWidth();
-    },
+    }
 
-    _setWeekdateHeaderWidth: function() {
-        if (this._digitWidth != NaN && this.show_week_numbers && this._weekdateHeader) {
+    _setWeekdateHeaderWidth() {
+        if (!isNaN(this._digitWidth) && this.show_week_numbers && this._weekdateHeader) {
             this._weekdateHeader.set_width (this._digitWidth * WEEKDATE_HEADER_WIDTH_DIGITS);
         }
-    },
+    }
 
-    _onScroll : function(actor, event) {
+    _onScroll (actor, event) {
         switch (event.get_scroll_direction()) {
         case Clutter.ScrollDirection.UP:
         case Clutter.ScrollDirection.LEFT:
@@ -294,9 +286,9 @@ Calendar.prototype = {
             this._onNextMonthButtonClicked();
             break;
         }
-    },
+    }
 
-    _applyDateBrowseAction: function(yearChange, monthChange) {
+    _applyDateBrowseAction(yearChange, monthChange) {
         let oldDate = this._selectedDate;
         let newMonth = oldDate.getMonth() + monthChange;
 
@@ -318,25 +310,25 @@ Calendar.prototype = {
         let newDate = new Date();
         newDate.setFullYear(newYear, newMonth, newDayOfMonth);
         this.setDate(newDate, false);
-    },
+    }
 
-    _onPrevYearButtonClicked: function() {
+    _onPrevYearButtonClicked() {
         this._applyDateBrowseAction(-1, 0);
-    },
+    }
 
-    _onNextYearButtonClicked: function() {
+    _onNextYearButtonClicked() {
         this._applyDateBrowseAction(+1, 0);
-    },
+    }
 
-    _onPrevMonthButtonClicked: function() {
+    _onPrevMonthButtonClicked() {
         this._applyDateBrowseAction(0, -1);
-    },
+    }
 
-    _onNextMonthButtonClicked: function() {
+    _onNextMonthButtonClicked() {
         this._applyDateBrowseAction(0, +1);
-    },
+    }
 
-    _update: function(forceReload) {
+    _update(forceReload) {
         let now = new Date();
 
         this._monthLabel.text = this._selectedDate.toLocaleFormat('%OB').capitalize();
@@ -404,7 +396,7 @@ Calendar.prototype = {
             iter.setTime(iter.getTime() + MSECS_IN_DAY);
             if (iter.getDay() == this._weekStart) {
                 row++;
-                // We always stop after placing 6 rows, even if month fits in 4 
+                // We always stop after placing 6 rows, even if month fits in 4
                 // to prevent issues with jumping controls, see #226
                 if (row > 7) {
                     break;
@@ -412,7 +404,7 @@ Calendar.prototype = {
             }
         }
     }
-};
+}
 
 Signals.addSignalMethods(Calendar.prototype);
 

--- a/files/usr/share/cinnamon/applets/expo@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/expo@cinnamon.org/applet.js
@@ -3,11 +3,11 @@ const Lang = imports.lang;
 const Main = imports.ui.main;
 const Settings = imports.ui.settings;
 
-function MyApplet(metadata, orientation, panel_height, instance_id) {
+function CinnamonExpoApplet(metadata, orientation, panel_height, instance_id) {
     this._init(metadata, orientation, panel_height, instance_id);
 }
 
-MyApplet.prototype = {
+CinnamonExpoApplet.prototype = {
     __proto__: Applet.IconApplet.prototype,
 
     _init: function(metadata, orientation, panel_height, instance_id) {
@@ -48,6 +48,5 @@ MyApplet.prototype = {
 };
 
 function main(metadata, orientation, panel_height, instance_id) {
-    let myApplet = new MyApplet(metadata, orientation, panel_height, instance_id);
-    return myApplet;
+    return new CinnamonExpoApplet(metadata, orientation, panel_height, instance_id);
 }

--- a/files/usr/share/cinnamon/applets/expo@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/expo@cinnamon.org/applet.js
@@ -3,15 +3,9 @@ const Lang = imports.lang;
 const Main = imports.ui.main;
 const Settings = imports.ui.settings;
 
-function CinnamonExpoApplet(metadata, orientation, panel_height, instance_id) {
-    this._init(metadata, orientation, panel_height, instance_id);
-}
-
-CinnamonExpoApplet.prototype = {
-    __proto__: Applet.IconApplet.prototype,
-
-    _init: function(metadata, orientation, panel_height, instance_id) {
-        Applet.IconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
+class CinnamonExpoApplet extends Applet.IconApplet {
+    constructor(metadata, orientation, panel_height, instance_id) {
+        super(orientation, panel_height, instance_id);
 
         try {
             this.set_applet_icon_symbolic_name("cinnamon-expo");
@@ -27,25 +21,25 @@ CinnamonExpoApplet.prototype = {
         catch (e) {
             global.logError(e);
         }
-    },
+    }
 
-    on_applet_clicked: function(event) {
+    on_applet_clicked(event) {
         if (this._hover_activates)
             return;
         this.doAction();
-    },
+    }
 
-    _onEntered: function(event) {
+    _onEntered(event) {
         if (!this._hover_activates || global.settings.get_boolean("panel-edit-mode"))
             return;
         this.doAction();
-    },
+    }
 
-    doAction: function() {
+    doAction() {
         if (!Main.expo.animationInProgress)
             Main.expo.toggle();
     }
-};
+}
 
 function main(metadata, orientation, panel_height, instance_id) {
     return new CinnamonExpoApplet(metadata, orientation, panel_height, instance_id);

--- a/files/usr/share/cinnamon/applets/inhibit@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/inhibit@cinnamon.org/applet.js
@@ -120,12 +120,12 @@ InhibitSwitch.prototype = {
     }
 };
 
-function MyApplet(metadata, orientation, panel_height, instanceId) {
+function CinnamonInhibitApplet(metadata, orientation, panel_height, instanceId) {
     this._init(metadata, orientation, panel_height, instanceId);
 }
 
 
-MyApplet.prototype = {
+CinnamonInhibitApplet.prototype = {
     __proto__: Applet.IconApplet.prototype,
 
     _init: function(metadata, orientation, panel_height, instanceId) {
@@ -166,6 +166,5 @@ MyApplet.prototype = {
 };
 
 function main(metadata, orientation, panel_height, instanceId) {
-    let myApplet = new MyApplet(metadata, orientation, panel_height, instanceId);
-    return myApplet;
+    return new CinnamonInhibitApplet(metadata, orientation, panel_height, instanceId);
 }

--- a/files/usr/share/cinnamon/applets/inhibit@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/inhibit@cinnamon.org/applet.js
@@ -9,18 +9,10 @@ const GnomeSession = imports.misc.gnomeSession;
 const INHIBIT_IDLE_FLAG = 8;
 const INHIBIT_SLEEP_FLAG = 4;
 
-function InhibitSwitch(applet) {
-    this._init(applet);
-}
-
-InhibitSwitch.prototype = {
-    __proto__: PopupMenu.PopupBaseMenuItem.prototype,
-
-    _init: function(applet) {
-
+class InhibitSwitch extends PopupMenu.PopupBaseMenuItem {
+    constructor(applet) {
+        super();
         this._applet = applet;
-
-        PopupMenu.PopupBaseMenuItem.prototype._init.call(this);
 
         this.label = new St.Label({ text: _("Power management") });
 
@@ -56,9 +48,9 @@ InhibitSwitch.prototype = {
             this.propId = this.sessionProxy.connect("g-properties-changed",
                                                     Lang.bind(this, this.updateStatus));
         }));
-    },
+    }
 
-    activate: function(event) {
+    activate(event) {
         if (this._switch.actor.mapped) {
             this._switch.toggle();
         }
@@ -66,9 +58,9 @@ InhibitSwitch.prototype = {
         this.toggled(this._switch.state);
 
         PopupMenu.PopupBaseMenuItem.prototype.activate.call(this, event, true);
-    },
+    }
 
-    updateStatus: function(o) {
+    updateStatus(o) {
         let current_state = this.sessionProxy.InhibitedActions;
 
         if (current_state & INHIBIT_IDLE_FLAG ||
@@ -88,9 +80,9 @@ InhibitSwitch.prototype = {
             this.tooltip.set_text("");
             this._statusIcon.set_opacity(0);
         }
-    },
+    }
 
-    toggled: function(active) {
+    toggled(active) {
         if (!active && !this.sessionCookie) {
             this.sessionProxy.InhibitRemote("inhibit@cinnamon.org",
                                             0,
@@ -105,9 +97,9 @@ InhibitSwitch.prototype = {
             this.sessionCookie = null;
             this.updateStatus();
         }
-    },
+    }
 
-    kill: function() {
+    kill() {
         if (!this.sessionProxy)
             return;
 
@@ -118,18 +110,11 @@ InhibitSwitch.prototype = {
 
         this.sessionProxy.disconnect(this.propId);
     }
-};
-
-function CinnamonInhibitApplet(metadata, orientation, panel_height, instanceId) {
-    this._init(metadata, orientation, panel_height, instanceId);
 }
 
-
-CinnamonInhibitApplet.prototype = {
-    __proto__: Applet.IconApplet.prototype,
-
-    _init: function(metadata, orientation, panel_height, instanceId) {
-        Applet.IconApplet.prototype._init.call(this, orientation, panel_height, instanceId);
+class CinnamonInhibitApplet extends Applet.IconApplet {
+    constructor(metadata, orientation, panel_height, instanceId) {
+        super(orientation, panel_height, instanceId);
 
         this.metadata = metadata;
 
@@ -154,16 +139,16 @@ CinnamonInhibitApplet.prototype = {
         }));
 
         this.menu.addMenuItem(this.notificationsSwitch);
-    },
+    }
 
-    on_applet_clicked: function(event) {
+    on_applet_clicked(event) {
         this.menu.toggle();
-    },
+    }
 
-    on_applet_removed_from_panel: function() {
+    on_applet_removed_from_panel() {
         this.inhibitSwitch.kill();
     }
-};
+}
 
 function main(metadata, orientation, panel_height, instanceId) {
     return new CinnamonInhibitApplet(metadata, orientation, panel_height, instanceId);

--- a/files/usr/share/cinnamon/applets/keyboard@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/keyboard@cinnamon.org/applet.js
@@ -11,12 +11,8 @@ const Cairo = imports.cairo;
 
 const PANEL_EDIT_MODE_KEY = "panel-edit-mode";
 
-function EmblemedIcon() {
-    this._init.apply(this, arguments);
-}
-
-EmblemedIcon.prototype = {
-    _init: function(path, id, style_class) {
+class EmblemedIcon {
+    constructor(path, id, style_class) {
         this.path = path;
         this.id = id;
 
@@ -24,15 +20,15 @@ EmblemedIcon.prototype = {
 
         this.actor.connect("style-changed", Lang.bind(this, this._style_changed));
         this.actor.connect("repaint", Lang.bind(this, this._repaint));
-    },
+    }
 
-    _style_changed: function(actor) {
+    _style_changed(actor) {
         let icon_size = 0.5 + this.actor.get_theme_node().get_length("icon-size");
 
         this.actor.natural_width = this.actor.natural_height = icon_size;
-    },
+    }
 
-    _repaint: function(actor) {
+    _repaint(actor) {
         let cr = actor.get_context();
         let [w, h] = actor.get_surface_size();
 
@@ -77,34 +73,28 @@ EmblemedIcon.prototype = {
                                                         this.id);
 
         cr.$dispose();
-    },
+    }
 
     /* Monkey patch St.Icon functions used in js/ui/applet.js IconApplet so
        we can use its _setStyle() function for figuring out how big we should
        be
      */
-    get_icon_type: function() {
+    get_icon_type() {
         return St.IconType.FULLCOLOR;
-    },
+    }
 
-    set_icon_size: function(size) {
+    set_icon_size(size) {
         this.actor.width = this.actor.height = size;
-    },
+    }
 
-    set_style_class_name: function(name) {
+    set_style_class_name(name) {
         return;
     }
-};
-
-function LayoutMenuItem() {
-    this._init.apply(this, arguments);
 }
 
-LayoutMenuItem.prototype = {
-    __proto__: PopupMenu.PopupBaseMenuItem.prototype,
-
-    _init: function(config, id, indicator, long_name) {
-        PopupMenu.PopupBaseMenuItem.prototype._init.call(this);
+class LayoutMenuItem extends PopupMenu.PopupBaseMenuItem {
+    constructor(config, id, indicator, long_name) {
+        super();
 
         this._config = config;
         this._id = id;
@@ -112,23 +102,17 @@ LayoutMenuItem.prototype = {
         this.indicator = indicator;
         this.addActor(this.label);
         this.addActor(this.indicator);
-    },
+    }
 
-    activate: function(event) {
+    activate(event) {
         PopupMenu.PopupBaseMenuItem.prototype.activate.call(this);
         this._config.set_current_group(this._id);
     }
-};
-
-function MyApplet(metadata, orientation, panel_height, instance_id) {
-    this._init(metadata, orientation, panel_height, instance_id);
 }
 
-MyApplet.prototype = {
-    __proto__: Applet.TextIconApplet.prototype,
-
-    _init: function(metadata, orientation, panel_height, instance_id) {
-        Applet.TextIconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
+class CinnamonKeyboardApplet extends Applet.TextIconApplet {
+    constructor(metadata, orientation, panel_height, instance_id) {
+        super(orientation, panel_height, instance_id);
 
         this.setAllowedLayout(Applet.AllowedLayout.BOTH);
 
@@ -169,9 +153,9 @@ MyApplet.prototype = {
         catch (e) {
             global.logError(e);
         }
-    },
+    }
 
-    _onPanelEditModeChanged: function() {
+    _onPanelEditModeChanged() {
         if (global.settings.get_boolean(PANEL_EDIT_MODE_KEY)) {
             if (!this.actor.visible) {
                 this.set_applet_icon_symbolic_name("input-keyboard");
@@ -181,9 +165,9 @@ MyApplet.prototype = {
         else {
             this._syncConfig();
         }
-    },
+    }
 
-    on_applet_added_to_panel: function() {
+    on_applet_added_to_panel() {
         this._config = new XApp.KbdLayoutController();
 
         if (global.settings.get_boolean(PANEL_EDIT_MODE_KEY)) {
@@ -195,13 +179,13 @@ MyApplet.prototype = {
 
         this._config.connect('layout-changed', Lang.bind(this, this._syncGroup));
         this._config.connect('config-changed', Lang.bind(this, this._syncConfig));
-    },
+    }
 
-    on_applet_clicked: function(event) {
+    on_applet_clicked(event) {
         this.menu.toggle();
-    },
+    }
 
-    _syncConfig: function() {
+    _syncConfig() {
         for (let i = 0; i < this._layoutItems.length; i++)
             this._layoutItems[i].destroy();
 
@@ -256,9 +240,9 @@ MyApplet.prototype = {
         }
 
         Mainloop.idle_add(Lang.bind(this, this._syncGroup));
-    },
+    }
 
-    _syncGroup: function() {
+    _syncGroup() {
         let selected = this._config.get_current_group();
 
         if (this._selectedLayout) {
@@ -307,14 +291,13 @@ MyApplet.prototype = {
             this.set_applet_label(name);
             this._applet_icon_box.hide();
         }
-    },
+    }
 
-    on_applet_removed_from_panel: function() {
+    on_applet_removed_from_panel() {
         Main.systrayManager.unregisterRole("keyboard", this.metadata.uuid);
     }
 };
 
 function main(metadata, orientation, panel_height, instance_id) {
-    let myApplet = new MyApplet(metadata, orientation, panel_height, instance_id);
-    return myApplet;
+    return new CinnamonKeyboardApplet(metadata, orientation, panel_height, instance_id);
 }

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -52,65 +52,55 @@ let appsys = Cinnamon.AppSystem.get_default();
  * want to use it.
  */
 
-function VisibleChildIterator(container) {
-    this._init(container);
-}
-
-VisibleChildIterator.prototype = {
-    _init: function(container) {
+class VisibleChildIterator {
+    constructor(container) {
         this.container = container;
         this.reloadVisible();
-    },
+    }
 
-    reloadVisible: function() {
+    reloadVisible() {
         this.array = this.container.get_focus_chain()
             .filter(x => !(x._delegate instanceof PopupMenu.PopupSeparatorMenuItem));
-    },
+    }
 
-    getNextVisible: function(curChild) {
+    getNextVisible(curChild) {
         return this.getVisibleItem(this.array.indexOf(curChild) + 1);
-    },
+    }
 
-    getPrevVisible: function(curChild) {
+    getPrevVisible(curChild) {
         return this.getVisibleItem(this.array.indexOf(curChild) - 1);
-    },
+    }
 
-    getFirstVisible: function() {
+    getFirstVisible() {
         return this.array[0];
-    },
+    }
 
-    getLastVisible: function() {
+    getLastVisible() {
         return this.array[this.array.length - 1];
-    },
+    }
 
-    getVisibleIndex: function(curChild) {
+    getVisibleIndex(curChild) {
         return this.array.indexOf(curChild);
-    },
+    }
 
-    getVisibleItem: function(index) {
+    getVisibleItem(index) {
         let len = this.array.length;
         index = ((index % len) + len) % len;
         return this.array[index];
-    },
+    }
 
-    getNumVisibleChildren: function() {
+    getNumVisibleChildren() {
         return this.array.length;
-    },
+    }
 
-    getAbsoluteIndexOfChild: function(child) {
+    getAbsoluteIndexOfChild(child) {
         return this.container.get_children().indexOf(child);
     }
-};
-
-function ApplicationContextMenuItem(appButton, label, action, iconName) {
-    this._init(appButton, label, action, iconName);
 }
 
-ApplicationContextMenuItem.prototype = {
-    __proto__: PopupMenu.PopupBaseMenuItem.prototype,
-
-    _init: function (appButton, label, action, iconName) {
-        PopupMenu.PopupBaseMenuItem.prototype._init.call(this, {focusOnHover: false});
+class ApplicationContextMenuItem extends PopupMenu.PopupBaseMenuItem {
+    constructor(appButton, label, action, iconName) {
+        super({focusOnHover: false});
 
         this._appButton = appButton;
         this._action = action;
@@ -125,9 +115,9 @@ ApplicationContextMenuItem.prototype = {
         }
 
         this.addActor(this.label);
-    },
+    }
 
-    activate: function (event) {
+    activate (event) {
         switch (this._action){
             case "add_to_panel": {
                 if (!Main.AppletManager.get_role_provider_exists(Main.AppletManager.Roles.PANEL_LAUNCHER)) {
@@ -175,19 +165,13 @@ ApplicationContextMenuItem.prototype = {
         return false;
     }
 
-};
-
-function GenericApplicationButton(appsMenuButton, app) {
-    this._init(appsMenuButton, app);
 }
 
-GenericApplicationButton.prototype = {
-    __proto__: PopupMenu.PopupBaseMenuItem.prototype,
-
-    _init: function(appsMenuButton, app, withMenu) {
+class GenericApplicationButton extends PopupMenu.PopupBaseMenuItem {
+    constructor(appsMenuButton, app, withMenu) {
+        super({hover: false});
         this.app = app;
         this.appsMenuButton = appsMenuButton;
-        PopupMenu.PopupBaseMenuItem.prototype._init.call(this, {hover: false});
 
         this.withMenu = withMenu;
         if (this.withMenu){
@@ -195,22 +179,22 @@ GenericApplicationButton.prototype = {
             this.menu.actor.set_style_class_name('menu-context-menu');
             this.menu.connect('open-state-changed', Lang.bind(this, this._subMenuOpenStateChanged));
         }
-    },
+    }
 
-    highlight: function() {
+    highlight() {
         this.actor.add_style_pseudo_class('highlighted');
-    },
+    }
 
-    unhighlight: function() {
+    unhighlight() {
         var app_key = this.app.get_id();
         if (app_key == null) {
             app_key = this.app.get_name() + ":" + this.app.get_description();
         }
         this.appsMenuButton._knownApps.push(app_key);
         this.actor.remove_style_pseudo_class('highlighted');
-    },
+    }
 
-    _onButtonReleaseEvent: function (actor, event) {
+    _onButtonReleaseEvent(actor, event) {
         if (event.get_button()==1){
             this.activate(event);
         }
@@ -218,25 +202,25 @@ GenericApplicationButton.prototype = {
             this.activateContextMenus(event);
         }
         return true;
-    },
+    }
 
-    activate: function(event) {
+    activate(event) {
         this.unhighlight();
         this.app.open_new_window(-1);
         this.appsMenuButton.menu.close();
-    },
+    }
 
-    activateContextMenus: function(event) {
+    activateContextMenus(event) {
         if (this.withMenu && !this.menu.isOpen)
             this.appsMenuButton.closeContextMenus(this.app, true);
         this.toggleMenu();
-    },
+    }
 
-    closeMenu: function() {
+    closeMenu() {
         if (this.withMenu) this.menu.close();
-    },
+    }
 
-    toggleMenu: function() {
+    toggleMenu() {
         if (!this.withMenu) return;
 
         if (!this.menu.isOpen){
@@ -268,9 +252,9 @@ GenericApplicationButton.prototype = {
             }
         }
         this.menu.toggle();
-    },
+    }
 
-    _subMenuOpenStateChanged: function() {
+    _subMenuOpenStateChanged() {
         if (this.menu.isOpen) {
             this.appsMenuButton._activeContextMenuParent = this;
             this.appsMenuButton._scrollToButton(this.menu);
@@ -278,13 +262,13 @@ GenericApplicationButton.prototype = {
             this.appsMenuButton._activeContextMenuItem = null;
             this.appsMenuButton._activeContextMenuParent = null;
         }
-    },
+    }
 
     get _contextIsOpen() {
         return this.menu.isOpen;
-    },
+    }
 
-    destroy: function() {
+    destroy() {
         this.label.destroy();
 
         if (this.icon) {
@@ -299,14 +283,9 @@ GenericApplicationButton.prototype = {
     }
 };
 
-function TransientButton(appsMenuButton, pathOrCommand) {
-    this._init(appsMenuButton, pathOrCommand);
-}
-
-TransientButton.prototype = {
-    __proto__: PopupMenu.PopupSubMenuMenuItem.prototype,
-
-    _init: function(appsMenuButton, pathOrCommand) {
+class TransientButton extends PopupMenu.PopupBaseMenuItem {
+    constructor(appsMenuButton, pathOrCommand) {
+        super({hover: false});
         let displayPath = pathOrCommand;
         if (pathOrCommand.charAt(0) == '~') {
             pathOrCommand = pathOrCommand.slice(1);
@@ -326,23 +305,22 @@ TransientButton.prototype = {
         this.pathOrCommand = pathOrCommand;
 
         this.appsMenuButton = appsMenuButton;
-        PopupMenu.PopupBaseMenuItem.prototype._init.call(this, {hover: false});
 
         // We need this fake app to help appEnterEvent/appLeaveEvent
         // work with our search result.
         this.app = {
             get_app_info: {
-                get_filename: function() {
+                get_filename() {
                     return pathOrCommand;
                 }
             },
-            get_id: function() {
+            get_id() {
                 return -1;
             },
-            get_description: function() {
+            get_description() {
                 return this.pathOrCommand;
             },
-            get_name: function() {
+            get_name() {
                 return '';
             }
         };
@@ -372,16 +350,16 @@ TransientButton.prototype = {
         this.label.set_style(MAX_BUTTON_WIDTH);
         this.addActor(this.label);
         this.isDraggableApp = false;
-    },
+    }
 
-    _onButtonReleaseEvent: function (actor, event) {
+    _onButtonReleaseEvent (actor, event) {
         if (event.get_button()==1){
             this.activate(event);
         }
         return true;
-    },
+    }
 
-    activate: function(event) {
+    activate(event) {
         if (this.handler != null) {
             this.handler.launch([this.file], null);
         } else {
@@ -396,17 +374,11 @@ TransientButton.prototype = {
 
         this.appsMenuButton.menu.close();
     }
-};
-
-function ApplicationButton(appsMenuButton, app, showIcon) {
-    this._init(appsMenuButton, app, showIcon);
 }
 
-ApplicationButton.prototype = {
-    __proto__: GenericApplicationButton.prototype,
-
-    _init: function(appsMenuButton, app, showIcon) {
-        GenericApplicationButton.prototype._init.call(this, appsMenuButton, app, true);
+class ApplicationButton extends GenericApplicationButton {
+    constructor(appsMenuButton, app, showIcon) {
+        super(appsMenuButton, app, true);
         this.category = [];
         this.actor.set_style_class_name('menu-application-button');
 
@@ -427,13 +399,13 @@ ApplicationButton.prototype = {
             this.icon.realize();
         }
         this.label.realize();
-    },
+    }
 
-    get_app_id: function() {
+    get_app_id() {
         return this.app.get_id();
-    },
+    }
 
-    getDragActor: function() {
+    getDragActor() {
         let favorites = AppFavorites.getAppFavorites().getFavorites();
         let nbFavorites = favorites.length;
         let monitorHeight = Main.layoutManager.primaryMonitor.height;
@@ -442,49 +414,43 @@ ApplicationButton.prototype = {
         if (icon_size > MAX_FAV_ICON_SIZE)
             icon_size = MAX_FAV_ICON_SIZE;
         return this.app.create_icon_texture(icon_size);
-    },
+    }
 
     // Returns the original actor that should align with the actor
     // we show as the item is being dragged.
-    getDragActorSource: function() {
+    getDragActorSource() {
         return this.actor;
-    },
+    }
 
-    _onDragEnd: function() {
+    _onDragEnd() {
         this.appsMenuButton.favoritesBox._delegate._clearDragPlaceholder();
     }
-};
-
-function SearchProviderResultButton(appsMenuButton, provider, result) {
-    this._init(appsMenuButton, provider, result);
 }
 
-SearchProviderResultButton.prototype = {
-    __proto__: PopupMenu.PopupBaseMenuItem.prototype,
-
-    _init: function(appsMenuButton, provider, result) {
+class SearchProviderResultButton extends PopupMenu.PopupBaseMenuItem {
+    constructor(appsMenuButton, provider, result) {
+        super({hover: false});
         this.provider = provider;
         this.result = result;
 
         this.appsMenuButton = appsMenuButton;
-        PopupMenu.PopupBaseMenuItem.prototype._init.call(this, {hover: false});
         this.actor.set_style_class_name('menu-application-button');
 
         // We need this fake app to help appEnterEvent/appLeaveEvent
         // work with our search result.
         this.app = {
             get_app_info: {
-                get_filename: function() {
+                get_filename() {
                     return result.id;
                 }
             },
-            get_id: function() {
+            get_id() {
                 return -1;
             },
-            get_description: function() {
+            get_description() {
                 return result.description;
             },
-            get_name: function() {
+            get_name() {
                 return result.label;
             }
         };
@@ -508,16 +474,16 @@ SearchProviderResultButton.prototype = {
             this.icon.realize();
         }
         this.label.realize();
-    },
+    }
 
-    _onButtonReleaseEvent: function (actor, event) {
+    _onButtonReleaseEvent (actor, event) {
         if (event.get_button() == 1){
             this.activate(event);
         }
         return true;
-    },
+    }
 
-    activate: function(event) {
+    activate(event) {
         try{
             this.provider.on_result_selected(this.result);
             this.appsMenuButton.menu.close();
@@ -527,22 +493,17 @@ SearchProviderResultButton.prototype = {
             global.logError(e);
         }
     }
-};
-
-function PlaceButton(appsMenuButton, place, button_name, showIcon) {
-    this._init(appsMenuButton, place, button_name, showIcon);
 }
 
-PlaceButton.prototype = {
-    __proto__: PopupMenu.PopupBaseMenuItem.prototype,
-
-    _init: function(appsMenuButton, place, button_name, showIcon) {
-        PopupMenu.PopupBaseMenuItem.prototype._init.call(this, {hover: false});
+class PlaceButton extends PopupMenu.PopupBaseMenuItem {
+    constructor(appsMenuButton, place, button_name, showIcon) {
+        super({hover: false});
         this.appsMenuButton = appsMenuButton;
         this.place = place;
         this.button_name = button_name;
         this.actor.set_style_class_name('menu-application-button');
         this.actor._delegate = this;
+
         this.label = new St.Label({ text: this.button_name, style_class: 'menu-application-button-label' });
         this.label.clutter_text.ellipsize = Pango.EllipsizeMode.END;
         this.label.set_style(MAX_BUTTON_WIDTH);
@@ -557,30 +518,24 @@ PlaceButton.prototype = {
         if (showIcon)
             this.icon.realize();
         this.label.realize();
-    },
+    }
 
-    _onButtonReleaseEvent: function (actor, event) {
+    _onButtonReleaseEvent (actor, event) {
         if (event.get_button()==1){
             this.place.launch();
             this.appsMenuButton.menu.close();
         }
-    },
+    }
 
-    activate: function(event) {
+    activate(event) {
         this.place.launch();
         this.appsMenuButton.menu.close();
     }
-};
-
-function RecentContextMenuItem(recentButton, label, is_default, callback) {
-    this._init(recentButton, label, is_default, callback);
 }
 
-RecentContextMenuItem.prototype = {
-    __proto__: PopupMenu.PopupBaseMenuItem.prototype,
-
-    _init: function (recentButton, label, is_default, callback) {
-        PopupMenu.PopupBaseMenuItem.prototype._init.call(this, {focusOnHover: false});
+class RecentContextMenuItem extends PopupMenu.PopupBaseMenuItem {
+    constructor(recentButton, label, is_default, callback) {
+        super({focusOnHover: false});
 
         this._recentButton = recentButton;
         this._callback = callback;
@@ -589,23 +544,17 @@ RecentContextMenuItem.prototype = {
 
         if (is_default)
             this.label.style = "font-weight: bold;";
-    },
+    }
 
-    activate: function (event) {
+    activate (event) {
         this._callback();
         return false;
     }
-};
-
-function RecentButton(appsMenuButton, file, showIcon) {
-    this._init(appsMenuButton, file, showIcon);
 }
 
-RecentButton.prototype = {
-    __proto__: PopupMenu.PopupBaseMenuItem.prototype,
-
-    _init: function(appsMenuButton, file, showIcon) {
-        PopupMenu.PopupBaseMenuItem.prototype._init.call(this, {hover: false});
+class RecentButton extends PopupMenu.PopupBaseMenuItem {
+    constructor(appsMenuButton, file, showIcon) {
+        super({hover: false});
         this.mimeType = file.mimeType;
         this.uri = file.uri;
         this.uriDecoded = file.uriDecoded;
@@ -627,9 +576,9 @@ RecentButton.prototype = {
         if (showIcon)
             this.icon.realize();
         this.label.realize();
-    },
+    }
 
-    _onButtonReleaseEvent: function (actor, event) {
+    _onButtonReleaseEvent (actor, event) {
         if (event.get_button()==1){
             this.activate(event);
         }
@@ -637,9 +586,9 @@ RecentButton.prototype = {
             this.activateContextMenus(event);
         }
         return true;
-    },
+    }
 
-    activate: function(event) {
+    activate(event) {
         try {
             Gio.app_info_launch_default_for_uri(this.uri, global.create_app_launch_context());
             this.appsMenuButton.menu.close();
@@ -653,27 +602,27 @@ RecentButton.prototype = {
             notification.setUrgency(MessageTray.Urgency.NORMAL);
             source.notify(notification);
         }
-    },
+    }
 
-    activateContextMenus: function(event) {
+    activateContextMenus(event) {
         let menu = this.appsMenuButton.recentContextMenu;
 
         if (menu != null && menu.sourceActor._delegate != this)
             this.appsMenuButton.closeContextMenus(this, true);
 
         this.toggleMenu();
-    },
+    }
 
-    closeMenu: function() {
+    closeMenu() {
         this.menu = null;
         this.menu.close();
-    },
+    }
 
-    hasLocalPath: function(file) {
+    hasLocalPath(file) {
         return file.is_native() || file.get_path() != null;
-    },
+    }
 
-    toggleMenu: function() {
+    toggleMenu() {
         if (this.appsMenuButton.recentContextMenu == null) {
             this.appsMenuButton.createRecentContextMenu(this.actor);
         }
@@ -754,13 +703,13 @@ RecentButton.prototype = {
             }
         }
         this.appsMenuButton.recentContextMenu.toggle();
-    },
+    }
 
     get _contextIsOpen() {
         return this.menu != null && this.menu.isOpen;
-    },
+    }
 
-    destroy: function() {
+    destroy() {
         this.file = null;
         this.appsMenuButton = null;
         this.label.destroy();
@@ -768,18 +717,12 @@ RecentButton.prototype = {
             this.icon.destroy();
 
         PopupMenu.PopupBaseMenuItem.prototype.destroy.call(this);
-    },
-};
-
-function NoRecentDocsButton(label, icon, reactive, callback) {
-    this._init(label, icon, reactive, callback);
+    }
 }
 
-NoRecentDocsButton.prototype = {
-    __proto__: PopupMenu.PopupBaseMenuItem.prototype,
-
-    _init: function(label, icon, reactive, callback) {
-        PopupMenu.PopupBaseMenuItem.prototype._init.call(this, {hover: false});
+class NoRecentDocsButton extends PopupMenu.PopupBaseMenuItem {
+    constructor(label, icon, reactive, callback) {
+        super({hover: false});
         this.actor.set_style_class_name('menu-application-button');
         this.actor._delegate = this;
         this.button_name = "";
@@ -798,24 +741,18 @@ NoRecentDocsButton.prototype = {
 
         this.actor.reactive = reactive;
         this.callback = callback;
-    },
+    }
 
-    _onButtonReleaseEvent: function (actor, event) {
+    _onButtonReleaseEvent (actor, event) {
         if (event.get_button() == 1) {
             this.callback();
         }
     }
-};
-
-function RecentClearButton(appsMenuButton) {
-    this._init(appsMenuButton);
 }
 
-RecentClearButton.prototype = {
-    __proto__: PopupMenu.PopupBaseMenuItem.prototype,
-
-    _init: function(appsMenuButton) {
-        PopupMenu.PopupBaseMenuItem.prototype._init.call(this, {hover: false});
+class RecentClearButton extends PopupMenu.PopupBaseMenuItem {
+    constructor(appsMenuButton) {
+        super({hover: false});
         this.appsMenuButton = appsMenuButton;
         this.actor.set_style_class_name('menu-application-button');
         this.button_name = _("Clear list");
@@ -824,30 +761,24 @@ RecentClearButton.prototype = {
         this.icon = new St.Icon({ icon_name: 'edit-clear', icon_type: St.IconType.SYMBOLIC, icon_size: APPLICATION_ICON_SIZE });
         this.addActor(this.icon);
         this.addActor(this.label);
-    },
+    }
 
-    _onButtonReleaseEvent: function (actor, event) {
+    _onButtonReleaseEvent (actor, event) {
         if (event.get_button()==1){
             this.activate(event);
         }
-    },
+    }
 
-    activate: function(event) {
+    activate(event) {
         this.appsMenuButton.menu.close();
         let GtkRecent = new Gtk.RecentManager();
         GtkRecent.purge_items();
     }
-};
-
-function CategoryButton(app, showIcon) {
-    this._init(app, showIcon);
 }
 
-CategoryButton.prototype = {
-    __proto__: PopupMenu.PopupBaseMenuItem.prototype,
-
-    _init: function(category, showIcon) {
-        PopupMenu.PopupBaseMenuItem.prototype._init.call(this, {hover: false});
+class CategoryButton extends PopupMenu.PopupBaseMenuItem {
+    constructor(category, showIcon) {
+        super({hover: false});
 
         this.actor.set_style_class_name('menu-category-button');
         var label;
@@ -880,17 +811,11 @@ CategoryButton.prototype = {
         this.addActor(this.label);
         this.label.realize();
     }
-};
-
-function PlaceCategoryButton(app, showIcon) {
-    this._init(app, showIcon);
 }
 
-PlaceCategoryButton.prototype = {
-    __proto__: PopupMenu.PopupBaseMenuItem.prototype,
-
-    _init: function(category, showIcon) {
-        PopupMenu.PopupBaseMenuItem.prototype._init.call(this, {hover: false});
+class PlaceCategoryButton extends PopupMenu.PopupBaseMenuItem {
+    constructor(category, showIcon) {
+        super({hover: false});
         this.actor.set_style_class_name('menu-category-button');
         this.actor._delegate = this;
         this.label = new St.Label({ text: _("Places"), style_class: 'menu-category-button-label' });
@@ -904,17 +829,11 @@ PlaceCategoryButton.prototype = {
         this.addActor(this.label);
         this.label.realize();
     }
-};
-
-function RecentCategoryButton(app, showIcon) {
-    this._init(app, showIcon);
 }
 
-RecentCategoryButton.prototype = {
-    __proto__: PopupMenu.PopupBaseMenuItem.prototype,
-
-    _init: function(category, showIcon) {
-        PopupMenu.PopupBaseMenuItem.prototype._init.call(this, {hover: false});
+class RecentCategoryButton extends PopupMenu.PopupBaseMenuItem {
+    constructor(category, showIcon) {
+        super({hover: false});
         this.actor.set_style_class_name('menu-category-button');
         this.actor._delegate = this;
         this.label = new St.Label({ text: _("Recent Files"), style_class: 'menu-category-button-label' });
@@ -928,17 +847,11 @@ RecentCategoryButton.prototype = {
         this.addActor(this.label);
         this.label.realize();
     }
-};
-
-function FavoritesButton(appsMenuButton, app, nbFavorites) {
-    this._init(appsMenuButton, app, nbFavorites);
 }
 
-FavoritesButton.prototype = {
-    __proto__: GenericApplicationButton.prototype,
-
-    _init: function(appsMenuButton, app, nbFavorites) {
-        GenericApplicationButton.prototype._init.call(this, appsMenuButton, app);
+class FavoritesButton extends GenericApplicationButton {
+    constructor(appsMenuButton, app, nbFavorites) {
+        super(appsMenuButton, app);
         let monitorHeight = Main.layoutManager.primaryMonitor.height;
         let real_size = (0.7 * monitorHeight) / nbFavorites;
         let icon_size = 0.6 * real_size / global.ui_scale;
@@ -955,36 +868,30 @@ FavoritesButton.prototype = {
         this._draggable = DND.makeDraggable(this.actor);
         this._draggable.connect('drag-end', Lang.bind(this, this._onDragEnd));
         this.isDraggableApp = true;
-    },
+    }
 
-    _onDragEnd: function() {
+    _onDragEnd() {
         this.actor.get_parent()._delegate._clearDragPlaceholder();
-    },
+    }
 
-    get_app_id: function() {
+    get_app_id() {
         return this.app.get_id();
-    },
+    }
 
-    getDragActor: function() {
+    getDragActor() {
         return new Clutter.Clone({ source: this.actor });
-    },
+    }
 
     // Returns the original actor that should align with the actor
     // we show as the item is being dragged.
-    getDragActorSource: function() {
+    getDragActorSource() {
         return this.actor;
     }
-};
-
-function SystemButton(appsMenuButton, icon, nbFavorites, name, desc) {
-    this._init(appsMenuButton, icon, nbFavorites, name, desc);
 }
 
-SystemButton.prototype = {
-    __proto__: PopupMenu.PopupSubMenuMenuItem.prototype,
-
-    _init: function(appsMenuButton, icon, nbFavorites, name, desc) {
-        PopupMenu.PopupBaseMenuItem.prototype._init.call(this, {hover: false});
+class SystemButton extends PopupMenu.PopupSubMenuMenuItem {
+    constructor(appsMenuButton, icon, nbFavorites, name, desc) {
+        super({hover: false});
 
         this.name = name;
         this.desc = desc;
@@ -1000,26 +907,22 @@ SystemButton.prototype = {
         let iconObj = new St.Icon({icon_name: icon, icon_size: icon_size, icon_type: St.IconType.FULLCOLOR});
         this.addActor(iconObj);
         iconObj.realize();
-    },
+    }
 
-    _onButtonReleaseEvent: function(actor, event) {
+    _onButtonReleaseEvent(actor, event) {
         if (event.get_button() == 1) {
             this.activate();
         }
     }
-};
-
-function CategoriesApplicationsBox() {
-    this._init();
 }
 
-CategoriesApplicationsBox.prototype = {
-    _init: function() {
+class CategoriesApplicationsBox {
+    constructor() {
         this.actor = new St.BoxLayout();
         this.actor._delegate = this;
-    },
+    }
 
-    acceptDrop : function(source, actor, x, y, time) {
+    acceptDrop (source, actor, x, y, time) {
         if (source instanceof FavoritesButton){
             source.actor.destroy();
             actor.destroy();
@@ -1027,39 +930,35 @@ CategoriesApplicationsBox.prototype = {
             return true;
         }
         return false;
-    },
+    }
 
-    handleDragOver : function(source, actor, x, y, time) {
+    handleDragOver (source, actor, x, y, time) {
         if (source instanceof FavoritesButton)
             return DND.DragMotionResult.POINTING_DROP;
 
         return DND.DragMotionResult.CONTINUE;
     }
-};
-
-function FavoritesBox() {
-    this._init();
 }
 
-FavoritesBox.prototype = {
-    _init: function() {
+class FavoritesBox {
+    constructor() {
         this.actor = new St.BoxLayout({ vertical: true });
         this.actor._delegate = this;
 
         this._dragPlaceholder = null;
         this._dragPlaceholderPos = -1;
         this._animatingPlaceholdersCount = 0;
-    },
+    }
 
-    _clearDragPlaceholder: function() {
+    _clearDragPlaceholder() {
         if (this._dragPlaceholder) {
             this._dragPlaceholder.animateOutAndDestroy();
             this._dragPlaceholder = null;
             this._dragPlaceholderPos = -1;
         }
-    },
+    }
 
-    handleDragOver : function(source, actor, x, y, time) {
+    handleDragOver (source, actor, x, y, time) {
         let app = source.app;
 
         let favorites = AppFavorites.getAppFavorites().getFavorites();
@@ -1134,10 +1033,10 @@ FavoritesBox.prototype = {
             return DND.DragMotionResult.COPY_DROP;
 
         return DND.DragMotionResult.MOVE_DROP;
-    },
+    }
 
     // Draggable target interface
-    acceptDrop : function(source, actor, x, y, time) {
+    acceptDrop (source, actor, x, y, time) {
         let app = source.app;
 
         let id = app.get_id();
@@ -1174,17 +1073,11 @@ FavoritesBox.prototype = {
 
         return true;
     }
-};
-
-function CinnamonMenuApplet(orientation, panel_height, instance_id) {
-    this._init(orientation, panel_height, instance_id);
 }
 
-CinnamonMenuApplet.prototype = {
-    __proto__: Applet.TextIconApplet.prototype,
-
-    _init: function(orientation, panel_height, instance_id) {
-        Applet.TextIconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
+class CinnamonMenuApplet extends Applet.TextIconApplet {
+    constructor(orientation, panel_height, instance_id) {
+        super(orientation, panel_height, instance_id);
 
         this.setAllowedLayout(Applet.AllowedLayout.BOTH);
 
@@ -1284,23 +1177,23 @@ CinnamonMenuApplet.prototype = {
         this._refreshAll();
 
         this.set_show_label_in_vertical_panels(false);
-    },
+    }
 
-    _updateKeybinding: function() {
+    _updateKeybinding() {
         Main.keybindingManager.addHotKey("overlay-key-" + this.instance_id, this.overlayKey, Lang.bind(this, function() {
             if (!Main.overview.visible && !Main.expo.visible)
                 this.menu.toggle_with_options(this.enableAnimation);
         }));
-    },
+    }
 
-    onAppSysChanged: function() {
+    onAppSysChanged() {
         if (this.refreshing == false) {
             this.refreshing = true;
             Mainloop.timeout_add_seconds(1, Lang.bind(this, this._refreshAll));
         }
-    },
+    }
 
-    _refreshAll: function() {
+    _refreshAll() {
         try {
             this._refreshApps();
             this._refreshFavs();
@@ -1313,22 +1206,22 @@ CinnamonMenuApplet.prototype = {
             global.log(exception);
         }
         this.refreshing = false;
-    },
+    }
 
-    _refreshBelowApps: function() {
+    _refreshBelowApps() {
         this._refreshPlaces();
         this._refreshRecent();
 
         this._resizeApplicationsBox();
-    },
+    }
 
-    openMenu: function() {
+    openMenu() {
         if (!this._applet_context_menu.isOpen) {
             this.menu.open(this.enableAnimation);
         }
-    },
+    }
 
-    _clearDelayCallbacks: function() {
+    _clearDelayCallbacks() {
         if (this._appletHoverDelayId > 0) {
             Mainloop.source_remove(this._appletHoverDelayId);
             this._appletHoverDelayId = 0;
@@ -1339,9 +1232,9 @@ CinnamonMenuApplet.prototype = {
         }
 
         return false;
-    },
+    }
 
-    _updateActivateOnHover: function() {
+    _updateActivateOnHover() {
         if (this._appletEnterEventId > 0) {
             this.actor.disconnect(this._appletEnterEventId);
             this._appletEnterEventId = 0;
@@ -1363,15 +1256,15 @@ CinnamonMenuApplet.prototype = {
                 }
             }));
         }
-    },
+    }
 
-    _recalc_height: function() {
+    _recalc_height() {
         let scrollBoxHeight = (this.leftBox.get_allocation_box().y2-this.leftBox.get_allocation_box().y1) -
                                (this.searchBox.get_allocation_box().y2-this.searchBox.get_allocation_box().y1);
         this.applicationsScrollBox.style = "height: "+scrollBoxHeight / global.ui_scale +"px;";
-    },
+    }
 
-    on_orientation_changed: function (orientation) {
+    on_orientation_changed (orientation) {
         this.orientation = orientation;
 
         this.menu.destroy();
@@ -1385,25 +1278,25 @@ CinnamonMenuApplet.prototype = {
         if (this.initial_load_done)
             this._refreshAll();
         this._updateIconAndLabel();
-    },
+    }
 
-    on_applet_added_to_panel: function () {
+    on_applet_added_to_panel () {
         this.initial_load_done = true;
-    },
+    }
 
-    on_applet_removed_from_panel: function () {
+    on_applet_removed_from_panel () {
         Main.keybindingManager.removeHotKey("overlay-key-" + this.instance_id);
-    },
+    }
 
-    _launch_editor: function() {
+    _launch_editor() {
         Util.spawnCommandLine("cinnamon-menu-editor");
-    },
+    }
 
-    on_applet_clicked: function(event) {
+    on_applet_clicked(event) {
         this.menu.toggle_with_options(this.enableAnimation);
-    },
+    }
 
-    _onSourceKeyPress: function(actor, event) {
+    _onSourceKeyPress(actor, event) {
         let symbol = event.get_key_symbol();
 
         if (symbol == Clutter.KEY_space || symbol == Clutter.KEY_Return) {
@@ -1419,9 +1312,9 @@ CinnamonMenuApplet.prototype = {
             return true;
         } else
             return false;
-    },
+    }
 
-    _onOpenStateChanged: function(menu, open) {
+    _onOpenStateChanged(menu, open) {
         if (open) {
             if (this._appletEnterEventId > 0) {
                 this.actor.handler_block(this._appletEnterEventId);
@@ -1460,23 +1353,23 @@ CinnamonMenuApplet.prototype = {
             this._clearAllSelections(true);
             this.destroyVectorBox();
         }
-    },
+    }
 
-    _initial_cat_selection: function (start_index) {
+    _initial_cat_selection (start_index) {
         let n = this._applicationsButtons.length;
         for (let i = start_index; i < n; i++) {
             this._applicationsButtons[i].actor.show();
         }
-    },
+    }
 
-    destroy: function() {
+    destroy() {
         this.actor._delegate = null;
         this.menu.destroy();
         this.actor.destroy();
         this.emit('destroy');
-    },
+    }
 
-    _set_default_menu_icon: function() {
+    _set_default_menu_icon() {
         let path = global.datadir + "/theme/menu.svg";
         if (GLib.file_test(path, GLib.FileTest.EXISTS)) {
             this.set_applet_icon_path(path);
@@ -1490,17 +1383,17 @@ CinnamonMenuApplet.prototype = {
         }
         /* If all else fails, this will yield no icon */
         this.set_applet_icon_path("");
-    },
+    }
 
-    _favboxtoggle: function() {
+    _favboxtoggle() {
         if (!this.favBoxShow) {
             this.leftPane.hide();
         } else {
             this.leftPane.show();
         }
-    },
+    }
 
-    _updateIconAndLabel: function(){
+    _updateIconAndLabel(){
         try {
             if (this.menuIconCustom) {
                 if (this.menuIcon == "") {
@@ -1539,9 +1432,9 @@ CinnamonMenuApplet.prototype = {
             else
                 this.set_applet_label("");
         }
-    },
+    }
 
-    _recentMenuOpenStateChanged: function(recentContextMenu) {
+    _recentMenuOpenStateChanged(recentContextMenu) {
         if (recentContextMenu.isOpen) {
             this._activeContextMenuParent = recentContextMenu.sourceActor._delegate;
             this._scrollToButton(recentContextMenu);
@@ -1554,16 +1447,16 @@ CinnamonMenuApplet.prototype = {
                 }
             }
         }
-    },
+    }
 
-    createRecentContextMenu: function(actor) {
+    createRecentContextMenu(actor) {
         let menu = new PopupMenu.PopupSubMenu(actor);
         menu.actor.set_style_class_name('menu-context-menu');
         menu.connect('open-state-changed', Lang.bind(this, this._recentMenuOpenStateChanged));
         this.recentContextMenu = menu;
-    },
+    }
 
-    _navigateContextMenu: function(button, symbol, ctrlKey) {
+    _navigateContextMenu(button, symbol, ctrlKey) {
         if (symbol === Clutter.KEY_Menu || symbol === Clutter.Escape ||
             (ctrlKey && (symbol === Clutter.KEY_Return || symbol === Clutter.KP_Enter))) {
             button.activateContextMenus();
@@ -1626,9 +1519,9 @@ CinnamonMenuApplet.prototype = {
                 break;
             }
         }
-    },
+    }
 
-    _onMenuKeyPress: function(actor, event) {
+    _onMenuKeyPress(actor, event) {
         let symbol = event.get_key_symbol();
         let item_actor;
         let index = 0;
@@ -2030,9 +1923,9 @@ CinnamonMenuApplet.prototype = {
         }
         item_actor._delegate.emit('enter-event');
         return true;
-    },
+    }
 
-    _addEnterEvent: function(button, callback) {
+    _addEnterEvent(button, callback) {
         let _callback = Lang.bind(this, function() {
             let parent = button.actor.get_parent();
             if (this._activeContainer === this.categoriesBox && parent !== this._activeContainer) {
@@ -2062,9 +1955,9 @@ CinnamonMenuApplet.prototype = {
         });
         button.connect('enter-event', _callback);
         button.actor.connect('enter-event', _callback);
-    },
+    }
 
-    _clearPrevSelection: function(actor) {
+    _clearPrevSelection(actor) {
         if (this._previousSelectedActor && this._previousSelectedActor != actor) {
             if (this._previousSelectedActor._delegate instanceof ApplicationButton ||
                 this._previousSelectedActor._delegate instanceof RecentButton ||
@@ -2077,9 +1970,9 @@ CinnamonMenuApplet.prototype = {
                      this._previousSelectedActor._delegate instanceof SystemButton)
                 this._previousSelectedActor.remove_style_pseudo_class("hover");
         }
-    },
+    }
 
-    _clearPrevCatSelection: function(actor) {
+    _clearPrevCatSelection(actor) {
         if (this._previousTreeSelectedActor && this._previousTreeSelectedActor != actor) {
             this._previousTreeSelectedActor.style_class = "menu-category-button";
 
@@ -2096,7 +1989,7 @@ CinnamonMenuApplet.prototype = {
                 child.style_class = "menu-category-button";
             }));
         }
-    },
+    }
 
     /*
      * The vectorBox overlays the the categoriesBox to aid in navigation from categories to apps
@@ -2116,7 +2009,7 @@ CinnamonMenuApplet.prototype = {
      *  |____\|C
      */
 
-    _getVectorInfo: function() {
+    _getVectorInfo() {
         let [mx, my, mask] = global.get_pointer();
         let [bx, by] = this.categoriesOverlayBox.get_transformed_position();
         let [bw, bh] = this.categoriesOverlayBox.get_transformed_size();
@@ -2132,9 +2025,9 @@ CinnamonMenuApplet.prototype = {
                  my: xformed_my,
                  w: bw,
                  h: bh };
-    },
+    }
 
-    makeVectorBox: function(actor) {
+    makeVectorBox(actor) {
         this.destroyVectorBox(actor);
         let vi = this._getVectorInfo();
         if (!vi) {
@@ -2156,17 +2049,17 @@ CinnamonMenuApplet.prototype = {
         this.vectorBox.connect("motion-event", Lang.bind(this, this.maybeUpdateVectorBox));
         this.actor_motion_id = actor.connect("motion-event", Lang.bind(this, this.maybeUpdateVectorBox));
         this.current_motion_actor = actor;
-    },
+    }
 
-    maybeUpdateVectorBox: function() {
+    maybeUpdateVectorBox() {
         if (this.vector_update_loop) {
             Mainloop.source_remove(this.vector_update_loop);
             this.vector_update_loop = 0;
         }
         this.vector_update_loop = Mainloop.timeout_add(50, Lang.bind(this, this.updateVectorBox));
-    },
+    }
 
-    updateVectorBox: function(actor) {
+    updateVectorBox(actor) {
         if (this.vectorBox) {
             let vi = this._getVectorInfo();
             if (vi) {
@@ -2179,9 +2072,9 @@ CinnamonMenuApplet.prototype = {
         }
         this.vector_update_loop = 0;
         return false;
-    },
+    }
 
-    destroyVectorBox: function(actor) {
+    destroyVectorBox(actor) {
         if (this.vectorBox != null) {
             this.vectorBox.destroy();
             this.vectorBox = null;
@@ -2191,9 +2084,9 @@ CinnamonMenuApplet.prototype = {
             this.actor_motion_id = 0;
             this.current_motion_actor = null;
         }
-    },
+    }
 
-    _refreshPlaces : function() {
+    _refreshPlaces () {
         for (let i = 0; i < this._placesButtons.length; i ++) {
             this._placesButtons[i].actor.destroy();
         }
@@ -2280,9 +2173,9 @@ CinnamonMenuApplet.prototype = {
         this._setCategoriesButtonActive(!this.searchActive);
 
         this._resizeApplicationsBox();
-    },
+    }
 
-    _refreshRecent : function() {
+    _refreshRecent () {
         if (this.privacy_settings.get_boolean(REMEMBER_RECENT_KEY)) {
             if (this.recentButton == null) {
                 this.recentButton = new RecentCategoryButton(null, this.showCategoryIcons);
@@ -2502,9 +2395,9 @@ CinnamonMenuApplet.prototype = {
         this._setCategoriesButtonActive(!this.searchActive);
 
         this._resizeApplicationsBox();
-    },
+    }
 
-    _refreshApps : function() {
+    _refreshApps () {
         /* iterate in reverse, so multiple splices will not upset
          * the remaining elements */
         for (let i = this._categoryButtons.length - 1; i > -1; i--) {
@@ -2646,9 +2539,9 @@ CinnamonMenuApplet.prototype = {
         }
 
         this._appsWereRefreshed = true;
-    },
+    }
 
-    _favEnterEvent : function(button) {
+    _favEnterEvent (button) {
         button.actor.add_style_pseudo_class("hover");
         if (button instanceof FavoritesButton) {
             this.selectedAppTitle.set_text(button.app.get_name());
@@ -2660,16 +2553,16 @@ CinnamonMenuApplet.prototype = {
             this.selectedAppTitle.set_text(button.name);
             this.selectedAppDescription.set_text(button.desc);
         }
-    },
+    }
 
-    _favLeaveEvent : function(widget, event, button) {
+    _favLeaveEvent (widget, event, button) {
         this._previousSelectedActor = button.actor;
         button.actor.remove_style_pseudo_class("hover");
         this.selectedAppTitle.set_text("");
         this.selectedAppDescription.set_text("");
-    },
+    }
 
-    _refreshFavs : function() {
+    _refreshFavs () {
         //Remove all favorites
         this.favoritesBox.destroy_all_children();
 
@@ -2754,9 +2647,9 @@ CinnamonMenuApplet.prototype = {
         this.favoritesBox.add(button.actor, { y_align: St.Align.END, y_fill: false });
 
         this._recalc_height();
-    },
+    }
 
-    _loadCategory: function(dir, top_dir) {
+    _loadCategory(dir, top_dir) {
         var iter = dir.iter();
         var has_entries = false;
         var nextType;
@@ -2810,16 +2703,16 @@ CinnamonMenuApplet.prototype = {
             }
         }
         return has_entries;
-    },
+    }
 
-    _appLeaveEvent: function(a, b, applicationButton) {
+    _appLeaveEvent(a, b, applicationButton) {
         this._previousSelectedActor = applicationButton.actor;
         applicationButton.actor.style_class = "menu-application-button";
         this.selectedAppTitle.set_text("");
         this.selectedAppDescription.set_text("");
-    },
+    }
 
-    _appEnterEvent: function(applicationButton) {
+    _appEnterEvent(applicationButton) {
         this.selectedAppTitle.set_text(applicationButton.app.get_name());
         if (applicationButton.app.get_description())
             this.selectedAppDescription.set_text(applicationButton.app.get_description());
@@ -2828,18 +2721,18 @@ CinnamonMenuApplet.prototype = {
         this._previousVisibleIndex = this.appBoxIter.getVisibleIndex(applicationButton.actor);
         this._clearPrevSelection(applicationButton.actor);
         applicationButton.actor.style_class = "menu-application-button-selected";
-    },
+    }
 
-    _scrollToButton: function(button) {
+    _scrollToButton(button) {
         var current_scroll_value = this.applicationsScrollBox.get_vscroll_bar().get_adjustment().get_value();
         var box_height = this.applicationsScrollBox.get_allocation_box().y2-this.applicationsScrollBox.get_allocation_box().y1;
         var new_scroll_value = current_scroll_value;
         if (current_scroll_value > button.actor.get_allocation_box().y1-10) new_scroll_value = button.actor.get_allocation_box().y1-10;
         if (box_height+current_scroll_value < button.actor.get_allocation_box().y2+10) new_scroll_value = button.actor.get_allocation_box().y2-box_height+10;
         if (new_scroll_value!=current_scroll_value) this.applicationsScrollBox.get_vscroll_bar().get_adjustment().set_value(new_scroll_value);
-    },
+    }
 
-    _display : function() {
+    _display () {
         this._activeContainer = null;
         this._activeActor = null;
         this.vectorBox = null;
@@ -2949,9 +2842,9 @@ CinnamonMenuApplet.prototype = {
         }));
 
         this.menu.actor.connect("allocation-changed", Lang.bind(this, this._on_allocation_changed));
-    },
+    }
 
-    _updateVFade: function() {
+    _updateVFade() {
         let mag_on = this.a11y_settings.get_boolean("screen-magnifier-enabled") &&
                      this.a11y_mag_settings.get_double("mag-factor") > 1.0;
         if (mag_on) {
@@ -2959,17 +2852,17 @@ CinnamonMenuApplet.prototype = {
         } else {
             this.applicationsScrollBox.style_class = "vfade menu-applications-scrollbox";
         }
-    },
+    }
 
-    _update_autoscroll: function() {
+    _update_autoscroll() {
         this.applicationsScrollBox.set_auto_scrolling(this.autoscroll_enabled);
-    },
+    }
 
-    _on_allocation_changed: function(box, flags, data) {
+    _on_allocation_changed(box, flags, data) {
         this._recalc_height();
-    },
+    }
 
-    _clearAllSelections: function(hide_apps) {
+    _clearAllSelections(hide_apps) {
         let actors = this.applicationsBox.get_children();
         for (let i = 0; i < actors.length; i++) {
             let actor = actors[i];
@@ -2990,9 +2883,9 @@ CinnamonMenuApplet.prototype = {
             actor.remove_style_pseudo_class("hover");
             actor.show();
         }
-    },
+    }
 
-    _select_category : function(name) {
+    _select_category (name) {
         if (name === this.lastSelectedCategory) {
             return;
         }
@@ -3013,9 +2906,9 @@ CinnamonMenuApplet.prototype = {
         }
 
         this.closeContextMenus(null, false);
-    },
+    }
 
-    closeContextMenus: function(excluded, animate) {
+    closeContextMenus(excluded, animate) {
         for (let app in this._applicationsButtons){
             if (this._applicationsButtons[app] != excluded && this._applicationsButtons[app].menu.isOpen){
                 if (animate)
@@ -3040,17 +2933,17 @@ CinnamonMenuApplet.prototype = {
             this._activeContextMenuParent = null;
             this._activeContextMenuItem = null;
         }
-    },
+    }
 
-    _resize_actor_iter: function(actor) {
+    _resize_actor_iter(actor) {
         let [min, nat] = actor.get_preferred_width(-1.0);
         if (nat > this._applicationsBoxWidth){
             this._applicationsBoxWidth = nat;
             this.applicationsBox.set_width(this._applicationsBoxWidth + 42); // The answer to life...
         }
-    },
+    }
 
-    _resizeApplicationsBox: function() {
+    _resizeApplicationsBox() {
         this._applicationsBoxWidth = 0;
         this.applicationsBox.set_width(-1);
         let child = this.applicationsBox.get_first_child();
@@ -3059,9 +2952,9 @@ CinnamonMenuApplet.prototype = {
         while ((child = child.get_next_sibling()) != null) {
             this._resize_actor_iter(child);
         }
-    },
+    }
 
-    _displayButtons: function(appCategory, places, recent, apps, autocompletes){
+    _displayButtons(appCategory, places, recent, apps, autocompletes){
         if (appCategory) {
             if (appCategory == "all") {
                 this._applicationsButtons.forEach( function (item, index) {
@@ -3149,9 +3042,9 @@ CinnamonMenuApplet.prototype = {
                 item.actor.hide();
             }
         });
-    },
+    }
 
-    _setCategoriesButtonActive: function(active) {
+    _setCategoriesButtonActive(active) {
         try {
             let categoriesButtons = this.categoriesBox.get_children();
             for (var i in categoriesButtons) {
@@ -3165,18 +3058,18 @@ CinnamonMenuApplet.prototype = {
         } catch (e) {
             global.log(e);
         }
-     },
+     }
 
-     resetSearch: function(){
+     resetSearch(){
         this.searchEntry.set_text("");
         this._previousSearchPattern = "";
         this.searchActive = false;
         this._clearAllSelections(true);
         this._setCategoriesButtonActive(true);
         global.stage.set_key_focus(this.searchEntry);
-     },
+     }
 
-     _onSearchTextChanged: function (se, prop) {
+     _onSearchTextChanged (se, prop) {
         if (this.menuIsOpening) {
             this.menuIsOpening = false;
             return;
@@ -3214,27 +3107,27 @@ CinnamonMenuApplet.prototype = {
             }
             return;
         }
-    },
+    }
 
-    _listBookmarks: function(pattern){
+    _listBookmarks(pattern){
        let bookmarks = Main.placesManager.getBookmarks();
        var res = [];
        for (let id = 0; id < bookmarks.length; id++) {
           if (!pattern || bookmarks[id].name.toLowerCase().indexOf(pattern)!=-1) res.push(bookmarks[id]);
        }
        return res;
-    },
+    }
 
-    _listDevices: function(pattern){
+    _listDevices(pattern){
        let devices = Main.placesManager.getMounts();
        var res = [];
        for (let id = 0; id < devices.length; id++) {
           if (!pattern || devices[id].name.toLowerCase().indexOf(pattern)!=-1) res.push(devices[id]);
        }
        return res;
-    },
+    }
 
-    _listApplications: function(category_menu_id, pattern){
+    _listApplications(category_menu_id, pattern){
         var applist = [];
         if (category_menu_id) {
             applist = category_menu_id;
@@ -3265,9 +3158,9 @@ CinnamonMenuApplet.prototype = {
             }
         } else res = applist;
         return res;
-    },
+    }
 
-    _doSearch: function(){
+    _doSearch(){
         this._searchTimeoutId = 0;
         let pattern = this.searchEntryText.get_text().replace(/^\s+/g, '').replace(/\s+$/g, '').toLowerCase();
         pattern = Util.latinise(pattern);
@@ -3347,9 +3240,9 @@ CinnamonMenuApplet.prototype = {
         }));
 
         return false;
-    },
+    }
 
-    _getCompletion : function(text) {
+    _getCompletion (text) {
         if (text.indexOf('/') != -1) {
             if (text.substr(text.length - 1) == '/') {
                 return '';
@@ -3359,17 +3252,17 @@ CinnamonMenuApplet.prototype = {
         } else {
             return false;
         }
-    },
+    }
 
-    _getCompletions : function(text) {
+    _getCompletions (text) {
         if (text.indexOf('/') != -1) {
             return this._pathCompleter.get_completions(text);
         } else {
             return [];
         }
-    },
+    }
 
-    _run : function(input) {
+    _run (input) {
         this._commandError = false;
         if (input) {
             let path = null;

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1176,11 +1176,11 @@ FavoritesBox.prototype = {
     }
 };
 
-function MyApplet(orientation, panel_height, instance_id) {
+function CinnamonMenuApplet(orientation, panel_height, instance_id) {
     this._init(orientation, panel_height, instance_id);
 }
 
-MyApplet.prototype = {
+CinnamonMenuApplet.prototype = {
     __proto__: Applet.TextIconApplet.prototype,
 
     _init: function(orientation, panel_height, instance_id) {
@@ -3404,6 +3404,5 @@ MyApplet.prototype = {
 };
 
 function main(metadata, orientation, panel_height, instance_id) {
-    let myApplet = new MyApplet(orientation, panel_height, instance_id);
-    return myApplet;
+    return new CinnamonMenuApplet(orientation, panel_height, instance_id);
 }

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -60,7 +60,7 @@ class VisibleChildIterator {
 
     reloadVisible() {
         this.array = this.container.get_focus_chain()
-            .filter(x => !(x._delegate instanceof PopupMenu.PopupSeparatorMenuItem));
+        .filter(x => !(x._delegate instanceof PopupMenu.PopupSeparatorMenuItem));
     }
 
     getNextVisible(curChild) {
@@ -338,7 +338,7 @@ class TransientButton extends PopupMenu.PopupBaseMenuItem {
         } catch (e) {
             this.handler = null;
             let iconName = this.isPath ? 'folder' : 'unknown';
-            this.icon = new St.Icon({icon_name: iconName, icon_size: APPLICATION_ICON_SIZE, icon_type: St.IconType.FULLCOLOR,});
+            this.icon = new St.Icon({icon_name: iconName, icon_size: APPLICATION_ICON_SIZE, icon_type: St.IconType.FULLCOLOR});
             // @todo Would be nice to indicate we don't have a handler for this file.
             this.actor.set_style_class_name('menu-application-button');
         }
@@ -1413,7 +1413,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                 this._set_default_menu_icon();
             }
         } catch(e) {
-           global.logWarning("Could not load icon file \""+this.menuIcon+"\" for menu button");
+            global.logWarning("Could not load icon file \""+this.menuIcon+"\" for menu button");
         }
 
         if (this.menuIconCustom && this.menuIcon == "") {
@@ -1694,8 +1694,8 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                             }
                             else {
                                 item_actor = (this._previousVisibleIndex != null) ?
-                                                this.appBoxIter.getVisibleItem(this._previousVisibleIndex) :
-                                                this.appBoxIter.getFirstVisible();
+                                    this.appBoxIter.getVisibleItem(this._previousVisibleIndex) :
+                                    this.appBoxIter.getFirstVisible();
                             }
                             break;
                         case "left":
@@ -1708,8 +1708,8 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                                     item_actor = this.categoriesBox.get_child_at_index(index);
                                 } else {
                                     item_actor = (this._previousVisibleIndex != null) ?
-                                                    this.appBoxIter.getVisibleItem(this._previousVisibleIndex) :
-                                                    this.appBoxIter.getFirstVisible();
+                                        this.appBoxIter.getVisibleItem(this._previousVisibleIndex) :
+                                        this.appBoxIter.getFirstVisible();
                                 }
                             }
                             break;
@@ -1744,8 +1744,8 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                         case "right":
                             this._previousSelectedActor = this.applicationsBox.get_child_at_index(index);
                             item_actor = (this._previousTreeSelectedActor != null) ?
-                                            this._previousTreeSelectedActor :
-                                            this.catBoxIter.getFirstVisible();
+                                this._previousTreeSelectedActor :
+                                this.catBoxIter.getFirstVisible();
                             this._previousTreeSelectedActor = item_actor;
                             index = item_actor.get_parent()._vis_iter.getAbsoluteIndexOfChild(item_actor);
 
@@ -1758,8 +1758,8 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                         case "left":
                             this._previousSelectedActor = this.applicationsBox.get_child_at_index(index);
                             item_actor = (this._previousTreeSelectedActor != null) ?
-                                            this._previousTreeSelectedActor :
-                                            this.catBoxIter.getFirstVisible();
+                                this._previousTreeSelectedActor :
+                                this.catBoxIter.getFirstVisible();
                             this._previousTreeSelectedActor = item_actor;
                             break;
                         case "top":
@@ -1786,21 +1786,21 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                             break;
                         case "right":
                             item_actor = (this._previousTreeSelectedActor != null) ?
-                                            this._previousTreeSelectedActor :
-                                            this.catBoxIter.getFirstVisible();
+                                this._previousTreeSelectedActor :
+                                this.catBoxIter.getFirstVisible();
                             this._previousTreeSelectedActor = item_actor;
                             break;
                         case "left":
                             item_actor = (this._previousTreeSelectedActor != null) ?
-                                            this._previousTreeSelectedActor :
-                                            this.catBoxIter.getFirstVisible();
+                                this._previousTreeSelectedActor :
+                                this.catBoxIter.getFirstVisible();
                             this._previousTreeSelectedActor = item_actor;
                             index = item_actor.get_parent()._vis_iter.getAbsoluteIndexOfChild(item_actor);
 
                             item_actor._delegate.emit('enter-event');
                             item_actor = (this._previousVisibleIndex != null) ?
-                                            this.appBoxIter.getVisibleItem(this._previousVisibleIndex) :
-                                            this.appBoxIter.getFirstVisible();
+                                this.appBoxIter.getVisibleItem(this._previousVisibleIndex) :
+                                this.appBoxIter.getFirstVisible();
                             break;
                         case "top":
                             item_actor = this.favBoxIter.getFirstVisible();
@@ -1833,7 +1833,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                     item_actor._delegate.activateContextMenus();
                 return true;
             } else if (this._activeContainer === this.favoritesBox && symbol === Clutter.Delete) {
-               item_actor = this.favoritesBox.get_child_at_index(this._selectedItemIndex);
+                item_actor = this.favoritesBox.get_child_at_index(this._selectedItemIndex);
                 if (item_actor._delegate instanceof FavoritesButton) {
                     let favorites = AppFavorites.getAppFavorites().getFavorites();
                     let numFavorites = favorites.length;
@@ -2429,14 +2429,14 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
 
                 this.makeVectorBox(this._allAppsCategoryButton.actor);
             }
-         }));
-         this._allAppsCategoryButton.actor.connect('leave-event', Lang.bind(this, function () {
+        }));
+        this._allAppsCategoryButton.actor.connect('leave-event', Lang.bind(this, function () {
             this._previousSelectedActor = this._allAppsCategoryButton.actor;
             this._allAppsCategoryButton.isHovered = false;
-         }));
+        }));
 
-         this.categoriesBox.add_actor(this._allAppsCategoryButton.actor);
-         this._categoryButtons.push(this._allAppsCategoryButton);
+        this.categoriesBox.add_actor(this._allAppsCategoryButton.actor);
+        this._categoryButtons.push(this._allAppsCategoryButton);
 
         let trees = [appsys.get_tree()];
 
@@ -2463,10 +2463,10 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                 let prefIdB = prefCats.indexOf(menuIdB);
 
                 if (prefIdA < 0 && prefIdB >= 0) {
-                  return -1;
+                    return -1;
                 }
                 if (prefIdA >= 0 && prefIdB < 0) {
-                  return 1;
+                    return 1;
                 }
 
                 let nameA = a.get_name().toLowerCase();
@@ -2521,8 +2521,8 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                     handleEnterEvent(categoryButton, dir);
                     handleLeaveEvent(categoryButton, dir);
 
-                  this._categoryButtons.push(categoryButton);
-                  this.categoriesBox.add_actor(categoryButton.actor);
+                    this._categoryButtons.push(categoryButton);
+                    this.categoriesBox.add_actor(categoryButton.actor);
                 }
             }
         }
@@ -2584,8 +2584,8 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
 
         //Separator
         if (launchers.length != 0) {
-                let separator = new PopupMenu.PopupSeparatorMenuItem();
-                this.favoritesBox.add(separator.actor, { y_align: St.Align.END, y_fill: false });
+            let separator = new PopupMenu.PopupSeparatorMenuItem();
+            this.favoritesBox.add(separator.actor, { y_align: St.Align.END, y_fill: false });
         }
 
         //Lock screen
@@ -2793,12 +2793,12 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         let vscroll = this.applicationsScrollBox.get_vscroll_bar();
         vscroll.connect('scroll-start',
                         Lang.bind(this, function() {
-                                      this.menu.passEvents = true;
-                                  }));
+                            this.menu.passEvents = true;
+                        }));
         vscroll.connect('scroll-stop',
                         Lang.bind(this, function() {
-                                      this.menu.passEvents = false;
-                                  }));
+                            this.menu.passEvents = false;
+                        }));
 
         this.applicationsBox = new St.BoxLayout({ style_class: 'menu-applications-inner-box', vertical:true });
         this.applicationsBox.add_style_class_name('menu-applications-box'); //this is to support old themes
@@ -2963,61 +2963,61 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
             } else {
                 this._applicationsButtons.forEach( function (item, index) {
                     if (item.category.indexOf(appCategory) != -1) {
-                            item.actor.show();
+                        item.actor.show();
                     } else {
-                            item.actor.hide();
+                        item.actor.hide();
                     }
                 });
             }
         } else if (apps) {
             for (let i = 0; i < this._applicationsButtons.length; i++) {
-                    if (apps.indexOf(this._applicationsButtons[i].app.get_id()) != -1) {
-                            this._applicationsButtons[i].actor.show();
-                    } else {
-                            this._applicationsButtons[i].actor.hide();
-                    }
+                if (apps.indexOf(this._applicationsButtons[i].app.get_id()) != -1) {
+                    this._applicationsButtons[i].actor.show();
+                } else {
+                    this._applicationsButtons[i].actor.hide();
+                }
             }
         } else {
             this._applicationsButtons.forEach( function (item, index) {
-                        item.actor.hide();
+                item.actor.hide();
             });
         }
         if (places) {
             if (places == -1) {
                 this._placesButtons.forEach( function (item, index) {
-                   item.actor.show();
+                    item.actor.show();
                 });
             } else {
                 for (let i = 0; i < this._placesButtons.length; i++) {
                     if (places.indexOf(this._placesButtons[i].button_name) != -1) {
-                            this._placesButtons[i].actor.show();
+                        this._placesButtons[i].actor.show();
                     } else {
-                            this._placesButtons[i].actor.hide();
+                        this._placesButtons[i].actor.hide();
                     }
                 }
             }
         } else {
             this._placesButtons.forEach( function (item, index) {
-                        item.actor.hide();
+                item.actor.hide();
             });
         }
         if (recent) {
             if (recent == -1) {
                 this._recentButtons.forEach( function (item, index) {
-                        item.actor.show();
+                    item.actor.show();
                 });
             } else {
                 for (let i = 0; i < this._recentButtons.length; i++) {
                     if (recent.indexOf(this._recentButtons[i].button_name) != -1) {
-                            this._recentButtons[i].actor.show();
+                        this._recentButtons[i].actor.show();
                     } else {
-                            this._recentButtons[i].actor.hide();
+                        this._recentButtons[i].actor.hide();
                     }
                 }
             }
         } else {
             this._recentButtons.forEach( function (item, index) {
-                        item.actor.hide();
+                item.actor.hide();
             });
         }
         if (autocompletes) {
@@ -3054,22 +3054,22 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                 } else {
                     button.set_style_class_name("menu-category-button-greyed");
                 }
-             }
+            }
         } catch (e) {
             global.log(e);
         }
-     }
+    }
 
-     resetSearch(){
+    resetSearch(){
         this.searchEntry.set_text("");
         this._previousSearchPattern = "";
         this.searchActive = false;
         this._clearAllSelections(true);
         this._setCategoriesButtonActive(true);
         global.stage.set_key_focus(this.searchEntry);
-     }
+    }
 
-     _onSearchTextChanged (se, prop) {
+    _onSearchTextChanged (se, prop) {
         if (this.menuIsOpening) {
             this.menuIsOpening = false;
             return;
@@ -3110,21 +3110,21 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
     }
 
     _listBookmarks(pattern){
-       let bookmarks = Main.placesManager.getBookmarks();
-       var res = [];
-       for (let id = 0; id < bookmarks.length; id++) {
-          if (!pattern || bookmarks[id].name.toLowerCase().indexOf(pattern)!=-1) res.push(bookmarks[id]);
-       }
-       return res;
+        let bookmarks = Main.placesManager.getBookmarks();
+        var res = [];
+        for (let id = 0; id < bookmarks.length; id++) {
+            if (!pattern || bookmarks[id].name.toLowerCase().indexOf(pattern)!=-1) res.push(bookmarks[id]);
+        }
+        return res;
     }
 
     _listDevices(pattern){
-       let devices = Main.placesManager.getMounts();
-       var res = [];
-       for (let id = 0; id < devices.length; id++) {
-          if (!pattern || devices[id].name.toLowerCase().indexOf(pattern)!=-1) res.push(devices[id]);
-       }
-       return res;
+        let devices = Main.placesManager.getMounts();
+        var res = [];
+        for (let id = 0; id < devices.length; id++) {
+            if (!pattern || devices[id].name.toLowerCase().indexOf(pattern)!=-1) res.push(devices[id]);
+        }
+        return res;
     }
 
     _listApplications(category_menu_id, pattern){
@@ -3137,24 +3137,24 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         let res;
         if (pattern){
             res = [];
-            var regexpPattern = new RegExp("\\b"+pattern);
-            var foundByName = false;
-            for (var i in this._applicationsButtons) {
+            let regexpPattern = new RegExp("\\b"+pattern);
+            let foundByName = false;
+            for (let i in this._applicationsButtons) {
                 let app = this._applicationsButtons[i].app;
                 if (Util.latinise(app.get_name().toLowerCase()).match(regexpPattern) != null) {
-                  res.push(app.get_id());
-                  foundByName = true;
+                    res.push(app.get_id());
+                    foundByName = true;
                 }
             }
             if (!foundByName) {
-              for (var i in this._applicationsButtons) {
-                  let app = this._applicationsButtons[i].app;
-                  if (Util.latinise(app.get_name().toLowerCase()).indexOf(pattern)!=-1 ||
-                      (app.get_keywords() && Util.latinise(app.get_keywords().toLowerCase()).indexOf(pattern)!=-1) ||
-                      (app.get_description() && Util.latinise(app.get_description().toLowerCase()).indexOf(pattern)!=-1) ||
-                      (app.get_id() && Util.latinise(app.get_id().slice(0, -8).toLowerCase()).indexOf(pattern)!=-1))
-                           res.push(app.get_id());
-              }
+                for (let i in this._applicationsButtons) {
+                    let app = this._applicationsButtons[i].app;
+                    if (Util.latinise(app.get_name().toLowerCase()).indexOf(pattern)!=-1 ||
+                        (app.get_keywords() && Util.latinise(app.get_keywords().toLowerCase()).indexOf(pattern)!=-1) ||
+                        (app.get_description() && Util.latinise(app.get_description().toLowerCase()).indexOf(pattern)!=-1) ||
+                        (app.get_id() && Util.latinise(app.get_id().slice(0, -8).toLowerCase()).indexOf(pattern)!=-1))
+                        res.push(app.get_id());
+                }
             }
         } else res = applist;
         return res;
@@ -3216,26 +3216,26 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
 
         SearchProviderManager.launch_all(pattern, Lang.bind(this, function(provider, results){
             try{
-            for (var i in results){
-                if (results[i].type != 'software')
-                {
-                    let button = new SearchProviderResultButton(this, provider, results[i]);
-                    button.actor.connect('leave-event', Lang.bind(this, this._appLeaveEvent, button));
-                    this._addEnterEvent(button, Lang.bind(this, this._appEnterEvent, button));
-                    this._searchProviderButtons.push(button);
-                    this.applicationsBox.add_actor(button.actor);
-                    button.actor.realize();
-                    if (this._selectedItemIndex === null) {
-                        this.appBoxIter.reloadVisible();
-                        let item_actor = this.appBoxIter.getFirstVisible();
-                        this._selectedItemIndex = this.appBoxIter.getAbsoluteIndexOfChild(item_actor);
-                        this._activeContainer = this.applicationsBox;
-                        if (item_actor && item_actor != this.searchEntry) {
-                            item_actor._delegate.emit('enter-event');
+                for (var i in results){
+                    if (results[i].type != 'software')
+                    {
+                        let button = new SearchProviderResultButton(this, provider, results[i]);
+                        button.actor.connect('leave-event', Lang.bind(this, this._appLeaveEvent, button));
+                        this._addEnterEvent(button, Lang.bind(this, this._appEnterEvent, button));
+                        this._searchProviderButtons.push(button);
+                        this.applicationsBox.add_actor(button.actor);
+                        button.actor.realize();
+                        if (this._selectedItemIndex === null) {
+                            this.appBoxIter.reloadVisible();
+                            let item_actor = this.appBoxIter.getFirstVisible();
+                            this._selectedItemIndex = this.appBoxIter.getAbsoluteIndexOfChild(item_actor);
+                            this._activeContainer = this.applicationsBox;
+                            if (item_actor && item_actor != this.searchEntry) {
+                                item_actor._delegate.emit('enter-event');
+                            }
                         }
                     }
                 }
-            }
             }catch(e){global.log(e);}
         }));
 

--- a/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
@@ -1654,11 +1654,11 @@ RescanMenuItem.prototype = {
 };
 
 
-function MyApplet(metadata, orientation, panel_height, instance_id) {
+function CinnamonNetworkApplet(metadata, orientation, panel_height, instance_id) {
     this._init(metadata, orientation, panel_height, instance_id);
 }
 
-MyApplet.prototype = {
+CinnamonNetworkApplet.prototype = {
     __proto__: Applet.IconApplet.prototype,
 
     _init: function(metadata, orientation, panel_height, instance_id) {
@@ -2322,6 +2322,5 @@ MyApplet.prototype = {
 };
 
 function main(metadata, orientation, panel_height, instance_id) {
-    let myApplet = new MyApplet(metadata, orientation, panel_height, instance_id);
-    return myApplet;
+    return new CinnamonNetworkApplet(metadata, orientation, panel_height, instance_id);
 }

--- a/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
@@ -13,15 +13,9 @@ const Gettext = imports.gettext.domain("cinnamon-applets");
 
 const PANEL_EDIT_MODE_KEY = "panel-edit-mode";
 
-function CinnamonNotificationsApplet(metadata, orientation, panel_height, instanceId) {
-    this._init(metadata, orientation, panel_height, instanceId);
-}
-
-CinnamonNotificationsApplet.prototype = {
-    __proto__: Applet.TextIconApplet.prototype,
-
-    _init: function(metadata, orientation, panel_height, instanceId) {
-        Applet.TextIconApplet.prototype._init.call(this, orientation, panel_height, instanceId);
+class CinnamonNotificationsApplet extends Applet.TextIconApplet {
+    constructor(metadata, orientation, panel_height, instanceId) {
+        super(orientation, panel_height, instanceId);
 
         this.setAllowedLayout(Applet.AllowedLayout.BOTH);
 
@@ -44,9 +38,9 @@ CinnamonNotificationsApplet.prototype = {
         // States
         this._blinking = false;
         this._blink_toggle = false;
-    },
+    }
 
-    _display: function() {
+    _display() {
         // Always start the applet empty, void of any notifications.
         this.set_applet_icon_symbolic_name("empty-notif");
         this.set_applet_tooltip(_("Notifications"));
@@ -98,9 +92,9 @@ CinnamonNotificationsApplet.prototype = {
         this._alt_crit_icon = new St.Icon({icon_name: 'alt-critical-notif', icon_type: St.IconType.SYMBOLIC, reactive: true, track_hover: true, style_class: 'system-status-icon' });
 
         this._on_panel_edit_mode_changed();
-    },
+    }
 
-    _notification_added: function (mtray, notification) {	// Notification event handler.
+    _notification_added (mtray, notification) {	// Notification event handler.
         // Ignore transient notifications?
         if (this.ignoreTransientNotifications && notification.isTransient) {
             notification.destroy();
@@ -137,9 +131,9 @@ CinnamonNotificationsApplet.prototype = {
         notification._timeLabel.show();
 
         this.update_list();
-    },
+    }
 
-    _item_clicked: function(notification, destroyed) {
+    _item_clicked(notification, destroyed) {
         let i = this.notifications.indexOf(notification);
         if (i != -1) {
             this.notifications.splice(i, 1);
@@ -148,9 +142,9 @@ CinnamonNotificationsApplet.prototype = {
             }
         }
         this.update_list();
-    },
+    }
 
-    update_list: function () {
+    update_list () {
         try {
             let count = this.notifications.length;
             if (count > 0) {	// There are notifications.
@@ -196,9 +190,9 @@ CinnamonNotificationsApplet.prototype = {
         catch (e) {
             global.logError(e);
         }
-    },
+    }
 
-    _clear_all: function() {
+    _clear_all() {
         let count = this.notifications.length;
         if (count > 0) {
             for (let i = count-1; i >=0; i--) {
@@ -208,29 +202,29 @@ CinnamonNotificationsApplet.prototype = {
         }
         this.notifications = [];
         this.update_list();
-    },
+    }
 
-    _show_hide_tray: function() {	// Show or hide the notification tray.
+    _show_hide_tray() {	// Show or hide the notification tray.
         if (this.notifications.length || this.showEmptyTray) {
             this.actor.show();
         } else {
             this.actor.hide();
         }
-    },
+    }
 
-    _on_panel_edit_mode_changed: function () {
+    _on_panel_edit_mode_changed () {
         if (global.settings.get_boolean(PANEL_EDIT_MODE_KEY)) {
             this.actor.show();
         } else {
             this.update_list();
         }
-    },
+    }
 
-    on_applet_added_to_panel: function() {
+    on_applet_added_to_panel() {
         this.on_orientation_changed(this._orientation);
-    },
+    }
 
-    on_orientation_changed: function (orientation) {
+    on_orientation_changed (orientation) {
         this._orientation = orientation;
 
         if (this.menu) {
@@ -239,14 +233,14 @@ CinnamonNotificationsApplet.prototype = {
         this.menu = new Applet.AppletPopupMenu(this, orientation);
         this.menuManager.addMenu(this.menu);
         this._display();
-    },
+    }
 
-    on_applet_clicked: function(event) {
+    on_applet_clicked(event) {
         this._update_timestamp();
         this.menu.toggle();
-    },
+    }
 
-    _update_timestamp: function () {
+    _update_timestamp() {
         let len = this.notifications.length;
         if (len > 0) {
             for (let i = 0; i < len; i++) {
@@ -255,9 +249,9 @@ CinnamonNotificationsApplet.prototype = {
                 notification._timeLabel.clutter_text.set_markup(timeify(orig_time));
             }
         }
-    },
+    }
 
-    critical_blink: function () {
+    critical_blink () {
         if (!this._blinking)
             return;
         if (this._blink_toggle) {
@@ -268,7 +262,7 @@ CinnamonNotificationsApplet.prototype = {
         this._blink_toggle = !this._blink_toggle;
         Mainloop.timeout_add_seconds(1, Lang.bind(this, this.critical_blink));
     }
-};
+}
 
 function main(metadata, orientation, panel_height, instanceId) {
     return new CinnamonNotificationsApplet(metadata, orientation, panel_height, instanceId);

--- a/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
@@ -13,11 +13,11 @@ const Gettext = imports.gettext.domain("cinnamon-applets");
 
 const PANEL_EDIT_MODE_KEY = "panel-edit-mode";
 
-function MyApplet(metadata, orientation, panel_height, instanceId) {
+function CinnamonNotificationsApplet(metadata, orientation, panel_height, instanceId) {
     this._init(metadata, orientation, panel_height, instanceId);
 }
 
-MyApplet.prototype = {
+CinnamonNotificationsApplet.prototype = {
     __proto__: Applet.TextIconApplet.prototype,
 
     _init: function(metadata, orientation, panel_height, instanceId) {
@@ -271,8 +271,7 @@ MyApplet.prototype = {
 };
 
 function main(metadata, orientation, panel_height, instanceId) {
-    let myApplet = new MyApplet(metadata, orientation, panel_height, instanceId);
-    return myApplet;
+    return new CinnamonNotificationsApplet(metadata, orientation, panel_height, instanceId);
 }
 
 function stringify(count) {

--- a/files/usr/share/cinnamon/applets/on-screen-keyboard@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/on-screen-keyboard@cinnamon.org/applet.js
@@ -3,25 +3,19 @@ const Gio = imports.gi.Gio;
 const Lang = imports.lang;
 const Main = imports.ui.main;
 
-function CinnamonOnScreenKeyboardApplet(metadata, orientation, panel_height, instanceId) {
-    this._init(metadata, orientation, panel_height, instanceId);
-}
-
-CinnamonOnScreenKeyboardApplet.prototype = {
-    __proto__: Applet.IconApplet.prototype,
-
-    _init: function(metadata, orientation, panel_height, instanceId) {
-        Applet.IconApplet.prototype._init.call(this, orientation, panel_height, instanceId);
+class CinnamonOnScreenKeyboardApplet extends Applet.IconApplet {
+    constructor(metadata, orientation, panel_height, instanceId) {
+        super(orientation, panel_height, instanceId);
         this.settings = new Gio.Settings({ schema_id: 'org.cinnamon.desktop.a11y.applications' });
         this.settings.connect('changed::screen-keyboard-enabled', Lang.bind(this, this.update_status));
         this.update_status();
-    },
+    }
 
-    on_applet_clicked: function(event) {
+    on_applet_clicked(event) {
         Main.keyboard.toggle();
-     },
+    }
 
-    update_status: function() {
+    update_status() {
         if (this.settings.get_boolean("screen-keyboard-enabled")) {
             this.set_applet_icon_symbolic_name('on-screen-keyboard');
             this.set_applet_tooltip(_("Click to toggle the on-screen keyboard"));
@@ -30,7 +24,7 @@ CinnamonOnScreenKeyboardApplet.prototype = {
             this.set_applet_tooltip(_("Click to enable the on-screen keyboard"));
         }
     }
-};
+}
 
 function main(metadata, orientation, panel_height, instanceId) {
     return new CinnamonOnScreenKeyboardApplet(metadata, orientation, panel_height, instanceId);

--- a/files/usr/share/cinnamon/applets/on-screen-keyboard@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/on-screen-keyboard@cinnamon.org/applet.js
@@ -3,11 +3,11 @@ const Gio = imports.gi.Gio;
 const Lang = imports.lang;
 const Main = imports.ui.main;
 
-function MyApplet(metadata, orientation, panel_height, instanceId) {
+function CinnamonOnScreenKeyboardApplet(metadata, orientation, panel_height, instanceId) {
     this._init(metadata, orientation, panel_height, instanceId);
 }
 
-MyApplet.prototype = {
+CinnamonOnScreenKeyboardApplet.prototype = {
     __proto__: Applet.IconApplet.prototype,
 
     _init: function(metadata, orientation, panel_height, instanceId) {
@@ -33,6 +33,5 @@ MyApplet.prototype = {
 };
 
 function main(metadata, orientation, panel_height, instanceId) {
-    let myApplet = new MyApplet(metadata, orientation, panel_height, instanceId);
-    return myApplet;
+    return new CinnamonOnScreenKeyboardApplet(metadata, orientation, panel_height, instanceId);
 }

--- a/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
@@ -576,7 +576,7 @@ class CinnamonPanelLaunchersApplet extends Applet.Applet {
                     this._animatingPlaceholdersCount++;
                     this._dragPlaceholder.actor.connect('destroy',
                         Lang.bind(this, function() {
-                        this._animatingPlaceholdersCount--;
+                            this._animatingPlaceholdersCount--;
                         }));
                 }
                 this._dragPlaceholder = null;

--- a/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
@@ -319,11 +319,11 @@ PanelAppLauncher.prototype = {
     }
 };
 
-function MyApplet(metadata, orientation, panel_height, instance_id) {
+function CinnamonPanelLaunchersApplet(metadata, orientation, panel_height, instance_id) {
     this._init(metadata, orientation, panel_height, instance_id);
 }
 
-MyApplet.prototype = {
+CinnamonPanelLaunchersApplet.prototype = {
     __proto__: Applet.Applet.prototype,
 
     _init: function(metadata, orientation, panel_height, instance_id) {
@@ -657,9 +657,8 @@ MyApplet.prototype = {
         return true;
     }
 };
-Signals.addSignalMethods(MyApplet.prototype);
+Signals.addSignalMethods(CinnamonPanelLaunchersApplet.prototype);
 
 function main(metadata, orientation, panel_height, instance_id) {
-    let myApplet = new MyApplet(metadata, orientation, panel_height, instance_id);
-    return myApplet;
+    return new CinnamonPanelLaunchersApplet(metadata, orientation, panel_height, instance_id);
 }

--- a/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
@@ -239,12 +239,12 @@ BrightnessSlider.prototype = {
     }
 };
 
-function MyApplet(metadata, orientation, panel_height, instanceId) {
+function CinnamonPowerApplet(metadata, orientation, panel_height, instanceId) {
     this._init(metadata, orientation, panel_height, instanceId);
 }
 
 
-MyApplet.prototype = {
+CinnamonPowerApplet.prototype = {
     __proto__: Applet.TextIconApplet.prototype,
 
     _init: function(metadata, orientation, panel_height, instanceId) {
@@ -575,6 +575,5 @@ MyApplet.prototype = {
 };
 
 function main(metadata, orientation, panel_height, instanceId) {
-    let myApplet = new MyApplet(metadata, orientation, panel_height, instanceId);
-    return myApplet;
+    return new CinnamonPowerApplet(metadata, orientation, panel_height, instanceId);
 }

--- a/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
@@ -6,10 +6,8 @@ const Lang = imports.lang;
 const St = imports.gi.St;
 const Tooltips = imports.ui.tooltips;
 const PopupMenu = imports.ui.popupMenu;
-const Pango = imports.gi.Pango;
 const Main = imports.ui.main;
 const Settings = imports.ui.settings;
-const GnomeSession = imports.misc.gnomeSession;
 
 const BrightnessBusName = "org.cinnamon.SettingsDaemon.Power.Screen";
 const KeyboardBusName = "org.cinnamon.SettingsDaemon.Power.Keyboard";
@@ -95,15 +93,9 @@ function deviceToIcon(type, icon) {
     }
 }
 
-function DeviceItem() {
-    this._init.apply(this, arguments);
-}
-
-DeviceItem.prototype = {
-    __proto__: PopupMenu.PopupBaseMenuItem.prototype,
-
-    _init: function(device, status, aliases) {
-        PopupMenu.PopupBaseMenuItem.prototype._init.call(this, { reactive: false });
+class DeviceItem extends PopupMenu.PopupBaseMenuItem {
+    constructor(device, status, aliases) {
+        super({reactive: false});
 
         let [device_id, vendor, model, device_type, icon, percentage, state, time, timepercentage] = device;
 
@@ -151,25 +143,19 @@ DeviceItem.prototype = {
     }
 }
 
-function BrightnessSlider(applet, label, icon, busName, minimum_value){
-    this._init(applet, label, icon, busName, minimum_value);
-}
-
-BrightnessSlider.prototype = {
-    __proto__: PopupMenu.PopupSliderMenuItem.prototype,
-
-    _init: function(applet, label, icon, busName, minimum_value){
-        PopupMenu.PopupSliderMenuItem.prototype._init.call(this, 0);
+class BrightnessSlider extends PopupMenu.PopupSliderMenuItem {
+    constructor(applet, label, icon, busName, minimum_value) {
+        super(0);
         this.actor.hide();
 
         this._applet = applet;
         this._seeking = false;
         this._minimum_value = minimum_value;
 
-        this.connect("drag-begin", Lang.bind(this, function(){
+        this.connect("drag-begin", Lang.bind(this, function() {
             this._seeking = true;
         }));
-        this.connect("drag-end", Lang.bind(this, function(){
+        this.connect("drag-end", Lang.bind(this, function() {
             this._seeking = false;
         }));
 
@@ -186,9 +172,9 @@ BrightnessSlider.prototype = {
             this._proxy = proxy;
             this._proxy.GetPercentageRemote(Lang.bind(this, this._dbusAcquired));
         }));
-    },
+    }
 
-    _dbusAcquired: function(b, error){
+    _dbusAcquired(b, error) {
         if(error)
             return;
 
@@ -201,54 +187,47 @@ BrightnessSlider.prototype = {
         //get notified
         this._proxy.connectSignal('Changed', Lang.bind(this, this._getBrightness));
         this._applet.menu.connect("open-state-changed", Lang.bind(this, this._getBrightnessForcedUpdate));
-    },
+    }
 
-    _sliderChanged: function(slider, value) {
+    _sliderChanged(slider, value) {
         if (value < this._minimum_value) {
             value = this._minimum_value;
         }
         this._setBrightness(Math.round(value * 100));
-    },
+    }
 
-    _getBrightness: function() {
+    _getBrightness() {
         //This func is called when dbus signal is received.
         //Only update items value when slider is not used
         if (!this._seeking)
             this._getBrightnessForcedUpdate();
-    },
+    }
 
-    _getBrightnessForcedUpdate: function() {
+    _getBrightnessForcedUpdate() {
         this._proxy.GetPercentageRemote(Lang.bind(this, function(b) {
             this._updateBrightnessLabel(b);
             this.setValue(b / 100);
         }));
-    },
+    }
 
-    _setBrightness: function(value) {
+    _setBrightness(value) {
         this._proxy.SetPercentageRemote(value, Lang.bind(this, function(b) {
             this._updateBrightnessLabel(b);
         }));
-    },
+    }
 
-    _updateBrightnessLabel: function(value) {
+    _updateBrightnessLabel(value) {
         this.tooltipText = this.label;
         if(value)
             this.tooltipText += ": " + value + "%";
 
         this.tooltip.set_text(this.tooltipText);
     }
-};
-
-function CinnamonPowerApplet(metadata, orientation, panel_height, instanceId) {
-    this._init(metadata, orientation, panel_height, instanceId);
 }
 
-
-CinnamonPowerApplet.prototype = {
-    __proto__: Applet.TextIconApplet.prototype,
-
-    _init: function(metadata, orientation, panel_height, instanceId) {
-        Applet.TextIconApplet.prototype._init.call(this, orientation, panel_height, instanceId);
+class CinnamonPowerApplet extends Applet.TextIconApplet {
+    constructor(metadata, orientation, panel_height, instanceId) {
+        super(orientation, panel_height, instanceId);
 
         this.setAllowedLayout(Applet.AllowedLayout.BOTH);
 
@@ -298,9 +277,9 @@ CinnamonPowerApplet.prototype = {
         }));
 
         this.set_show_label_in_vertical_panels(false);
-    },
+    }
 
-    _onPanelEditModeChanged: function() {
+    _onPanelEditModeChanged() {
         if (global.settings.get_boolean(PANEL_EDIT_MODE_KEY)) {
             if (!this.actor.visible) {
                 this.set_applet_icon_symbolic_name("battery-missing");
@@ -310,37 +289,37 @@ CinnamonPowerApplet.prototype = {
         else {
             this._devicesChanged();
         }
-    },
+    }
 
-    _on_device_aliases_changed: function() {
+    _on_device_aliases_changed() {
         this.aliases = global.settings.get_strv("device-aliases");
         this._devicesChanged();
-    },
+    }
 
-    _onButtonPressEvent: function(actor, event){
+    _onButtonPressEvent(actor, event) {
         //toggle keyboard brightness on middle click
-        if(event.get_button() === 2){
-            this.keyboard._proxy.ToggleRemote(function(){});
+        if(event.get_button() === 2) {
+            this.keyboard._proxy.ToggleRemote(function() {});
         }
         return Applet.Applet.prototype._onButtonPressEvent.call(this, actor, event);
-    },
+    }
 
-    on_applet_clicked: function(event) {
+    on_applet_clicked(event) {
         this.menu.toggle();
-    },
+    }
 
-    _onScrollEvent: function(actor, event) {
+    _onScrollEvent(actor, event) {
         //adjust screen brightness on scroll
         let direction = event.get_scroll_direction();
         if (direction == Clutter.ScrollDirection.UP) {
-            this.brightness._proxy.StepUpRemote(function(){});
+            this.brightness._proxy.StepUpRemote(function() {});
         } else if (direction == Clutter.ScrollDirection.DOWN) {
-            this.brightness._proxy.StepDownRemote(function(){});
+            this.brightness._proxy.StepDownRemote(function() {});
         }
         this.brightness._getBrightnessForcedUpdate();
-    },
+    }
 
-    _getDeviceStatus: function(device) {
+    _getDeviceStatus(device) {
         let status = ""
         let [device_id, vendor, model, device_type, icon, percentage, state, seconds] = device;
 
@@ -389,14 +368,14 @@ CinnamonPowerApplet.prototype = {
         }
 
         return status;
-    },
+    }
 
-    on_panel_height_changed: function() {
+    on_panel_height_changed() {
         if (this._proxy)
             this._devicesChanged();
-    },
+    }
 
-    showDeviceInPanel: function(device) {
+    showDeviceInPanel(device) {
         let [device_id, vendor, model, device_type, icon, percentage, state, seconds] = device;
         let status = this._getDeviceStatus(device);
         this.set_applet_tooltip(status);
@@ -448,9 +427,9 @@ CinnamonPowerApplet.prototype = {
         } else {
             this._applet_icon.set_style_class_name ('system-status-icon');
         }
-    },
+    }
 
-    _devicesChanged: function() {
+    _devicesChanged() {
 
         this._devices = [];
         this._primaryDevice = null;
@@ -531,7 +510,7 @@ CinnamonPowerApplet.prototype = {
                     this.set_applet_label("");
                     let icon = this._proxy.Icon;
                     if(icon) {
-                        if (icon != this.panel_icon_name){
+                        if (icon != this.panel_icon_name) {
                             this.panel_icon_name = icon;
                             this.set_applet_icon_symbolic_name('battery-full');
                             let gicon = Gio.icon_new_for_string(icon);
@@ -567,12 +546,12 @@ CinnamonPowerApplet.prototype = {
                 }
             }
         }));
-    },
+    }
 
-    on_applet_removed_from_panel: function() {
+    on_applet_removed_from_panel() {
         Main.systrayManager.unregisterId(this.metadata.uuid);
     }
-};
+}
 
 function main(metadata, orientation, panel_height, instanceId) {
     return new CinnamonPowerApplet(metadata, orientation, panel_height, instanceId);

--- a/files/usr/share/cinnamon/applets/recent@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/recent@cinnamon.org/applet.js
@@ -114,11 +114,11 @@ class CinnamonRecentApplet extends Applet.IconApplet {
                     new_button = this._recentButtons.find(button => ((button.uri) && (button.uri == uri)));
 
                     if (new_button == undefined) {
-                         let icon = this.RecentManager._infosByTimestamp[id].createIcon(22);
-                         let menuItem = new MyPopupMenuItem(icon, this.RecentManager._infosByTimestamp[id].name, uri, {});
-                         this.menu.addMenuItem(menuItem);
-                         menuItem.connect('activate', Lang.bind(this, this._launchFile, this.RecentManager._infosByTimestamp[id]));
-                         new_button = menuItem;
+                        let icon = this.RecentManager._infosByTimestamp[id].createIcon(22);
+                        let menuItem = new MyPopupMenuItem(icon, this.RecentManager._infosByTimestamp[id].name, uri, {});
+                        this.menu.addMenuItem(menuItem);
+                        menuItem.connect('activate', Lang.bind(this, this._launchFile, this.RecentManager._infosByTimestamp[id]));
+                        new_button = menuItem;
                     }
 
                     new_recents.push(new_button);

--- a/files/usr/share/cinnamon/applets/recent@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/recent@cinnamon.org/applet.js
@@ -10,17 +10,9 @@ const PRIVACY_SCHEMA = "org.cinnamon.desktop.privacy";
 const REMEMBER_RECENT_KEY = "remember-recent-files";
 const PANEL_EDIT_MODE_KEY = "panel-edit-mode";
 
-function MyPopupMenuItem()
-{
-    this._init.apply(this, arguments);
-}
-
-MyPopupMenuItem.prototype =
-{
-    __proto__: PopupMenu.PopupBaseMenuItem.prototype,
-
-    _init: function(icon, text, uri, params) {
-        PopupMenu.PopupBaseMenuItem.prototype._init.call(this, params);
+class MyPopupMenuItem extends PopupMenu.PopupBaseMenuItem {
+    constructor(icon, text, uri, params) {
+        super(params);
         this.box = new St.BoxLayout({ style_class: 'popup-combobox-item' });
         this.icon = icon;
         this.uri = uri;
@@ -35,90 +27,79 @@ MyPopupMenuItem.prototype =
     }
 };
 
-function CinnamonRecentApplet(orientation, panel_height, instance_id) {
-    this._init(orientation, panel_height, instance_id);
-}
+class CinnamonRecentApplet extends Applet.IconApplet {
+    constructor(orientation, panel_height, instance_id) {
+        super(orientation, panel_height, instance_id);
 
-CinnamonRecentApplet.prototype = {
-    __proto__: Applet.IconApplet.prototype,
+        this.set_applet_icon_symbolic_name("document-open-recent");
+        this.set_applet_tooltip(_("Recent documents"));
 
-    _init: function(orientation, panel_height, instance_id) {
-        Applet.IconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
+        this.menuManager = new PopupMenu.PopupMenuManager(this);
+        this.menu = new Applet.AppletPopupMenu(this, orientation);
+        this.menuManager.addMenu(this.menu);
 
-        try {
-            this.set_applet_icon_symbolic_name("document-open-recent");
-            this.set_applet_tooltip(_("Recent documents"));
+        this.mainContainer = new St.BoxLayout({ vertical: true });
+        this.menu.addActor(this.mainContainer);
 
-            this.menuManager = new PopupMenu.PopupMenuManager(this);
-            this.menu = new Applet.AppletPopupMenu(this, orientation);
-            this.menuManager.addMenu(this.menu);
+        this.recentsScrollBox = new St.ScrollView({ x_fill: true, y_fill: false, y_align: St.Align.START });
+        this.recentsScrollBox.set_auto_scrolling(true);
+        this.mainContainer.add(this.recentsScrollBox);
 
-            this.mainContainer = new St.BoxLayout({ vertical: true });
-            this.menu.addActor(this.mainContainer);
+        this.recentsBox = new St.BoxLayout({ vertical:true });
+        this.recentsScrollBox.add_actor(this.recentsBox);
+        this.recentsScrollBox.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC);
 
-            this.recentsScrollBox = new St.ScrollView({ x_fill: true, y_fill: false, y_align: St.Align.START });
-            this.recentsScrollBox.set_auto_scrolling(true);
-            this.mainContainer.add(this.recentsScrollBox);
+        this.RecentManager = new DocInfo.DocManager();
+        this.privacy_settings = new Gio.Settings( {schema_id: PRIVACY_SCHEMA} );
 
-            this.recentsBox = new St.BoxLayout({ vertical:true });
-            this.recentsScrollBox.add_actor(this.recentsBox);
-            this.recentsScrollBox.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC);
+        this._recentButtons = [];
+        this._display();
 
-            this.RecentManager = new DocInfo.DocManager();
-            this.privacy_settings = new Gio.Settings( {schema_id: PRIVACY_SCHEMA} );
+        this.recent_id = this.RecentManager.connect('changed', Lang.bind(this, this._refreshRecents));
+        this.settings_id = this.privacy_settings.connect("changed::" + REMEMBER_RECENT_KEY, Lang.bind(this, this._refreshRecents));
+        global.settings.connect('changed::' + PANEL_EDIT_MODE_KEY, Lang.bind(this, this._on_panel_edit_mode_changed));
+    }
 
-            this._recentButtons = [];
-            this._display();
-
-            this.recent_id = this.RecentManager.connect('changed', Lang.bind(this, this._refreshRecents));
-            this.settings_id = this.privacy_settings.connect("changed::" + REMEMBER_RECENT_KEY, Lang.bind(this, this._refreshRecents));
-            global.settings.connect('changed::' + PANEL_EDIT_MODE_KEY, Lang.bind(this, this._on_panel_edit_mode_changed));
-        }
-        catch (e) {
-            global.logError(e);
-        }
-    },
-
-    _on_panel_edit_mode_changed: function () {
+    _on_panel_edit_mode_changed () {
         if (global.settings.get_boolean(PANEL_EDIT_MODE_KEY)) {
             this.actor.show();
         } else {
             this.actor.visible = this._recentButtons.length > 0;
         }
-    },
+    }
 
-    on_applet_removed_from_panel: function () {
+    on_applet_removed_from_panel () {
         this.RecentManager.disconnect(this.recent_id);
         this.privacy_settings.disconnect(this.settings_id);
-    },
+    }
 
-    on_applet_clicked: function(event) {
+    on_applet_clicked(event) {
         this.menu.toggle();
-    },
+    }
 
-    _display: function() {
+    _display() {
         this._refreshRecents();
-    },
+    }
 
-    _launchFile: function(a, b, c, docinfo) {
+    _launchFile(a, b, c, docinfo) {
         docinfo.launch();
-    },
+    }
 
-    _clearAll: function() {
+    _clearAll() {
         let GtkRecent = new Gtk.RecentManager();
         GtkRecent.purge_items();
-    },
+    }
 
-    destroy: function() {
+    destroy() {
         this.RecentManager.disconnectAll();
         this.actor._delegate = null;
         this.menu.destroy();
         this.actor.destroy();
         this._recentButtons = null;
         this.emit('destroy');
-    },
+    }
 
-    _refreshRecents: function() {
+    _refreshRecents() {
         if (this.privacy_settings.get_boolean(REMEMBER_RECENT_KEY)) {
             let new_recents = [];
             let have_recents = false;
@@ -231,7 +212,7 @@ CinnamonRecentApplet.prototype = {
         }
         this._on_panel_edit_mode_changed();
     }
-};
+}
 
 function main(metadata, orientation, panel_height, instance_id) {
     return new CinnamonRecentApplet(orientation, panel_height, instance_id);

--- a/files/usr/share/cinnamon/applets/recent@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/recent@cinnamon.org/applet.js
@@ -35,11 +35,11 @@ MyPopupMenuItem.prototype =
     }
 };
 
-function MyApplet(orientation, panel_height, instance_id) {
+function CinnamonRecentApplet(orientation, panel_height, instance_id) {
     this._init(orientation, panel_height, instance_id);
 }
 
-MyApplet.prototype = {
+CinnamonRecentApplet.prototype = {
     __proto__: Applet.IconApplet.prototype,
 
     _init: function(orientation, panel_height, instance_id) {
@@ -234,6 +234,5 @@ MyApplet.prototype = {
 };
 
 function main(metadata, orientation, panel_height, instance_id) {
-    let myApplet = new MyApplet(orientation, panel_height, instance_id);
-    return myApplet;
+    return new CinnamonRecentApplet(orientation, panel_height, instance_id);
 }

--- a/files/usr/share/cinnamon/applets/removable-drives@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/removable-drives@cinnamon.org/applet.js
@@ -8,15 +8,9 @@ const PopupMenu = imports.ui.popupMenu;
 
 const PANEL_EDIT_MODE_KEY = "panel-edit-mode";
 
-function DriveMenuItem(place) {
-    this._init(place);
-}
-
-DriveMenuItem.prototype = {
-    __proto__: PopupMenu.PopupBaseMenuItem.prototype,
-
-    _init: function(place) {
-        PopupMenu.PopupBaseMenuItem.prototype._init.call(this);
+class DriveMenuItem extends PopupMenu.PopupBaseMenuItem {
+    constructor(place) {
+        super();
 
         this.place = place;
 
@@ -29,72 +23,61 @@ DriveMenuItem.prototype = {
         let ejectButton = new St.Button({ child: ejectIcon });
         ejectButton.connect('clicked', Lang.bind(this, this._eject));
         this.addActor(ejectButton);
-    },
-
-    _eject: function() {
-        this.place.remove();
-    },
-
-    activate: function(event) {
-        this.place.launch({ timestamp: event.get_time() });
-        PopupMenu.PopupBaseMenuItem.prototype.activate.call(this, event);
     }
-};
 
-function CinnamonRemovableDrivesApplet(orientation, panel_height, instance_id) {
-    this._init(orientation, panel_height, instance_id);
+    _eject() {
+        this.place.remove();
+    }
+
+    activate(event) {
+        this.place.launch({ timestamp: event.get_time() });
+        super.activate(event);
+    }
 }
 
-CinnamonRemovableDrivesApplet.prototype = {
-    __proto__: Applet.IconApplet.prototype,
+class CinnamonRemovableDrivesApplet extends Applet.IconApplet {
+    constructor(orientation, panel_height, instance_id) {
+        super(orientation, panel_height, instance_id);
 
-    _init: function(orientation, panel_height, instance_id) {
-        Applet.IconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
+        this.set_applet_icon_symbolic_name("drive-harddisk");
+        this.set_applet_tooltip(_("Removable drives"));
 
-        try {
-            this.set_applet_icon_symbolic_name("drive-harddisk");
-            this.set_applet_tooltip(_("Removable drives"));
+        global.settings.connect('changed::' + PANEL_EDIT_MODE_KEY, Lang.bind(this, this._onPanelEditModeChanged));
 
-            global.settings.connect('changed::' + PANEL_EDIT_MODE_KEY, Lang.bind(this, this._onPanelEditModeChanged));
+        this.menuManager = new PopupMenu.PopupMenuManager(this);
+        this.menu = new Applet.AppletPopupMenu(this, orientation);
+        this.menuManager.addMenu(this.menu);
 
-            this.menuManager = new PopupMenu.PopupMenuManager(this);
-            this.menu = new Applet.AppletPopupMenu(this, orientation);
-            this.menuManager.addMenu(this.menu);
+        this._contentSection = new PopupMenu.PopupMenuSection();
+        this.menu.addMenuItem(this._contentSection);
 
-            this._contentSection = new PopupMenu.PopupMenuSection();
-            this.menu.addMenuItem(this._contentSection);
+        this._update();
 
-            this._update();
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+        this.menu.addAction(_("Open file manager"), function(event) {
+            let homeFile = Gio.file_new_for_path(GLib.get_home_dir());
+            let homeUri = homeFile.get_uri();
+            Gio.app_info_launch_default_for_uri(homeUri, null);
+        });
 
-            this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-            this.menu.addAction(_("Open file manager"), function(event) {
-                let homeFile = Gio.file_new_for_path(GLib.get_home_dir());
-                let homeUri = homeFile.get_uri();
-                Gio.app_info_launch_default_for_uri(homeUri, null);
-            });
+        Main.placesManager.connect('mounts-updated', Lang.bind(this, this._update));
+        this._onPanelEditModeChanged();
+    }
 
-            Main.placesManager.connect('mounts-updated', Lang.bind(this, this._update));
-            this._onPanelEditModeChanged();
-        }
-        catch (e) {
-            global.logError(e);
-        }
-    },
-
-    _onPanelEditModeChanged: function() {
+    _onPanelEditModeChanged() {
         if (global.settings.get_boolean(PANEL_EDIT_MODE_KEY)) {
             this.actor.show();
         }
         else {
             this._update();
         }
-    },
+    }
 
-    on_applet_clicked: function(event) {
+    on_applet_clicked(event) {
         this.menu.toggle();
-    },
+    }
 
-    _update: function() {
+    _update() {
         this._contentSection.removeAll();
 
         let mounts = Main.placesManager.getMounts();
@@ -108,8 +91,7 @@ CinnamonRemovableDrivesApplet.prototype = {
 
         this.actor.visible = any;
     }
-
-};
+}
 
 function main(metadata, orientation, panel_height, instance_id) {
     return new CinnamonRemovableDrivesApplet(orientation, panel_height, instance_id);

--- a/files/usr/share/cinnamon/applets/removable-drives@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/removable-drives@cinnamon.org/applet.js
@@ -41,11 +41,11 @@ DriveMenuItem.prototype = {
     }
 };
 
-function MyApplet(orientation, panel_height, instance_id) {
+function CinnamonRemovableDrivesApplet(orientation, panel_height, instance_id) {
     this._init(orientation, panel_height, instance_id);
 }
 
-MyApplet.prototype = {
+CinnamonRemovableDrivesApplet.prototype = {
     __proto__: Applet.IconApplet.prototype,
 
     _init: function(orientation, panel_height, instance_id) {
@@ -112,6 +112,5 @@ MyApplet.prototype = {
 };
 
 function main(metadata, orientation, panel_height, instance_id) {
-    let myApplet = new MyApplet(orientation, panel_height, instance_id);
-    return myApplet;
+    return new CinnamonRemovableDrivesApplet(orientation, panel_height, instance_id);
 }

--- a/files/usr/share/cinnamon/applets/scale@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/scale@cinnamon.org/applet.js
@@ -3,15 +3,9 @@ const Lang = imports.lang;
 const Main = imports.ui.main;
 const Settings = imports.ui.settings;
 
-function CinnamonScaleApplet(metadata, orientation, panel_height, instance_id) {
-    this._init(metadata, orientation, panel_height, instance_id);
-}
-
-CinnamonScaleApplet.prototype = {
-    __proto__: Applet.IconApplet.prototype,
-
-    _init: function(metadata, orientation, panel_height, instance_id) {
-        Applet.IconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
+class CinnamonScaleApplet extends Applet.IconApplet {
+    constructor(metadata, orientation, panel_height, instance_id) {
+        super(orientation, panel_height, instance_id);
 
         try {
             this.set_applet_icon_symbolic_name("cinnamon-scale");
@@ -27,25 +21,25 @@ CinnamonScaleApplet.prototype = {
         catch (e) {
             global.logError(e);
         }
-    },
+    }
 
-    on_applet_clicked: function(event) {
+    on_applet_clicked(event) {
         if (this._hover_activates)
             return;
         this.doAction();
-    },
+    }
 
-    _onEntered: function(event) {
+    _onEntered(event) {
         if (!this._hover_activates || global.settings.get_boolean("panel-edit-mode"))
             return;
         this.doAction();
-    },
+    }
 
-    doAction: function() {
+    doAction() {
         if (!Main.overview.animationInProgress)
             Main.overview.toggle();
     }
-};
+}
 
 function main(metadata, orientation, panel_height, instance_id) {
     return new CinnamonScaleApplet(metadata, orientation, panel_height, instance_id);

--- a/files/usr/share/cinnamon/applets/scale@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/scale@cinnamon.org/applet.js
@@ -3,11 +3,11 @@ const Lang = imports.lang;
 const Main = imports.ui.main;
 const Settings = imports.ui.settings;
 
-function MyApplet(metadata, orientation, panel_height, instance_id) {
+function CinnamonScaleApplet(metadata, orientation, panel_height, instance_id) {
     this._init(metadata, orientation, panel_height, instance_id);
 }
 
-MyApplet.prototype = {
+CinnamonScaleApplet.prototype = {
     __proto__: Applet.IconApplet.prototype,
 
     _init: function(metadata, orientation, panel_height, instance_id) {
@@ -48,6 +48,5 @@ MyApplet.prototype = {
 };
 
 function main(metadata, orientation, panel_height, instance_id) {
-    let myApplet = new MyApplet(metadata, orientation, panel_height, instance_id);
-    return myApplet;
+    return new CinnamonScaleApplet(metadata, orientation, panel_height, instance_id);
 }

--- a/files/usr/share/cinnamon/applets/separator@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/separator@cinnamon.org/applet.js
@@ -2,28 +2,21 @@ const Applet = imports.ui.applet;
 const St = imports.gi.St;
 const Clutter = imports.gi.Clutter;
 
-function CinnamonSeparatorApplet(orientation, panel_height, instance_id) {
-    this._init(orientation, panel_height, instance_id);
-}
-
-CinnamonSeparatorApplet.prototype = {
-    __proto__: Applet.Applet.prototype,
-
-    _init: function(orientation, panel_height, instance_id) {
-        Applet.Applet.prototype._init.call(this, orientation, panel_height, instance_id);
+class CinnamonSeparatorApplet extends Applet.Applet {
+    constructor(orientation, panel_height, instance_id) {
+        super(orientation, panel_height, instance_id);
         this.actor.style_class = 'applet-separator';
 
         this.setAllowedLayout(Applet.AllowedLayout.BOTH);
 
         this.on_orientation_changed(orientation);
-    },
+    }
 
-    on_panel_height_changed: function() {
+    on_panel_height_changed() {
         this.on_orientation_changed(this.orientation);
-    },
+    }
 
-    on_orientation_changed: function(neworientation) {
-
+    on_orientation_changed(neworientation) {
         this.orientation = neworientation;
 
         if (this.orientation == St.Side.TOP || this.orientation == St.Side.BOTTOM) {
@@ -44,8 +37,8 @@ CinnamonSeparatorApplet.prototype = {
             this._line.set_height(2);
             this._line.set_width((this._panelHeight - 8));
         }
-    },
-};
+    }
+}
 
 function main(metadata, orientation, panel_height, instance_id) {
     return new CinnamonSeparatorApplet(orientation, panel_height, instance_id);

--- a/files/usr/share/cinnamon/applets/separator@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/separator@cinnamon.org/applet.js
@@ -2,11 +2,11 @@ const Applet = imports.ui.applet;
 const St = imports.gi.St;
 const Clutter = imports.gi.Clutter;
 
-function MyApplet(orientation, panel_height, instance_id) {
+function CinnamonSeparatorApplet(orientation, panel_height, instance_id) {
     this._init(orientation, panel_height, instance_id);
 }
 
-MyApplet.prototype = {
+CinnamonSeparatorApplet.prototype = {
     __proto__: Applet.Applet.prototype,
 
     _init: function(orientation, panel_height, instance_id) {
@@ -48,6 +48,5 @@ MyApplet.prototype = {
 };
 
 function main(metadata, orientation, panel_height, instance_id) {
-    let myApplet = new MyApplet(orientation, panel_height, instance_id);
-    return myApplet;
+    return new CinnamonSeparatorApplet(orientation, panel_height, instance_id);
 }

--- a/files/usr/share/cinnamon/applets/settings-example@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/settings-example@cinnamon.org/applet.js
@@ -7,15 +7,9 @@ const Gio = imports.gi.Gio;
 const Tweener = imports.ui.tweener;
 const Main = imports.ui.main;
 
-function CinnamonSettingsExampleApplet(orientation, panel_height, instance_id) {
-    this._init(orientation, panel_height, instance_id); // Be sure to pass instanceId from the main function
-}
-
-CinnamonSettingsExampleApplet.prototype = {
-    __proto__: Applet.TextIconApplet.prototype,
-
-    _init: function(orientation, panel_height, instance_id) {
-        Applet.TextIconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
+class CinnamonSettingsExampleApplet extends Applet.TextIconApplet {
+    constructor(orientation, panel_height, instance_id) {
+        super(orientation, panel_height, instance_id);
 
         this.menuManager = new PopupMenu.PopupMenuManager(this);
         this.menu = new Applet.AppletPopupMenu(this, orientation);
@@ -57,13 +51,13 @@ CinnamonSettingsExampleApplet.prototype = {
         /* Let's set up our applet's initial state now that we have our setting properties defined */
         this.on_keybinding_changed();
         this.on_settings_changed();
-    },
+    }
 
-    on_keybinding_changed: function() {
+    on_keybinding_changed() {
         Main.keybindingManager.addHotKey("must-be-unique-id", this.keybinding, Lang.bind(this, this.on_hotkey_triggered));
-    },
+    }
 
-    on_settings_changed: function() {
+    on_settings_changed() {
         if (this.use_custom) {
             this.set_applet_label(this.custom_label);
         } else {
@@ -83,23 +77,23 @@ CinnamonSettingsExampleApplet.prototype = {
 
         this.actor.style = "background-color:" + this.bg_color + "; width:" + this.spinner_number + "px";
 
-    },
+    }
 
-    on_signal_test_fired: function(setting_prov, key, oldval, newval) {
+    on_signal_test_fired(setting_prov, key, oldval, newval) {
         global.logError("Test signal fired.  Old value for key "+ key + " was " + oldval + ".  New value is " + newval + ".");
-    },
+    }
 
-    on_slider_changed: function(slider, value) {
+    on_slider_changed(slider, value) {
         this.scale_val = value;  // This is our BIDIRECTIONAL setting - by updating this.scale_val,
                                                // Our configuration file will also be updated
-    },
+    }
 
 
 /* This method is a callback that is defined by a button type in our settings file
  * This button will appear in the configuration dialog, and pressing it will call this method
  * This could useful to open a link to your web page, or just about anything you want
  */
-    on_config_button_pressed: function() {
+    on_config_button_pressed() {
         this.set_applet_label(_("YOU PRESSED THE BUTTON!!!"));
 
         let timeoutId = Mainloop.timeout_add(3000, Lang.bind(this, function() {
@@ -111,35 +105,35 @@ CinnamonSettingsExampleApplet.prototype = {
             margin_left: 10,
             time: 0.5,
             transition: this.tween_function,
-            onComplete: function(){
+            onComplete() {
                 Tweener.addTween(this._applet_icon, {
                     margin_left: 0,
                     time: 0.5,
                     transition: this.tween_function
                 });
             },
-           onCompleteScope: this
+            onCompleteScope: this
         });
-    },
+    }
 
-    on_hotkey_triggered: function() {
+    on_hotkey_triggered() {
         this.set_applet_label(_("YOU USED THE HOTKEY!!!"));
 
         let timeoutId = Mainloop.timeout_add(3000, Lang.bind(this, function() {
             this.on_settings_changed();
         }));
-    },
+    }
 
-    on_applet_clicked: function(event) {
+    on_applet_clicked(event) {
         this.menu.toggle();
-    },
+    }
 
-    on_applet_removed_from_panel: function() {
+    on_applet_removed_from_panel() {
         this.settings.finalize();    // This is called when a user removes the applet from the panel.. we want to
                                      // Remove any connections and file listeners here, which our settings object
                                      // has a few of
     }
-};
+}
 
 function main(metadata, orientation, panel_height, instance_id) {  // Make sure you collect and pass on instanceId
     return new CinnamonSettingsExampleApplet(orientation, panel_height, instance_id);

--- a/files/usr/share/cinnamon/applets/settings-example@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/settings-example@cinnamon.org/applet.js
@@ -7,11 +7,11 @@ const Gio = imports.gi.Gio;
 const Tweener = imports.ui.tweener;
 const Main = imports.ui.main;
 
-function MyApplet(orientation, panel_height, instance_id) {
+function CinnamonSettingsExampleApplet(orientation, panel_height, instance_id) {
     this._init(orientation, panel_height, instance_id); // Be sure to pass instanceId from the main function
 }
 
-MyApplet.prototype = {
+CinnamonSettingsExampleApplet.prototype = {
     __proto__: Applet.TextIconApplet.prototype,
 
     _init: function(orientation, panel_height, instance_id) {
@@ -142,7 +142,6 @@ MyApplet.prototype = {
 };
 
 function main(metadata, orientation, panel_height, instance_id) {  // Make sure you collect and pass on instanceId
-    let myApplet = new MyApplet(orientation, panel_height, instance_id);
-    return myApplet;
+    return new CinnamonSettingsExampleApplet(orientation, panel_height, instance_id);
 }
 

--- a/files/usr/share/cinnamon/applets/settings@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/settings@cinnamon.org/applet.js
@@ -2,45 +2,31 @@ const Applet = imports.ui.applet;
 const Panel = imports.ui.panel;
 const PopupMenu = imports.ui.popupMenu;
 
-function CinnamonSettingsApplet(orientation, panel_height, instance_id) {
-    this._init(orientation, panel_height, instance_id);
-}
+class CinnamonSettingsApplet extends Applet.IconApplet {
+    constructor(orientation, panel_height, instance_id) {
+        super(orientation, panel_height, instance_id);
 
-CinnamonSettingsApplet.prototype = {
-    __proto__: Applet.IconApplet.prototype,
-
-    _init: function(orientation, panel_height, instance_id) {
-        Applet.IconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
-
-        try {
-            this.set_applet_icon_symbolic_name("go-up");
-            this.set_applet_tooltip(_("Settings"));
-            this.menuManager = new PopupMenu.PopupMenuManager(this);
-            this._buildMenu(orientation);
-
-        }
-        catch (e) {
-            global.logError(e);
-        }
-    },
-
-    on_applet_clicked: function(event) {
-        this.menu.toggle();
-    },
-
-    _buildMenu: function(orientation) {
-        this.menu = new Applet.AppletPopupMenu(this, orientation);
-        this.menuManager.addMenu(this.menu);
-        Panel.populateSettingsMenu(this.menu);
-    },
-
-    on_orientation_changed: function(orientation){
-        this.menu.destroy();
+        this.set_applet_icon_symbolic_name("go-up");
+        this.set_applet_tooltip(_("Settings"));
+        this.menuManager = new PopupMenu.PopupMenuManager(this);
         this._buildMenu(orientation);
     }
 
+    on_applet_clicked(event) {
+        this.menu.toggle();
+    }
 
-};
+    _buildMenu(orientation) {
+        this.menu = new Applet.AppletPopupMenu(this, orientation);
+        this.menuManager.addMenu(this.menu);
+        Panel.populateSettingsMenu(this.menu);
+    }
+
+    on_orientation_changed(orientation) {
+        this.menu.destroy();
+        this._buildMenu(orientation);
+    }
+}
 
 function main(metadata, orientation, panel_height, instance_id) {
     return new CinnamonSettingsApplet(orientation, panel_height, instance_id);

--- a/files/usr/share/cinnamon/applets/settings@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/settings@cinnamon.org/applet.js
@@ -2,11 +2,11 @@ const Applet = imports.ui.applet;
 const Panel = imports.ui.panel;
 const PopupMenu = imports.ui.popupMenu;
 
-function MyApplet(orientation, panel_height, instance_id) {
+function CinnamonSettingsApplet(orientation, panel_height, instance_id) {
     this._init(orientation, panel_height, instance_id);
 }
 
-MyApplet.prototype = {
+CinnamonSettingsApplet.prototype = {
     __proto__: Applet.IconApplet.prototype,
 
     _init: function(orientation, panel_height, instance_id) {
@@ -43,6 +43,5 @@ MyApplet.prototype = {
 };
 
 function main(metadata, orientation, panel_height, instance_id) {
-    let myApplet = new MyApplet(orientation, panel_height, instance_id);
-    return myApplet;
+    return new CinnamonSettingsApplet(orientation, panel_height, instance_id);
 }

--- a/files/usr/share/cinnamon/applets/show-desklets@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/show-desklets@cinnamon.org/applet.js
@@ -5,8 +5,8 @@ const Settings = imports.ui.settings;
 
 // ES2015 class syntax can be used for Cinnamon 3.8+
 class CinnamonShowDeskletsApplet extends Applet.IconApplet {
-    _init(orientation, panel_height, instance_id) {
-        super._init(orientation, panel_height, instance_id);
+    constructor(orientation, panel_height, instance_id) {
+        super(orientation, panel_height, instance_id);
 
         this.set_applet_icon_name('cs-desklets');
         this.set_applet_tooltip(_('Show Desklets'));

--- a/files/usr/share/cinnamon/applets/show-desklets@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/show-desklets@cinnamon.org/applet.js
@@ -4,7 +4,7 @@ const Main = imports.ui.main;
 const Settings = imports.ui.settings;
 
 // ES2015 class syntax can be used for Cinnamon 3.8+
-class MyApplet extends Applet.IconApplet {
+class CinnamonShowDeskletsApplet extends Applet.IconApplet {
     _init(orientation, panel_height, instance_id) {
         super._init(orientation, panel_height, instance_id);
 
@@ -58,5 +58,5 @@ class MyApplet extends Applet.IconApplet {
 }
 
 function main(metadata, orientation, panel_height, instance_id) {
-    return new MyApplet(orientation, panel_height, instance_id);
+    return new CinnamonShowDeskletsApplet(orientation, panel_height, instance_id);
 }

--- a/files/usr/share/cinnamon/applets/show-desktop@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/show-desktop@cinnamon.org/applet.js
@@ -9,7 +9,7 @@ const Clutter = imports.gi.Clutter;
 const Lang = imports.lang;
 const SignalManager = imports.misc.signalManager;
 
-class MyApplet extends Applet.IconApplet {
+class CinnamonShowDesktopApplet extends Applet.IconApplet {
 
     _init(orientation, panel_height, instance_id) {
         super._init(orientation, panel_height, instance_id);
@@ -123,5 +123,5 @@ class MyApplet extends Applet.IconApplet {
 }
 
 function main(metadata, orientation, panel_height, instance_id) {
-    return new MyApplet(orientation, panel_height, instance_id);
+    return new CinnamonShowDesktopApplet(orientation, panel_height, instance_id);
 }

--- a/files/usr/share/cinnamon/applets/show-desktop@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/show-desktop@cinnamon.org/applet.js
@@ -10,9 +10,8 @@ const Lang = imports.lang;
 const SignalManager = imports.misc.signalManager;
 
 class CinnamonShowDesktopApplet extends Applet.IconApplet {
-
-    _init(orientation, panel_height, instance_id) {
-        super._init(orientation, panel_height, instance_id);
+    constructor(orientation, panel_height, instance_id) {
+        super(orientation, panel_height, instance_id);
 
         this.settings = new Settings.AppletSettings(this, "show-desktop@cinnamon.org", instance_id);
 

--- a/files/usr/share/cinnamon/applets/slideshow@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/slideshow@cinnamon.org/applet.js
@@ -6,11 +6,11 @@ const Applet = imports.ui.applet;
 const PopupMenu = imports.ui.popupMenu;
 const Util = imports.misc.util;
 
-function MyApplet(metadata, orientation, panel_height, instanceId) {
+function CinnamonSlideshowApplet(metadata, orientation, panel_height, instanceId) {
     this._init(metadata, orientation, panel_height, instanceId);
 }
 
-MyApplet.prototype = {
+CinnamonSlideshowApplet.prototype = {
     __proto__: Applet.IconApplet.prototype,
 
     _init: function(metadata, orientation, panel_height, instanceId) {
@@ -117,6 +117,5 @@ MyApplet.prototype = {
 };
 
 function main(metadata, orientation, panel_height, instanceId) {
-    let myApplet = new MyApplet(metadata, orientation, panel_height, instanceId);
-    return myApplet;
+    return new CinnamonSlideshowApplet(metadata, orientation, panel_height, instanceId);
 }

--- a/files/usr/share/cinnamon/applets/slideshow@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/slideshow@cinnamon.org/applet.js
@@ -6,64 +6,52 @@ const Applet = imports.ui.applet;
 const PopupMenu = imports.ui.popupMenu;
 const Util = imports.misc.util;
 
-function CinnamonSlideshowApplet(metadata, orientation, panel_height, instanceId) {
-    this._init(metadata, orientation, panel_height, instanceId);
-}
-
-CinnamonSlideshowApplet.prototype = {
-    __proto__: Applet.IconApplet.prototype,
-
-    _init: function(metadata, orientation, panel_height, instanceId) {
-        Applet.IconApplet.prototype._init.call(this, orientation, panel_height, instanceId);
+class CinnamonSlideshowApplet extends Applet.IconApplet {
+    constructor(metadata, orientation, panel_height, instanceId) {
+        super(orientation, panel_height, instanceId);
 
         this._slideshowSettings = new Gio.Settings({ schema_id: 'org.cinnamon.desktop.background.slideshow' });
 
-        try {
-            if (this._slideshowSettings.get_boolean("slideshow-enabled")) {
-                if (!this._slideshowSettings.get_boolean("slideshow-paused")) {
-                    this.set_applet_icon_symbolic_name('slideshow-play-symbolic.svg');
-                    this.set_applet_tooltip(_("Click to pause the slideshow"));
-                } else {
-                    this.set_applet_icon_symbolic_name('slideshow-pause-symbolic.svg');
-                    this.set_applet_tooltip(_("Click to resume the slideshow"));
-                }
+        if (this._slideshowSettings.get_boolean("slideshow-enabled")) {
+            if (!this._slideshowSettings.get_boolean("slideshow-paused")) {
+                this.set_applet_icon_symbolic_name('slideshow-play-symbolic.svg');
+                this.set_applet_tooltip(_("Click to pause the slideshow"));
             } else {
-                this.set_applet_icon_symbolic_name('slideshow-disabled-symbolic.svg');
-                this.set_applet_tooltip(_("The slideshow is disabled"));
+                this.set_applet_icon_symbolic_name('slideshow-pause-symbolic.svg');
+                this.set_applet_tooltip(_("Click to resume the slideshow"));
             }
-
-            this._slideshowSettings.connect("changed::slideshow-enabled", Lang.bind(this, this._on_slideshow_enabled_changed));
-            this._slideshowSettings.connect("changed::slideshow-paused", Lang.bind(this, this._on_slideshow_paused_changed));
-
-            this.enable_slideshow_switch = new PopupMenu.PopupSwitchMenuItem(_("Slideshow"), this._slideshowSettings.get_boolean("slideshow-enabled"));
-            this._applet_context_menu.addMenuItem(this.enable_slideshow_switch);
-            this.enable_slideshow_switch.connect("toggled", Lang.bind(this, this._on_slideshow_enabled_toggled));
-
-            this._applet_context_menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-
-            this.next_image_context_menu_item = new PopupMenu.PopupIconMenuItem(_("Next Background"),
-                    "media-seek-forward",
-                    St.IconType.SYMBOLIC);
-            this.next_image_context_menu_item.connect('activate', Lang.bind(this, this.get_next_image));
-            this._applet_context_menu.addMenuItem(this.next_image_context_menu_item);
-
-            this._applet_context_menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-
-            this.open_settings_context_menu_item = new PopupMenu.PopupIconMenuItem(_("Background Settings"),
-                    "preferences-desktop-wallpaper",
-                    St.IconType.SYMBOLIC);
-            this.open_settings_context_menu_item.connect('activate', Lang.bind(this, function() {
-                Util.spawnCommandLine("cinnamon-settings backgrounds");
-            }));
-            this._applet_context_menu.addMenuItem(this.open_settings_context_menu_item);
-        }
-        catch(e) {
-            global.logError(e);
+        } else {
+            this.set_applet_icon_symbolic_name('slideshow-disabled-symbolic.svg');
+            this.set_applet_tooltip(_("The slideshow is disabled"));
         }
 
-    },
+        this._slideshowSettings.connect("changed::slideshow-enabled", Lang.bind(this, this._on_slideshow_enabled_changed));
+        this._slideshowSettings.connect("changed::slideshow-paused", Lang.bind(this, this._on_slideshow_paused_changed));
 
-    on_applet_clicked: function(event) {
+        this.enable_slideshow_switch = new PopupMenu.PopupSwitchMenuItem(_("Slideshow"), this._slideshowSettings.get_boolean("slideshow-enabled"));
+        this._applet_context_menu.addMenuItem(this.enable_slideshow_switch);
+        this.enable_slideshow_switch.connect("toggled", Lang.bind(this, this._on_slideshow_enabled_toggled));
+
+        this._applet_context_menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+
+        this.next_image_context_menu_item = new PopupMenu.PopupIconMenuItem(_("Next Background"),
+                "media-seek-forward",
+                St.IconType.SYMBOLIC);
+        this.next_image_context_menu_item.connect('activate', Lang.bind(this, this.get_next_image));
+        this._applet_context_menu.addMenuItem(this.next_image_context_menu_item);
+
+        this._applet_context_menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+
+        this.open_settings_context_menu_item = new PopupMenu.PopupIconMenuItem(_("Background Settings"),
+                "preferences-desktop-wallpaper",
+                St.IconType.SYMBOLIC);
+        this.open_settings_context_menu_item.connect('activate', Lang.bind(this, function() {
+            Util.spawnCommandLine("cinnamon-settings backgrounds");
+        }));
+        this._applet_context_menu.addMenuItem(this.open_settings_context_menu_item);
+    }
+
+    on_applet_clicked(event) {
         if (this._slideshowSettings.get_boolean("slideshow-enabled")) {
             if (!this._slideshowSettings.get_boolean("slideshow-paused")) {
                 this._slideshowSettings.set_boolean("slideshow-paused", true);
@@ -75,9 +63,9 @@ CinnamonSlideshowApplet.prototype = {
                 this.set_applet_tooltip(_("Click to pause the slideshow"));
             }
         }
-    },
+    }
 
-    _on_slideshow_enabled_toggled: function() {
+    _on_slideshow_enabled_toggled() {
         if (this._slideshowSettings.get_boolean("slideshow-enabled")) {
             this._slideshowSettings.set_boolean("slideshow-enabled", false);
             this.set_applet_icon_symbolic_name('slideshow-disabled-symbolic.svg');
@@ -87,9 +75,9 @@ CinnamonSlideshowApplet.prototype = {
             this.set_applet_icon_symbolic_name('slideshow-play-symbolic.svg');
             this.set_applet_tooltip(_("Click to pause the slideshow"));
         }
-    },
+    }
 
-    _on_slideshow_enabled_changed: function() {
+    _on_slideshow_enabled_changed() {
         if (this._slideshowSettings.get_boolean("slideshow-enabled")) {
             this.enable_slideshow_switch.setToggleState(true);
             this.set_applet_icon_symbolic_name('slideshow-play-symbolic.svg');
@@ -99,9 +87,9 @@ CinnamonSlideshowApplet.prototype = {
             this.set_applet_icon_symbolic_name('slideshow-disabled-symbolic.svg');
             this.set_applet_tooltip(_("The slideshow is disabled"));
         }
-    },
+    }
 
-    _on_slideshow_paused_changed: function() {
+    _on_slideshow_paused_changed() {
         if (this._slideshowSettings.get_boolean("slideshow-paused")) {
             this.set_applet_icon_symbolic_name('slideshow-pause-symbolic.svg');
             this.set_applet_tooltip(_("Click to resume the slideshow"));
@@ -109,12 +97,12 @@ CinnamonSlideshowApplet.prototype = {
             this.set_applet_icon_symbolic_name('slideshow-play-symbolic.svg');
             this.set_applet_tooltip(_("Click to pause the slideshow"));
         }
-    },
+    }
 
-    get_next_image: function() {
+    get_next_image() {
         Main.slideshowManager.getNextImage();
     }
-};
+}
 
 function main(metadata, orientation, panel_height, instanceId) {
     return new CinnamonSlideshowApplet(metadata, orientation, panel_height, instanceId);

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -37,12 +37,8 @@ const ICON_SIZE = 28;
 const CINNAMON_DESKTOP_SOUNDS = "org.cinnamon.desktop.sound";
 const MAXIMUM_VOLUME_KEY = "maximum-volume";
 
-function ControlButton() {
-    this._init.apply(this, arguments);
-}
-
-ControlButton.prototype = {
-    _init: function(icon, tooltip, callback, small = false) {
+class ControlButton {
+    constructor(icon, tooltip, callback, small = false) {
         this.actor = new St.Bin();
 
         this.button = new St.Button();
@@ -59,37 +55,31 @@ ControlButton.prototype = {
         this.actor.add_actor(this.button);
 
         this.tooltip = new Tooltips.Tooltip(this.button, tooltip);
-    },
+    }
 
-    getActor: function() {
+    getActor() {
         return this.actor;
-    },
+    }
 
-    setData: function(icon, tooltip) {
+    setData(icon, tooltip) {
         this.icon.icon_name = icon;
         this.tooltip.set_text(tooltip);
-    },
+    }
 
-    setActive: function(status){
+    setActive(status) {
         this.button.change_style_pseudo_class("active", status);
-    },
+    }
 
-    setEnabled: function(status){
+    setEnabled(status) {
         this.button.change_style_pseudo_class("disabled", !status);
         this.button.can_focus = status;
         this.button.reactive = status;
     }
-};
-
-function VolumeSlider(){
-    this._init.apply(this, arguments);
 }
 
-VolumeSlider.prototype = {
-    __proto__: PopupMenu.PopupSliderMenuItem.prototype,
-
-    _init: function(applet, stream, tooltip, app_icon){
-        PopupMenu.PopupSliderMenuItem.prototype._init.call(this, 0);
+class VolumeSlider extends PopupMenu.PopupSliderMenuItem {
+    constructor(applet, stream, tooltip, app_icon) {
+        super(0);
         this.applet = applet;
 
         if(tooltip)
@@ -115,10 +105,10 @@ VolumeSlider.prototype = {
         this.addActor(this._slider, {span: -1, expand: true});
 
         this.connectWithStream(stream);
-    },
+    }
 
-    connectWithStream: function(stream){
-        if(!stream){
+    connectWithStream(stream) {
+        if(!stream) {
             this.actor.hide();
             this.stream = null;
         } else {
@@ -129,23 +119,23 @@ VolumeSlider.prototype = {
 
             let mutedId = stream.connect("notify::is-muted", Lang.bind(this, this._update));
             let volumeId = stream.connect("notify::volume", Lang.bind(this, this._update));
-            this.connect("destroy", function(){
+            this.connect("destroy", function() {
                 stream.disconnect(mutedId);
                 stream.disconnect(volumeId);
             });
         }
 
         this._update();
-    },
+    }
 
-    _onValueChanged: function(){
+    _onValueChanged() {
         if(!this.stream) return;
 
         let muted;
         // Use the scaled volume max only for the main output
         let volume = this._value * (this.isOutputSink ? this.applet._volumeMax : this.applet._volumeNorm);
 
-        if(this._value < 0.005){
+        if(this._value < 0.005) {
             volume = 0;
             muted = true;
         } else {
@@ -162,9 +152,9 @@ VolumeSlider.prototype = {
 
         if(!this._dragging)
             this.applet._notifyVolumeChange(this.stream);
-    },
+    }
 
-    _onScrollEvent: function (actor, event) {
+    _onScrollEvent(actor, event) {
         let direction = event.get_scroll_direction();
 
         if (direction == Clutter.ScrollDirection.DOWN) {
@@ -176,9 +166,9 @@ VolumeSlider.prototype = {
 
         this._slider.queue_repaint();
         this.emit('value-changed', this._value);
-    },
+    }
 
-    _onKeyPressEvent: function (actor, event) {
+    _onKeyPressEvent(actor, event) {
         let key = event.get_key_symbol();
         if (key == Clutter.KEY_Right || key == Clutter.KEY_Left) {
             let delta = key == Clutter.KEY_Right ? VOLUME_ADJUSTMENT_STEP : -VOLUME_ADJUSTMENT_STEP;
@@ -189,7 +179,7 @@ VolumeSlider.prototype = {
             return true;
         }
         return false;
-    },
+    }
 
 
     _update: function(){
@@ -224,9 +214,9 @@ VolumeSlider.prototype = {
 
         // send data to applet
         this.emit("values-changed", iconName, percentage);
-    },
+    }
 
-    _volumeToIcon: function(value){
+    _volumeToIcon(value) {
         let icon;
         if(value < 0.005) {
             icon = "muted";
@@ -241,17 +231,11 @@ VolumeSlider.prototype = {
         }
         return this.isMic? "microphone-sensitivity-" + icon : "audio-volume-" + icon;
     }
-};
-
-function StreamMenuSection(){
-    this._init.apply(this, arguments);
 }
 
-StreamMenuSection.prototype = {
-    __proto__: PopupMenu.PopupMenuSection.prototype,
-
-    _init: function(applet, stream){
-        PopupMenu.PopupMenuSection.prototype._init.call(this);
+class StreamMenuSection extends PopupMenu.PopupMenuSection {
+    constructor(applet, stream) {
+        super();
 
         let iconName = stream.icon_name;
         let name = stream.name;
@@ -284,17 +268,11 @@ StreamMenuSection.prototype = {
         let slider = new VolumeSlider(applet, stream, name, iconName);
         this.addMenuItem(slider);
     }
-};
-
-function Player() {
-    this._init.apply(this, arguments);
 }
 
-Player.prototype = {
-    __proto__: PopupMenu.PopupMenuSection.prototype,
-
-    _init: function(applet, busname, owner) {
-        PopupMenu.PopupMenuSection.prototype._init.call(this);
+class Player extends PopupMenu.PopupMenuSection {
+    constructor(applet, busname, owner) {
+        super();
         this.showPosition = true;
         this._owner = owner;
         this._busName = busname;
@@ -334,9 +312,9 @@ Player.prototype = {
                                                   this._dbus_acquired();
                                               }
                                           }));
-    },
+    }
 
-    _dbus_acquired: function() {
+    _dbus_acquired() {
         if (!this._prop || !this._mediaServerPlayer || !this._mediaServer)
             return;
 
@@ -354,7 +332,7 @@ Player.prototype = {
         playerBox.add_actor(this.playerLabel);
 
         if (this._mediaServer.CanRaise) {
-            let btn = new ControlButton("go-up", _("Open Player"), Lang.bind(this, function(){
+            let btn = new ControlButton("go-up", _("Open Player"), Lang.bind(this, function() {
                 if (this._name === "spotify") {
                     // Spotify isn't able to raise via Dbus once its main UI is closed
                     Util.spawn(['spotify']);
@@ -367,7 +345,7 @@ Player.prototype = {
             playerBox.add_actor(btn.actor);
         }
         if (this._mediaServer.CanQuit) {
-            let btn = new ControlButton("window-close", _("Quit Player"), Lang.bind(this, function(){
+            let btn = new ControlButton("window-close", _("Quit Player"), Lang.bind(this, function() {
                 this._mediaServer.QuitRemote();
                 this._applet.menu.close();
             }), true);
@@ -411,16 +389,16 @@ Player.prototype = {
 
         // Playback controls
         let trackControls = new St.Bin({x_align: St.Align.MIDDLE});
-        this._prevButton = new ControlButton("media-skip-backward", _("Previous"), Lang.bind(this, function(){
+        this._prevButton = new ControlButton("media-skip-backward", _("Previous"), Lang.bind(this, function() {
             this._mediaServerPlayer.PreviousRemote();
         }));
-        this._playButton = new ControlButton("media-playback-start", _("Play"), Lang.bind(this, function(){
+        this._playButton = new ControlButton("media-playback-start", _("Play"), Lang.bind(this, function() {
             this._mediaServerPlayer.PlayPauseRemote();
         }));
-        this._stopButton = new ControlButton("media-playback-stop", _("Stop"), Lang.bind(this, function(){
+        this._stopButton = new ControlButton("media-playback-stop", _("Stop"), Lang.bind(this, function() {
             this._mediaServerPlayer.StopRemote();
         }));
-        this._nextButton = new ControlButton("media-skip-forward", _("Next"), Lang.bind(this, function(){
+        this._nextButton = new ControlButton("media-skip-forward", _("Next"), Lang.bind(this, function() {
             this._mediaServerPlayer.NextRemote();
         }));
         this.trackInfo.add_actor(trackControls);
@@ -430,14 +408,14 @@ Player.prototype = {
         this.controls.add_actor(this._stopButton.getActor());
         this.controls.add_actor(this._nextButton.getActor());
         trackControls.set_child(this.controls);
-        if(this._mediaServerPlayer.LoopStatus){
+        if(this._mediaServerPlayer.LoopStatus) {
             this._loopButton = new ControlButton("media-playlist-consecutive", _("Consecutive Playing"), Lang.bind(this, this._toggleLoopStatus));
             this._loopButton.actor.visible = this._applet.extendedPlayerControl;
             this.controls.add_actor(this._loopButton.getActor());
 
             this._setLoopStatus(this._mediaServerPlayer.LoopStatus);
         }
-        if(this._mediaServerPlayer.Shuffle !== undefined){
+        if(this._mediaServerPlayer.Shuffle !== undefined) {
             this._shuffleButton = new ControlButton("media-playlist-shuffle", _("No Shuffle"), Lang.bind(this, this._toggleShuffle));
             this._shuffleButton.actor.visible = this._applet.extendedPlayerControl;
             this.controls.add_actor(this._shuffleButton.getActor());
@@ -512,23 +490,23 @@ Player.prototype = {
         }));
 
         //get the desktop entry and pass it to the applet
-        this._prop.GetRemote(MEDIA_PLAYER_2_NAME, "DesktopEntry", Lang.bind(this, function(value){
+        this._prop.GetRemote(MEDIA_PLAYER_2_NAME, "DesktopEntry", Lang.bind(this, function(value) {
             this._applet.passDesktopEntry(value[0].unpack());
         }));
 
         this._getPosition();
-    },
+    }
 
-    _getName: function() {
+    _getName() {
         return this._name.charAt(0).toUpperCase() + this._name.slice(1);
-    },
+    }
 
 
-    _setName: function(status) {
+    _setName(status) {
         this.playerLabel.set_text(this._getName() + " - " + _(status));
-    },
+    }
 
-    _updateControls: function() {
+    _updateControls() {
         this._prop.GetRemote(MEDIA_PLAYER_2_PLAYER_NAME, 'CanGoNext',
                              Lang.bind(this, function(value, err) {
                                 let canGoNext = true;
@@ -546,17 +524,17 @@ Player.prototype = {
                                 this._prevButton.setEnabled(canGoPrevious);
                                 })
                             );
-    },
+    }
 
-    _updatePositionSlider: function(position) {
+    _updatePositionSlider(position) {
         this._canSeek = this._getCanSeek();
 
         if (this._songLength == 0 || position == false)
             this._canSeek = false;
-    },
+    }
 
-    _setPosition: function(value) {
-        if(value === "slider"){
+    _setPosition(value) {
+        if(value === "slider") {
             let time = this._positionSlider._value * this._songLength;
             this._wantedSeekValue = Math.round(time * 1000000);
             this._mediaServerPlayer.SetPositionRemote(this._trackObj, time * 1000000);
@@ -568,17 +546,17 @@ Player.prototype = {
             this._currentTime = value / 1000000;
             this._updateTimer();
         }
-    },
+    }
 
-    _getPosition: function() {
+    _getPosition() {
         this._prop.GetRemote(MEDIA_PLAYER_2_PLAYER_NAME, 'Position', Lang.bind(this, function(position, ex) {
             if (!ex) {
                 this._setPosition(position[0].get_int64());
             }
         }));
-    },
+    }
 
-    _getCanSeek: function() {
+    _getCanSeek() {
         let can_seek = true;
         this._prop.GetRemote(MEDIA_PLAYER_2_PLAYER_NAME, 'CanSeek', Lang.bind(this, function(position, ex) {
             if (!ex) {
@@ -593,9 +571,9 @@ Player.prototype = {
             }
         }
         return can_seek;
-    },
+    }
 
-    _setMetadata: function(metadata) {
+    _setMetadata(metadata) {
         if (!metadata)
             return;
         if (metadata["mpris:length"]) {
@@ -681,9 +659,9 @@ Player.prototype = {
                 this._showCover(false);
         }
         this._applet.setAppletTextIcon(this, true);
-    },
+    }
 
-    _setStatus: function(status) {
+    _setStatus(status) {
         if (!status)
             return;
         this._updatePositionSlider();
@@ -710,9 +688,9 @@ Player.prototype = {
         }
 
         this._setName(status);
-    },
+    }
 
-    _toggleLoopStatus: function(){
+    _toggleLoopStatus() {
         let mapping = {
             "None": "Playlist",
             "Playlist": "Track",
@@ -721,9 +699,9 @@ Player.prototype = {
 
         this._mediaServerPlayer.LoopStatus = mapping[this._mediaServerPlayer.LoopStatus];
         this._setLoopStatus(this._mediaServerPlayer.LoopStatus);
-    },
+    }
 
-    _setLoopStatus: function(status){
+    _setLoopStatus(status) {
         if(status === "None")
             this._loopButton.setData("media-playlist-consecutive-symbolic", _("Consecutive Playing"));
         else if(status === "Track")
@@ -732,27 +710,27 @@ Player.prototype = {
             this._loopButton.setData("media-playlist-repeat", _("Repeat All"));
 
         this._loopButton.setActive(status !== "None");
-    },
+    }
 
-    _toggleShuffle: function(){
+    _toggleShuffle() {
         this._mediaServerPlayer.Shuffle = !this._mediaServerPlayer.Shuffle;
-    },
+    }
 
-    _setShuffle: function(status){
+    _setShuffle(status) {
         this._shuffleButton.setData("media-playlist-shuffle", status? _("Shuffle") : _("No Shuffle"));
         this._shuffleButton.setActive(status);
-    },
+    }
 
-    _updateTimer: function() {
+    _updateTimer() {
         if (!this._seeking && this.showPosition && this._canSeek) {
             if (!isNaN(this._currentTime) && !isNaN(this._songLength) && this._currentTime > 0)
                 this._positionSlider.setValue(this._currentTime / this._songLength);
             else
                 this._positionSlider.setValue(0);
         }
-    },
+    }
 
-    _runTimerCallback: function() {
+    _runTimerCallback() {
         if (this._playerStatus == 'Playing') {
             if (this._timerTicker < 10) {
                 this._currentTime += 1;
@@ -766,9 +744,9 @@ Player.prototype = {
         }
 
         return false;
-    },
+    }
 
-    _runTimer: function() {
+    _runTimer() {
         if (this._canSeek) {
             if (this._timeoutId != 0) {
                 Mainloop.source_remove(this._timeoutId);
@@ -781,35 +759,35 @@ Player.prototype = {
                 this._timeoutId = Mainloop.timeout_add(1000, Lang.bind(this, this._runTimerCallback));
             }
         }
-    },
+    }
 
-    _pauseTimer: function() {
+    _pauseTimer() {
         if (this._timeoutId != 0) {
             Mainloop.source_remove(this._timeoutId);
             this._timeoutId = 0;
         }
         this._updateTimer();
-    },
+    }
 
-    _stopTimer: function() {
+    _stopTimer() {
         this._currentTime = 0;
         this._pauseTimer();
         this._updateTimer();
-    },
+    }
 
-    _onDownloadedCover: function() {
+    _onDownloadedCover() {
         let cover_path = this._trackCoverFileTmp.get_path();
         this._showCover(cover_path);
-    },
+    }
 
-    _hideCover: function() {
+    _hideCover() {
         /*Tweener.addTween(this.trackCoverContainer, { opacity: 0,
             time: 0.3,
             transition: 'easeOutCubic',
         });*/
-    },
+    }
 
-    _showCover: function(cover_path) {
+    _showCover(cover_path) {
         /*Tweener.addTween(this._trackCover, { opacity: 0,
             time: 0.3,
             transition: 'easeOutCubic',
@@ -837,14 +815,14 @@ Player.prototype = {
                 });
             })
         });*/
-    },
+    }
 
-    onSettingsChanged: function(){
+    onSettingsChanged() {
         this._loopButton.actor.visible = this._applet.extendedPlayerControl;
         this._shuffleButton.actor.visible = this._applet.extendedPlayerControl;
-    },
+    }
 
-    destroy: function() {
+    destroy() {
         if (this._timeoutId != 0) {
             Mainloop.source_remove(this._timeoutId);
             this._timeoutId = 0;
@@ -856,18 +834,11 @@ Player.prototype = {
 
         PopupMenu.PopupMenuSection.prototype.destroy.call(this);
     }
-
-};
-
-function MediaPlayerLauncher(app, menu) {
-    this._init(app, menu);
 }
 
-MediaPlayerLauncher.prototype = {
-    __proto__: PopupMenu.PopupBaseMenuItem.prototype,
-
-    _init: function (app, menu) {
-        PopupMenu.PopupBaseMenuItem.prototype._init.call(this, {});
+class MediaPlayerLauncher extends PopupMenu.PopupBaseMenuItem {
+    constructor(app, menu) {
+        super({});
 
         this._app = app;
         this._menu = menu;
@@ -876,182 +847,171 @@ MediaPlayerLauncher.prototype = {
         this._icon = app.create_icon_texture(ICON_SIZE);
         this.addActor(this._icon, { expand: false });
         this.connect("activate", Lang.bind(this, this._onActivate));
-    },
+    }
 
-    _onActivate: function(actor, event, keepMenu) {
+    _onActivate(actor, event, keepMenu) {
         this._app.activate_full(-1, event.get_time());
     }
-};
-
-function CinnamonSoundApplet(metadata, orientation, panel_height, instanceId) {
-    this._init(metadata, orientation, panel_height, instanceId);
 }
 
-CinnamonSoundApplet.prototype = {
-    __proto__: Applet.TextIconApplet.prototype,
-
-    _init: function(metadata, orientation, panel_height, instanceId) {
-        Applet.TextIconApplet.prototype._init.call(this, orientation, panel_height, instanceId);
+class CinnamonSoundApplet extends Applet.TextIconApplet {
+    constructor(metadata, orientation, panel_height, instanceId) {
+        super(orientation, panel_height, instanceId);
 
         this.setAllowedLayout(Applet.AllowedLayout.BOTH);
 
-        try {
-            this.metadata = metadata;
-            this.settings = new Settings.AppletSettings(this, metadata.uuid, instanceId);
-            this.settings.bind("showtrack", "showtrack", this.on_settings_changed);
-            this.settings.bind("middleClickAction", "middleClickAction");
-            this.settings.bind("horizontalScroll", "horizontalScroll")
-            this.settings.bind("showalbum", "showalbum", this.on_settings_changed);
-            this.settings.bind("truncatetext", "truncatetext", this.on_settings_changed);
-            this.settings.bind("keepAlbumAspectRatio", "keepAlbumAspectRatio", this.on_settings_changed);
-            this.settings.bind("hideSystray", "hideSystray", function() {
-                if (this.hideSystray) this.registerSystrayIcons();
-                else this.unregisterSystrayIcons();
-            });
-
-            this.settings.bind("playerControl", "playerControl", this.on_settings_changed);
-            this.settings.bind("extendedPlayerControl", "extendedPlayerControl", function(){
-                for(let i in this._players)
-                    this._players[i].onSettingsChanged();
-            });
-
-            this.settings.bind("_knownPlayers", "_knownPlayers");
+        this.metadata = metadata;
+        this.settings = new Settings.AppletSettings(this, metadata.uuid, instanceId);
+        this.settings.bind("showtrack", "showtrack", this.on_settings_changed);
+        this.settings.bind("middleClickAction", "middleClickAction");
+        this.settings.bind("horizontalScroll", "horizontalScroll")
+        this.settings.bind("showalbum", "showalbum", this.on_settings_changed);
+        this.settings.bind("truncatetext", "truncatetext", this.on_settings_changed);
+        this.settings.bind("keepAlbumAspectRatio", "keepAlbumAspectRatio", this.on_settings_changed);
+        this.settings.bind("hideSystray", "hideSystray", function() {
             if (this.hideSystray) this.registerSystrayIcons();
+            else this.unregisterSystrayIcons();
+        });
 
-            this.menuManager = new PopupMenu.PopupMenuManager(this);
-            this.menu = new Applet.AppletPopupMenu(this, orientation);
-            this.menuManager.addMenu(this.menu);
+        this.settings.bind("playerControl", "playerControl", this.on_settings_changed);
+        this.settings.bind("extendedPlayerControl", "extendedPlayerControl", function() {
+            for(let i in this._players)
+                this._players[i].onSettingsChanged();
+        });
 
-            this.set_applet_icon_symbolic_name('audio-x-generic');
+        this.settings.bind("_knownPlayers", "_knownPlayers");
+        if (this.hideSystray) this.registerSystrayIcons();
 
-            this._players = {};
-            this._playerItems = [];
-            this._activePlayer = null;
+        this.menuManager = new PopupMenu.PopupMenuManager(this);
+        this.menu = new Applet.AppletPopupMenu(this, orientation);
+        this.menuManager.addMenu(this.menu);
 
-            Interfaces.getDBusAsync(Lang.bind(this, function (proxy, error) {
-                this._dbus = proxy;
+        this.set_applet_icon_symbolic_name('audio-x-generic');
 
-                // player DBus name pattern
-                let name_regex = /^org\.mpris\.MediaPlayer2\./;
-                // load players
-                this._dbus.ListNamesRemote(Lang.bind(this,
-                    function(names) {
-                        for (let n in names[0]) {
-                            let name = names[0][n];
-                            if (name_regex.test(name)) {
-                                this._dbus.GetNameOwnerRemote(name, Lang.bind(this,
-                                    function(owner) {
-                                        this._addPlayer(name, owner);
-                                    }
-                                ));
-                            }
-                        }
-                    }
-                ));
+        this._players = {};
+        this._playerItems = [];
+        this._activePlayer = null;
 
-                // watch players
-                this._ownerChangedId = this._dbus.connectSignal('NameOwnerChanged', Lang.bind(this,
-                    function(proxy, sender, [name, old_owner, new_owner]) {
+        Interfaces.getDBusAsync(Lang.bind(this, function (proxy, error) {
+            this._dbus = proxy;
+
+            // player DBus name pattern
+            let name_regex = /^org\.mpris\.MediaPlayer2\./;
+            // load players
+            this._dbus.ListNamesRemote(Lang.bind(this,
+                function(names) {
+                    for (let n in names[0]) {
+                        let name = names[0][n];
                         if (name_regex.test(name)) {
-                            if (new_owner && !old_owner)
-                                this._addPlayer(name, new_owner);
-                            else if (old_owner && !new_owner)
-                                this._removePlayer(name, old_owner);
-                            else
-                                this._changePlayerOwner(name, old_owner, new_owner);
+                            this._dbus.GetNameOwnerRemote(name, Lang.bind(this,
+                                function(owner) {
+                                    this._addPlayer(name, owner);
+                                }
+                            ));
                         }
                     }
-                ));
-            }));
+                }
+            ));
 
-            this._control = new Cvc.MixerControl({ name: 'Cinnamon Volume Control' });
-            this._control.connect('state-changed', Lang.bind(this, this._onControlStateChanged));
+            // watch players
+            this._ownerChangedId = this._dbus.connectSignal('NameOwnerChanged', Lang.bind(this,
+                function(proxy, sender, [name, old_owner, new_owner]) {
+                    if (name_regex.test(name)) {
+                        if (new_owner && !old_owner)
+                            this._addPlayer(name, new_owner);
+                        else if (old_owner && !new_owner)
+                            this._removePlayer(name, old_owner);
+                        else
+                            this._changePlayerOwner(name, old_owner, new_owner);
+                    }
+                }
+            ));
+        }));
 
-            this._control.connect('output-added', Lang.bind(this, this._onDeviceAdded, "output"));
-            this._control.connect('output-removed', Lang.bind(this, this._onDeviceRemoved, "output"));
-            this._control.connect('active-output-update', Lang.bind(this, this._onDeviceUpdate, "output"));
+        this._control = new Cvc.MixerControl({ name: 'Cinnamon Volume Control' });
+        this._control.connect('state-changed', Lang.bind(this, this._onControlStateChanged));
 
-            this._control.connect('input-added', Lang.bind(this, this._onDeviceAdded, "input"));
-            this._control.connect('input-removed', Lang.bind(this, this._onDeviceRemoved, "input"));
-            this._control.connect('active-input-update', Lang.bind(this, this._onDeviceUpdate, "input"));
+        this._control.connect('output-added', Lang.bind(this, this._onDeviceAdded, "output"));
+        this._control.connect('output-removed', Lang.bind(this, this._onDeviceRemoved, "output"));
+        this._control.connect('active-output-update', Lang.bind(this, this._onDeviceUpdate, "output"));
 
-            this._control.connect('stream-added', Lang.bind(this, this._onStreamAdded));
-            this._control.connect('stream-removed', Lang.bind(this, this._onStreamRemoved));
+        this._control.connect('input-added', Lang.bind(this, this._onDeviceAdded, "input"));
+        this._control.connect('input-removed', Lang.bind(this, this._onDeviceRemoved, "input"));
+        this._control.connect('active-input-update', Lang.bind(this, this._onDeviceUpdate, "input"));
 
-            this._sound_settings = new Gio.Settings({ schema_id: CINNAMON_DESKTOP_SOUNDS });
-            this._volumeMax = this._sound_settings.get_int(MAXIMUM_VOLUME_KEY) / 100 * this._control.get_vol_max_norm();
-            this._volumeNorm = this._control.get_vol_max_norm();
+        this._control.connect('stream-added', Lang.bind(this, this._onStreamAdded));
+        this._control.connect('stream-removed', Lang.bind(this, this._onStreamRemoved));
 
-            this._streams = [];
-            this._devices = [];
-            this._recordingAppsNum = 0;
+        this._sound_settings = new Gio.Settings({ schema_id: CINNAMON_DESKTOP_SOUNDS });
+        this._volumeMax = this._sound_settings.get_int(MAXIMUM_VOLUME_KEY) / 100 * this._control.get_vol_max_norm();
+        this._volumeNorm = this._control.get_vol_max_norm();
 
-            this._output = null;
-            this._outputMutedId = 0;
-            this._outputIcon = "audio-volume-muted";
+        this._streams = [];
+        this._devices = [];
+        this._recordingAppsNum = 0;
 
-            this._input = null;
-            this._inputMutedId = 0;
+        this._output = null;
+        this._outputMutedId = 0;
+        this._outputIcon = "audio-volume-muted";
 
-            this._icon_name = '';
-            this._icon_path = null;
-            this._iconTimeoutId = 0;
+        this._input = null;
+        this._inputMutedId = 0;
 
-            this.actor.connect('scroll-event', Lang.bind(this, this._onScrollEvent));
+        this._icon_name = '';
+        this._icon_path = null;
+        this._iconTimeoutId = 0;
 
-            this.mute_out_switch = new PopupMenu.PopupSwitchIconMenuItem(_("Mute output"), false, "audio-volume-muted", St.IconType.SYMBOLIC);
-            this.mute_in_switch = new PopupMenu.PopupSwitchIconMenuItem(_("Mute input"), false, "microphone-sensitivity-muted", St.IconType.SYMBOLIC);
-            this._applet_context_menu.addMenuItem(this.mute_out_switch);
-            this._applet_context_menu.addMenuItem(this.mute_in_switch);
+        this.actor.connect('scroll-event', Lang.bind(this, this._onScrollEvent));
 
-            this._applet_context_menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+        this.mute_out_switch = new PopupMenu.PopupSwitchIconMenuItem(_("Mute output"), false, "audio-volume-muted", St.IconType.SYMBOLIC);
+        this.mute_in_switch = new PopupMenu.PopupSwitchIconMenuItem(_("Mute input"), false, "microphone-sensitivity-none", St.IconType.SYMBOLIC);
+        this._applet_context_menu.addMenuItem(this.mute_out_switch);
+        this._applet_context_menu.addMenuItem(this.mute_in_switch);
 
-            this._outputApplicationsMenu = new PopupMenu.PopupSubMenuMenuItem(_("Applications"));
-            this._selectOutputDeviceItem = new PopupMenu.PopupSubMenuMenuItem(_("Output device"));
-            this._applet_context_menu.addMenuItem(this._outputApplicationsMenu);
-            this._applet_context_menu.addMenuItem(this._selectOutputDeviceItem);
-            this._outputApplicationsMenu.actor.hide();
-            this._selectOutputDeviceItem.actor.hide();
+        this._applet_context_menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
-            this._inputSection = new PopupMenu.PopupMenuSection();
-            this._inputVolumeSection = new VolumeSlider(this, null, _("Microphone"), null);
-            this._inputVolumeSection.connect("values-changed", Lang.bind(this, this._inputValuesChanged));
-            this._selectInputDeviceItem = new PopupMenu.PopupSubMenuMenuItem(_("Input device"));
-            this._inputSection.addMenuItem(this._inputVolumeSection);
-            this._inputSection.addMenuItem(this._selectInputDeviceItem);
-            this._applet_context_menu.addMenuItem(this._inputSection);
+        this._outputApplicationsMenu = new PopupMenu.PopupSubMenuMenuItem(_("Applications"));
+        this._selectOutputDeviceItem = new PopupMenu.PopupSubMenuMenuItem(_("Output device"));
+        this._applet_context_menu.addMenuItem(this._outputApplicationsMenu);
+        this._applet_context_menu.addMenuItem(this._selectOutputDeviceItem);
+        this._outputApplicationsMenu.actor.hide();
+        this._selectOutputDeviceItem.actor.hide();
 
-            this._selectInputDeviceItem.actor.hide();
-            this._inputSection.actor.hide();
+        this._inputSection = new PopupMenu.PopupMenuSection();
+        this._inputVolumeSection = new VolumeSlider(this, null, _("Microphone"), null);
+        this._inputVolumeSection.connect("values-changed", Lang.bind(this, this._inputValuesChanged));
+        this._selectInputDeviceItem = new PopupMenu.PopupSubMenuMenuItem(_("Input device"));
+        this._inputSection.addMenuItem(this._inputVolumeSection);
+        this._inputSection.addMenuItem(this._selectInputDeviceItem);
+        this._applet_context_menu.addMenuItem(this._inputSection);
 
-            this._applet_context_menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+        this._selectInputDeviceItem.actor.hide();
+        this._inputSection.actor.hide();
 
-            this.mute_out_switch.connect('toggled', Lang.bind(this, this._toggle_out_mute));
-            this.mute_in_switch.connect('toggled', Lang.bind(this, this._toggle_in_mute));
+        this._applet_context_menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
-            this._control.open();
+        this.mute_out_switch.connect('toggled', Lang.bind(this, this._toggle_out_mute));
+        this.mute_in_switch.connect('toggled', Lang.bind(this, this._toggle_in_mute));
 
-            this._volumeControlShown = false;
+        this._control.open();
 
-            this._showFixedElements();
-            this.set_show_label_in_vertical_panels(false);
-            this.set_applet_label(this._applet_label.get_text());
+        this._volumeControlShown = false;
 
-            let appsys = Cinnamon.AppSystem.get_default();
-            appsys.connect("installed-changed", Lang.bind(this, this._updateLaunchPlayer));
+        this._showFixedElements();
+        this.set_show_label_in_vertical_panels(false);
+        this.set_applet_label(this._applet_label.get_text());
 
-            if (this._volumeMax > this._volumeNorm) {
-                this._outputVolumeSection.set_mark(this._volumeNorm / this._volumeMax);
-            }
+        let appsys = Cinnamon.AppSystem.get_default();
+        appsys.connect("installed-changed", Lang.bind(this, this._updateLaunchPlayer));
 
-            this._sound_settings.connect("changed::" + MAXIMUM_VOLUME_KEY, Lang.bind(this, this._on_sound_settings_change));
+        if (this._volumeMax > this._volumeNorm) {
+            this._outputVolumeSection.set_mark(this._volumeNorm / this._volumeMax);
         }
-        catch (e) {
-            global.logError(e);
-        }
-    },
 
-    _on_sound_settings_change : function() {
+        this._sound_settings.connect("changed::" + MAXIMUM_VOLUME_KEY, Lang.bind(this, this._on_sound_settings_change));
+    }
+
+    _on_sound_settings_change () {
         this._volumeMax = this._sound_settings.get_int(MAXIMUM_VOLUME_KEY) / 100 * this._control.get_vol_max_norm();
         if (this._volumeMax > this._volumeNorm) {
             this._outputVolumeSection.set_mark(this._volumeNorm / this._volumeMax);
@@ -1060,18 +1020,18 @@ CinnamonSoundApplet.prototype = {
             this._outputVolumeSection.set_mark(0);
         }
         this._outputVolumeSection._update();
-    },
+    }
 
-    on_settings_changed : function() {
+    on_settings_changed () {
         if(this.playerControl && this._activePlayer)
             this.setAppletTextIcon(this._players[this._activePlayer], true);
         else
             this.setAppletTextIcon();
 
         this._changeActivePlayer(this._activePlayer);
-    },
+    }
 
-    on_applet_removed_from_panel : function() {
+    on_applet_removed_from_panel () {
         if (this.hideSystray)
             this.unregisterSystrayIcons();
         if (this._iconTimeoutId) {
@@ -1082,13 +1042,13 @@ CinnamonSoundApplet.prototype = {
 
         for(let i in this._players)
             this._players[i].destroy();
-    },
+    }
 
-    on_applet_clicked: function(event) {
+    on_applet_clicked(event) {
         this.menu.toggle();
-    },
+    }
 
-    _toggle_out_mute: function() {
+    _toggle_out_mute() {
         if (this._output.is_muted) {
             this._output.change_is_muted(false);
             this.mute_out_switch.setToggleState(false);
@@ -1096,9 +1056,9 @@ CinnamonSoundApplet.prototype = {
             this._output.change_is_muted(true);
             this.mute_out_switch.setToggleState(true);
         }
-    },
+    }
 
-    _toggle_in_mute: function() {
+    _toggle_in_mute() {
         if (this._input.is_muted) {
             this._input.change_is_muted(false);
             this.mute_in_switch.setToggleState(false);
@@ -1106,9 +1066,9 @@ CinnamonSoundApplet.prototype = {
             this._input.change_is_muted(true);
             this.mute_in_switch.setToggleState(true);
         }
-    },
+    }
 
-    _onScrollEvent: function(actor, event) {
+    _onScrollEvent(actor, event) {
         let direction = event.get_scroll_direction();
         let currentVolume = this._output.volume;
 
@@ -1144,9 +1104,9 @@ CinnamonSoundApplet.prototype = {
         }
 
         this._notifyVolumeChange(this._output);
-    },
+    }
 
-    _onButtonPressEvent: function (actor, event) {
+    _onButtonPressEvent (actor, event) {
         let buttonId = event.get_button();
 
         //mute or play / pause players on middle click
@@ -1167,9 +1127,9 @@ CinnamonSoundApplet.prototype = {
         }
 
         return Applet.Applet.prototype._onButtonPressEvent.call(this, actor, event);
-    },
+    }
 
-    setIcon: function(icon, source) {
+    setIcon(icon, source) {
         if (this._iconTimeoutId) {
             Mainloop.source_remove(this._iconTimeoutId);
             this._iconTimeoutId = null;
@@ -1203,9 +1163,9 @@ CinnamonSoundApplet.prototype = {
             //if we have no active player show the output icon
             this.set_applet_icon_symbolic_name(this._outputIcon);
         }
-    },
+    }
 
-    setAppletIcon: function(player, path) {
+    setAppletIcon(player, path) {
         if (path) {
             if (path === true) {
                 // Restore the icon path from the saved path.
@@ -1228,9 +1188,9 @@ CinnamonSoundApplet.prototype = {
         else {
             this.setIcon('audio-x-generic', 'player-name');
         }
-    },
+    }
 
-    setAppletText: function(player) {
+    setAppletText(player) {
         let title_text = "";
         if (this.showtrack && player && player._playerStatus == 'Playing') {
             title_text = player._title + ' - ' + player._artist;
@@ -1239,25 +1199,25 @@ CinnamonSoundApplet.prototype = {
             }
         }
         this.set_applet_label(title_text);
-    },
+    }
 
-    setAppletTextIcon: function(player, icon) {
+    setAppletTextIcon(player, icon) {
         if (player && player._owner != this._activePlayer)
             return;
         this.setAppletIcon(player, icon);
         this.setAppletText(player);
-    },
+    }
 
-    _isInstance: function(busName) {
+    _isInstance(busName) {
         // MPRIS instances are in the form
         //   org.mpris.MediaPlayer2.name.instanceXXXX
         // ...except for VLC, which to this day uses
         //   org.mpris.MediaPlayer2.name-XXXX
         return busName.split('.').length > 4 ||
                 /^org\.mpris\.MediaPlayer2\.vlc-\d+$/.test(busName);
-    },
+    }
 
-    _addPlayer: function(busName, owner) {
+    _addPlayer(busName, owner) {
         if (this._players[owner]) {
             let prevName = this._players[owner]._busName;
             // HAVE: ADDING: ACTION:
@@ -1284,9 +1244,9 @@ CinnamonSoundApplet.prototype = {
             this._updatePlayerMenuItems();
             this.setAppletTextIcon();
         }
-    },
+    }
 
-    _switchPlayer: function(owner) {
+    _switchPlayer(owner) {
         if(this._players[owner]) {
             // The player exists, switch to it
             this._changeActivePlayer(owner);
@@ -1297,9 +1257,9 @@ CinnamonSoundApplet.prototype = {
             this._removePlayerItem(owner);
             this._updatePlayerMenuItems();
         }
-    },
+    }
 
-    _removePlayerItem: function(owner) {
+    _removePlayerItem(owner) {
         // Remove the player from the player switching list
         for(let i = 0, l = this._playerItems.length; i < l; ++i) {
             let playerItem = this._playerItems[i];
@@ -1309,9 +1269,9 @@ CinnamonSoundApplet.prototype = {
                 break;
             }
         }
-    },
+    }
 
-    _removePlayer: function(busName, owner) {
+    _removePlayer(busName, owner) {
         if (this._players[owner] && this._players[owner]._busName == busName) {
             this._removePlayerItem(owner);
 
@@ -1329,9 +1289,9 @@ CinnamonSoundApplet.prototype = {
             this._updatePlayerMenuItems();
             this.setAppletTextIcon();
         }
-    },
+    }
 
-    _changePlayerOwner: function(busName, oldOwner, newOwner) {
+    _changePlayerOwner(busName, oldOwner, newOwner) {
         if (this._players[oldOwner] && busName == this._players[oldOwner]._busName) {
             this._players[newOwner] = this._players[oldOwner];
             this._players[newOwner]._owner = newOwner;
@@ -1339,10 +1299,10 @@ CinnamonSoundApplet.prototype = {
             if (this._activePlayer == oldOwner)
                 this._activePlayer = newOwner;
         }
-    },
+    }
 
     //will be called by an instance of #Player
-    passDesktopEntry: function(entry){
+    passDesktopEntry(entry) {
         //do we know already this player?
         for (let i = 0, l = this._knownPlayers.length; i < l; ++i) {
             if (this._knownPlayers[i] === entry)
@@ -1352,9 +1312,9 @@ CinnamonSoundApplet.prototype = {
         this._knownPlayers.push(entry);
         this._knownPlayers.save();
         this._updateLaunchPlayer();
-    },
+    }
 
-    _showFixedElements: function() {
+    _showFixedElements() {
         // The list to use when switching between active players
         this._chooseActivePlayerItem = new PopupMenu.PopupSubMenuMenuItem(_("Choose player controls"));
         this._chooseActivePlayerItem.actor.hide();
@@ -1374,14 +1334,14 @@ CinnamonSoundApplet.prototype = {
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
         this.menu.addSettingsAction(_("Sound Settings"), 'sound');
-    },
+    }
 
-    _updateLaunchPlayer: function() {
+    _updateLaunchPlayer() {
         let availablePlayers = [];
 
         let appsys = Cinnamon.AppSystem.get_default();
         //_knownPlayers is an array containing the paths of desktop files
-        for(let i = 0, l = this._knownPlayers.length; i < l; ++i){
+        for(let i = 0, l = this._knownPlayers.length; i < l; ++i) {
             let app = appsys.lookup_app(this._knownPlayers[i] + ".desktop");
             if (app)
                 availablePlayers.push(app);
@@ -1398,9 +1358,9 @@ CinnamonSoundApplet.prototype = {
         } else {
             this._launchPlayerItem.actor.hide();
         }
-    },
+    }
 
-    _updatePlayerMenuItems: function() {
+    _updatePlayerMenuItems() {
         if (this.playerControl && this._activePlayer) {
             this._launchPlayerItem.actor.hide();
             this._chooseActivePlayerItem.actor.show();
@@ -1422,9 +1382,9 @@ CinnamonSoundApplet.prototype = {
                 this._launchPlayerItem.actor.hide();
             }
         }
-    },
+    }
 
-    _changeActivePlayer: function(player) {
+    _changeActivePlayer(player) {
         if (this._activePlayer)
             this.menu.box.remove_actor(this._players[this._activePlayer].actor);
 
@@ -1434,31 +1394,31 @@ CinnamonSoundApplet.prototype = {
         }
 
         this._updatePlayerMenuItems();
-    },
+    }
 
-    _notifyVolumeChange: function(stream) {
+    _notifyVolumeChange(stream) {
         Main.soundManager.playVolume('volume', stream.decibel);
-    },
+    }
 
-    _mutedChanged: function(object, param_spec, property) {
+    _mutedChanged(object, param_spec, property) {
         if (property == "_output") {
             this.mute_out_switch.setToggleState(this._output.is_muted);
         } else if (property == "_input") {
             this.mute_in_switch.setToggleState(this._input.is_muted);
         }
-    },
+    }
 
-    _outputValuesChanged: function(actor, iconName, percentage) {
+    _outputValuesChanged(actor, iconName, percentage) {
         this.setIcon(iconName, "output");
         this.mute_out_switch.setIconSymbolicName(iconName);
         this.set_applet_tooltip(_("Volume") + ": " + percentage);
-    },
+    }
 
-    _inputValuesChanged: function(actor, iconName) {
+    _inputValuesChanged(actor, iconName) {
         this.mute_in_switch.setIconSymbolicName(iconName);
-    },
+    }
 
-    _onControlStateChanged: function() {
+    _onControlStateChanged() {
         if (this._control.get_state() == Cvc.MixerControlState.READY) {
             this._readOutput();
             this._readInput();
@@ -1466,9 +1426,9 @@ CinnamonSoundApplet.prototype = {
         } else {
             this.actor.hide();
         }
-    },
+    }
 
-    _readOutput: function() {
+    _readOutput() {
         if (this._outputMutedId) {
             this._output.disconnect(this._outputMutedId);
             this._outputMutedId = 0;
@@ -1481,9 +1441,9 @@ CinnamonSoundApplet.prototype = {
         } else {
             this.setIcon("audio-volume-muted-symbolic", "output");
         }
-    },
+    }
 
-    _readInput: function() {
+    _readInput() {
         if (this._inputMutedId) {
             this._input.disconnect(this._inputMutedId);
             this._inputMutedId = 0;
@@ -1496,13 +1456,13 @@ CinnamonSoundApplet.prototype = {
         } else {
             this._inputSection.actor.hide();
         }
-    },
+    }
 
-    _onDeviceAdded: function(control, id, type){
+    _onDeviceAdded(control, id, type) {
         let device = this._control["lookup_" + type + "_id"](id);
 
         let item = new PopupMenu.PopupMenuItem(device.description);
-        item.activate = Lang.bind(this, function(){
+        item.activate = Lang.bind(this, function() {
             this._control["change_" + type](device);
         });
 
@@ -1518,10 +1478,10 @@ CinnamonSoundApplet.prototype = {
             selectItem.actor.show();
 
         this._devices.push({id: id, type: type, item: item});
-    },
+    }
 
-    _onDeviceRemoved: function(control, id, type){
-        for (let i = 0, l = this._devices.length; i < l; ++i){
+    _onDeviceRemoved(control, id, type) {
+        for (let i = 0, l = this._devices.length; i < l; ++i) {
             if (this._devices[i].type === type && this._devices[i].id === id) {
                 let device = this._devices[i];
                 if (device.item)
@@ -1536,18 +1496,18 @@ CinnamonSoundApplet.prototype = {
                 break;
             }
         }
-    },
+    }
 
-    _onDeviceUpdate: function(control, id, type){
+    _onDeviceUpdate(control, id, type) {
         this["_read" + type[0].toUpperCase() + type.slice(1)]();
 
         for (let i = 0, l = this._devices.length; i < l; ++i) {
             if (this._devices[i].type === type)
                 this._devices[i].item.setShowDot(id === this._devices[i].id);
         }
-    },
+    }
 
-    _onStreamAdded: function(control, id){
+    _onStreamAdded(control, id) {
         let stream = this._control.lookup_stream_id(id);
         let appId = stream.application_id;
 
@@ -1568,11 +1528,11 @@ CinnamonSoundApplet.prototype = {
             if (this._recordingAppsNum++ === 0)
                 this._inputSection.actor.show();
         }
-    },
+    }
 
-    _onStreamRemoved: function(control, id){
+    _onStreamRemoved(control, id) {
         for (let i = 0, l = this._streams.length; i < l; ++i) {
-            if(this._streams[i].id === id){
+            if(this._streams[i].id === id) {
                 let stream = this._streams[i];
                 if(stream.item)
                     stream.item.destroy();
@@ -1589,21 +1549,21 @@ CinnamonSoundApplet.prototype = {
                 break;
             }
         }
-    },
+    }
 
-    registerSystrayIcons: function() {
+    registerSystrayIcons() {
         for (let i = 0; i < players_with_seek_support.length; i++) {
             Main.systrayManager.registerRole(players_with_seek_support[i], this.metadata.uuid);
         }
         for (let i = 0; i < players_without_seek_support.length; i++) {
             Main.systrayManager.registerRole(players_without_seek_support[i], this.metadata.uuid);
         }
-    },
+    }
 
-    unregisterSystrayIcons: function() {
+    unregisterSystrayIcons() {
         Main.systrayManager.unregisterId(this.metadata.uuid);
     }
-};
+}
 
 function main(metadata, orientation, panel_height, instanceId) {
     return new CinnamonSoundApplet(metadata, orientation, panel_height, instanceId);

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -182,7 +182,7 @@ class VolumeSlider extends PopupMenu.PopupSliderMenuItem {
     }
 
 
-    _update: function(){
+    _update() {
         // value: percentage of volume_max (set as value in the widget)
         // visible_value: percentage of volume_norm (shown to the user)
         // these only differ for the output, and only when the user changes the maximum volume
@@ -477,16 +477,16 @@ class Player extends PopupMenu.PopupMenuSection {
         }));
 
         this._propChangedId = this._prop.connectSignal('PropertiesChanged', Lang.bind(this, function(proxy, sender, [iface, props]) {
-                if (props.PlaybackStatus)
-                    this._setStatus(props.PlaybackStatus.unpack());
-                if (props.Metadata)
-                    this._setMetadata(props.Metadata.deep_unpack());
-                if (props.CanGoNext || props.CanGoPrevious)
-                    this._updateControls();
-                if (props.LoopStatus)
-                    this._setLoopStatus(props.LoopStatus.unpack());
-                if (props.Shuffle)
-                    this._setShuffle(props.Shuffle.unpack());
+            if (props.PlaybackStatus)
+                this._setStatus(props.PlaybackStatus.unpack());
+            if (props.Metadata)
+                this._setMetadata(props.Metadata.deep_unpack());
+            if (props.CanGoNext || props.CanGoPrevious)
+                this._updateControls();
+            if (props.LoopStatus)
+                this._setLoopStatus(props.LoopStatus.unpack());
+            if (props.Shuffle)
+                this._setShuffle(props.Shuffle.unpack());
         }));
 
         //get the desktop entry and pass it to the applet
@@ -508,22 +508,22 @@ class Player extends PopupMenu.PopupMenuSection {
 
     _updateControls() {
         this._prop.GetRemote(MEDIA_PLAYER_2_PLAYER_NAME, 'CanGoNext',
-                             Lang.bind(this, function(value, err) {
-                                let canGoNext = true;
-                                if (!err)
-                                    canGoNext = value[0].unpack();
-                                this._nextButton.setEnabled(canGoNext);
-                                })
-                            );
+            Lang.bind(this, function(value, err) {
+                let canGoNext = true;
+                if (!err)
+                    canGoNext = value[0].unpack();
+                this._nextButton.setEnabled(canGoNext);
+            })
+        );
 
         this._prop.GetRemote(MEDIA_PLAYER_2_PLAYER_NAME, 'CanGoPrevious',
-                             Lang.bind(this, function(value, err) {
-                                let canGoPrevious = true;
-                                if (!err)
-                                    canGoPrevious = value[0].unpack();
-                                this._prevButton.setEnabled(canGoPrevious);
-                                })
-                            );
+            Lang.bind(this, function(value, err) {
+                let canGoPrevious = true;
+                if (!err)
+                    canGoPrevious = value[0].unpack();
+                this._prevButton.setEnabled(canGoPrevious);
+            })
+        );
     }
 
     _updatePositionSlider(position) {
@@ -792,22 +792,22 @@ class Player extends PopupMenu.PopupMenuSection {
             time: 0.3,
             transition: 'easeOutCubic',
             onComplete: Lang.bind(this, function() {*/
-                this.coverBox.remove_actor(this.cover);
-                if (! cover_path || ! GLib.file_test(cover_path, GLib.FileTest.EXISTS)) {
-                    this.cover = new St.Icon({style_class: 'sound-player-generic-coverart', important: true, icon_name: "media-optical", icon_size: 300, icon_type: St.IconType.FULLCOLOR});
-                    cover_path = null;
-                }
-                else {
-                    if (this._applet.keepAlbumAspectRatio) {
-                        this.cover = new Clutter.Texture({width: 300, keep_aspect_ratio: true, filter_quality: 2, filename: cover_path});
-                    }
-                    else {
-                        this.cover = new Clutter.Texture({width: 300, height: 300, keep_aspect_ratio: false, filter_quality: 2, filename: cover_path});
-                    }
-                }
-                this.coverBox.add_actor(this.cover);
-                this.coverBox.set_child_below_sibling(this.cover, this.trackInfo);
-                this._applet.setAppletTextIcon(this, cover_path);
+        this.coverBox.remove_actor(this.cover);
+        if (! cover_path || ! GLib.file_test(cover_path, GLib.FileTest.EXISTS)) {
+            this.cover = new St.Icon({style_class: 'sound-player-generic-coverart', important: true, icon_name: "media-optical", icon_size: 300, icon_type: St.IconType.FULLCOLOR});
+            cover_path = null;
+        }
+        else {
+            if (this._applet.keepAlbumAspectRatio) {
+                this.cover = new Clutter.Texture({width: 300, keep_aspect_ratio: true, filter_quality: 2, filename: cover_path});
+            }
+            else {
+                this.cover = new Clutter.Texture({width: 300, height: 300, keep_aspect_ratio: false, filter_quality: 2, filename: cover_path});
+            }
+        }
+        this.coverBox.add_actor(this.cover);
+        this.coverBox.set_child_below_sibling(this.cover, this.trackInfo);
+        this._applet.setAppletTextIcon(this, cover_path);
 
                 /*Tweener.addTween(this._trackCover, { opacity: 255,
                     time: 0.3,
@@ -1490,8 +1490,8 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
 
                 //hide submenu if showing them is unnecessary
                 let selectItem = this["_select" + type[0].toUpperCase() + type.slice(1) + "DeviceItem"];
-                if(selectItem.menu.numMenuItems <= 1)
-                        selectItem.actor.hide();
+                if (selectItem.menu.numMenuItems <= 1)
+                    selectItem.actor.hide();
 
                 this._devices.splice(i, 1);
                 break;

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -1390,7 +1390,8 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
 
         this._activePlayer = player;
         if (this.playerControl && this._activePlayer != null) {
-            this.menu.addMenuItem(this._players[player], 1);
+            let menuItem = this._players[player];
+            this.menu.addMenuItem(menuItem, 1);
         }
 
         this._updatePlayerMenuItems();

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -883,11 +883,11 @@ MediaPlayerLauncher.prototype = {
     }
 };
 
-function MyApplet(metadata, orientation, panel_height, instanceId) {
+function CinnamonSoundApplet(metadata, orientation, panel_height, instanceId) {
     this._init(metadata, orientation, panel_height, instanceId);
 }
 
-MyApplet.prototype = {
+CinnamonSoundApplet.prototype = {
     __proto__: Applet.TextIconApplet.prototype,
 
     _init: function(metadata, orientation, panel_height, instanceId) {
@@ -1606,6 +1606,5 @@ MyApplet.prototype = {
 };
 
 function main(metadata, orientation, panel_height, instanceId) {
-    let myApplet = new MyApplet(metadata, orientation, panel_height, instanceId);
-    return myApplet;
+    return new CinnamonSoundApplet(metadata, orientation, panel_height, instanceId);
 }

--- a/files/usr/share/cinnamon/applets/spacer@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/spacer@cinnamon.org/applet.js
@@ -2,11 +2,11 @@ const Applet = imports.ui.applet;
 const St = imports.gi.St;
 const Settings = imports.ui.settings;
 
-function MyApplet(metadata, orientation, panelHeight, instance_id) {
+function CinnamonSpacerApplet(metadata, orientation, panelHeight, instance_id) {
     this._init(metadata, orientation, panelHeight, instance_id);
 }
 
-MyApplet.prototype = {
+CinnamonSpacerApplet.prototype = {
     __proto__: Applet.IconApplet.prototype,
 
     _init: function(metadata, orientation, panelHeight, instance_id) {
@@ -51,6 +51,5 @@ MyApplet.prototype = {
 };
 
 function main(metadata, orientation, panelHeight, instance_id) {
-    let myApplet = new MyApplet(metadata, orientation, panelHeight, instance_id);
-    return myApplet;
+    return new CinnamonSpacerApplet(metadata, orientation, panelHeight, instance_id);
 }

--- a/files/usr/share/cinnamon/applets/spacer@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/spacer@cinnamon.org/applet.js
@@ -2,15 +2,9 @@ const Applet = imports.ui.applet;
 const St = imports.gi.St;
 const Settings = imports.ui.settings;
 
-function CinnamonSpacerApplet(metadata, orientation, panelHeight, instance_id) {
-    this._init(metadata, orientation, panelHeight, instance_id);
-}
-
-CinnamonSpacerApplet.prototype = {
-    __proto__: Applet.IconApplet.prototype,
-
-    _init: function(metadata, orientation, panelHeight, instance_id) {
-        Applet.IconApplet.prototype._init.call(this, orientation, panelHeight, instance_id);
+class CinnamonSpacerApplet extends Applet.IconApplet {
+    constructor(metadata, orientation, panelHeight, instance_id) {
+        super(orientation, panelHeight, instance_id);
         this.actor.track_hover = false;
 
         this.bin = new St.Bin();
@@ -23,9 +17,9 @@ CinnamonSpacerApplet.prototype = {
         this.orientation = orientation;
 
         this.width_changed();
-    },
+    }
 
-    on_orientation_changed: function(neworientation) {
+    on_orientation_changed(neworientation) {
         this.orientation = neworientation;
 
         if (this.bin) {
@@ -36,19 +30,19 @@ CinnamonSpacerApplet.prototype = {
 
             this.width_changed();
         }
-    },
+    }
 
-    width_changed: function() {
+    width_changed() {
         if (this.orientation == St.Side.TOP || this.orientation == St.Side.BOTTOM)
             this.bin.width = this.width;
         else
             this.bin.height = this.width;
-    },
+    }
 
-    on_applet_removed_from_panel: function() {
+    on_applet_removed_from_panel() {
         this.settings.finalize();
     }
-};
+}
 
 function main(metadata, orientation, panelHeight, instance_id) {
     return new CinnamonSpacerApplet(metadata, orientation, panelHeight, instance_id);

--- a/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
@@ -42,11 +42,11 @@ IndicatorMenuFactory.prototype = {
     }
 };
 
-function MyApplet(orientation, panel_height, instance_id) {
+function CinnamonSystrayApplet(orientation, panel_height, instance_id) {
     this._init(orientation, panel_height, instance_id);
 }
 
-MyApplet.prototype = {
+CinnamonSystrayApplet.prototype = {
     __proto__: Applet.Applet.prototype,
 
     _init: function(orientation, panel_height, instance_id) {
@@ -381,6 +381,5 @@ MyApplet.prototype = {
 };
 
 function main(metadata, orientation, panel_height, instance_id) {
-    let myApplet = new MyApplet(orientation, panel_height, instance_id);
-    return myApplet;
+    return new CinnamonSystrayApplet(orientation, panel_height, instance_id);
 }

--- a/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
@@ -13,18 +13,12 @@ const ICON_SCALE_FACTOR = 0.8; // for custom panel heights, 20 (default icon siz
 const DEFAULT_ICON_SIZE = 20;
 
 // Override the factory and create an AppletPopupMenu instead of a PopupMenu
-function IndicatorMenuFactory() {
-   this._init.apply(this, arguments);
-}
+class IndicatorMenuFactory extends PopupMenu.PopupMenuFactory {
+    constructor() {
+        super();
+    }
 
-IndicatorMenuFactory.prototype = {
-    __proto__: PopupMenu.PopupMenuFactory.prototype,
-
-    _init: function() {
-        PopupMenu.PopupMenuFactory.prototype._init.call(this);
-    },
-
-    _createShellItem: function(factoryItem, launcher, orientation) {
+    _createShellItem(factoryItem, launcher, orientation) {
         // Decide whether it's a submenu or not
         let shellItem = null;
         let item_type = factoryItem.getFactoryType();
@@ -40,17 +34,11 @@ IndicatorMenuFactory.prototype = {
             shellItem = new PopupMenu.PopupIndicatorMenuItem("FIXME");
         return shellItem;
     }
-};
-
-function CinnamonSystrayApplet(orientation, panel_height, instance_id) {
-    this._init(orientation, panel_height, instance_id);
 }
 
-CinnamonSystrayApplet.prototype = {
-    __proto__: Applet.Applet.prototype,
-
-    _init: function(orientation, panel_height, instance_id) {
-        Applet.Applet.prototype._init.call(this, orientation, panel_height, instance_id);
+class CinnamonSystrayApplet extends Applet.Applet {
+    constructor(orientation, panel_height, instance_id) {
+        super(orientation, panel_height, instance_id);
 
         this.setAllowedLayout(Applet.AllowedLayout.BOTH);
 
@@ -81,9 +69,9 @@ CinnamonSystrayApplet.prototype = {
         this.menuManager = new PopupMenu.PopupMenuManager(this);
         this._signalAdded = 0;
         this._signalRemoved = 0;
-    },
+    }
 
-    _addIndicatorSupport: function() {
+    _addIndicatorSupport() {
         let manager = Main.indicatorManager;
 
         // Blacklist some of the icons
@@ -104,9 +92,9 @@ CinnamonSystrayApplet.prototype = {
             this._signalAdded = manager.connect('indicator-added', Lang.bind(this, this._onIndicatorAdded));
         if (this._signalRemoved == 0)
             this._signalRemoved = manager.connect('indicator-removed', Lang.bind(this, this._onIndicatorRemoved));
-    },
+    }
 
-    _removeIndicatorSupport: function() {
+    _removeIndicatorSupport() {
         if (this.signalAdded) {
             Main.indicatorManager.disconnect(this.signalAdded);
             this.signalAdded = 0;
@@ -122,9 +110,9 @@ CinnamonSystrayApplet.prototype = {
 
         this._shellIndicators = [];
 
-    },
+    }
 
-    _onIndicatorAdded: function(manager, appIndicator) {
+    _onIndicatorAdded(manager, appIndicator) {
         if (!(appIndicator.id in this._shellIndicators)) {
             let size = null;
             size = this._getIconSize(this._panelHeight / global.ui_scale);
@@ -152,26 +140,26 @@ CinnamonSystrayApplet.prototype = {
                 }
             }));
         }
-    },
+    }
 
-    _onEnterEvent: function(actor, event) {
+    _onEnterEvent(actor, event) {
        this.set_applet_tooltip(actor._delegate.getToolTip());
-    },
+    }
 
-    _onLeaveEvent: function(actor, event) {
+    _onLeaveEvent(actor, event) {
         this.set_applet_tooltip("");
-    },
+    }
 
-    _onIndicatorIconDestroy: function(actor) {
+    _onIndicatorIconDestroy(actor) {
         for (let i = 0; i < this._shellIndicators.length; i++) {
             if (this._shellIndicators[i].instance.actor == actor) {
                 this._shellIndicators.splice(this._shellIndicators.indexOf(this._shellIndicators[i]), 1);
                 break;
             }
         }
-    },
+    }
 
-    _getIconSize: function(ht) {
+    _getIconSize(ht) {
         let size;
         let disp_size = ht * ICON_SCALE_FACTOR;  // hidpi with largest panel, gets up to 80
 
@@ -191,9 +179,9 @@ CinnamonSystrayApplet.prototype = {
             size = 48;
         }
         return size;
-    },
+    }
 
-    _onIndicatorRemoved: function(manager, appIndicator) {
+    _onIndicatorRemoved(manager, appIndicator) {
         for (let i = 0; i < this._shellIndicators.length; i++) {
             if (this._shellIndicators[i].id === appIndicator.id) {
                 this._shellIndicators[i].instance.destroy();
@@ -201,25 +189,25 @@ CinnamonSystrayApplet.prototype = {
                 break;
             }
         }
-    },
+    }
 
-    on_applet_clicked: function(event) {
-    },
+    on_applet_clicked(event) {
+    }
 
-    on_orientation_changed: function(neworientation) {
+    on_orientation_changed(neworientation) {
         if (neworientation == St.Side.TOP || neworientation == St.Side.BOTTOM) {
             this.manager.set_vertical(false);
         } else {
             this.manager.set_vertical(true);
         }
-    },
+    }
 
-    on_applet_removed_from_panel: function () {
+    on_applet_removed_from_panel () {
         this._signalManager.disconnectAllSignals();
         this._removeIndicatorSupport();
-    },
+    }
 
-    on_applet_added_to_panel: function() {
+    on_applet_added_to_panel() {
         Main.statusIconDispatcher.start(this.actor.get_parent().get_parent());
 
         this._signalManager.connect(Main.statusIconDispatcher, 'status-icon-added', this._onTrayIconAdded, this);
@@ -227,9 +215,9 @@ CinnamonSystrayApplet.prototype = {
         this._signalManager.connect(Main.statusIconDispatcher, 'before-redisplay', this._onBeforeRedisplay, this);
         this._signalManager.connect(Main.systrayManager, "changed", Main.statusIconDispatcher.redisplay, Main.statusIconDispatcher);
         this._addIndicatorSupport();
-    },
+    }
 
-    on_panel_height_changed: function() {
+    on_panel_height_changed() {
         Main.statusIconDispatcher.redisplay();
         let size = null;
         size = this._getIconSize(this._panelHeight / global.ui_scale);
@@ -240,9 +228,9 @@ CinnamonSystrayApplet.prototype = {
                 this._shellIndicators[i].instance.setSize(size);
             }
         }
-    },
+    }
 
-    _onBeforeRedisplay: function() {
+    _onBeforeRedisplay() {
         // Mark all icons as obsolete
         // There might still be pending delayed operations to insert/resize of them
         // And that would crash Cinnamon
@@ -259,9 +247,9 @@ CinnamonSystrayApplet.prototype = {
         for (let i = 0; i < children.length; i++) {
             children[i].destroy();
         }
-    },
+    }
 
-    _onTrayIconAdded: function(o, icon, role) {
+    _onTrayIconAdded(o, icon, role) {
         try {
             let hiddenIcons = Main.systrayManager.getRoles();
 
@@ -304,18 +292,18 @@ CinnamonSystrayApplet.prototype = {
         } catch (e) {
             global.logError(e);
         }
-    },
+    }
 
-    _insertStatusItemLater: function(role, icon, position, delay) {
+    _insertStatusItemLater(role, icon, position, delay) {
         // Inserts an icon in the systray after a delay (useful for buggy icons)
         // Delaying the insertion of pidgin by 10 seconds for instance is known to fix it on empty disk cache
         let timerId = Mainloop.timeout_add(delay, Lang.bind(this, function() {
             this._insertStatusItem(role, icon, position);
             Mainloop.source_remove(timerId);
         }));
-    },
+    }
 
-    _onTrayIconRemoved: function(o, icon) {
+    _onTrayIconRemoved(o, icon) {
         icon.obsolete = true;
         for (var i = 0; i < this._statusItems.length; i++) {
             if (this._statusItems[i] == icon) {
@@ -328,9 +316,9 @@ CinnamonSystrayApplet.prototype = {
         }
 
         icon.destroy();
-    },
+    }
 
-    _insertStatusItem: function(role, icon, position) {
+    _insertStatusItem(role, icon, position) {
         if (icon.obsolete == true) {
             return;
         }
@@ -360,9 +348,9 @@ CinnamonSystrayApplet.prototype = {
             icon.set_scale((DEFAULT_ICON_SIZE * global.ui_scale) / icon.width,
                            (DEFAULT_ICON_SIZE * global.ui_scale) / icon.height);
         }
-    },
+    }
 
-    _resizeStatusItem: function(role, icon) {
+    _resizeStatusItem(role, icon) {
         if (icon.obsolete == true) {
             return;
         }
@@ -375,10 +363,8 @@ CinnamonSystrayApplet.prototype = {
             global.log("Resized " + role + " with normalized size (" + icon.get_width() + "x" + icon.get_height() + "px)");
             //Note: dropbox doesn't scale, even though we resize it...
         }
-    },
-
-
-};
+    }
+}
 
 function main(metadata, orientation, panel_height, instance_id) {
     return new CinnamonSystrayApplet(orientation, panel_height, instance_id);

--- a/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
@@ -143,7 +143,7 @@ class CinnamonSystrayApplet extends Applet.Applet {
     }
 
     _onEnterEvent(actor, event) {
-       this.set_applet_tooltip(actor._delegate.getToolTip());
+        this.set_applet_tooltip(actor._delegate.getToolTip());
     }
 
     _onLeaveEvent(actor, event) {

--- a/files/usr/share/cinnamon/applets/trash@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/trash@cinnamon.org/applet.js
@@ -52,7 +52,7 @@ class CinnamonTrashApplet extends Applet.IconApplet {
     }
 
     _onTrashChange() {
-      if (this.trash_changed_timeout > 0) {
+        if (this.trash_changed_timeout > 0) {
             Mainloop.source_remove(this.trash_changed_timeout);
             this.trash_changed_timeout = 0;
         }

--- a/files/usr/share/cinnamon/applets/trash@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/trash@cinnamon.org/applet.js
@@ -9,11 +9,11 @@ const Util = imports.misc.util;
 
 const MESSAGE = _("Are you sure you want to delete all items from the trash?") + "\n" + _("This operation cannot be undone.");
 
-function MyApplet(orientation, panel_height, instance_id) {
+function CinnamonTrashApplet(orientation, panel_height, instance_id) {
     this._init(orientation, panel_height, instance_id);
 }
 
-MyApplet.prototype = {
+CinnamonTrashApplet.prototype = {
     __proto__: Applet.IconApplet.prototype,
 
     _init: function(orientation, panel_height, instance_id) {
@@ -94,6 +94,5 @@ MyApplet.prototype = {
 };
 
 function main(metadata, orientation, panel_height, instance_id) {
-    let myApplet = new MyApplet(orientation, panel_height, instance_id);
-    return myApplet;
+    return new CinnamonTrashApplet(orientation, panel_height, instance_id);
 }

--- a/files/usr/share/cinnamon/applets/trash@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/trash@cinnamon.org/applet.js
@@ -9,38 +9,27 @@ const Util = imports.misc.util;
 
 const MESSAGE = _("Are you sure you want to delete all items from the trash?") + "\n" + _("This operation cannot be undone.");
 
-function CinnamonTrashApplet(orientation, panel_height, instance_id) {
-    this._init(orientation, panel_height, instance_id);
-}
+class CinnamonTrashApplet extends Applet.IconApplet {
+    constructor(orientation, panel_height, instance_id) {
+        super(orientation, panel_height, instance_id);
 
-CinnamonTrashApplet.prototype = {
-    __proto__: Applet.IconApplet.prototype,
+        this.set_applet_icon_symbolic_name("user-trash");
+        this.set_applet_tooltip(_("Trash"));
 
-    _init: function(orientation, panel_height, instance_id) {
-        Applet.IconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
+        this.trash_path = 'trash:///';
+        this.trash_directory =  Gio.file_new_for_uri(this.trash_path);
 
-        try {
-            this.set_applet_icon_symbolic_name("user-trash");
-            this.set_applet_tooltip(_("Trash"));
+        this._initContextMenu();
 
-            this.trash_path = 'trash:///';
-            this.trash_directory =  Gio.file_new_for_uri(this.trash_path);
+        this.trash_changed_timeout = 0;
 
-            this._initContextMenu();
+        this._onTrashChange();
 
-            this.trash_changed_timeout = 0;
+        this.monitor = this.trash_directory.monitor_directory(0, null);
+        this.monitor.connect('changed', Lang.bind(this, this._onTrashChange));
+    }
 
-            this._onTrashChange();
-
-            this.monitor = this.trash_directory.monitor_directory(0, null);
-            this.monitor.connect('changed', Lang.bind(this, this._onTrashChange));
-        }
-        catch (e) {
-            global.logError(e);
-        }
-    },
-
-    _initContextMenu: function () {
+    _initContextMenu() {
         this.empty_item = new PopupMenu.PopupIconMenuItem(_("Empty Trash"),
                 "list-remove",
                 St.IconType.SYMBOLIC);
@@ -52,26 +41,26 @@ CinnamonTrashApplet.prototype = {
                 St.IconType.SYMBOLIC);
         this.open_item.connect('activate', Lang.bind(this, this._openTrash));
         this._applet_context_menu.addMenuItem(this.open_item);
-    },
+    }
 
-    on_applet_clicked: function(event) {
+    on_applet_clicked(event) {
         this._openTrash();
-    },
+    }
 
-    _openTrash: function() {
+    _openTrash() {
         Gio.app_info_launch_default_for_uri(this.trash_directory.get_uri(), null);
-    },
+    }
 
-    _onTrashChange: function() {
+    _onTrashChange() {
       if (this.trash_changed_timeout > 0) {
             Mainloop.source_remove(this.trash_changed_timeout);
             this.trash_changed_timeout = 0;
         }
 
         this.trash_changed_timeout = Mainloop.timeout_add_seconds(1, Lang.bind(this, this._onTrashChangeTimeout));
-    },
+    }
 
-    _onTrashChangeTimeout: function() {
+    _onTrashChangeTimeout() {
         this.trash_changed_timeout = 0;
         if (this.trash_directory.query_exists(null)) {
             let children = this.trash_directory.enumerate_children('standard::*', Gio.FileQueryInfoFlags.NONE, null);
@@ -82,16 +71,16 @@ CinnamonTrashApplet.prototype = {
             }
             children.close(null);
         }
-    },
+    }
 
-    _emptyTrash: function() {
+    _emptyTrash() {
         new ModalDialog.ConfirmDialog(MESSAGE, this._doEmptyTrash).open();
-    },
+    }
 
-    _doEmptyTrash: function() {
+    _doEmptyTrash() {
         Util.spawn(['gvfs-trash', '--empty']);
     }
-};
+}
 
 function main(metadata, orientation, panel_height, instance_id) {
     return new CinnamonTrashApplet(orientation, panel_height, instance_id);

--- a/files/usr/share/cinnamon/applets/user@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/user@cinnamon.org/applet.js
@@ -10,151 +10,139 @@ const GnomeSession = imports.misc.gnomeSession;
 const ScreenSaver = imports.misc.screenSaver;
 const Settings = imports.ui.settings;
 
-
-function CinnamonUserApplet(orientation, panel_height, instance_id) {
-    this._init(orientation, panel_height, instance_id);
-}
-
-CinnamonUserApplet.prototype = {
-    __proto__: Applet.TextIconApplet.prototype,
-
-    _init: function(orientation, panel_height, instance_id) {
-        Applet.TextIconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
+class CinnamonUserApplet extends Applet.TextIconApplet {
+    constructor(orientation, panel_height, instance_id) {
+        super(orientation, panel_height, instance_id);
 
         this.setAllowedLayout(Applet.AllowedLayout.BOTH);
 
-        try {
-            this._session = new GnomeSession.SessionManager();
-            this._screenSaverProxy = new ScreenSaver.ScreenSaverProxy();
-            this.settings = new Settings.AppletSettings(this, "user@cinnamon.org", instance_id);
+        this._session = new GnomeSession.SessionManager();
+        this._screenSaverProxy = new ScreenSaver.ScreenSaverProxy();
+        this.settings = new Settings.AppletSettings(this, "user@cinnamon.org", instance_id);
 
-            this.set_applet_icon_symbolic_name("avatar-default");
+        this.set_applet_icon_symbolic_name("avatar-default");
 
-            this.menuManager = new PopupMenu.PopupMenuManager(this);
-            this.menu = new Applet.AppletPopupMenu(this, orientation);
-            this.menuManager.addMenu(this.menu);
-            this._contentSection = new PopupMenu.PopupMenuSection();
-            this.menu.addMenuItem(this._contentSection);
+        this.menuManager = new PopupMenu.PopupMenuManager(this);
+        this.menu = new Applet.AppletPopupMenu(this, orientation);
+        this.menuManager.addMenu(this.menu);
+        this._contentSection = new PopupMenu.PopupMenuSection();
+        this.menu.addMenuItem(this._contentSection);
 
-            let userBox = new St.BoxLayout({ style_class: 'user-box', reactive: true, vertical: false });
+        let userBox = new St.BoxLayout({ style_class: 'user-box', reactive: true, vertical: false });
 
-            this._userIcon = new St.Bin({ style_class: 'user-icon'});
+        this._userIcon = new St.Bin({ style_class: 'user-icon'});
 
-            this.settings.bind("display-name", "disp_name", this._updateLabel);
+        this.settings.bind("display-name", "disp_name", this._updateLabel);
 
-            userBox.connect('button-press-event', Lang.bind(this, function() {
-                this.menu.toggle();
-                Util.spawnCommandLine("cinnamon-settings user");
-            }));
+        userBox.connect('button-press-event', Lang.bind(this, function() {
+            this.menu.toggle();
+            Util.spawnCommandLine("cinnamon-settings user");
+        }));
 
-            this._userIcon.hide();
-            userBox.add(this._userIcon,
-                        { x_fill:  true,
-                          y_fill:  false,
-                          x_align: St.Align.END,
-                          y_align: St.Align.START });
-            this.userLabel = new St.Label(({ style_class: 'user-label'}));
-            userBox.add(this.userLabel,
-                        { x_fill:  true,
-                          y_fill:  false,
-                          x_align: St.Align.END,
-                          y_align: St.Align.MIDDLE });
+        this._userIcon.hide();
+        userBox.add(this._userIcon,
+                    { x_fill:  true,
+                      y_fill:  false,
+                      x_align: St.Align.END,
+                      y_align: St.Align.START });
+        this.userLabel = new St.Label(({ style_class: 'user-label'}));
+        userBox.add(this.userLabel,
+                    { x_fill:  true,
+                      y_fill:  false,
+                      x_align: St.Align.END,
+                      y_align: St.Align.MIDDLE });
 
-            this.menu.addActor(userBox);
+        this.menu.addActor(userBox);
 
-            this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
-            let item = new PopupMenu.PopupIconMenuItem(_("System Settings"), "preferences-system", St.IconType.SYMBOLIC);
-            item.connect('activate', Lang.bind(this, function() {
-                Util.spawnCommandLine("cinnamon-settings");
-            }));
-            this.menu.addMenuItem(item);
+        let item = new PopupMenu.PopupIconMenuItem(_("System Settings"), "preferences-system", St.IconType.SYMBOLIC);
+        item.connect('activate', Lang.bind(this, function() {
+            Util.spawnCommandLine("cinnamon-settings");
+        }));
+        this.menu.addMenuItem(item);
 
-            this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
-            item = new PopupMenu.PopupIconMenuItem(_("Lock Screen"), "system-lock-screen", St.IconType.SYMBOLIC);
-            item.connect('activate', Lang.bind(this, function() {
-                let screensaver_settings = new Gio.Settings({ schema_id: "org.cinnamon.desktop.screensaver" });
-                let screensaver_dialog = Gio.file_new_for_path("/usr/bin/cinnamon-screensaver-command");
-                if (screensaver_dialog.query_exists(null)) {
-                    if (screensaver_settings.get_boolean("ask-for-away-message")) {
-                        Util.spawnCommandLine("cinnamon-screensaver-lock-dialog");
-                    }
-                    else {
-                        Util.spawnCommandLine("cinnamon-screensaver-command --lock");
-                    }
+        item = new PopupMenu.PopupIconMenuItem(_("Lock Screen"), "system-lock-screen", St.IconType.SYMBOLIC);
+        item.connect('activate', Lang.bind(this, function() {
+            let screensaver_settings = new Gio.Settings({ schema_id: "org.cinnamon.desktop.screensaver" });
+            let screensaver_dialog = Gio.file_new_for_path("/usr/bin/cinnamon-screensaver-command");
+            if (screensaver_dialog.query_exists(null)) {
+                if (screensaver_settings.get_boolean("ask-for-away-message")) {
+                    Util.spawnCommandLine("cinnamon-screensaver-lock-dialog");
                 }
                 else {
-                    this._screenSaverProxy.LockRemote();
+                    Util.spawnCommandLine("cinnamon-screensaver-command --lock");
                 }
-            }));
-            this.menu.addMenuItem(item);
+            }
+            else {
+                this._screenSaverProxy.LockRemote();
+            }
+        }));
+        this.menu.addMenuItem(item);
 
-            if (GLib.getenv("XDG_SEAT_PATH")) {
-                // LightDM
-                item = new PopupMenu.PopupIconMenuItem(_("Switch User"), "system-switch-user", St.IconType.SYMBOLIC);
-                item.connect('activate', Lang.bind(this, function() {
-                    Util.spawnCommandLine("cinnamon-screensaver-command --lock");
-                    Util.spawnCommandLine("dm-tool switch-to-greeter");
-                }));
-                this.menu.addMenuItem(item);
-            }
-            else if (GLib.file_test("/usr/bin/mdmflexiserver", GLib.FileTest.EXISTS)) {
-                // MDM
-                item = new PopupMenu.PopupIconMenuItem(_("Switch User"), "system-switch-user", St.IconType.SYMBOLIC);
-                item.connect('activate', Lang.bind(this, function() {
-                    Util.spawnCommandLine("mdmflexiserver");
-                }));
-                this.menu.addMenuItem(item);
-            }
-            else if (GLib.file_test("/usr/bin/gdmflexiserver", GLib.FileTest.EXISTS)) {
-                // GDM
-                item = new PopupMenu.PopupIconMenuItem(_("Switch User"), "system-switch-user", St.IconType.SYMBOLIC);
-                item.connect('activate', Lang.bind(this, function() {
-                    Util.spawnCommandLine("cinnamon-screensaver-command --lock");
-                    Util.spawnCommandLine("gdmflexiserver");
-                }));
-                this.menu.addMenuItem(item);
-            }
-
-            item = new PopupMenu.PopupIconMenuItem(_("Log Out..."), "logout", St.IconType.SYMBOLIC);
+        if (GLib.getenv("XDG_SEAT_PATH")) {
+            // LightDM
+            item = new PopupMenu.PopupIconMenuItem(_("Switch User"), "system-switch-user", St.IconType.SYMBOLIC);
             item.connect('activate', Lang.bind(this, function() {
-                this._session.LogoutRemote(0);
+                Util.spawnCommandLine("cinnamon-screensaver-command --lock");
+                Util.spawnCommandLine("dm-tool switch-to-greeter");
             }));
             this.menu.addMenuItem(item);
-
-            this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-
-            item = new PopupMenu.PopupIconMenuItem(_("Power Off..."), "system-shutdown", St.IconType.SYMBOLIC);
+        }
+        else if (GLib.file_test("/usr/bin/mdmflexiserver", GLib.FileTest.EXISTS)) {
+            // MDM
+            item = new PopupMenu.PopupIconMenuItem(_("Switch User"), "system-switch-user", St.IconType.SYMBOLIC);
             item.connect('activate', Lang.bind(this, function() {
-                this._session.ShutdownRemote();
+                Util.spawnCommandLine("mdmflexiserver");
             }));
             this.menu.addMenuItem(item);
-
-            this._user = AccountsService.UserManager.get_default().get_user(GLib.get_user_name());
-            this._userLoadedId = this._user.connect('notify::is-loaded', Lang.bind(this, this._onUserChanged));
-            this._userChangedId = this._user.connect('changed', Lang.bind(this, this._onUserChanged));
-            this._onUserChanged();
-            this.set_show_label_in_vertical_panels(false);
         }
-        catch (e) {
-            global.logError(e);
+        else if (GLib.file_test("/usr/bin/gdmflexiserver", GLib.FileTest.EXISTS)) {
+            // GDM
+            item = new PopupMenu.PopupIconMenuItem(_("Switch User"), "system-switch-user", St.IconType.SYMBOLIC);
+            item.connect('activate', Lang.bind(this, function() {
+                Util.spawnCommandLine("cinnamon-screensaver-command --lock");
+                Util.spawnCommandLine("gdmflexiserver");
+            }));
+            this.menu.addMenuItem(item);
         }
-    },
 
-    on_applet_clicked: function(event) {
+        item = new PopupMenu.PopupIconMenuItem(_("Log Out..."), "logout", St.IconType.SYMBOLIC);
+        item.connect('activate', Lang.bind(this, function() {
+            this._session.LogoutRemote(0);
+        }));
+        this.menu.addMenuItem(item);
+
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+
+        item = new PopupMenu.PopupIconMenuItem(_("Power Off..."), "system-shutdown", St.IconType.SYMBOLIC);
+        item.connect('activate', Lang.bind(this, function() {
+            this._session.ShutdownRemote();
+        }));
+        this.menu.addMenuItem(item);
+
+        this._user = AccountsService.UserManager.get_default().get_user(GLib.get_user_name());
+        this._userLoadedId = this._user.connect('notify::is-loaded', Lang.bind(this, this._onUserChanged));
+        this._userChangedId = this._user.connect('changed', Lang.bind(this, this._onUserChanged));
+        this._onUserChanged();
+        this.set_show_label_in_vertical_panels(false);
+    }
+
+    on_applet_clicked(event) {
         this.menu.toggle();
-    },
+    }
 
-    _updateLabel: function() {
+    _updateLabel() {
         if (this.disp_name) {
             this.set_applet_label(this._user.get_real_name());
         } else {
             this.set_applet_label("");
         }
-    },
+    }
 
-    _onUserChanged: function() {
+    _onUserChanged() {
         if (this._user.is_loaded) {
             this.set_applet_tooltip(this._user.get_real_name());
             this.userLabel.set_text (this._user.get_real_name());
@@ -173,12 +161,12 @@ CinnamonUserApplet.prototype = {
             }
             this._updateLabel();
         }
-    },
+    }
 
-    on_applet_removed_from_panel: function() {
+    on_applet_removed_from_panel() {
         this.settings.finalize();
     }
-};
+}
 
 function main(metadata, orientation, panel_height, instance_id) {
     return new CinnamonUserApplet(orientation, panel_height, instance_id);

--- a/files/usr/share/cinnamon/applets/user@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/user@cinnamon.org/applet.js
@@ -11,11 +11,11 @@ const ScreenSaver = imports.misc.screenSaver;
 const Settings = imports.ui.settings;
 
 
-function MyApplet(orientation, panel_height, instance_id) {
+function CinnamonUserApplet(orientation, panel_height, instance_id) {
     this._init(orientation, panel_height, instance_id);
 }
 
-MyApplet.prototype = {
+CinnamonUserApplet.prototype = {
     __proto__: Applet.TextIconApplet.prototype,
 
     _init: function(orientation, panel_height, instance_id) {
@@ -181,6 +181,5 @@ MyApplet.prototype = {
 };
 
 function main(metadata, orientation, panel_height, instance_id) {
-    let myApplet = new MyApplet(orientation, panel_height, instance_id);
-    return myApplet;
+    return new CinnamonUserApplet(orientation, panel_height, instance_id);
 }

--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -72,15 +72,9 @@ const FLASH_INTERVAL = 500;
 const WINDOW_PREVIEW_WIDTH = 200;
 const WINDOW_PREVIEW_HEIGHT = 150;
 
-function WindowPreview(item, metaWindow, previewScale, showLabel) {
-    this._init(item, metaWindow, previewScale, showLabel);
-}
-
-WindowPreview.prototype = {
-    __proto__: Tooltips.TooltipBase.prototype,
-
-    _init: function(item, metaWindow, previewScale, showLabel) {
-        Tooltips.TooltipBase.prototype._init.call(this, item.actor);
+class WindowPreview extends Tooltips.TooltipBase {
+    constructor(item, metaWindow, previewScale, showLabel) {
+        super(item.actor);
         this._applet = item._applet;
         this.uiScale = St.ThemeContext.get_for_stage(global.stage).scale_factor;
         this.thumbScale = previewScale;
@@ -104,31 +98,31 @@ WindowPreview.prototype = {
 
         this.thumbnailBin = new St.Bin();
         this.actor.add_actor(this.thumbnailBin);
-    },
+    }
 
-    _onEnterEvent: function(actor, event) {
+    _onEnterEvent(actor, event) {
         if (this._applet._tooltipShowing)
             this.show();
         else if (!this._showTimer)
             this._showTimer = Mainloop.timeout_add(300, Lang.bind(this, this._onShowTimerComplete));
 
         this.mousePosition = event.get_coords();
-    },
+    }
 
-    _getScaledTextureSize: function(windowTexture) {
+    _getScaledTextureSize(windowTexture) {
         let [width, height] = windowTexture.get_size();
         let scale = this.thumbScale * this.uiScale *
                     Math.min(WINDOW_PREVIEW_WIDTH / width, WINDOW_PREVIEW_HEIGHT / height);
         return [ width * scale,
                  height * scale ];
-    },
+    }
 
-    _hide: function(actor, event) {
+    _hide(actor, event) {
         Tooltips.TooltipBase.prototype._hide.call(this, actor, event);
         this._applet.erodeTooltip();
-    },
+    }
 
-    show: function() {
+    show() {
         if (!this.actor || this._applet._menuOpen)
             return;
 
@@ -192,9 +186,9 @@ WindowPreview.prototype = {
         this.visible = true;
         this._applet.cancelErodeTooltip();
         this._applet._tooltipShowing = true;
-    },
+    }
 
-    hide: function() {
+    hide() {
         if (this._sizeChangedId != null) {
             this.muffinWindow.disconnect(this._sizeChangedId);
             this._sizeChangedId = null;
@@ -207,13 +201,13 @@ WindowPreview.prototype = {
             this.actor.hide();
         }
         this.visible = false;
-    },
+    }
 
-    set_text: function(text) {
+    set_text(text) {
         this.label.set_text(text);
-    },
+    }
 
-    _destroy: function() {
+    _destroy() {
         if (this._sizeChangedId != null) {
             this.muffinWindow.disconnect(this._sizeChangedId);
             this.sizeChangedId = null;
@@ -227,15 +221,10 @@ WindowPreview.prototype = {
         }
         this.actor = null;
     }
-};
-
-function AppMenuButton(applet, metaWindow, alert) {
-    this._init(applet, metaWindow, alert);
 }
 
-AppMenuButton.prototype = {
-    _init: function(applet, metaWindow, alert) {
-
+class AppMenuButton {
+    constructor(applet, metaWindow, alert) {
         this.actor = new Cinnamon.GenericContainer({
             name: 'appMenu',
             style_class: 'window-list-item-box',
@@ -349,14 +338,14 @@ AppMenuButton.prototype = {
         this.window_signals.connect(this.metaWindow, "notify::icon", this.setIcon, this);
         this.window_signals.connect(this.metaWindow, "notify::appears-focused", this.onFocus, this);
         this.window_signals.connect(this.metaWindow, "unmanaged", this.onUnmanaged, this);
-    },
+    }
 
-    onUnmanaged: function() {
+    onUnmanaged() {
         this.destroy();
         this._windows.splice(this._windows.indexOf(this), 1);
-    },
+    }
 
-    onPreviewChanged: function() {
+    onPreviewChanged() {
         if (this._tooltip)
             this._tooltip.destroy();
 
@@ -366,16 +355,16 @@ AppMenuButton.prototype = {
             this._tooltip = new Tooltips.PanelItemTooltip(this, "", this._applet.orientation);
 
         this.setDisplayTitle();
-    },
+    }
 
-    onPanelEditModeChanged: function() {
+    onPanelEditModeChanged() {
         let editMode = global.settings.get_boolean("panel-edit-mode");
         if (this._draggable)
             this._draggable.inhibit = editMode;
         this.actor.reactive = !editMode;
-    },
+    }
 
-    onScrollModeChanged: function() {
+    onScrollModeChanged() {
         if (this._applet.scrollable) {
             this.scrollConnector = this.actor.connect('scroll-event', Lang.bind(this, this._onScrollEvent));
         } else {
@@ -384,9 +373,9 @@ AppMenuButton.prototype = {
                 this.scrollConnector = null;
             }
         }
-    },
+    }
 
-    _onScrollEvent: function(actor, event) {
+    _onScrollEvent(actor, event) {
         let direction = event.get_scroll_direction();
 
         // Find the current focused window
@@ -417,9 +406,9 @@ AppMenuButton.prototype = {
             i = windows.length - 1;
 
         Main.activateWindow(windows[i].metaWindow, global.get_current_time());
-    },
+    }
 
-    _onDragBegin: function() {
+    _onDragBegin() {
         if (this._applet.orientation == St.Side.TOP || this._applet.orientation == St.Side.BOTTOM) {
             this._draggable._overrideY = this.actor.get_transformed_position()[1];
             this._draggable._overrideX = null;
@@ -430,32 +419,32 @@ AppMenuButton.prototype = {
 
         this._tooltip.hide();
         this._tooltip.preventShow = true;
-    },
+    }
 
-    _onDragEnd: function() {
+    _onDragEnd() {
         this.actor.show();
         this._applet.clearDragPlaceholder();
         this._tooltip.preventShow = false;
-    },
+    }
 
-    _onDragCancelled: function() {
+    _onDragCancelled() {
         this.actor.show();
         this._applet.clearDragPlaceholder();
         this._tooltip.preventShow = false;
-    },
+    }
 
-    getDragActor: function() {
+    getDragActor() {
         let clone    = new Clutter.Clone({ source: this.actor });
         clone.width  = this.actor.width;
         clone.height = this.actor.height;
         return clone;
-    },
+    }
 
-    getDragActorSource: function() {
+    getDragActorSource() {
         return this.actor;
-    },
+    }
 
-    handleDragOver: function(source, actor, x, y, time) {
+    handleDragOver(source, actor, x, y, time) {
         if (this._draggable && this._draggable.inhibit) {
             return DND.DragMotionResult.CONTINUE;
         }
@@ -469,13 +458,13 @@ AppMenuButton.prototype = {
          * and we will open the window for them. */
         this._toggleWindow(true);
         return DND.DragMotionResult.NO_DROP;
-    },
+    }
 
-    acceptDrop: function(source, actor, x, y, time) {
+    acceptDrop(source, actor, x, y, time) {
         return false;
-    },
+    }
 
-    setDisplayTitle: function() {
+    setDisplayTitle() {
         let title   = this.metaWindow.get_title();
         let tracker = Cinnamon.WindowTracker.get_default();
         let app = tracker.get_window_app(this.metaWindow);
@@ -504,18 +493,18 @@ AppMenuButton.prototype = {
         }
 
         this._label.set_text(title);
-    },
+    }
 
-    destroy: function() {
+    destroy() {
         this.window_signals.disconnectAllSignals();
         this._tooltip.destroy();
         if (this.rightClickMenu) {
             this.rightClickMenu.destroy();
         }
         this.actor.destroy();
-    },
+    }
 
-    _hasFocus: function() {
+    _hasFocus() {
         if (this.metaWindow.minimized)
             return false;
 
@@ -531,9 +520,9 @@ AppMenuButton.prototype = {
             return true;
         });
         return transientHasFocus;
-    },
+    }
 
-    onFocus: function() {
+    onFocus() {
         if (this._hasFocus()) {
             this.actor.add_style_pseudo_class('focus');
             this.actor.remove_style_class_name("window-list-item-demands-attention");
@@ -547,9 +536,9 @@ AppMenuButton.prototype = {
         } else {
             this.actor.remove_style_pseudo_class('focus');
         }
-    },
+    }
 
-    _onButtonRelease: function(actor, event) {
+    _onButtonRelease(actor, event) {
         this._tooltip.hide();
         if (this.alert) {
             if (event.get_button() == 1)
@@ -566,9 +555,9 @@ AppMenuButton.prototype = {
             this.metaWindow.delete(global.get_current_time());
         }
         return true;
-    },
+    }
 
-    _onButtonPress: function(actor, event) {
+    _onButtonPress(actor, event) {
         this._tooltip.hide();
         if (!this.alert && event.get_button() == 3) {
             this.rightClickMenu.mouseEvent = event;
@@ -578,9 +567,9 @@ AppMenuButton.prototype = {
                 this.actor.add_style_pseudo_class('focus');
             }
         }
-    },
+    }
 
-    _toggleWindow: function(fromDrag){
+    _toggleWindow(fromDrag){
         if (!this._hasFocus()) {
             Main.activateWindow(this.metaWindow, global.get_current_time());
             this.actor.add_style_pseudo_class('focus');
@@ -588,15 +577,15 @@ AppMenuButton.prototype = {
             this.metaWindow.minimize();
             this.actor.remove_style_pseudo_class('focus');
         }
-    },
+    }
 
-    _onIconBoxStyleChanged: function() {
+    _onIconBoxStyleChanged() {
         let node = this._iconBox.get_theme_node();
         this._iconBottomClip = node.get_length('app-icon-bottom-clip');
         this._updateIconBoxClipAndGeometry();
-    },
+    }
 
-    _updateIconBoxClipAndGeometry: function() {
+    _updateIconBoxClipAndGeometry() {
         let allocation = this._iconBox.allocation;
         if (this._iconBottomClip > 0)
             this._iconBox.set_clip(0, 0,
@@ -610,9 +599,9 @@ AppMenuButton.prototype = {
         [rect.width, rect.height] = this.actor.get_transformed_size();
 
         this.metaWindow.set_icon_geometry(rect);
-    },
+    }
 
-    _getPreferredWidth: function(actor, forHeight, alloc) {
+    _getPreferredWidth(actor, forHeight, alloc) {
         let [minSize, naturalSize] = this._iconBox.get_preferred_width(forHeight);
         // minimum size just enough for icon if we ever get that many apps going
         alloc.min_size = naturalSize;
@@ -630,9 +619,9 @@ AppMenuButton.prototype = {
         } else {
             alloc.natural_size = this._applet._panelHeight;
         }
-    },
+    }
 
-    _getPreferredHeight: function(actor, forWidth, alloc) {
+    _getPreferredHeight(actor, forWidth, alloc) {
         let [minSize1, naturalSize1] = this._iconBox.get_preferred_height(forWidth);
 
         if (this.labelVisible) {
@@ -653,9 +642,9 @@ AppMenuButton.prototype = {
         } else {
             alloc.natural_size = naturalSize1;
         }
-    },
+    }
 
-    _allocate: function(actor, box, flags) {
+    _allocate(actor, box, flags) {
         let allocWidth = box.x2 - box.x1;
         let allocHeight = box.y2 - box.y1;
 
@@ -714,9 +703,9 @@ AppMenuButton.prototype = {
 
         let clip_width = Math.max((this.actor.width) * (this._progress / 100.0), 1.0);
         this.progressOverlay.set_clip(0, 0, clip_width, this.actor.height);
-    },
+    }
 
-    updateLabelVisible: function() {
+    updateLabelVisible() {
         if (this._applet.orientation == St.Side.TOP || this._applet.orientation == St.Side.BOTTOM) {
             this._label.show();
             this.labelVisible = true;
@@ -724,9 +713,9 @@ AppMenuButton.prototype = {
             this._label.hide();
             this.labelVisible = false;
         }
-    },
+    }
 
-    setIcon: function() {
+    setIcon() {
         let tracker = Cinnamon.WindowTracker.get_default();
         let app = tracker.get_window_app(this.metaWindow);
 
@@ -748,9 +737,9 @@ AppMenuButton.prototype = {
 
         if (old_child)
             old_child.destroy();
-    },
+    }
 
-    getAttention: function() {
+    getAttention() {
         if (this._needsAttention)
             return false;
 
@@ -758,9 +747,9 @@ AppMenuButton.prototype = {
         let counter = 0;
         this._flashButton(counter);
         return true;
-    },
+    }
 
-    _flashButton: function(counter) {
+    _flashButton(counter) {
         if (!this._needsAttention)
             return;
 
@@ -778,15 +767,9 @@ AppMenuButton.prototype = {
     }
 };
 
-function AppMenuButtonRightClickMenu(launcher, metaWindow, orientation) {
-    this._init(launcher, metaWindow, orientation);
-}
-
-AppMenuButtonRightClickMenu.prototype = {
-    __proto__: Applet.AppletPopupMenu.prototype,
-
-    _init: function(launcher, metaWindow, orientation) {
-        Applet.AppletPopupMenu.prototype._init.call(this, launcher, orientation);
+class AppMenuButtonRightClickMenu extends Applet.AppletPopupMenu {
+    constructor(launcher, metaWindow, orientation) {
+        super(launcher, orientation);
 
         this._launcher = launcher;
         this._windows = launcher._applet._windows;
@@ -794,9 +777,9 @@ AppMenuButtonRightClickMenu.prototype = {
 
         this.orientation = orientation;
         this.metaWindow = metaWindow;
-    },
+    }
 
-    _populateMenu: function() {
+    _populateMenu() {
         let mw = this.metaWindow;
         let item;
         let length;
@@ -942,34 +925,28 @@ AppMenuButtonRightClickMenu.prototype = {
             mw.delete(global.get_current_time());
         });
         this.addMenuItem(item);
-    },
+    }
 
-    _onToggled: function(actor, isOpening){
+    _onToggled(actor, isOpening){
         if (this.isOpen)
             this._launcher._applet._menuOpen = true;
         else
             this._launcher._applet._menuOpen = false;
-    },
+    }
 
-    toggle: function() {
+    toggle() {
         if (!this.isOpen) {
             this.removeAll();
             this._populateMenu();
         }
 
         Applet.AppletPopupMenu.prototype.toggle.call(this);
-    },
-};
-
-function CinnamonWindowListApplet(orientation, panel_height, instance_id) {
-    this._init(orientation, panel_height, instance_id);
+    }
 }
 
-CinnamonWindowListApplet.prototype = {
-    __proto__: Applet.Applet.prototype,
-
-    _init: function(orientation, panel_height, instance_id) {
-        Applet.Applet.prototype._init.call(this, orientation, panel_height, instance_id);
+class CinnamonWindowListApplet extends Applet.Applet {
+    constructor(orientation, panel_height, instance_id) {
+        super(orientation, panel_height, instance_id);
 
         this.signals = new SignalManager.SignalManager(null);
 
@@ -1027,26 +1004,26 @@ CinnamonWindowListApplet.prototype = {
 
         this.on_orientation_changed(orientation);
         this._updateAttentionGrabber();
-    },
+    }
 
-    on_applet_added_to_panel: function(userEnabled) {
+    on_applet_added_to_panel(userEnabled) {
         this._updateSpacing();
         this.appletEnabled = true;
-    },
+    }
 
-    on_applet_removed_from_panel: function() {
+    on_applet_removed_from_panel() {
         this.signals.disconnectAllSignals();
-    },
+    }
 
-    on_applet_instances_changed: function() {
+    on_applet_instances_changed() {
         this._updateWatchedMonitors();
-    },
+    }
 
-    on_panel_height_changed: function() {
+    on_panel_height_changed() {
         this._refreshAllItems();
-    },
+    }
 
-    on_orientation_changed: function(orientation) {
+    on_orientation_changed(orientation) {
         this.orientation = orientation;
 
         for (let window of this._windows)
@@ -1097,38 +1074,38 @@ CinnamonWindowListApplet.prototype = {
         if (this.appletEnabled) {
             this._updateSpacing();
         }
-    },
+    }
 
-    _updateSpacing: function() {
+    _updateSpacing() {
         let themeNode = this.actor.get_theme_node();
         let spacing = themeNode.get_length('spacing');
         this.manager.set_spacing(spacing * global.ui_scale);
-    },
+    }
 
-    _onWindowAddedAsync: function(screen, metaWindow, monitor) {
+    _onWindowAddedAsync(screen, metaWindow, monitor) {
         Mainloop.timeout_add(20, Lang.bind(this, this._onWindowAdded, screen, metaWindow, monitor));
-    },
+    }
 
-    _onWindowAdded: function(screen, metaWindow, monitor) {
+    _onWindowAdded(screen, metaWindow, monitor) {
         if (this._shouldAdd(metaWindow))
             this._addWindow(metaWindow, false);
-    },
+    }
 
-    _onWindowMonitorChanged: function(screen, metaWindow, monitor) {
+    _onWindowMonitorChanged(screen, metaWindow, monitor) {
         if (this._shouldAdd(metaWindow))
             this._addWindow(metaWindow, false);
         else
             this._removeWindow(metaWindow);
-    },
+    }
 
-    _onWindowWorkspaceChanged: function(screen, metaWindow, metaWorkspace) {
+    _onWindowWorkspaceChanged(screen, metaWindow, metaWorkspace) {
         let window = this._windows.find(win => (win.metaWindow == metaWindow));
 
         if (window)
             this._refreshItem(window);
-    },
+    }
 
-    _onWindowSkipTaskbarChanged: function(screen, metaWindow) {
+    _onWindowSkipTaskbarChanged(screen, metaWindow) {
         let window = this._windows.find(win => (win.metaWindow == metaWindow));
 
         if (window && !Main.isInteresting(metaWindow)) {
@@ -1137,9 +1114,9 @@ CinnamonWindowListApplet.prototype = {
         }
 
         this._onWindowAdded(screen, metaWindow, 0);
-    },
+    }
 
-    _updateAttentionGrabber: function() {
+    _updateAttentionGrabber() {
         if (this.enableAlerts) {
             this.signals.connect(global.display, "window-marked-urgent", this._onWindowDemandsAttention, this);
             this.signals.connect(global.display, "window-demands-attention", this._onWindowDemandsAttention, this);
@@ -1147,19 +1124,19 @@ CinnamonWindowListApplet.prototype = {
             this.signals.disconnect("window-marked-urgent");
             this.signals.disconnect("window-demands-attention");
         }
-    },
+    }
 
-    _onEnableScrollChanged: function() {
+    _onEnableScrollChanged() {
         for (let window of this._windows)
             window.onScrollModeChanged();
-    },
+    }
 
-    _onPreviewChanged: function() {
+    _onPreviewChanged() {
         for (let window of this._windows)
             window.onPreviewChanged();
-    },
+    }
 
-    _onWindowDemandsAttention : function(display, window) {
+    _onWindowDemandsAttention (display, window) {
         // Magic to look for AppMenuButton owning window
         let i = this._windows.length;
         while (i-- && this._windows[i].metaWindow != window);
@@ -1174,9 +1151,9 @@ CinnamonWindowListApplet.prototype = {
 
         if (window.get_workspace() != global.screen.get_active_workspace())
             this._addWindow(window, true);
-    },
+    }
 
-    _refreshItem: function(window) {
+    _refreshItem(window) {
         window.actor.visible =
             (window.metaWindow.get_workspace() == global.screen.get_active_workspace()) ||
             window.metaWindow.is_on_all_workspaces() ||
@@ -1188,21 +1165,21 @@ CinnamonWindowListApplet.prototype = {
          * one isn't shown! */
         if (window.alert)
             window.actor.visible = !window.actor.visible;
-    },
+    }
 
-    _refreshAllItems: function() {
+    _refreshAllItems() {
         for (let window of this._windows) {
             this._refreshItem(window);
         }
-    },
+    }
 
-    _reTitleItems: function() {
+    _reTitleItems() {
         for (let window of this._windows) {
             window.setDisplayTitle();
         }
-    },
+    }
 
-    _updateWatchedMonitors: function() {
+    _updateWatchedMonitors() {
         let n_mons = Gdk.Screen.get_default().get_n_monitors();
         let on_primary = this.panel.monitorIndex == Main.layoutManager.primaryIndex;
         let instances = Main.AppletManager.getRunningInstancesForUuid(this._uuid);
@@ -1248,9 +1225,9 @@ CinnamonWindowListApplet.prototype = {
             else
                 this._removeWindow(window);
         }
-    },
+    }
 
-    _addWindow: function(metaWindow, alert) {
+    _addWindow(metaWindow, alert) {
         for (let window of this._windows)
             if (window.metaWindow == metaWindow &&
                 window.alert == alert)
@@ -1275,9 +1252,9 @@ CinnamonWindowListApplet.prototype = {
                 }
             }
         }
-    },
+    }
 
-    _removeWindow: function(metaWindow) {
+    _removeWindow(metaWindow) {
         let i = this._windows.length;
         // Do an inverse loop because we might remove some elements
         while (i--) {
@@ -1286,14 +1263,14 @@ CinnamonWindowListApplet.prototype = {
                 this._windows.splice(i, 1);
             }
         }
-    },
+    }
 
-    _shouldAdd: function(metaWindow) {
+    _shouldAdd(metaWindow) {
         return Main.isInteresting(metaWindow) &&
             this._monitorWatchList.indexOf(metaWindow.get_monitor()) != -1;
-    },
+    }
 
-    handleDragOver: function(source, actor, x, y, time) {
+    handleDragOver(source, actor, x, y, time) {
         if (this._inEditMode)
             return DND.DragMotionResult.MOVE_DROP;
         if (!(source instanceof AppMenuButton))
@@ -1332,26 +1309,26 @@ CinnamonWindowListApplet.prototype = {
         }
 
         return DND.DragMotionResult.MOVE_DROP;
-    },
+    }
 
-    acceptDrop: function(source, actor, x, y, time) {
+    acceptDrop(source, actor, x, y, time) {
         if (!(source instanceof AppMenuButton)) return false;
         if (this._dragPlaceholderPos == undefined) return false;
 
         this.manager_container.set_child_at_index(source.actor, this._dragPlaceholderPos);
 
         return true;
-    },
+    }
 
-    clearDragPlaceholder: function() {
+    clearDragPlaceholder() {
         if (this._dragPlaceholder) {
             this._dragPlaceholder.actor.destroy();
             this._dragPlaceholder = undefined;
             this._dragPlaceholderPos = undefined;
         }
-    },
+    }
 
-    erodeTooltip: function() {
+    erodeTooltip() {
         if (this._tooltipErodeTimer) {
             Mainloop.source_remove(this._tooltipErodeTimer);
             this._tooltipErodeTimer = null;
@@ -1362,15 +1339,15 @@ CinnamonWindowListApplet.prototype = {
             this._tooltipErodeTimer = null;
             return false;
         }));
-    },
+    }
 
-    cancelErodeTooltip: function() {
+    cancelErodeTooltip() {
         if (this._tooltipErodeTimer) {
             Mainloop.source_remove(this._tooltipErodeTimer);
             this._tooltipErodeTimer = null;
         }
     }
-};
+}
 
 function main(metadata, orientation, panel_height, instance_id) {
     return new CinnamonWindowListApplet(orientation, panel_height, instance_id);

--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -380,13 +380,13 @@ class AppMenuButton {
 
         // Find the current focused window
         let windows = this.actor.get_parent().get_children()
-            .filter(function(item) {
-                return item.visible;
-            }).map(function(item) {
-                return item._delegate;
-            });
+        .filter(function(item) {
+            return item.visible;
+        }).map(function(item) {
+            return item._delegate;
+        });
 
-            windows = windows.reverse();
+        windows = windows.reverse();
 
         let i = windows.length;
         while (i-- && !windows[i].metaWindow.has_focus());
@@ -835,7 +835,7 @@ class AppMenuButtonRightClickMenu extends Applet.AppletPopupMenu {
                         ws.setSensitive(false);
 
                     ws.connect('activate', function() {
-                       mw.change_workspace(global.screen.get_workspace_by_index(j));
+                        mw.change_workspace(global.screen.get_workspace_by_index(j));
                     });
                     item.menu.addMenuItem(ws);
                 }

--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -961,11 +961,11 @@ AppMenuButtonRightClickMenu.prototype = {
     },
 };
 
-function MyApplet(orientation, panel_height, instance_id) {
+function CinnamonWindowListApplet(orientation, panel_height, instance_id) {
     this._init(orientation, panel_height, instance_id);
 }
 
-MyApplet.prototype = {
+CinnamonWindowListApplet.prototype = {
     __proto__: Applet.Applet.prototype,
 
     _init: function(orientation, panel_height, instance_id) {
@@ -1373,6 +1373,5 @@ MyApplet.prototype = {
 };
 
 function main(metadata, orientation, panel_height, instance_id) {
-    let myApplet = new MyApplet(orientation, panel_height, instance_id);
-    return myApplet;
+    return new CinnamonWindowListApplet(orientation, panel_height, instance_id);
 }

--- a/files/usr/share/cinnamon/applets/windows-quick-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/windows-quick-list@cinnamon.org/applet.js
@@ -5,133 +5,125 @@ const PopupMenu = imports.ui.popupMenu;
 const St = imports.gi.St;
 const Main = imports.ui.main;
 
-function CinnamonWindowsQuickListApplet(metadata, orientation, panel_height, instance_id) {
-    this._init(metadata, orientation, panel_height, instance_id);
-}
+class CinnamonWindowsQuickListApplet extends Applet.IconApplet {
+    constructor(metadata, orientation, panel_height, instance_id) {
+        super(orientation, panel_height, instance_id);
 
-CinnamonWindowsQuickListApplet.prototype = {
-    __proto__: Applet.IconApplet.prototype,
+        this.set_applet_icon_symbolic_name('windows-quick-list');
+        this.set_applet_tooltip(_('All windows'));
+        this._menu = new Applet.AppletPopupMenu(this, orientation);
+        this.menuManager = new PopupMenu.PopupMenuManager(this);
+        this.menuManager.addMenu(this._menu);
+        this.subMenuItemWrapper = new PopupMenu.PopupSubMenuMenuItem(null);
+        this.subMenuItemWrapper.actor.set_style_class_name('');
+        this.subMenuItemWrapper.menu.actor.set_style_class_name('');
+        this.menu = this.subMenuItemWrapper.menu;
+        this._menu.addMenuItem(this.subMenuItemWrapper);
+    }
 
-    _init: function(metadata, orientation, panel_height, instance_id) {
-        Applet.IconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
-
-        try {
-            this.set_applet_icon_symbolic_name("windows-quick-list");
-            this.set_applet_tooltip(_("All windows"));
-            this._menu = new Applet.AppletPopupMenu(this, orientation);
-            this.menuManager = new PopupMenu.PopupMenuManager(this);
-            this.menuManager.addMenu(this._menu);
-            this.subMenuItemWrapper = new PopupMenu.PopupSubMenuMenuItem(null);
-            this.subMenuItemWrapper.actor.set_style_class_name('');
-            this.subMenuItemWrapper.menu.actor.set_style_class_name('');
-            this.menu = this.subMenuItemWrapper.menu;
-            this._menu.addMenuItem(this.subMenuItemWrapper);
-        }
-        catch (e) {
-            global.logError(e);
-        }
-    },
-
-    updateMenu: function() {
+    updateMenu() {
         this.menu.removeAll();
         let empty_menu = true;
-        try {
-            let tracker = Cinnamon.WindowTracker.get_default();
+        let tracker = Cinnamon.WindowTracker.get_default();
 
-            for ( let wks=0; wks<global.screen.n_workspaces; ++wks ) {
-                // construct a list with all windows
-                let workspace_name = Main.getWorkspaceName(wks);
-                let metaWorkspace = global.screen.get_workspace_by_index(wks);
-                let windows = metaWorkspace.list_windows();
-                let sticky_windows = windows.filter(
-                        function(w) {
-                            return !w.is_skip_taskbar() && w.is_on_all_workspaces();
-                            }
-                                        );
-                windows = windows.filter(
-                        function(w) {
-                            return !w.is_skip_taskbar() && !w.is_on_all_workspaces();
-                            }
-                                        );
+        for (let wks = 0; wks < global.screen.n_workspaces; ++wks) {
+            // construct a list with all windows
+            let workspace_name = Main.getWorkspaceName(wks);
+            let metaWorkspace = global.screen.get_workspace_by_index(wks);
+            let windows = metaWorkspace.list_windows();
+            let sticky_windows = windows.filter(function(w) {
+                return !w.is_skip_taskbar() && w.is_on_all_workspaces();
+            });
+            windows = windows.filter(function(w) {
+                return !w.is_skip_taskbar() && !w.is_on_all_workspaces();
+            });
 
-                windows = windows.filter( Main.isInteresting );
+            windows = windows.filter(Main.isInteresting);
 
-                if(sticky_windows.length && (wks==0)) {
-                    for ( let i = 0; i < sticky_windows.length; ++i ) {
-                        let metaWindow = sticky_windows[i];
-                        let item = new PopupMenu.PopupMenuItem(metaWindow.get_title());
-                            item.label.add_style_class_name('window-sticky');
-                        item.connect('activate', Lang.bind(this, function() { this.activateWindow(metaWorkspace, metaWindow); } ));
-                        item._window = sticky_windows[i];
-                        let app = tracker.get_window_app(item._window);
-                        item._icon = app.create_icon_texture_for_window(24, item._window);
-                        item.addActor(item._icon, { align: St.Align.END });
-                        this.menu.addMenuItem(item);
-                        empty_menu = false;
+            if (sticky_windows.length && wks == 0) {
+                for (let i = 0; i < sticky_windows.length; ++i) {
+                    let metaWindow = sticky_windows[i];
+                    let item = new PopupMenu.PopupMenuItem(metaWindow.get_title());
+                    item.label.add_style_class_name('window-sticky');
+                    item.connect(
+                        'activate',
+                        Lang.bind(this, function() {
+                            this.activateWindow(metaWorkspace, metaWindow);
+                        })
+                    );
+                    item._window = sticky_windows[i];
+                    let app = tracker.get_window_app(item._window);
+                    item._icon = app.create_icon_texture_for_window(24, item._window);
+                    item.addActor(item._icon, {align: St.Align.END});
+                    this.menu.addMenuItem(item);
+                    empty_menu = false;
+                }
+                this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+            }
+
+            if (windows.length) {
+                if (wks > 0) {
+                    this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+                }
+                if (global.screen.n_workspaces > 1) {
+                    let item = new PopupMenu.PopupMenuItem(workspace_name);
+                    item.actor.reactive = false;
+                    item.actor.can_focus = false;
+                    item.label.add_style_class_name('popup-subtitle-menu-item');
+                    if (wks == global.screen.get_active_workspace().index()) {
+                        item.setShowDot(true);
                     }
-                        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+                    this.menu.addMenuItem(item);
+                    empty_menu = false;
                 }
 
-                if(windows.length) {
-                    if(wks>0) {
-                        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-                    }
-                    if(global.screen.n_workspaces>1) {
-                        let item = new PopupMenu.PopupMenuItem(workspace_name);
-                        item.actor.reactive = false;
-                        item.actor.can_focus = false;
-                        item.label.add_style_class_name('popup-subtitle-menu-item');
-                        if(wks == global.screen.get_active_workspace().index()) {
-                            item.setShowDot(true);
-                        }
-                        this.menu.addMenuItem(item);
-                        empty_menu = false;
-                    }
-
-
-                    for ( let i = 0; i < windows.length; ++i ) {
-                        let metaWindow = windows[i];
-                        let item = new PopupMenu.PopupMenuItem(windows[i].get_title());
-                        item.connect('activate', Lang.bind(this, function() { this.activateWindow(metaWorkspace, metaWindow); } ));
-                        item._window = windows[i];
-                        let app = tracker.get_window_app(item._window);
-                        item._icon = app.create_icon_texture_for_window(24, item._window);
-                        item.addActor(item._icon, { align: St.Align.END });
-                        this.menu.addMenuItem(item);
-                        empty_menu = false;
-                    }
+                for (let i = 0; i < windows.length; ++i) {
+                    let metaWindow = windows[i];
+                    let item = new PopupMenu.PopupMenuItem(windows[i].get_title());
+                    item.connect(
+                        'activate',
+                        Lang.bind(this, function() {
+                            this.activateWindow(metaWorkspace, metaWindow);
+                        })
+                    );
+                    item._window = windows[i];
+                    let app = tracker.get_window_app(item._window);
+                    item._icon = app.create_icon_texture_for_window(24, item._window);
+                    item.addActor(item._icon, {align: St.Align.END});
+                    this.menu.addMenuItem(item);
+                    empty_menu = false;
                 }
             }
-        } catch(e) {
-            global.logError(e);
         }
         if (empty_menu) {
-            let item = new PopupMenu.PopupMenuItem(_("No open windows"));
+            let item = new PopupMenu.PopupMenuItem(_('No open windows'));
             item.actor.reactive = false;
             item.actor.can_focus = false;
             item.label.add_style_class_name('popup-subtitle-menu-item');
             this.menu.addMenuItem(item);
         }
-    },
+    }
 
-    activateWindow: function(metaWorkspace, metaWindow) {
+    activateWindow(metaWorkspace, metaWindow) {
         if (this._menu.isOpen) {
             this._menu.toggle_with_options(false);
         }
         this.menu.toggle();
-        if(!metaWindow.is_on_all_workspaces()) { metaWorkspace.activate(global.get_current_time()); }
+        if (!metaWindow.is_on_all_workspaces()) {
+            metaWorkspace.activate(global.get_current_time());
+        }
         metaWindow.unminimize();
         metaWindow.activate(global.get_current_time());
-    },
+    }
 
-    on_applet_clicked: function(event) {
+    on_applet_clicked(event) {
         this.updateMenu();
         if (!this._menu.isOpen) {
             this._menu.toggle_with_options(false);
         }
         this.menu.toggle();
     }
-};
+}
 
 function main(metadata, orientation, panel_height, instance_id) {
     return new CinnamonWindowsQuickListApplet(metadata, orientation, panel_height, instance_id);

--- a/files/usr/share/cinnamon/applets/windows-quick-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/windows-quick-list@cinnamon.org/applet.js
@@ -5,11 +5,11 @@ const PopupMenu = imports.ui.popupMenu;
 const St = imports.gi.St;
 const Main = imports.ui.main;
 
-function MyApplet(metadata, orientation, panel_height, instance_id) {
+function CinnamonWindowsQuickListApplet(metadata, orientation, panel_height, instance_id) {
     this._init(metadata, orientation, panel_height, instance_id);
 }
 
-MyApplet.prototype = {
+CinnamonWindowsQuickListApplet.prototype = {
     __proto__: Applet.IconApplet.prototype,
 
     _init: function(metadata, orientation, panel_height, instance_id) {
@@ -134,6 +134,5 @@ MyApplet.prototype = {
 };
 
 function main(metadata, orientation, panel_height, instance_id) {
-    let myApplet = new MyApplet(metadata, orientation, panel_height, instance_id);
-    return myApplet;
+    return new CinnamonWindowsQuickListApplet(metadata, orientation, panel_height, instance_id);
 }

--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
@@ -316,13 +316,13 @@ class CinnamonWorkspaceSwitcher extends Applet.Applet {
         let suppress_graph = false; // suppress the graph and replace by buttons if size ratio
                                     // would be unworkable in a vertical panel
         if (this.orientation == St.Side.LEFT || this.orientation == St.Side.RIGHT) {
-          let workspace_size = new Meta.Rectangle();
-          global.screen.get_workspace_by_index(0).get_work_area_all_monitors(workspace_size);
-          let sizeRatio = workspace_size.width / workspace_size.height;
-          if (sizeRatio >= 2.35) {  // completely empirical, other than the widest
+            let workspace_size = new Meta.Rectangle();
+            global.screen.get_workspace_by_index(0).get_work_area_all_monitors(workspace_size);
+            let sizeRatio = workspace_size.width / workspace_size.height;
+            if (sizeRatio >= 2.35) {  // completely empirical, other than the widest
                                     // ratio single screen I know is 21*9 = 2.33
-              suppress_graph = true;
-          }
+                suppress_graph = true;
+            }
         }
 
         if (this.display_type == "visual" && !suppress_graph)

--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
@@ -13,12 +13,8 @@ const Pango = imports.gi.Pango;
 
 const MIN_SWITCH_INTERVAL_MS = 220;
 
-function WorkspaceButton(index, applet) {
-    this._init(index, applet);
-}
-
-WorkspaceButton.prototype = {
-    _init : function(index, applet) {
+class WorkspaceButton {
+    constructor(index, applet) {
         this.index = index;
         this.applet = applet;
         this.workspace = global.screen.get_workspace_by_index(this.index);
@@ -29,39 +25,33 @@ WorkspaceButton.prototype = {
 
         this.ws_signals.connect(this.workspace, "window-added", this.update, this);
         this.ws_signals.connect(this.workspace, "window-removed", this.update, this);
-    },
+    }
 
-    show : function() {
+    show() {
         this.actor.connect('button-release-event', Lang.bind(this, this.onClicked));
         this._tooltip = new Tooltips.PanelItemTooltip(this, this.workspace_name, this.applet.orientation);
-    },
+    }
 
-    onClicked: function(actor, event) {
+    onClicked(actor, event) {
         if (event.get_button() == 1) {
             Main.wm.moveToWorkspace(this.workspace);
         }
-    },
+    }
 
-    update: function() {
+    update() {
         // defined in subclass
-    },
+    }
 
-    destroy: function() {
+    destroy() {
         this.ws_signals.disconnectAllSignals();
         this._tooltip.destroy();
         this.actor.destroy();
     }
-};
-
-function WorkspaceGraph(index, applet) {
-    this._init(index, applet);
 }
 
-WorkspaceGraph.prototype = {
-    __proto__: WorkspaceButton.prototype,
-
-    _init: function(index, applet) {
-        WorkspaceButton.prototype._init.call(this, index, applet);
+class WorkspaceGraph extends WorkspaceButton {
+    constructor(index, applet) {
+        super(index, applet);
 
         this.actor = new St.Bin({ reactive: true,
                                   style_class: 'workspace',
@@ -86,9 +76,9 @@ WorkspaceGraph.prototype = {
         if (index == global.screen.get_active_workspace_index()) {
             this.actor.add_style_pseudo_class('active');
         }
-    },
+    }
 
-    scale: function (windows_rect, workspace_rect, area_width, area_height) {
+    scale (windows_rect, workspace_rect, area_width, area_height) {
         let scaled_rect = new Meta.Rectangle();
         let x_ratio = area_width / workspace_rect.width;
         let y_ratio = area_height / workspace_rect.height;
@@ -97,84 +87,75 @@ WorkspaceGraph.prototype = {
         scaled_rect.width = windows_rect.width * x_ratio;
         scaled_rect.height = windows_rect.height * y_ratio;
         return scaled_rect;
-    },
+    }
 
-    sortWindowsByUserTime: function (win1, win2) {
+    sortWindowsByUserTime (win1, win2) {
         let t1 = win1.get_user_time();
         let t2 = win2.get_user_time();
         return (t2 < t1) ? 1 : -1;
-    },
+    }
 
-    onRepaint: function(area) {
-        try {
-            let graphThemeNode = this.graphArea.get_theme_node();
-            let workspaceThemeNode = this.panelApplet.actor.get_theme_node();
-            let height = this.panelApplet._panelHeight - workspaceThemeNode.get_vertical_padding();
-            let borderWidth = workspaceThemeNode.get_border_width(St.Side.TOP) + workspaceThemeNode.get_border_width(St.Side.BOTTOM);
+    onRepaint(area) {
+        let graphThemeNode = this.graphArea.get_theme_node();
+        let workspaceThemeNode = this.panelApplet.actor.get_theme_node();
+        let height = this.panelApplet._panelHeight - workspaceThemeNode.get_vertical_padding();
+        let borderWidth = workspaceThemeNode.get_border_width(St.Side.TOP) + workspaceThemeNode.get_border_width(St.Side.BOTTOM);
 
-            this.graphArea.set_size(this.sizeRatio * height, height - borderWidth);
-            let cr = area.get_context();
-            let [area_width, area_height] = area.get_surface_size();
+        this.graphArea.set_size(this.sizeRatio * height, height - borderWidth);
+        let cr = area.get_context();
+        let [area_width, area_height] = area.get_surface_size();
 
-            // construct a list with all windows
-            let windows = this.workspace.list_windows();
-            windows = windows.filter( Main.isInteresting );
-            windows = windows.filter(
-                function(w) {
-                    return !w.is_skip_taskbar() && !w.minimized;
-                });
-            windows.sort(this.sortWindowsByUserTime);
+        // construct a list with all windows
+        let windows = this.workspace.list_windows();
+        windows = windows.filter( Main.isInteresting );
+        windows = windows.filter(
+            function(w) {
+                return !w.is_skip_taskbar() && !w.minimized;
+            });
+        windows.sort(this.sortWindowsByUserTime);
 
-            if (windows.length) {
-                let windowBackgroundColor;
-                let windowBorderColor;
-                for (let i = 0; i < windows.length; ++i) {
-                    let metaWindow = windows[i];
-                    let scaled_rect = this.scale(metaWindow.get_outer_rect(), this.workspace_size, area_width, area_height);
+        if (windows.length) {
+            let windowBackgroundColor;
+            let windowBorderColor;
+            for (let i = 0; i < windows.length; ++i) {
+                let metaWindow = windows[i];
+                let scaled_rect = this.scale(metaWindow.get_outer_rect(), this.workspace_size, area_width, area_height);
 
-                    cr.setLineWidth(1);
-                    if (metaWindow.has_focus()) {
-                        windowBorderColor = graphThemeNode.get_color('-active-window-border');
-                        Clutter.cairo_set_source_color(cr, windowBorderColor);
-                    }
-                    else {
-                        windowBorderColor = graphThemeNode.get_color('-inactive-window-border');
-                        Clutter.cairo_set_source_color(cr, windowBorderColor);
-                    }
-                    cr.rectangle(scaled_rect.x, scaled_rect.y, scaled_rect.width, scaled_rect.height);
-                    cr.strokePreserve();
-                    if (metaWindow.has_focus()) {
-                        windowBackgroundColor = graphThemeNode.get_color('-active-window-background');
-                        Clutter.cairo_set_source_color(cr, windowBackgroundColor);
-                    }
-                    else {
-                        windowBackgroundColor = graphThemeNode.get_color('-inactive-window-background');
-                        Clutter.cairo_set_source_color(cr, windowBackgroundColor);
-                    }
-
-                    cr.fill();
+                cr.setLineWidth(1);
+                if (metaWindow.has_focus()) {
+                    windowBorderColor = graphThemeNode.get_color('-active-window-border');
+                    Clutter.cairo_set_source_color(cr, windowBorderColor);
                 }
+                else {
+                    windowBorderColor = graphThemeNode.get_color('-inactive-window-border');
+                    Clutter.cairo_set_source_color(cr, windowBorderColor);
+                }
+                cr.rectangle(scaled_rect.x, scaled_rect.y, scaled_rect.width, scaled_rect.height);
+                cr.strokePreserve();
+                if (metaWindow.has_focus()) {
+                    windowBackgroundColor = graphThemeNode.get_color('-active-window-background');
+                    Clutter.cairo_set_source_color(cr, windowBackgroundColor);
+                }
+                else {
+                    windowBackgroundColor = graphThemeNode.get_color('-inactive-window-background');
+                    Clutter.cairo_set_source_color(cr, windowBackgroundColor);
+                }
+
+                cr.fill();
             }
-
-            cr.$dispose();
-        } catch(e) {
-            global.logError(e);
         }
-    },
 
-    update: function() {
+        cr.$dispose();
+    }
+
+    update() {
         this.graphArea.queue_repaint();
     }
-};
-
-function SimpleButton(index, applet) {
-    this._init(index, applet);
 }
 
-SimpleButton.prototype = {
-    __proto__: WorkspaceButton.prototype,
-    _init : function(index, applet) {
-        WorkspaceButton.prototype._init.call(this, index, applet);
+class SimpleButton extends WorkspaceButton {
+    constructor(index, applet) {
+        super(index, applet);
 
         this.actor = new St.Button({ name: 'workspaceButton',
                                      style_class: 'workspace-button',
@@ -194,94 +175,79 @@ SimpleButton.prototype = {
         let label = new St.Label({ text: (index + 1).toString() });
         label.clutter_text.set_ellipsize(Pango.EllipsizeMode.NONE);
         this.actor.set_child(label);
-    },
-
-    update: function() {
-
     }
-};
-
-function CinnamonWorkspaceSwitcher(metadata, orientation, panel_height, instance_id) {
-    this._init(metadata, orientation, panel_height, instance_id);
 }
 
-CinnamonWorkspaceSwitcher.prototype = {
-    __proto__: Applet.Applet.prototype,
-
-    _init: function(metadata, orientation, panel_height, instance_id) {
-        Applet.Applet.prototype._init.call(this, orientation, panel_height, instance_id);
+class CinnamonWorkspaceSwitcher extends Applet.Applet {
+    constructor(metadata, orientation, panel_height, instance_id) {
+        super(orientation, panel_height, instance_id);
 
         this.setAllowedLayout(Applet.AllowedLayout.BOTH);
 
-        try {
-            this.orientation = orientation;
-            this.panel_height = panel_height;
-            this.signals = new SignalManager.SignalManager(null);
-            this.buttons = [];
-            this._last_switch = 0;
-            this._last_switch_direction = 0;
+        this.orientation = orientation;
+        this.panel_height = panel_height;
+        this.signals = new SignalManager.SignalManager(null);
+        this.buttons = [];
+        this._last_switch = 0;
+        this._last_switch_direction = 0;
 
-            let manager;
-            if (this.orientation == St.Side.TOP || this.orientation == St.Side.BOTTOM) {
-                manager = new Clutter.BoxLayout({ spacing: 2 * global.ui_scale,
-                                                  homogeneous: true,
-                                                  orientation: Clutter.Orientation.HORIZONTAL });
-            } else {
-                manager = new Clutter.BoxLayout({ spacing: 2 * global.ui_scale,
-                                                  homogeneous: true,
-                                                  orientation: Clutter.Orientation.VERTICAL });
-            }
-            this.manager = manager;
-            this.manager_container = new Clutter.Actor({ layout_manager: manager });
-            this.actor.add_actor (this.manager_container);
-            this.manager_container.show();
-
-            this._focusWindow = 0;
-            if (global.display.focus_window)
-                this._focusWindow = global.display.focus_window.get_compositor_private();
-
-            this.settings = new Settings.AppletSettings(this, metadata.uuid, instance_id);
-            this.settings.bind("display_type", "display_type", this._createButtons);
-
-            this.actor.connect('scroll-event', this.hook.bind(this));
-
-            this._createButtons();
-            global.screen.connect('notify::n-workspaces', Lang.bind(this, this.onNumberOfWorkspacesChanged));
-            global.window_manager.connect('switch-workspace', Lang.bind(this, this._createButtons));
-            this.on_panel_edit_mode_changed();
-            global.settings.connect('changed::panel-edit-mode', Lang.bind(this, this.on_panel_edit_mode_changed));
-
-            let expoMenuItem = new PopupMenu.PopupIconMenuItem(_("Manage workspaces (Expo)"), "view-grid-symbolic", St.IconType.SYMBOLIC);
-            expoMenuItem.connect('activate', Lang.bind(this, function() {
-                if (!Main.expo.animationInProgress)
-                    Main.expo.toggle();
-            }));
-            this._applet_context_menu.addMenuItem(expoMenuItem);
-
-            let addWorkspaceMenuItem = new PopupMenu.PopupIconMenuItem (_("Add a new workspace"), "list-add", St.IconType.SYMBOLIC);
-            addWorkspaceMenuItem.connect('activate', Lang.bind(this, function() {
-                Main._addWorkspace();
-            }));
-            this._applet_context_menu.addMenuItem(addWorkspaceMenuItem);
-
-            this.removeWorkspaceMenuItem = new PopupMenu.PopupIconMenuItem (_("Remove the current workspace"), "list-remove", St.IconType.SYMBOLIC);
-            this.removeWorkspaceMenuItem.connect('activate', Lang.bind(this, function() {
-                this.removeWorkspace();
-            }));
-            this._applet_context_menu.addMenuItem(this.removeWorkspaceMenuItem);
-            this.removeWorkspaceMenuItem.setSensitive(global.screen.n_workspaces > 1);
+        let manager;
+        if (this.orientation == St.Side.TOP || this.orientation == St.Side.BOTTOM) {
+            manager = new Clutter.BoxLayout({ spacing: 2 * global.ui_scale,
+                                                homogeneous: true,
+                                                orientation: Clutter.Orientation.HORIZONTAL });
+        } else {
+            manager = new Clutter.BoxLayout({ spacing: 2 * global.ui_scale,
+                                                homogeneous: true,
+                                                orientation: Clutter.Orientation.VERTICAL });
         }
-        catch (e) {
-            global.logError(e);
-        }
-    },
+        this.manager = manager;
+        this.manager_container = new Clutter.Actor({ layout_manager: manager });
+        this.actor.add_actor (this.manager_container);
+        this.manager_container.show();
 
-    onNumberOfWorkspacesChanged: function() {
+        this._focusWindow = 0;
+        if (global.display.focus_window)
+            this._focusWindow = global.display.focus_window.get_compositor_private();
+
+        this.settings = new Settings.AppletSettings(this, metadata.uuid, instance_id);
+        this.settings.bind("display_type", "display_type", this._createButtons);
+
+        this.actor.connect('scroll-event', this.hook.bind(this));
+
+        this._createButtons();
+        global.screen.connect('notify::n-workspaces', Lang.bind(this, this.onNumberOfWorkspacesChanged));
+        global.window_manager.connect('switch-workspace', Lang.bind(this, this._createButtons));
+        this.on_panel_edit_mode_changed();
+        global.settings.connect('changed::panel-edit-mode', Lang.bind(this, this.on_panel_edit_mode_changed));
+
+        let expoMenuItem = new PopupMenu.PopupIconMenuItem(_("Manage workspaces (Expo)"), "view-grid-symbolic", St.IconType.SYMBOLIC);
+        expoMenuItem.connect('activate', Lang.bind(this, function() {
+            if (!Main.expo.animationInProgress)
+                Main.expo.toggle();
+        }));
+        this._applet_context_menu.addMenuItem(expoMenuItem);
+
+        let addWorkspaceMenuItem = new PopupMenu.PopupIconMenuItem (_("Add a new workspace"), "list-add", St.IconType.SYMBOLIC);
+        addWorkspaceMenuItem.connect('activate', Lang.bind(this, function() {
+            Main._addWorkspace();
+        }));
+        this._applet_context_menu.addMenuItem(addWorkspaceMenuItem);
+
+        this.removeWorkspaceMenuItem = new PopupMenu.PopupIconMenuItem (_("Remove the current workspace"), "list-remove", St.IconType.SYMBOLIC);
+        this.removeWorkspaceMenuItem.connect('activate', Lang.bind(this, function() {
+            this.removeWorkspace();
+        }));
+        this._applet_context_menu.addMenuItem(this.removeWorkspaceMenuItem);
+        this.removeWorkspaceMenuItem.setSensitive(global.screen.n_workspaces > 1);
+    }
+
+    onNumberOfWorkspacesChanged() {
         this.removeWorkspaceMenuItem.setSensitive(global.screen.n_workspaces > 1);
         this._createButtons();
-    },
+    }
 
-    removeWorkspace : function (){
+    removeWorkspace  (){
         if (global.screen.n_workspaces <= 1) {
             return;
         }
@@ -298,16 +264,16 @@ CinnamonWorkspaceSwitcher.prototype = {
         else {
             removeAction();
         }
-    },
+    }
 
-    on_panel_edit_mode_changed: function() {
+    on_panel_edit_mode_changed() {
         let reactive = !global.settings.get_boolean('panel-edit-mode');
         for (let i = 0; i < this.buttons.length; ++i) {
             this.buttons[i].reactive = reactive;
         }
-    },
+    }
 
-    on_orientation_changed: function(neworientation) {
+    on_orientation_changed(neworientation) {
         this.orientation = neworientation;
 
         if (this.orientation == St.Side.TOP || this.orientation == St.Side.BOTTOM)
@@ -316,13 +282,13 @@ CinnamonWorkspaceSwitcher.prototype = {
             this.manager.set_vertical(true);
 
         this._createButtons();
-    },
+    }
 
-    on_panel_height_changed: function() {
+    on_panel_height_changed() {
         this._createButtons();
-    },
+    }
 
-    hook: function(actor, event) {
+    hook(actor, event) {
         let now = (new Date()).getTime();
         let direction = event.get_scroll_direction();
 
@@ -340,9 +306,9 @@ CinnamonWorkspaceSwitcher.prototype = {
             this._last_switch = now;
             this._last_switch_direction = direction;
         }
-    },
+    }
 
-    _createButtons: function() {
+    _createButtons() {
         for (let i = 0; i < this.buttons.length; ++i) {
             this.buttons[i].destroy();
         }
@@ -383,9 +349,9 @@ CinnamonWorkspaceSwitcher.prototype = {
             this.signals.connect(global.display, "notify::focus-window", this._onFocusChanged, this);
             this._onFocusChanged();
         }
-    },
+    }
 
-    _onFocusChanged: function() {
+    _onFocusChanged() {
         if (global.display.focus_window &&
             this._focusWindow == global.display.focus_window.get_compositor_private())
             return;
@@ -400,17 +366,17 @@ CinnamonWorkspaceSwitcher.prototype = {
         this.signals.connect(this._focusWindow, "position-changed", Lang.bind(this, this._onPositionChanged), this);
         this.signals.connect(this._focusWindow, "size-changed", Lang.bind(this, this._onPositionChanged), this);
         this._onPositionChanged();
-    },
+    }
 
-    _onPositionChanged: function() {
+    _onPositionChanged() {
         let button = this.buttons[global.screen.get_active_workspace_index()];
         button.update();
-    },
+    }
 
-    on_applet_removed_from_panel: function() {
+    on_applet_removed_from_panel() {
         this.signals.disconnectAllSignals();
     }
-};
+}
 
 function main(metadata, orientation, panel_height, instance_id) {
     return new CinnamonWorkspaceSwitcher(metadata, orientation, panel_height, instance_id);

--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
@@ -201,11 +201,11 @@ SimpleButton.prototype = {
     }
 };
 
-function MyApplet(metadata, orientation, panel_height, instance_id) {
+function CinnamonWorkspaceSwitcher(metadata, orientation, panel_height, instance_id) {
     this._init(metadata, orientation, panel_height, instance_id);
 }
 
-MyApplet.prototype = {
+CinnamonWorkspaceSwitcher.prototype = {
     __proto__: Applet.Applet.prototype,
 
     _init: function(metadata, orientation, panel_height, instance_id) {
@@ -413,6 +413,5 @@ MyApplet.prototype = {
 };
 
 function main(metadata, orientation, panel_height, instance_id) {
-    let myApplet = new MyApplet(metadata, orientation, panel_height, instance_id);
-    return myApplet;
+    return new CinnamonWorkspaceSwitcher(metadata, orientation, panel_height, instance_id);
 }

--- a/files/usr/share/cinnamon/applets/xrandr@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/xrandr@cinnamon.org/applet.js
@@ -22,11 +22,11 @@ let rotations = [ [ CinnamonDesktop.RRRotation.ROTATION_0, N_("Normal") ],
           [ CinnamonDesktop.RRRotation.ROTATION_180, N_("Upside-down") ]
         ];
 
-function MyApplet(orientation, panel_height, instance_id) {
+function CinnamonXrandrApplet(orientation, panel_height, instance_id) {
     this._init(orientation, panel_height, instance_id);
 }
 
-MyApplet.prototype = {
+CinnamonXrandrApplet.prototype = {
     __proto__: Applet.IconApplet.prototype,
 
     _init: function(orientation, panel_height, instance_id) {
@@ -141,6 +141,5 @@ MyApplet.prototype = {
 };
 
 function main(metadata, orientation, panel_height, instance_id) {
-    let myApplet = new MyApplet(orientation, panel_height, instance_id);
-    return myApplet;
+    return new CinnamonXrandrApplet(orientation, panel_height, instance_id);
 }

--- a/files/usr/share/cinnamon/applets/xrandr@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/xrandr@cinnamon.org/applet.js
@@ -10,68 +10,59 @@ const PopupMenu = imports.ui.popupMenu;
 
 const N_ = function(e) { return e; };
 
-const possibleRotations = [ CinnamonDesktop.RRRotation.ROTATION_0,
-                CinnamonDesktop.RRRotation.ROTATION_90,
-                CinnamonDesktop.RRRotation.ROTATION_180,
-                CinnamonDesktop.RRRotation.ROTATION_270
-              ];
+const possibleRotations = [
+    CinnamonDesktop.RRRotation.ROTATION_0,
+    CinnamonDesktop.RRRotation.ROTATION_90,
+    CinnamonDesktop.RRRotation.ROTATION_180,
+    CinnamonDesktop.RRRotation.ROTATION_270
+];
 
-let rotations = [ [ CinnamonDesktop.RRRotation.ROTATION_0, N_("Normal") ],
-          [ CinnamonDesktop.RRRotation.ROTATION_90, N_("Left") ],
-          [ CinnamonDesktop.RRRotation.ROTATION_270, N_("Right") ],
-          [ CinnamonDesktop.RRRotation.ROTATION_180, N_("Upside-down") ]
-        ];
+let rotations = [
+    [CinnamonDesktop.RRRotation.ROTATION_0, N_("Normal")],
+    [CinnamonDesktop.RRRotation.ROTATION_90, N_("Left")],
+    [CinnamonDesktop.RRRotation.ROTATION_270, N_("Right")],
+    [CinnamonDesktop.RRRotation.ROTATION_180, N_("Upside-down")]
+];
 
-function CinnamonXrandrApplet(orientation, panel_height, instance_id) {
-    this._init(orientation, panel_height, instance_id);
-}
+class CinnamonXrandrApplet extends Applet.IconApplet {
+    constructor(orientation, panel_height, instance_id) {
+        super(orientation, panel_height, instance_id);
 
-CinnamonXrandrApplet.prototype = {
-    __proto__: Applet.IconApplet.prototype,
+        this.set_applet_icon_symbolic_name("preferences-desktop-display");
+        this.set_applet_tooltip(_("Display"));
 
-    _init: function(orientation, panel_height, instance_id) {
-        Applet.IconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
+        this.menuManager = new PopupMenu.PopupMenuManager(this);
+        this.menu = new Applet.AppletPopupMenu(this, orientation);
+        this.menuManager.addMenu(this.menu);
+
+        Interfaces.getDBusProxyAsync("org.cinnamon.SettingsDaemon.XRANDR_2", Lang.bind(this, function(proxy, error) {
+            this._proxy = proxy;
+        }));
 
         try {
-            this.set_applet_icon_symbolic_name("preferences-desktop-display");
-            this.set_applet_tooltip(_("Display"));
-
-            this.menuManager = new PopupMenu.PopupMenuManager(this);
-            this.menu = new Applet.AppletPopupMenu(this, orientation);
-            this.menuManager.addMenu(this.menu);
-
-            Interfaces.getDBusProxyAsync("org.cinnamon.SettingsDaemon.XRANDR_2", Lang.bind(this, function(proxy, error) {
-                this._proxy = proxy;
-            }));
-
-            try {
-                this._screen = new CinnamonDesktop.RRScreen({ gdk_screen: Gdk.Screen.get_default() });
-                this._screen.init(null);
-            } catch(e) {
-                // an error means there is no XRandR extension
-                global.logError(e);
-                this.actor.hide();
-                return;
-            }
-
-            this._createMenu();
-            this._screen.connect('changed', Lang.bind(this, this._randrEvent));
-        }
-        catch (e) {
+            this._screen = new CinnamonDesktop.RRScreen({ gdk_screen: Gdk.Screen.get_default() });
+            this._screen.init(null);
+        } catch(e) {
+            // an error means there is no XRandR extension
             global.logError(e);
+            this.actor.hide();
+            return;
         }
-    },
 
-    on_applet_clicked: function(event) {
+        this._createMenu();
+        this._screen.connect('changed', Lang.bind(this, this._randrEvent));
+    }
+
+    on_applet_clicked(event) {
         this.menu.toggle();
-    },
+    }
 
-    _randrEvent: function() {
+    _randrEvent() {
         this.menu.removeAll();
         this._createMenu();
-    },
+    }
 
-    _createMenu: function() {
+    _createMenu() {
         let config = CinnamonDesktop.RRConfig.new_current(this._screen);
         let outputs = config.get_outputs();
         for (let i = 0; i < outputs.length; i++) {
@@ -82,9 +73,9 @@ CinnamonXrandrApplet.prototype = {
         this.menu.addAction(_("Configure display settings..."), function() {
             GLib.spawn_command_line_async('cinnamon-settings display');
         });
-    },
+    }
 
-    _addOutputItem: function(config, output) {
+    _addOutputItem(config, output) {
         let item = new PopupMenu.PopupMenuItem("%s (%s)".format(output.get_display_name(), output.get_name()));
         item.label.add_style_class_name('display-subtitle');
         item.actor.reactive = false;
@@ -114,9 +105,9 @@ CinnamonXrandrApplet.prototype = {
                 this.menu.addMenuItem(item);
             }
         }
-    },
+    }
 
-    _getAllowedRotations: function(config, output) {
+    _getAllowedRotations(config, output) {
         let retval = 0;
 
         let current = output.get_rotation();
@@ -130,7 +121,7 @@ CinnamonXrandrApplet.prototype = {
 
         output.set_rotation(current);
 
-        if (retval.length == 0) {
+        if (retval.length === 0) {
             // what, no rotation?
             // what's current then?
             retval = current;

--- a/files/usr/share/cinnamon/desklets/clock@cinnamon.org/desklet.js
+++ b/files/usr/share/cinnamon/desklets/clock@cinnamon.org/desklet.js
@@ -6,14 +6,14 @@ const CinnamonDesktop = imports.gi.CinnamonDesktop;
 const Desklet = imports.ui.desklet;
 const Settings = imports.ui.settings;
 
-function MyDesklet(metadata, desklet_id){
+function CinnamonClockDesklet(metadata, desklet_id) {
     this._init(metadata, desklet_id);
 }
 
-MyDesklet.prototype = {
+CinnamonClockDesklet.prototype = {
     __proto__: Desklet.Desklet.prototype,
 
-    _init: function(metadata, desklet_id){
+    _init: function(metadata, desklet_id) {
         Desklet.Desklet.prototype._init.call(this, metadata);
         this._date = new St.Label({style_class: "clock-desklet-label"});
         this.setContent(this._date);
@@ -27,7 +27,7 @@ MyDesklet.prototype = {
         this.settings.bind("font-size", "size", this._onSettingsChanged);
         this.settings.bind("text-color", "color", this._onSettingsChanged);
         this.settings.bind("use-custom-format", "use_custom_format", this._onSettingsChanged);
-        
+
         this._menu.addSettingsAction(_("Date and Time Settings"), "calendar")
     },
 
@@ -35,7 +35,7 @@ MyDesklet.prototype = {
         this._updateClock();
     },
 
-    _onSettingsChanged: function(){
+    _onSettingsChanged: function() {
         this._date.style="font-size: " + this.size + "pt;\ncolor: " + this.color;
         this._updateFormatString();
         this._updateClock();
@@ -67,7 +67,7 @@ MyDesklet.prototype = {
         }
     },
 
-    _updateClock: function(){
+    _updateClock: function() {
         if (this.use_custom_format) {
             this._date.set_text(this.clock.get_clock());
         } else {
@@ -79,7 +79,6 @@ MyDesklet.prototype = {
     }
 }
 
-function main(metadata, desklet_id){
-    let desklet = new MyDesklet(metadata, desklet_id);
-    return desklet;
+function main(metadata, desklet_id) {
+    return new CinnamonClockDesklet(metadata, desklet_id);
 }

--- a/files/usr/share/cinnamon/desklets/clock@cinnamon.org/desklet.js
+++ b/files/usr/share/cinnamon/desklets/clock@cinnamon.org/desklet.js
@@ -1,20 +1,13 @@
 
-const Lang = imports.lang;
 const St = imports.gi.St;
 const CinnamonDesktop = imports.gi.CinnamonDesktop;
 
 const Desklet = imports.ui.desklet;
 const Settings = imports.ui.settings;
 
-function CinnamonClockDesklet(metadata, desklet_id) {
-    this._init(metadata, desklet_id);
-}
-
-CinnamonClockDesklet.prototype = {
-    __proto__: Desklet.Desklet.prototype,
-
-    _init: function(metadata, desklet_id) {
-        Desklet.Desklet.prototype._init.call(this, metadata);
+class CinnamonClockDesklet extends Desklet.Desklet {
+    constructor(metadata, desklet_id) {
+        super(metadata, desklet_id);
         this._date = new St.Label({style_class: "clock-desklet-label"});
         this.setContent(this._date);
         this.setHeader(_("Clock"));
@@ -29,34 +22,34 @@ CinnamonClockDesklet.prototype = {
         this.settings.bind("use-custom-format", "use_custom_format", this._onSettingsChanged);
 
         this._menu.addSettingsAction(_("Date and Time Settings"), "calendar")
-    },
+    }
 
-    _clockNotify: function(obj, pspec, data) {
+    _clockNotify(obj, pspec, data) {
         this._updateClock();
-    },
+    }
 
-    _onSettingsChanged: function() {
+    _onSettingsChanged() {
         this._date.style="font-size: " + this.size + "pt;\ncolor: " + this.color;
         this._updateFormatString();
         this._updateClock();
-    },
+    }
 
-    on_desklet_added_to_desktop: function() {
+    on_desklet_added_to_desktop() {
         this._onSettingsChanged();
 
         if (this.clock_notify_id == 0) {
             this.clock_notify_id = this.clock.connect("notify::clock", () => this._clockNotify());
         }
-    },
+    }
 
-    on_desklet_removed: function() {
+    on_desklet_removed() {
         if (this.clock_notify_id > 0) {
             this.clock.disconnect(this.clock_notify_id);
             this.clock_notify_id = 0;
         }
-    },
+    }
 
-    _updateFormatString: function() {
+    _updateFormatString() {
         if (this.use_custom_format) {
             if (!this.clock.set_format_string(this.format)) {
                 global.logError("Clock desklet: bad format - check your string.");
@@ -65,9 +58,9 @@ CinnamonClockDesklet.prototype = {
         } else {
             this.clock.set_format_string(null);
         }
-    },
+    }
 
-    _updateClock: function() {
+    _updateClock() {
         if (this.use_custom_format) {
             this._date.set_text(this.clock.get_clock());
         } else {

--- a/files/usr/share/cinnamon/desklets/launcher@cinnamon.org/desklet.js
+++ b/files/usr/share/cinnamon/desklets/launcher@cinnamon.org/desklet.js
@@ -3,7 +3,6 @@ const Cinnamon = imports.gi.Cinnamon;
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 const Lang = imports.lang;
-const Mainloop = imports.mainloop;
 const St = imports.gi.St;
 const Tweener = imports.ui.tweener;
 
@@ -16,69 +15,72 @@ const CUSTOM_LAUNCHERS_PATH = GLib.get_home_dir() + '/.cinnamon/panel-launchers/
 const ICON_SIZE = 48;
 const ANIM_ICON_SIZE = 40;
 
-function CinnamonLauncherDesklet(metadata, desklet_id) {
-    this._init(metadata, desklet_id);
-}
-
-CinnamonLauncherDesklet.prototype = {
-    __proto__: Desklet.Desklet.prototype,
-
-    _init: function(metadata, desklet_id) {
-        Desklet.Desklet.prototype._init.call(this, metadata, desklet_id);
+class CinnamonLauncherDesklet extends Desklet.Desklet {
+    constructor(metadata, desklet_id) {
+        super(metadata, desklet_id);
         this._launcherSettings = new Gio.Settings({schema_id: 'org.cinnamon.desklets.launcher'});
 
         this._onSettingsChanged();
         this._removing = false;
 
         this._menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-        this._menu.addAction(_("Add new launcher"), function() {
-                                 Util.spawnCommandLine("/usr/share/cinnamon/desklets/launcher@cinnamon.org/editorDialog.py");
-                             });
-        this._menu.addAction(_("Edit launcher"), Lang.bind(this, function() {
-                                                               Util.spawnCommandLine("/usr/share/cinnamon/desklets/launcher@cinnamon.org/editorDialog.py " + this.instance_id);
-                                                           }));
+        this._menu.addAction(_('Add new launcher'), function() {
+            Util.spawnCommandLine('/usr/share/cinnamon/desklets/launcher@cinnamon.org/editorDialog.py');
+        });
+        this._menu.addAction(
+            _('Edit launcher'),
+            Lang.bind(this, function() {
+                Util.spawnCommandLine('/usr/share/cinnamon/desklets/launcher@cinnamon.org/editorDialog.py ' + this.instance_id);
+            })
+        );
 
         this._settingsSignalId = this._launcherSettings.connect('changed::launcher-list', Lang.bind(this, this._onSettingsChanged));
 
         this.connect('destroy', Lang.bind(this, this._destroy));
-    },
+    }
 
-    _getApp: function() {
+    _getApp() {
         let settingsList = this._launcherSettings.get_strv('launcher-list');
         let appSys = Cinnamon.AppSystem.get_default();
         let desktopFile, app;
         for (let i in settingsList) {
-            if (settingsList[i].split(":")[0] == this.instance_id) {
-                desktopFile = settingsList[i].split(":")[1];
+            if (settingsList[i].split(':')[0] == this.instance_id) {
+                desktopFile = settingsList[i].split(':')[1];
                 app = appSys.lookup_app(desktopFile);
-                if (!app) app = appSys.lookup_settings_app(desktopFile);
-                if (!app) app = Gio.DesktopAppInfo.new_from_filename(CUSTOM_LAUNCHERS_PATH + desktopFile);
+                if (!app) {
+                    app = appSys.lookup_settings_app(desktopFile);
+                }
+                if (!app) {
+                    app = Gio.DesktopAppInfo.new_from_filename(CUSTOM_LAUNCHERS_PATH + desktopFile);
+                }
                 return app;
             }
         }
 
         // No desktop file found; Default to 'cinnamon-settings.desktop'
         return appSys.lookup_app('cinnamon-settings.desktop');
-    },
+    }
 
-    _getIconActor: function() {
-        if (this._app.create_icon_texture) // Test for the existence of the FUNCTION
+    _getIconActor() {
+        if (this._app.create_icon_texture) {
+            // Test for the existence of the FUNCTION
             return this._app.create_icon_texture(ICON_SIZE);
-        else
+        } else {
             return St.TextureCache.get_default().load_gicon(null, this._app.get_icon(), ICON_SIZE);
-    },
+        }
+    }
 
-    on_desklet_clicked: function() {
+    on_desklet_clicked() {
         this._launch();
-    },
+    }
 
-    on_desklet_removed: function() {
+    on_desklet_removed() {
         this._removing = true;
         let settingsList = this._launcherSettings.get_strv('launcher-list');
         let found = false;
         let i;
         for (i = 0; i < settingsList.length; i++) {
-            if (settingsList[i].split(":")[0] == this.instance_id) {
+            if (settingsList[i].split(':')[0] == this.instance_id) {
                 found = true;
                 break;
             }
@@ -90,56 +92,57 @@ CinnamonLauncherDesklet.prototype = {
 
         this._launcherSettings.disconnect(this._settingsSignalId);
         this._launcherSettings = null;
-    },
+    }
 
-    _onSettingsChanged: function() {
+    _onSettingsChanged() {
         if (!this._removing) {
             this._app = this._getApp();
             this._icon = this._getIconActor();
             this.setContent(this._icon);
             this.setHeader(this._app.get_name());
         }
-    },
+    }
 
-    _destroy: function() {
+    _destroy() {
         this._app = null;
         this._icon = null;
-    },
+    }
 
-    _animateIcon: function(step) {
-        if (step>=3) return;
-        Tweener.addTween(this._icon,
-                         { width: ANIM_ICON_SIZE * global.ui_scale,
-                           height: ANIM_ICON_SIZE * global.ui_scale,
-                           time: 0.2,
-                           transition: 'easeOutQuad',
-                           onComplete: function() {
-                               Tweener.addTween(this._icon,
-                                                { width: ICON_SIZE * global.ui_scale,
-                                                  height: ICON_SIZE * global.ui_scale,
-                                                  time: 0.2,
-                                                  transition: 'easeOutQuad',
-                                                  onComplete: function() {
-                                                      this._animateIcon(step+1);
-                                                  },
-                                                  onCompleteScope: this
-                                                });
-                           },
-                           onCompleteScope: this
-                         });
-    },
+    _animateIcon(step) {
+        if (step >= 3) return;
+        Tweener.addTween(this._icon, {
+            width: ANIM_ICON_SIZE * global.ui_scale,
+            height: ANIM_ICON_SIZE * global.ui_scale,
+            time: 0.2,
+            transition: 'easeOutQuad',
+            onComplete() {
+                Tweener.addTween(this._icon, {
+                    width: ICON_SIZE * global.ui_scale,
+                    height: ICON_SIZE * global.ui_scale,
+                    time: 0.2,
+                    transition: 'easeOutQuad',
+                    onComplete() {
+                        this._animateIcon(step + 1);
+                    },
+                    onCompleteScope: this
+                });
+            },
+            onCompleteScope: this
+        });
+    }
 
-    _launch: function() {
+    _launch() {
         let allocation = this.content.get_allocation_box();
         this.content.width = allocation.x2 - allocation.x1;
         this.content.height = allocation.y2 - allocation.y1;
         this._animateIcon(0);
-        if (this._app.open_new_window)
-            this._app.open_new_window(-1);
-        else
-            this._app.launch([], null);
+        if (this._app.open_new_window) {
+          this._app.open_new_window(-1);
+        } else {
+          this._app.launch([], null);
+        }
     }
-};
+}
 
 function main(metadata, desklet_id) {
     return new CinnamonLauncherDesklet(metadata, desklet_id);

--- a/files/usr/share/cinnamon/desklets/launcher@cinnamon.org/desklet.js
+++ b/files/usr/share/cinnamon/desklets/launcher@cinnamon.org/desklet.js
@@ -16,14 +16,14 @@ const CUSTOM_LAUNCHERS_PATH = GLib.get_home_dir() + '/.cinnamon/panel-launchers/
 const ICON_SIZE = 48;
 const ANIM_ICON_SIZE = 40;
 
-function MyDesklet(metadata, desklet_id){
+function CinnamonLauncherDesklet(metadata, desklet_id) {
     this._init(metadata, desklet_id);
 }
 
-MyDesklet.prototype = {
+CinnamonLauncherDesklet.prototype = {
     __proto__: Desklet.Desklet.prototype,
 
-    _init: function(metadata, desklet_id){
+    _init: function(metadata, desklet_id) {
         Desklet.Desklet.prototype._init.call(this, metadata, desklet_id);
         this._launcherSettings = new Gio.Settings({schema_id: 'org.cinnamon.desklets.launcher'});
 
@@ -48,7 +48,7 @@ MyDesklet.prototype = {
         let appSys = Cinnamon.AppSystem.get_default();
         let desktopFile, app;
         for (let i in settingsList) {
-            if (settingsList[i].split(":")[0] == this.instance_id){
+            if (settingsList[i].split(":")[0] == this.instance_id) {
                 desktopFile = settingsList[i].split(":")[1];
                 app = appSys.lookup_app(desktopFile);
                 if (!app) app = appSys.lookup_settings_app(desktopFile);
@@ -106,20 +106,20 @@ MyDesklet.prototype = {
         this._icon = null;
     },
 
-    _animateIcon: function(step){
+    _animateIcon: function(step) {
         if (step>=3) return;
         Tweener.addTween(this._icon,
                          { width: ANIM_ICON_SIZE * global.ui_scale,
                            height: ANIM_ICON_SIZE * global.ui_scale,
                            time: 0.2,
                            transition: 'easeOutQuad',
-                           onComplete: function(){
+                           onComplete: function() {
                                Tweener.addTween(this._icon,
                                                 { width: ICON_SIZE * global.ui_scale,
                                                   height: ICON_SIZE * global.ui_scale,
                                                   time: 0.2,
                                                   transition: 'easeOutQuad',
-                                                  onComplete: function(){
+                                                  onComplete: function() {
                                                       this._animateIcon(step+1);
                                                   },
                                                   onCompleteScope: this
@@ -141,7 +141,6 @@ MyDesklet.prototype = {
     }
 };
 
-function main(metadata, desklet_id){
-    let desklet = new MyDesklet(metadata, desklet_id);
-    return desklet;
+function main(metadata, desklet_id) {
+    return new CinnamonLauncherDesklet(metadata, desklet_id);
 }

--- a/files/usr/share/cinnamon/desklets/launcher@cinnamon.org/desklet.js
+++ b/files/usr/share/cinnamon/desklets/launcher@cinnamon.org/desklet.js
@@ -137,9 +137,9 @@ class CinnamonLauncherDesklet extends Desklet.Desklet {
         this.content.height = allocation.y2 - allocation.y1;
         this._animateIcon(0);
         if (this._app.open_new_window) {
-          this._app.open_new_window(-1);
+            this._app.open_new_window(-1);
         } else {
-          this._app.launch([], null);
+            this._app.launch([], null);
         }
     }
 }

--- a/files/usr/share/cinnamon/desklets/photoframe@cinnamon.org/desklet.js
+++ b/files/usr/share/cinnamon/desklets/photoframe@cinnamon.org/desklet.js
@@ -9,56 +9,47 @@ const Tweener = imports.ui.tweener;
 const Util = imports.misc.util;
 const Settings = imports.ui.settings;
 
-function CinnamonPhotoFrameDesklet(metadata, desklet_id) {
-    this._init(metadata, desklet_id);
-}
+class CinnamonPhotoFrameDesklet extends Desklet.Desklet {
+    constructor(metadata, desklet_id) {
+        super(metadata, desklet_id);
 
-CinnamonPhotoFrameDesklet.prototype = {
-    __proto__: Desklet.Desklet.prototype,
-
-    _init: function(metadata, desklet_id) {
-        Desklet.Desklet.prototype._init.call(this, metadata, desklet_id);
-
-
-        this.metadata = metadata
+        this.metadata = metadata;
         this.update_id = 0;
 
-        try {
-            this.settings = new Settings.DeskletSettings(this, this.metadata["uuid"], this.instance_id);
-            this.settings.bind("directory", "dir", this.on_setting_changed);
-            this.settings.bind("shuffle",  "shuffle", this.on_setting_changed);
-            this.settings.bind("delay", "delay", this.on_setting_changed);
-            this.settings.bind("height", "height", this.on_setting_changed);
-            this.settings.bind("width", "width", this.on_setting_changed);
-            this.settings.bind("fade-delay", "fade_delay", this.on_setting_changed);
-            this.settings.bind("effect", "effect", this.on_setting_changed);
-        } catch (e) {
-            global.logError(e);
-        }
+        this.settings = new Settings.DeskletSettings(this, this.metadata.uuid, this.instance_id);
+        this.settings.bind('directory', 'dir', this.on_setting_changed);
+        this.settings.bind('shuffle', 'shuffle', this.on_setting_changed);
+        this.settings.bind('delay', 'delay', this.on_setting_changed);
+        this.settings.bind('height', 'height', this.on_setting_changed);
+        this.settings.bind('width', 'width', this.on_setting_changed);
+        this.settings.bind('fade-delay', 'fade_delay', this.on_setting_changed);
+        this.settings.bind('effect', 'effect', this.on_setting_changed);
 
         this.dir_monitor_id = 0;
         this.dir_monitor = null;
         this.dir_file = null;
 
-        this.setHeader(_("Photo Frame"));
+        this.setHeader(_('Photo Frame'));
         this._setup_dir_monitor();
         this.setup_display();
-    },
+    }
 
-    on_setting_changed: function() {
-        if (this.update_id != 0)
+    on_setting_changed() {
+        if (this.update_id != 0) {
             Mainloop.source_remove(this.update_id);
+        }
         this.update_id = 0;
         this._setup_dir_monitor();
-        if (this.currentPicture)
+        if (this.currentPicture) {
             this.currentPicture.destroy();
+        }
         this._photoFrame.destroy();
         this.setup_display();
-    },
+    }
 
-    _setup_dir_monitor: function() {
-        if ((this.dir_monitor_id != 0) && (this.dir_monitor)) {
-            this.dir_monitor.disconnect(this.dir_monitor_id)
+    _setup_dir_monitor() {
+        if (this.dir_monitor_id != 0 && this.dir_monitor) {
+            this.dir_monitor.disconnect(this.dir_monitor_id);
             this.dir_monitor_id = 0;
         }
 
@@ -66,12 +57,12 @@ CinnamonPhotoFrameDesklet.prototype = {
            was changed to use a URI instead of a path. This check is just
            to ensure that people upgrading cinnamon versions will get the
            existing path converted to a proper URI */
-        if (this.dir.indexOf("://") === -1) {
+        if (this.dir.indexOf('://') === -1) {
             let file = Gio.file_new_for_path(this.dir);
-            this.dir = file.get_uri()
+            this.dir = file.get_uri();
         }
 
-        if (this.dir === " ") {
+        if (this.dir === ' ') {
             let file = Gio.file_new_for_path(GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_PICTURES));
             this.dir = file.get_uri();
         }
@@ -79,28 +70,28 @@ CinnamonPhotoFrameDesklet.prototype = {
         this.dir_file = Gio.file_new_for_uri(this.dir);
         this.dir_monitor = this.dir_file.monitor_directory(0, null);
         this.dir_monitor_id = this.dir_monitor.connect('changed', Lang.bind(this, this.on_setting_changed));
-    },
+    }
 
-    on_desklet_removed: function() {
+    on_desklet_removed() {
         if (this.dir_monitor_id && this.dir_monitor) {
-            this.dir_monitor.disconnect(this.dir_monitor_id)
-            this.dir_monitor_id = null
+            this.dir_monitor.disconnect(this.dir_monitor_id);
+            this.dir_monitor_id = null;
         }
 
         if (this.update_id != 0) {
             Mainloop.source_remove(this.update_id);
             this.update_id = 0;
         }
-    },
+    }
 
-    _scan_dir: function(dir) {
+    _scan_dir(dir) {
         let dir_file = Gio.file_new_for_uri(dir);
         let fileEnum = dir_file.enumerate_children('standard::type,standard::name', Gio.FileQueryInfoFlags.NONE, null);
 
         let info;
         while ((info = fileEnum.next_file(null)) != null) {
             let fileType = info.get_file_type();
-            let fileName = dir + "/" + info.get_name();
+            let fileName = dir + '/' + info.get_name();
             if (fileType != Gio.FileType.DIRECTORY) {
                 this._images.push(fileName);
             } else {
@@ -109,10 +100,9 @@ CinnamonPhotoFrameDesklet.prototype = {
         }
 
         fileEnum.close(null);
-    },
+    }
 
-
-    setup_display: function() {
+    setup_display() {
         this._photoFrame = new St.Bin({style_class: 'photoframe-box', x_align: St.Align.START});
 
         this._bin = new St.Bin();
@@ -122,12 +112,12 @@ CinnamonPhotoFrameDesklet.prototype = {
         this._photoFrame.set_child(this._bin);
         this.setContent(this._photoFrame);
 
-        if (this.effect == "black-and-white") {
+        if (this.effect == 'black-and-white') {
             let effect = new Clutter.DesaturateEffect();
             this._bin.add_effect(effect);
-        } else if (this.effect == "sepia") {
+        } else if (this.effect == 'sepia') {
             let color = new Clutter.Color();
-            color.from_hls(17.0, 0.59, 0.40);
+            color.from_hls(17.0, 0.59, 0.4);
             let colorize_effect = new Clutter.ColorizeEffect(color);
             let contrast_effect = new Clutter.BrightnessContrastEffect();
             let desaturate_effect = new Clutter.DesaturateEffect();
@@ -148,19 +138,19 @@ CinnamonPhotoFrameDesklet.prototype = {
             this.update_id = 0;
             this._update_loop();
         }
-    },
+    }
 
-    _update_loop: function() {
+    _update_loop() {
         this._update();
         this.update_id = Mainloop.timeout_add_seconds(this.delay, Lang.bind(this, this._update_loop));
-    },
+    }
 
-    _size_pic: function(image) {
+    _size_pic(image) {
         image.disconnect(image._notif_id);
 
         let height, width;
-        let imageRatio = image.width/image.height;
-        let frameRatio = this.width/this.height;
+        let imageRatio = image.width / image.height;
+        let frameRatio = this.width / this.height;
 
         if (imageRatio > frameRatio) {
             width = this.width;
@@ -171,90 +161,85 @@ CinnamonPhotoFrameDesklet.prototype = {
         }
 
         image.set_size(width, height);
-    },
+    }
 
-    _update: function() {
+    _update() {
         if (this.updateInProgress) {
             return;
         }
         this.updateInProgress = true;
-        try {
-            let image_path;
-            if (!this.shuffle) {
-                image_path = this._images.shift();
-                this._images.push(image_path);
-            } else {
-                image_path = this._images[Math.floor(Math.random() * this._images.length)];
-            }
-
-            if (!image_path) {
-                this.updateInProgress = false;
-                return;
-            }
-
-            let image = this._loadImage(image_path);
-
-            if (image == null) {
-                this.updateInProgress = false;
-                return;
-            }
-
-            let old_pic = this.currentPicture;
-            this.currentPicture = image;
-            this.currentPicture.path = image_path;
-
-            if (this.fade_delay > 0) {
-                Tweener.addTween(this._bin,
-                                 { opacity: 0,
-                                   time: this.fade_delay,
-                                   transition: 'easeInSine',
-                                   onComplete: Lang.bind(this, function() {
-                                                             this._bin.set_child(this.currentPicture);
-                                                             Tweener.addTween(this._bin,
-                                                                              { opacity: 255,
-                                                                                time: this.fade_delay,
-                                                                                transition: 'easeInSine'
-                                                                              });
-                                                         })
-                                 });
-            } else {
-                this._bin.set_child(this.currentPicture);
-            }
-            if (old_pic)
-                old_pic.destroy();
-        } catch (e) {
-            global.logError(e);
-        } finally {
-            this.updateInProgress = false;
+        let image_path;
+        if (!this.shuffle) {
+            image_path = this._images.shift();
+            this._images.push(image_path);
+        } else {
+            image_path = this._images[Math.floor(Math.random() * this._images.length)];
         }
-    },
 
-    on_desklet_clicked: function(event) {
+        if (!image_path) {
+            this.updateInProgress = false;
+            return;
+        }
+
+        let image = this._loadImage(image_path);
+
+        if (image == null) {
+            this.updateInProgress = false;
+            return;
+        }
+
+        let old_pic = this.currentPicture;
+        this.currentPicture = image;
+        this.currentPicture.path = image_path;
+
+        if (this.fade_delay > 0) {
+            Tweener.addTween(this._bin, {
+                opacity: 0,
+                time: this.fade_delay,
+                transition: 'easeInSine',
+                onComplete: () => {
+                    this._bin.set_child(this.currentPicture);
+                    Tweener.addTween(this._bin, {
+                        opacity: 255,
+                        time: this.fade_delay,
+                        transition: 'easeInSine'
+                    });
+                }
+            });
+        } else {
+            this._bin.set_child(this.currentPicture);
+        }
+        if (old_pic) {
+          old_pic.destroy();
+        }
+
+        this.updateInProgress = false;
+    }
+
+    on_desklet_clicked(event) {
         try {
             if (event.get_button() == 1) {
                 this._update();
+            } else if (event.get_button() == 2) {
+                Util.spawn(['xdg-open', this.currentPicture.path]);
             }
-            else if (event.get_button() == 2) {
-                Util.spawn(["xdg-open", this.currentPicture.path]);
-            }
-        }
-        catch (e) {
+        } catch (e) {
             global.logError(e);
         }
-    },
+    }
 
-    _loadImage: function(filePath) {
+    _loadImage(filePath) {
         try {
             let image = St.TextureCache.get_default().load_uri_async(filePath, this.width, this.height);
 
-            image._notif_id = image.connect("notify::size", Lang.bind(this, this._size_pic));
+            image._notif_id = image.connect('notify::size', Lang.bind(this, this._size_pic));
 
             return image;
         } catch (x) {
             // Probably a non-image is in the folder
             return null;
         }
-    },
+    }
 }
 
 function main(metadata, desklet_id) {

--- a/files/usr/share/cinnamon/desklets/photoframe@cinnamon.org/desklet.js
+++ b/files/usr/share/cinnamon/desklets/photoframe@cinnamon.org/desklet.js
@@ -210,7 +210,7 @@ class CinnamonPhotoFrameDesklet extends Desklet.Desklet {
             this._bin.set_child(this.currentPicture);
         }
         if (old_pic) {
-          old_pic.destroy();
+            old_pic.destroy();
         }
 
         this.updateInProgress = false;

--- a/files/usr/share/cinnamon/desklets/photoframe@cinnamon.org/desklet.js
+++ b/files/usr/share/cinnamon/desklets/photoframe@cinnamon.org/desklet.js
@@ -9,14 +9,14 @@ const Tweener = imports.ui.tweener;
 const Util = imports.misc.util;
 const Settings = imports.ui.settings;
 
-function MyDesklet(metadata, desklet_id){
+function CinnamonPhotoFrameDesklet(metadata, desklet_id) {
     this._init(metadata, desklet_id);
 }
 
-MyDesklet.prototype = {
+CinnamonPhotoFrameDesklet.prototype = {
     __proto__: Desklet.Desklet.prototype,
 
-    _init: function(metadata, desklet_id){
+    _init: function(metadata, desklet_id) {
         Desklet.Desklet.prototype._init.call(this, metadata, desklet_id);
 
 
@@ -150,7 +150,7 @@ MyDesklet.prototype = {
         }
     },
 
-    _update_loop: function(){
+    _update_loop: function() {
         this._update();
         this.update_id = Mainloop.timeout_add_seconds(this.delay, Lang.bind(this, this._update_loop));
     },
@@ -173,14 +173,14 @@ MyDesklet.prototype = {
         image.set_size(width, height);
     },
 
-    _update: function(){       
+    _update: function() {
         if (this.updateInProgress) {
             return;
         }
         this.updateInProgress = true;
         try {
             let image_path;
-            if (!this.shuffle){
+            if (!this.shuffle) {
                 image_path = this._images.shift();
                 this._images.push(image_path);
             } else {
@@ -226,11 +226,11 @@ MyDesklet.prototype = {
             global.logError(e);
         } finally {
             this.updateInProgress = false;
-        }       
+        }
     },
 
-    on_desklet_clicked: function(event){  
-        try {             
+    on_desklet_clicked: function(event) {
+        try {
             if (event.get_button() == 1) {
                 this._update();
             }
@@ -240,7 +240,7 @@ MyDesklet.prototype = {
         }
         catch (e) {
             global.logError(e);
-	}
+        }
     },
 
     _loadImage: function(filePath) {
@@ -257,7 +257,6 @@ MyDesklet.prototype = {
     },
 }
 
-function main(metadata, desklet_id){
-    let desklet = new MyDesklet(metadata, desklet_id);
-    return desklet;
+function main(metadata, desklet_id) {
+    return new CinnamonPhotoFrameDesklet(metadata, desklet_id);
 }

--- a/js/ui/tooltips.js
+++ b/js/ui/tooltips.js
@@ -56,7 +56,7 @@ const PanelLoc = {
  * `true`.
  */
 function TooltipBase(item) {
-    throw new TypeError("Trying to instantiate abstract class TooltipBase");
+    this._init(item);
 }
 
 TooltipBase.prototype = {


### PR DESCRIPTION
- Updates stock xlets with class syntax. `_init` needed to be replaced with `constructor` for cases where multiple levels of classes are subclassed for this to work, and the usage was adapted everywhere else for consistency. `constructor` is the equivalent of `function MyApplet(...) {...}` and `super` is the equivalent of `Applet.Applet.prototype.call(this, ...)`. Super calls the parent object.

- Remove large try-catch blocks found in _init methods and a couple other spots. This was done because there are already two or more levels of try-catch blocks wrapping xlet execution. Try-catch isn't free performance-wise, and can make debugging more difficult. Xlet exceptions are always caught by either an xlet manager, extension.js, or fileUtils.js.

- In the files where a lot of lines were already changed and the indentation looked rough, I ran [prettier-eslint](https://github.com/prettier/prettier-eslint) on the file. This auto-formats the code using the .eslintrc.json file in the Cinnamon repo.

- Updated fileUtils.js so classes can be imported from the xlet importer easily, for the Calendar applet. This cannot currently be done in non-xlet Cinnamon files without lexical scope warnings occurring from GJS' module implementation.

- Made the TooltipBase class a subclass-able object since it is being used that way in the window list applet - doesn't work with class syntax otherwise.

- Fixed SystemButton from the menu applet subclassing PopupSubMenuMenuItem and intializing with PopupBaseMenuItem, for class support. PopupSubMenuMenuItem inherits PopupBaseMenuItem.

- Excluded the network applet because of its complexity and outstanding PRs still open. Don't mind rebasing if other conflicting PRs get merged.

- Gives xlet constructors unique names.

- Fixes "reference to undefined property Symbol.toPrimitive" warning from the sound applet.