### PR TITLE
Hot corners cleanup and fixes

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_hotcorner.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_hotcorner.py
@@ -110,11 +110,7 @@ class HotCornerDisplay(Gtk.DrawingArea):
         Gtk.DrawingArea.__init__(self, **kwargs)
         self.connect('draw', self.expose)
 
-        self.cornerEnabled = []
-        self.cornerEnabled.append(True)
-        self.cornerEnabled.append(True)
-        self.cornerEnabled.append(True)
-        self.cornerEnabled.append(True)
+        self.cornerEnabled = [True, True, True, True]
 
     def setCornerEnabled(self, index, value):
         self.cornerEnabled[index] = value
@@ -123,7 +119,7 @@ class HotCornerDisplay(Gtk.DrawingArea):
         if self.cornerEnabled[index]:
             cr.set_source_rgba(self.activeColor.red, self.activeColor.green, self.activeColor.blue, self.activeColor.alpha)
         else:
-            cr.set_source_rgba(self.inactiveColor.red, self.inactiveColor.green, self.inactiveColor.blue, self.inactiveColor.alpha)
+            cr.set_source_rgba(1, 1, 1, .25)
 
     def _getColor(self, context, default, alternative):
         (succ, color) = context.lookup_color(default)
@@ -131,67 +127,57 @@ class HotCornerDisplay(Gtk.DrawingArea):
             (succ, color) = context.lookup_color(alternative)
         return color
 
-    #Renders button with corner visuals
+    # Render display with corner visuals
     def expose(self, widget, cr):
         context = self.get_style_context()
-        context.save()
-        context.add_class(Gtk.STYLE_CLASS_BUTTON)
 
         self.activeColor = self._getColor(context, "success_color", "question_bg_color")
-        self.inactiveColor = self._getColor(context, "error_color", "error_bg_color")
-        self.inactiveColor.alpha *= 0.35
         self.activeColor.alpha *= 0.9
 
         allocation = self.get_allocation()
 
-        self.allocWidth = allocation.width
-        self.allocHeight = allocation.height
-
-        cr.save()
         cr.set_antialias(cairo.ANTIALIAS_SUBPIXEL)
 
-        cr.rectangle(0, 0, self.allocWidth, self.allocHeight)
-        cr.clip()
-        Gtk.render_background(context, cr, -10, -10, self.allocWidth+20, self.allocHeight+20)
-
-        cr.rectangle(0, 0, self.allocWidth, self.allocHeight)
-        cr.clip()
+        middleX = allocation.width // 2
+        middleY = allocation.height // 2
+        pat = cairo.RadialGradient(middleX, middleY, 0, middleX, middleY, middleX)
+        pat.add_color_stop_rgb(.2, .25, .25, .25)
+        pat.add_color_stop_rgb(1, .15, .15, .15)
+        cr.set_source(pat)
+        cr.rectangle(0, 0, allocation.width, allocation.height)
+        cr.fill()
 
         cr.set_line_width(1)
 
+        cornerSize = 50
+
         self._setCornerColor(cr, 0)
-        cr.move_to(1,51)
-        cr.line_to(1,1)
-        cr.arc(1, 1, 51, _0_DEG, _90_DEG)
+        cr.move_to(0,0)
+        cr.line_to(cornerSize,0)
+        cr.arc(0, 0, cornerSize, _0_DEG, _90_DEG)
         cr.fill()
 
         self._setCornerColor(cr, 1)
-        cr.move_to(self.allocWidth-1,1)
-        cr.line_to(self.allocWidth-1,51)
-        cr.arc(self.allocWidth-1, 1, 51, _90_DEG, _180_DEG)
+        cr.move_to(allocation.width, 0)
+        cr.line_to(allocation.width, cornerSize)
+        cr.arc(allocation.width, 0, cornerSize, _90_DEG, _180_DEG)
         cr.fill()
 
         self._setCornerColor(cr, 2)
-        cr.move_to(1,self.allocHeight-1)
-        cr.line_to(1,self.allocHeight-51)
-        cr.arc(1, self.allocHeight, 51, _270_DEG, _90_DEG)
+        cr.move_to(0, allocation.height)
+        cr.line_to(0, allocation.height-cornerSize)
+        cr.arc(0, allocation.height, cornerSize, _270_DEG, _0_DEG)
         cr.fill()
 
         self._setCornerColor(cr, 3)
-        cr.move_to(self.allocWidth,self.allocHeight-50)
-        cr.line_to(self.allocWidth,self.allocHeight)
-        cr.arc(self.allocWidth, self.allocHeight, 50, _180_DEG, _270_DEG)
+        cr.move_to(allocation.width, allocation.height)
+        cr.line_to(allocation.width-cornerSize, allocation.height)
+        cr.arc(allocation.width, allocation.height, cornerSize, _180_DEG, _270_DEG)
         cr.fill()
 
         cr.set_source_rgba(0, 0, 0, 1)
-        cr.rectangle(0, 0, self.allocWidth, self.allocHeight)
+        cr.rectangle(0, 0, allocation.width, allocation.height)
         cr.stroke()
-
-        context.restore()
-
-        cr.stroke_preserve()
-
-        cr.restore()
 
         return True
 

--- a/js/ui/hotCorner.js
+++ b/js/ui/hotCorner.js
@@ -32,7 +32,7 @@ HotCornerManager.prototype = {
         this.parseGSettings();
         global.settings.connect('changed::' + OVERVIEW_CORNERS_KEY, Lang.bind(this, this.parseGSettings));
 
-        this.updatePosition(Main.layoutManager.primaryMonitor, Main.layoutManager.bottomMonitor);
+        this.updatePosition(Main.layoutManager.primaryMonitor);
     },
 
     parseGSettings: function() {
@@ -49,23 +49,23 @@ HotCornerManager.prototype = {
         return true;
     },
 
-    updatePosition: function(primaryMonitor, bottomMonitor) {
-        let p_x = primaryMonitor.x;
-        let p_y = primaryMonitor.y;
-        let b_x = bottomMonitor.x;
-        let b_y = bottomMonitor.y + bottomMonitor.height;
+    updatePosition: function(monitor) {
+        let left   = monitor.x;
+        let right  = monitor.x + monitor.width - 2;
+        let top    = monitor.y;
+        let bottom = monitor.y + monitor.height - 2;
 
         // Top Left: 0
-        this.corners[0].actor.set_position(p_x, p_y);
+        this.corners[0].actor.set_position(left, top);
 
         // Top Right: 1
-        this.corners[1].actor.set_position(p_x + primaryMonitor.width - 2, p_y);
+        this.corners[1].actor.set_position(right, top);
 
         // Bottom Left: 2
-        this.corners[2].actor.set_position(b_x, b_y - 1);
+        this.corners[2].actor.set_position(left, bottom);
 
         // Bottom Right: 3
-        this.corners[3].actor.set_position(b_x + bottomMonitor.width - 2, b_y - 1);
+        this.corners[3].actor.set_position(right, bottom);
 
         return true;
     }

--- a/js/ui/hotCorner.js
+++ b/js/ui/hotCorner.js
@@ -38,7 +38,7 @@ HotCornerManager.prototype = {
     parseGSettings: function() {
         let options = global.settings.get_strv(OVERVIEW_CORNERS_KEY);
         if (options.length != 4) {
-            global.log(_("Invalid overview options: Incorrect number of corners"));
+            global.logError(_("Invalid overview options: Incorrect number of corners"));
             return false;
         }
 

--- a/js/ui/hotCorner.js
+++ b/js/ui/hotCorner.js
@@ -189,7 +189,10 @@ HotCorner.prototype = {
 
         ripple._opacity = startOpacity;
 
-        ripple.set_anchor_point_from_gravity(Clutter.Gravity.CENTER);
+        // Set anchor point on the center of the ripples
+        ripple.set_pivot_point(0.5, 0.5);
+        ripple.set_translation(-ripple.width/2, -ripple.height/2, 0);
+
         ripple.visible = true;
         ripple.opacity = 255 * Math.sqrt(startOpacity);
         ripple.scale_x = ripple.scale_y = startScale;

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -108,7 +108,7 @@ LayoutManager.prototype = {
     // not exist yet when the LayoutManager was constructed.
     init: function() {
         this._chrome.init();
-        
+
         this.edgeRight = new EdgeFlip.EdgeFlipper(St.Side.RIGHT, Main.wm.actionFlipWorkspaceRight);
         this.edgeLeft = new EdgeFlip.EdgeFlipper(St.Side.LEFT, Main.wm.actionFlipWorkspaceLeft);
 
@@ -119,7 +119,7 @@ LayoutManager.prototype = {
 
         this.hotCornerManager = new HotCorner.HotCornerManager();
     },
-    
+
     _toggleExpo: function() {
         if (Main.expo.animationInProgress)
             return;
@@ -130,7 +130,7 @@ LayoutManager.prototype = {
         }
         Main.expo.toggle();
     },
-    
+
     _updateMonitors: function() {
         let screen = global.screen;
 
@@ -159,7 +159,7 @@ LayoutManager.prototype = {
 
     _updateBoxes: function() {
         if (this.hotCornerManager)
-            this.hotCornerManager.updatePosition(this.primaryMonitor, this.bottomMonitor);
+            this.hotCornerManager.updatePosition(this.primaryMonitor);
         this._chrome._queueUpdateRegions();
     },
 
@@ -238,7 +238,7 @@ LayoutManager.prototype = {
                            time: STARTUP_ANIMATION_TIME,
                            transition: 'easeOutQuad',
                            onComplete: this._startupAnimationComplete,
-                           onCompleteScope: this });       
+                           onCompleteScope: this });
     },
 
     _startupAnimationComplete: function() {
@@ -304,7 +304,7 @@ LayoutManager.prototype = {
         return false;
     },
 
-    /** 
+    /**
      * updateChrome:
      * @doVisibility (boolean): (optional) whether to recalculate visibility.
      *
@@ -539,7 +539,7 @@ Chrome.prototype = {
         }
         return -1;
     },
-    
+
     modifyActorParams: function(actor, params) {
         let index = this._findActor(actor);
         if (index == -1)


### PR DESCRIPTION
* Avoid systematic console warnings.
* Remove usage of deprecated functions.
* Place corners on the primary monitor when there is a bottom monitor. In general, hot corners aren't placed across monitors.
* Remove duplicated event listeners and buttons remains.
* Fix `shouldToggleOverviewOnClick` not taking effect.
* Update `cs_hotcorner` interface and internals