### PR TITLE
keyboard-settings: Fix the use of wide separators

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_keyboard.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_keyboard.py
@@ -256,7 +256,7 @@ class Module:
             headingbox.pack_end(Gtk.Label.new(_("To edit a keyboard binding, click it and press the new keys, or press backspace to clear it.")), False, False, 1)
 
             paned = Gtk.Paned(orientation = Gtk.Orientation.HORIZONTAL)
-            Gtk.StyleContext.add_class(Gtk.Widget.get_style_context(paned), "wide")
+            paned.set_wide_handle(True)
 
             left_vbox = Gtk.Box.new(Gtk.Orientation.VERTICAL, 2)
             right_vbox = Gtk.Box.new(Gtk.Orientation.VERTICAL, 2)


### PR DESCRIPTION
This is changed in gtk3.20+ and we need to fix this so they are themed
correctly