### PR TITLE
cinnamon-json-makepot: fix some issues

### DIFF
--- a/files/usr/bin/cinnamon-json-makepot
+++ b/files/usr/bin/cinnamon-json-makepot
@@ -15,16 +15,23 @@ import os
 import sys
 
 args = sys.argv[1:]
-potfile = args.pop()
-if '-j' in args:
-    args.remove('-j')
-elif '--js' in args:
-    args.remove('--js')
-else:
-    args.append('-j')
+if '-h' in args:
+    print("cinnamon-json-makepot is deprecated - please use cinnamon-xlet-makepot instead\ntype cinnamon-xlet-makepot -h for usage information.")
+    quit()
+elif '-i' not in args and '--install' not in args and
+     '-r' not in args and '--remove' not in args:
+    potfile = args.pop()
+    if '-j' in args:
+        args.remove('-j')
+    elif '--js' in args:
+        args.remove('--js')
+    else:
+        args.append('-j')
 
-args.append('-o '+potfile)
-# args.append(potfile)
+    args.append('-o')
+    args.append(potfile)
+
 args.append(os.getcwd())
-print(args)
-os.execvp("cinnamon-xlet-makepot", args)
+command = 'cinnamon-xlet-makepot'
+args.insert(0, command)
+os.execvp(command, args)


### PR DESCRIPTION
* The help option was causing the script to scan the current folder. Passing the -h option now imforms the user that cinnamon-json makepot is deprecated and gives a helpful tip about using cinnamon-xlet-makepot instead and then quits.
* Fixes the -i and -r options which use slightly different syntax.
* Include the command in the args list so the first arg doesn't get dropped.
* Properly append the output path to args rather than concatinating.