### PR TITLE
Melange: slight UI rework

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-looking-glass/page_inspect.py
+++ b/files/usr/share/cinnamon/cinnamon-looking-glass/page_inspect.py
@@ -65,7 +65,6 @@ class ModulePage(pageutils.WindowAndActionBars):
 
         self.back = pageutils.ImageButton("go-previous-symbolic")
         self.back.set_tooltip_text("Go back")
-        self.back.set_sensitive(False)
         self.back.connect("clicked", self.onBackButton)
         self.addToLeftBar(self.back, 1)
 
@@ -106,20 +105,22 @@ class ModulePage(pageutils.WindowAndActionBars):
             lookingGlassProxy.AddResult(path)
 
     def onBackButton(self, widget):
-        self.popInspectionElement()
+        if len(self.stack) > 0:
+            self.popInspectionElement()
+        else:
+            melangeApp.activatePage("results")
+
 
     def popInspectionElement(self):
         if len(self.stack) > 0:
             self.updateInspector(*self.stack.pop())
 
         sensitive = len(self.stack) > 0
-        self.back.set_sensitive(sensitive)
         self.insert.set_sensitive(sensitive)
 
     def pushInspectionElement(self):
         if self.currentInspection is not None:
             self.stack.append(self.currentInspection)
-            self.back.set_sensitive(True)
             self.insert.set_sensitive(True)
 
     def updateInspector(self, path, objType, name, value, pushToStack=False):
@@ -151,6 +152,5 @@ class ModulePage(pageutils.WindowAndActionBars):
     def inspectElement(self, path, objType, name, value):
         del self.stack[:]
         self.currentInspection = None
-        self.back.set_sensitive(False)
         self.insert.set_sensitive(False)
         self.updateInspector(path, objType, name, value)

--- a/js/ui/lookingGlass.js
+++ b/js/ui/lookingGlass.js
@@ -4,6 +4,7 @@ const Cinnamon = imports.gi.Cinnamon;
 const Clutter = imports.gi.Clutter;
 const Cogl = imports.gi.Cogl;
 const Gio = imports.gi.Gio;
+const GLib = imports.gi.GLib;
 const Lang = imports.lang;
 const Meta = imports.gi.Meta;
 const Signals = imports.signals;
@@ -515,7 +516,7 @@ Melange.prototype = {
 
         let resultObj;
 
-        let ts = new Date().getTime();
+        let ts = GLib.get_monotonic_time();
 
         try {
             resultObj = eval(fullCmd);
@@ -523,9 +524,9 @@ Melange.prototype = {
             resultObj = '<exception ' + e + '>';
         }
 
-        let ts2 = new Date().getTime();
+        let ts2 = GLib.get_monotonic_time();
 
-        let tooltip = _("Execution time (ms): ") + (ts2 - ts);
+        let tooltip = _("Execution time (ms): ") + (ts2 - ts) / 1000;
 
         this._pushResult(command, resultObj, tooltip);
 
@@ -591,8 +592,8 @@ Melange.prototype = {
         try {
             let inspector = new Inspector();
             inspector.connect('target', Lang.bind(this, function(i, target, stageX, stageY) {
-                this._pushResult('<inspect x:' + stageX + ' y:' + stageY + '>',
-                                 target, "");
+                let name = '<inspect x:' + stageX + ' y:' + stageY + '>';
+                this._pushResult(name, target, "Inspected actor");
             }));
             inspector.connect('closed', Lang.bind(this, function() {
                 this.emitInspectorDone();


### PR DESCRIPTION
Main window:
 - Adds a garbage collect button next to the inspect button. This is
   also on the currently disabled memory tab.

 - Removes description labels and adds tooltips instead

 - Uses nicer keybind display format

Inspect tab:
 - Back button is now always enabled. When the inspection stack is
   empty then the Results tab is activated.

Results tab:
 - Eval result tooltip: sub-millisecond precision for execution time

 - Inspection result tooltip: generic tooltip so it's not blank

Screenshots only show some of the changes:
Before:
![screenshot from 2018-03-30 23-09-02](https://user-images.githubusercontent.com/11601860/38168161-e05a98dc-34f9-11e8-8dda-c0af24a5e99f.png)
After:
![screenshot from 2018-03-30 23-05-43](https://user-images.githubusercontent.com/11601860/38168162-e0736b46-34f9-11e8-8c98-8f5f1be67391.png)
