### PR TITLE
Added "shutdown immediately" entries for lid close and power critical.

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_power.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_power.py
@@ -549,6 +549,7 @@ def get_available_options(up_client):
 
     lid_options = [
         ("suspend", _("Suspend")),
+        ("shutdown", _("Shutdown immediately")),
         ("hibernate", _("Hibernate")),
         ("nothing", _("Do nothing"))
     ]
@@ -563,6 +564,7 @@ def get_available_options(up_client):
     ]
 
     critical_options = [
+        ("shutdown", _("Shutdown immediately")),
         ("hibernate", _("Hibernate")),
         ("nothing", _("Do nothing"))
     ]


### PR DESCRIPTION
This change introduces the option to make your machine turn off completely when the lid is closed, as well as turning of when the power reaches a critical level.
I always find myself adding these lines manually in all my machines, so I figured I might not be the only one.