### PR TITLE
Default menu - fix unused selector .menu-category-button-button

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -1151,8 +1151,6 @@ StScrollBar StButton#vhandle:hover {
 
 }
 .menu-category-button-selected:hover {
-    background-color: #969696;
-    border-radius: 8px;
 }
 /* Name and description of the currently hovered item in the menu
  * This appears on the bottom right hand corner of the menu*/

--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -1150,7 +1150,7 @@ StScrollBar StButton#vhandle:hover {
     padding-right: 5px;
 
 }
-.menu-category-button-button:hover {
+.menu-category-button-selected:hover {
     background-color: #969696;
     border-radius: 8px;
 }


### PR DESCRIPTION
Hi,

`.menu-category-button-button` is unused and may simply be an uncaught typo from many years ago.

`..menu-category-button-selected` is valid and makes sense in this context and as written does distinguish visibly between the selected category and a hovered and selected category. Whether the visual effect is desirable I'll leave for others to decide.