### PR TITLE
Inhibit applet icon: fix uncolored parts

### DIFF
--- a/files/usr/share/cinnamon/applets/inhibit@cinnamon.org/icons/inhibit-active-symbolic.svg
+++ b/files/usr/share/cinnamon/applets/inhibit@cinnamon.org/icons/inhibit-active-symbolic.svg
@@ -1,117 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
-
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   id="svg7384"
-   height="16.001"
-   width="16"
-   version="1.1"
-   inkscape:version="0.48.4 r9939"
-   sodipodi:docname="inhibit-active-symbolic.svg">
-  <defs
-     id="defs10" />
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1146"
-     id="namedview8"
-     showgrid="false"
-     inkscape:zoom="14.749079"
-     inkscape:cx="25.414617"
-     inkscape:cy="21.704214"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg7384" />
-  <title
-     id="title9167">Gnome Symbolic Icon Theme</title>
-  <metadata
-     id="metadata90">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title>Gnome Symbolic Icon Theme</dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <path
-     style="fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none"
-     d="M 2.1875,0 C 0.9875,0 0,0.9875 0,2.1875 l 0,8.625 C 0,12.0124 0.9859,13 2.1875,13 l 5.125,0 0,-2 -5.125,0 C 2.0475,10.99 2,10.9425 2,10.8125 L 2,2.1875 C 2,2.0675 2.0575,2 2.1875,2 l 11.625,0 C 13.9363,2 14,2.0566 14,2.1875 l 0,5.625 2,0 0,-5.625 C 15.99,0.9775 15.0125,0 13.8125,0 z M 16,7.8125 c -10.6666667,5.459 -5.333333,2.7295 0,0 z m -2,0 c -9.3333333,5.459 -4.6666667,2.7295 0,0 z"
-     id="rect3849"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="sssscccssssscccsscccc" />
-  <path
-     inkscape:connector-curvature="0"
-     d="M 4.91,14 C 4.3816661,14.016759 3.9178886,14.517535 3.9416516,15.045601 3.9654145,15.573666 4.4722962,16.030763 5,16 l 1.7963476,0 c 0.5283126,0.0075 0.6074369,-0.471635 0.6074369,-1 0,-0.528365 0.056477,-0.939671 -0.4718352,-0.932199 L 5,14 C 4.968789,13.9985 4.937511,13.9985 4.9063,14 z"
-     style="text-indent:0;text-transform:none;block-progression:tb;color:#bebebe;fill:#bebebe"
-     id="path11751-2"
-     sodipodi:nodetypes="csccscccc" />
-  <text
-     xml:space="preserve"
-     style="font-size:6.70508957px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#bebebe;fill-opacity:1;stroke:none;font-family:Sans"
-     x="6.031539"
-     y="10.41249"
-     id="text2987"
-     sodipodi:linespacing="125%"
-     transform="matrix(0.94449235,-0.27338118,0.28276822,0.9769232,0,0)"><tspan
-       sodipodi:role="line"
-       id="tspan2989"
-       x="6.031539"
-       y="10.41249"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:center;letter-spacing:-0.52367997px;text-anchor:middle;baseline-shift:baseline;font-family:Liberation Mono;-inkscape-font-specification:Liberation Mono Bold" /></text>
-  <text
-     xml:space="preserve"
-     style="font-size:40px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#bebebe;fill-opacity:1;stroke:none;font-family:Saab;-inkscape-font-specification:Saab"
-     x="4.6104574"
-     y="7.4580932"
-     id="text3759"
-     sodipodi:linespacing="125%"><tspan
-       sodipodi:role="line"
-       id="tspan3761"
-       x="4.6104574"
-       y="7.4580932" /></text>
-  <text
-     xml:space="preserve"
-     style="font-size:6.46480846px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#bebebe;fill-opacity:1;stroke:none;font-family:Sans"
-     x="3.2014849"
-     y="8.8141088"
-     id="text3767"
-     sodipodi:linespacing="125%"><tspan
-       sodipodi:role="line"
-       id="tspan3769"
-       x="3.2014849"
-       y="8.8141088"
-       style="font-weight:bold;-inkscape-font-specification:Sans Bold">Z</tspan></text>
-  <path
-     inkscape:connector-curvature="0"
-     id="path3482-5"
-     d="m 12.341005,8.8395044 c -1.933001,0 -3.5000018,1.5669976 -3.5000018,3.4999976 0,1.933 1.5670008,3.5 3.5000018,3.5 1.933,0 3.5,-1.567 3.5,-3.5 0,-1.933 -1.567,-3.4999976 -3.5,-3.4999976 z M 9.8410032,11.808302 h 5.0000018 v 1.0312 H 9.8410032 v -1.0312 z"
-     style="color:#bebebe;fill:#ef2929"
-     class="error" />
-  <path
-     style="fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none"
-     d="m 8.75,4.03125 0,0.90625 2.46875,0 -2.25,2.71875 1.34375,0 2.40625,-2.90625 0,-0.71875 z"
-     id="rect3856"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="cccccccc" />
-  <g
-     style="font-size:6.46480846px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#bebebe;fill-opacity:1;stroke:none;font-family:Sans"
-     id="text3767-5" />
+<svg width="16" xmlns="http://www.w3.org/2000/svg" version="1.1" height="16">
+ <title>Gnome Symbolic Icon Theme</title>
+ <g fill="#bebebe">
+  <path d="m3 4.001 4.5-2e-7v1l-3 3h3v1h-4.5v-1l3-3h-3z"/>
+ </g>
+ <path d="m8.5 4.002v1h3l-3 3h1.5l3-3v-1h-4.5z" fill="#bebebe"/>
+ <path d="m2 0.0019531c-1.0907 0-2 0.9093-2 2v9c0 1.091 0.9093 2 2 2h6v-2h-6v-9h12v6h2v-6c0-1.0908-0.909-2-2-2h-12z" fill="#bebebe"/>
+ <path d="m5 14.002c-0.5454 0-1 0.455-1 1v0.5h0.209c0.1787 0.28 0.4394 0.5 0.791 0.5h3v-2h-3z" fill="#bebebe"/>
+ <path fill="#ef2929" d="m12.5 9.002a3.5 3.5 0 0 0 -3.5 3.5 3.5 3.5 0 0 0 3.5 3.5 3.5 3.5 0 0 0 3.5 -3.5 3.5 3.5 0 0 0 -3.5 -3.5zm-2.5 3h5v1h-5v-1z" class="error"/>
 </svg>

--- a/files/usr/share/cinnamon/applets/inhibit@cinnamon.org/icons/inhibit-symbolic.svg
+++ b/files/usr/share/cinnamon/applets/inhibit@cinnamon.org/icons/inhibit-symbolic.svg
@@ -1,114 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
-
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   id="svg7384"
-   height="16.001"
-   width="16"
-   version="1.1"
-   inkscape:version="0.48.4 r9939"
-   sodipodi:docname="inhibit-symbolic.svg">
-  <defs
-     id="defs10" />
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1146"
-     id="namedview8"
-     showgrid="false"
-     inkscape:zoom="14.749079"
-     inkscape:cx="36.12715"
-     inkscape:cy="21.704214"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg7384" />
-  <title
-     id="title9167">Gnome Symbolic Icon Theme</title>
-  <metadata
-     id="metadata90">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title>Gnome Symbolic Icon Theme</dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     id="layer10"
-     transform="translate(-122,-338)">
-    <path
-       id="rect11749-5"
-       style="block-progression:tb;text-indent:0;color:#bebebe;text-transform:none;fill:#bebebe"
-       d="m124.19 338c-1.2 0-2.19 0.99-2.19 2.19v8.625c0 1.1999 0.9859 2.1875 2.1875 2.1875h11.625c1.2016 0 2.1875-0.98758 2.1875-2.1875v-8.625c-0.01-1.21-1-2.2-2.2-2.2h-11.625zm0 2h11.625c0.1238 0 0.1875 0.0566 0.1875 0.1875v8.625c0 0.1309-0.0637 0.1875-0.1875 0.1875h-11.625c-0.14-0.01-0.2-0.07-0.2-0.2v-8.625c0-0.12 0.06-0.18 0.19-0.18z" />
-    <path
-       id="path11751-2"
-       style="block-progression:tb;text-indent:0;color:#bebebe;text-transform:none;fill:#bebebe"
-       d="m126.91 352a1.0011 1.0011 0 1 0 0.09 2h6a1.0001 1.0001 0 1 0 0 -2h-6a1.0001 1.0001 0 0 0 -0.0937 0z" />
-  </g>
-  <text
-     xml:space="preserve"
-     style="font-size:6.70508957px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#bebebe;fill-opacity:1;stroke:none;font-family:Sans"
-     x="6.031539"
-     y="10.41249"
-     id="text2987"
-     sodipodi:linespacing="125%"
-     transform="matrix(0.94449235,-0.27338118,0.28276822,0.9769232,0,0)"><tspan
-       sodipodi:role="line"
-       id="tspan2989"
-       x="6.031539"
-       y="10.41249"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:center;letter-spacing:-0.52367997px;text-anchor:middle;baseline-shift:baseline;font-family:Liberation Mono;-inkscape-font-specification:Liberation Mono Bold" /></text>
-  <text
-     xml:space="preserve"
-     style="font-size:40px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#bebebe;fill-opacity:1;stroke:none;font-family:Saab;-inkscape-font-specification:Saab"
-     x="4.6104574"
-     y="7.4580932"
-     id="text3759"
-     sodipodi:linespacing="125%"><tspan
-       sodipodi:role="line"
-       id="tspan3761"
-       x="4.6104574"
-       y="7.4580932" /></text>
-  <text
-     xml:space="preserve"
-     style="font-size:6.46480846px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#bebebe;fill-opacity:1;stroke:none;font-family:Sans"
-     x="3.2014849"
-     y="8.8141088"
-     id="text3767"
-     sodipodi:linespacing="125%"><tspan
-       sodipodi:role="line"
-       id="tspan3769"
-       x="3.2014849"
-       y="8.8141088"
-       style="font-weight:bold;-inkscape-font-specification:Sans Bold">Z</tspan></text>
-  <text
-     xml:space="preserve"
-     style="font-size:6.46480846px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#bebebe;fill-opacity:1;stroke:none;font-family:Sans"
-     x="8.4022541"
-     y="8.7297192"
-     id="text3767-5"
-     sodipodi:linespacing="125%"><tspan
-       sodipodi:role="line"
-       id="tspan3769-7"
-       x="8.4022541"
-       y="8.7297192"
-       style="font-weight:bold;-inkscape-font-specification:Sans Bold">Z</tspan></text>
+<svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" version="1.1">
+ <title>Gnome Symbolic Icon Theme</title>
+ <g fill="#bebebe">
+  <path d="m3 4.001 4.5-2e-7v1l-3 3h3v1h-4.5v-1l3-3h-3z"/>
+  <path d="m8.5 4.001 4.5-2e-7v1l-3 3h3v1h-4.5v-1l3-3h-3z"/>
+ </g>
+ <g fill="#bebebe">
+  <path d="m2 0.0019531c-1.0907 0-2 0.9093-2 2v9c0 1.0907 0.9093 2 2 2h12c1.0907 0 2-0.9093 2-2v-9c0-1.0908-0.909-2-2-2h-12zm0 2h12v9h-12v-9z"/>
+  <path d="m5 14.002c-0.54535 0-1 0.45465-1 1v0.5h0.20898c0.17868 0.28037 0.43946 0.5 0.79102 0.5h6c0.35155 0 0.61234-0.21963 0.79102-0.5h0.20898v-0.5c0-0.54535-0.45465-1-1-1h-6z"/>
+ </g>
 </svg>


### PR DESCRIPTION
The ZZ's inside where not paths and they weren't affected by the color property. I converted them to paths.

Screenshot of Mint-X: 
![screenshot from 2018-03-25 21-53-37](https://user-images.githubusercontent.com/10391266/37879301-07901d8c-3077-11e8-8e63-4f1b6a723cdb.png)