### PR TITLE
PEP8ify

### DIFF
--- a/generate_additional_files.py
+++ b/generate_additional_files.py
@@ -1,11 +1,14 @@
 #!/usr/bin/python3
 
+import os
+import gettext
+import sys
+
+sys.path.append('/usr/lib/linuxmint/common')  # noqa
+import additionalfiles
+
 DOMAIN = "cinnamon"
 PATH = "/usr/share/locale"
-
-import os, gettext, sys
-sys.path.append('/usr/lib/linuxmint/common')
-import additionalfiles
 
 os.environ['LANGUAGE'] = "en_US.UTF-8"
 gettext.install(DOMAIN, PATH)

--- a/generate_cs_module_desktop_files.py
+++ b/generate_cs_module_desktop_files.py
@@ -1,20 +1,18 @@
 #!/usr/bin/python3
 
+import os
+import gettext
+import glob
+import sys
+
+sys.path.append('/usr/lib/linuxmint/common')  # noqa
+import additionalfiles
+
 DOMAIN = "cinnamon"
 PATH = "/usr/share/locale"
 
-import os, gettext, sys
-sys.path.append('/usr/lib/linuxmint/common')
-import additionalfiles
-
 os.environ['LANGUAGE'] = "en_US.UTF-8"
 gettext.install(DOMAIN, PATH)
-
-import os
-import glob
-import polib
-import sys
-from gi.repository import GLib
 
 try:
     sys.path.append('files/usr/share/cinnamon/cinnamon-settings')
@@ -60,7 +58,7 @@ Categories=Settings;
 
         additionalfiles.generate(DOMAIN, PATH, "files/usr/share/applications/cinnamon-settings-%s.desktop" % mod.name, prefix, mod.sidePage.name, mod.comment, "", None, mod.sidePage.keywords)
 
-    except:
+    except Exception:
         print("Failed to load module %s" % module)
         import traceback
         traceback.print_exc()


### PR DESCRIPTION
Update scripts to match the pep8 guidelines
(https://www.python.org/dev/peps/pep-0008)

 - multiple imports in the same line
 - module level import not at top of file
 - polib imported but unused
 - gi imported but unused
 - bare except used: this is dangerous and should be avoided