### PR TITLE
default theme - add .menu-background{} as placeholder

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -1033,7 +1033,7 @@ StScrollBar StButton#vhandle:hover {
  * Menu (menu.js)
  * ===================================================================*/
 /* Main menu title */
-/* menu-background allows the stock menu applet to be themed separately from other applet menus */
+/* menu-background allows the menu applet to be themed separately from other applet menus */
 .menu-background {
 }
 .menu-favorites-box {

--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -1033,7 +1033,9 @@ StScrollBar StButton#vhandle:hover {
  * Menu (menu.js)
  * ===================================================================*/
 /* Main menu title */
-
+/* menu-background allows the stock menu applet to be themed separately from other applet menus */
+.menu-background {
+}
 .menu-favorites-box {
     padding: 10px;
     border: 1px solid #666;


### PR DESCRIPTION
Hi,

The style_class `.menu-background` was fixed in #5948.

I think it should be referenced in the default theme so that new themers are more likely to be aware of the possibility without necessarily trawling through the stock applet code.