### PR TITLE
menu applet - if no selected item when adding search provider results make first search provider result selected item

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -3345,7 +3345,7 @@ MyApplet.prototype = {
             }
             }catch(e){global.log(e);}
         }));
- 
+
         return false;
     },
 

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -3307,22 +3307,6 @@ MyApplet.prototype = {
         }
 
         this._displayButtons(null, placesResults, recentResults, appResults, acResults);
-
-        SearchProviderManager.launch_all(pattern, Lang.bind(this, function(provider, results){
-            try{
-            for (var i in results){
-                if (results[i].type != 'software')
-                {
-                    let button = new SearchProviderResultButton(this, provider, results[i]);
-                    button.actor.connect('leave-event', Lang.bind(this, this._appLeaveEvent, button));
-                    this._addEnterEvent(button, Lang.bind(this, this._appEnterEvent, button));
-                    this._searchProviderButtons.push(button);
-                    this.applicationsBox.add_actor(button.actor);
-                    button.actor.realize();
-                }
-            }
-            }catch(e){global.log(e);}
-        }));
         
         this.appBoxIter.reloadVisible();
         if (this.appBoxIter.getNumVisibleChildren() > 0) {
@@ -3337,6 +3321,31 @@ MyApplet.prototype = {
             this.selectedAppDescription.set_text("");
         }
 
+        SearchProviderManager.launch_all(pattern, Lang.bind(this, function(provider, results){
+            try{
+            for (var i in results){
+                if (results[i].type != 'software')
+                {
+                    let button = new SearchProviderResultButton(this, provider, results[i]);
+                    button.actor.connect('leave-event', Lang.bind(this, this._appLeaveEvent, button));
+                    this._addEnterEvent(button, Lang.bind(this, this._appEnterEvent, button));
+                    this._searchProviderButtons.push(button);
+                    this.applicationsBox.add_actor(button.actor);
+                    button.actor.realize();
+                    if (this._selectedItemIndex === null) {
+						this.appBoxIter.reloadVisible();
+                        let item_actor = this.appBoxIter.getFirstVisible();
+                        this._selectedItemIndex = this.appBoxIter.getAbsoluteIndexOfChild(item_actor);
+                        this._activeContainer = this.applicationsBox;
+                        if (item_actor && item_actor != this.searchEntry) {
+                            item_actor._delegate.emit('enter-event');
+                        }
+                    }
+                }
+            }
+            }catch(e){global.log(e);}
+        }));
+        
         return false;
     },
 

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -3308,19 +3308,6 @@ MyApplet.prototype = {
 
         this._displayButtons(null, placesResults, recentResults, appResults, acResults);
 
-        this.appBoxIter.reloadVisible();
-        if (this.appBoxIter.getNumVisibleChildren() > 0) {
-            let item_actor = this.appBoxIter.getFirstVisible();
-            this._selectedItemIndex = this.appBoxIter.getAbsoluteIndexOfChild(item_actor);
-            this._activeContainer = this.applicationsBox;
-            if (item_actor && item_actor != this.searchEntry) {
-                item_actor._delegate.emit('enter-event');
-            }
-        } else {
-            this.selectedAppTitle.set_text("");
-            this.selectedAppDescription.set_text("");
-        }
-
         SearchProviderManager.launch_all(pattern, Lang.bind(this, function(provider, results){
             try{
             for (var i in results){
@@ -3336,6 +3323,19 @@ MyApplet.prototype = {
             }
             }catch(e){global.log(e);}
         }));
+        
+        this.appBoxIter.reloadVisible();
+        if (this.appBoxIter.getNumVisibleChildren() > 0) {
+            let item_actor = this.appBoxIter.getFirstVisible();
+            this._selectedItemIndex = this.appBoxIter.getAbsoluteIndexOfChild(item_actor);
+            this._activeContainer = this.applicationsBox;
+            if (item_actor && item_actor != this.searchEntry) {
+                item_actor._delegate.emit('enter-event');
+            }
+        } else {
+            this.selectedAppTitle.set_text("");
+            this.selectedAppDescription.set_text("");
+        }
 
         return false;
     },

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -3333,7 +3333,7 @@ MyApplet.prototype = {
                     this.applicationsBox.add_actor(button.actor);
                     button.actor.realize();
                     if (this._selectedItemIndex === null) {
-						this.appBoxIter.reloadVisible();
+                        this.appBoxIter.reloadVisible();
                         let item_actor = this.appBoxIter.getFirstVisible();
                         this._selectedItemIndex = this.appBoxIter.getAbsoluteIndexOfChild(item_actor);
                         this._activeContainer = this.applicationsBox;

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -3307,7 +3307,7 @@ MyApplet.prototype = {
         }
 
         this._displayButtons(null, placesResults, recentResults, appResults, acResults);
-        
+
         this.appBoxIter.reloadVisible();
         if (this.appBoxIter.getNumVisibleChildren() > 0) {
             let item_actor = this.appBoxIter.getFirstVisible();
@@ -3345,7 +3345,7 @@ MyApplet.prototype = {
             }
             }catch(e){global.log(e);}
         }));
-        
+ 
         return false;
     },
 


### PR DESCRIPTION

Just reorders code so that search providers results are added before selecting first result as selected item.

Fixes #7412 

@NikoKrause - Stark Menu has the same issue and the same fix I think would apply. Cinnamenu doesn't have this issue.