### PR TITLE
Modal dialog: don't stretch icon, align it to the top

### DIFF
--- a/js/ui/modalDialog.js
+++ b/js/ui/modalDialog.js
@@ -469,6 +469,7 @@ SpicesAboutDialog.prototype = {
                 icon = new St.Icon({icon_name: "cs-"+type, icon_size: 48, icon_type: St.IconType.FULLCOLOR, style_class: "about-icon"});
             }
         }
+        icon.set_y_align(Clutter.ActorAlign.START);
         topBox.add_actor(icon);
 
         let topTextBox = new St.BoxLayout({vertical: true});


### PR DESCRIPTION
Before / after
![screenshot from 2018-03-25 11-33-52](https://user-images.githubusercontent.com/10391266/37873707-59085fb2-3022-11e8-9ed4-5bcd64d2b70c.png)
