### PR TITLE
environment/overrides: Harden St.Label.prototype.set_text

### DIFF
--- a/js/ui/environment.js
+++ b/js/ui/environment.js
@@ -103,6 +103,21 @@ function init() {
         return St.describe_actor(this);
     };
 
+    let originalSetText = St.Label.prototype.set_text;
+    St.Label.prototype.set_text = function(text) {
+        // Warn about non-strings being passed to set_text.
+        if (typeof text !== 'string') {
+            global.dump_gjs_stack(
+                `Invalid value of type ${typeof text} passed to St.Label.prototype.set_text.`
+            );
+            return false;
+        }
+        // Only call set_text if the text has changed.
+        if (text !== this.text) {
+            originalSetText.call(this, ...arguments);
+        }
+    };
+
     let origToString = Object.prototype.toString;
     Object.prototype.toString = function() {
         let base = origToString.call(this);

--- a/js/ui/overrides.js
+++ b/js/ui/overrides.js
@@ -100,18 +100,7 @@ function overrideGio() {
 function overrideDumpStack() {
     global._dump_gjs_stack = global.dump_gjs_stack;
     global.dump_gjs_stack = function(message = 'global.dump_gjs_stack():') {
-        try {
-            throw new Error();
-        } catch (e) {
-            let lines = e.stack.split('\n')
-            // Remove stack leading to this function, so the problem function is at the top.
-            for (let i = 0; i < lines.length; i++) {
-                if (lines[i].indexOf('overrides.js') > -1) {
-                    lines.splice(lines.indexOf(lines[i]), 1);
-                }
-            }
-            log(`${message}\n${lines.join('\n')}`);
-        }
+        global.logWarning(`${message}\n${new Error().stack}`);
     }
 }
 


### PR DESCRIPTION
- Warns about and prevents non-strings from being passed to `set_text`
- Prevents `set_text` from being called if the text hasn't changed
- Cleans up `overrideDumpStack`