### PR TITLE
Fix top panel overlapping the on-screen keyboard

### DIFF
--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -184,7 +184,7 @@ function heightsUsedMonitor (monitorIndex, listofpanels) {
             if (listofpanels[i].monitorIndex == monitorIndex) {
                 if (listofpanels[i].panelPosition == PanelLoc.top)
                     toppanelHeight = listofpanels[i].actor.height;
-                if (listofpanels[i].panelPosition == PanelLoc.bottom)
+                else if (listofpanels[i].panelPosition == PanelLoc.bottom)
                     bottompanelHeight = listofpanels[i].actor.height;
             }
         }


### PR DESCRIPTION
 * Add some padding to the OSK so that the top panel doesn't overlap it.
 * Also better calculate paddings to avoid a layout overflow.
 * Add a missing _else_ in _heightsUsedMonitor_.