### PR TITLE
[WIP] background effects: rework and turn on.

### DIFF
--- a/src/st/st-background-effect.c
+++ b/src/st/st-background-effect.c
@@ -1,30 +1,59 @@
 #include "st-background-effect.h"
 #include "st-cogl-wrapper.h"
-#define ST_BACKGROUND_EFFECT_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST ((klass), ST_TYPE_BACKGROUND_EFFECT, StBackgroundEffectClass))
-#define ST_IS_BACKGROUND_EFFECT_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE ((klass), ST_TYPE_BACKGROUND_EFFECT))
-#define ST_BACKGROUND_EFFECT_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS ((obj), ST_TYPE_BACKGROUND_EFFECT, StBackgroundEffectClass))
-
-G_DEFINE_TYPE (StBackgroundEffect, st_background_effect, CLUTTER_TYPE_OFFSCREEN_EFFECT);
-
 #include <gio/gio.h>
 #include <math.h>
+
+ /*
+  * Blur effect declarations
+  */
+
+#define ST_BACKGROUND_BLUR_EFFECT_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST ((klass), ST_TYPE_BACKGROUND_BLUR_EFFECT, StBackgroundBlurEffectClass))
+#define ST_IS_BACKGROUND_BLUR_EFFECT_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE ((klass), ST_TYPE_BACKGROUND_BLUR_EFFECT))
+#define ST_BACKGROUND_BLUR_EFFECT_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS ((obj), ST_TYPE_BACKGROUND_BLUR_EFFECT, StBackgroundBlurEffectClass))
+
+G_DEFINE_TYPE (StBackgroundBlurEffect, st_background_blur_effect, CLUTTER_TYPE_OFFSCREEN_EFFECT);
+
+static const gchar *box_blur_glsl_declarations =
+  "uniform vec2 pixel_step;\n";
+#define SAMPLE(offx, offy) \
+  "cogl_texel += texture2D (cogl_sampler, cogl_tex_coord.st + pixel_step * " \
+  "vec2 (" G_STRINGIFY (offx) ", " G_STRINGIFY (offy) ") * 2.0);\n"
+static const gchar *box_blur_glsl_shader =
+    "  cogl_texel = texture2D (cogl_sampler, cogl_tex_coord.st);\n"
+    SAMPLE (-1.0, -1.0)
+    SAMPLE ( 0.0, -1.0)
+    SAMPLE (+1.0, -1.0)
+    SAMPLE (-1.0,  0.0)
+    SAMPLE ( 0.0,  0.0)
+    SAMPLE (+1.0,  0.0)
+    SAMPLE (-1.0, +1.0)
+    SAMPLE ( 0.0, +1.0)
+    SAMPLE (+1.0, +1.0)
+    "  cogl_texel /= 10.0;\n";
+#undef SAMPLE
+
+/*
+ * bumpmap effect declarations
+ */
+
+#define ST_BACKGROUND_BUMPMAP_EFFECT_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST ((klass), ST_TYPE_BACKGROUND_BUMPMAP_EFFECT, StBackgroundBumpmapEffectClass))
+#define ST_IS_BACKGROUND_BUMPMAP_EFFECT_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE ((klass), ST_TYPE_BACKGROUND_BUMPMAP_EFFECT))
+#define ST_BACKGROUND_BUMPMAP_EFFECT_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS ((obj), ST_TYPE_BACKGROUND_BUMPMAP_EFFECT, StBackgroundBumpmapEffectClass))
+
+G_DEFINE_TYPE (StBackgroundBumpmapEffect, st_background_bumpmap_effect, CLUTTER_TYPE_OFFSCREEN_EFFECT);
 
 enum
 {
   PROP_0,
-
   PROP_BUMPMAP,
-
   PROP_LAST
 };
 
-static GParamSpec *obj_props[PROP_LAST];
-
-static const gchar *box_blur_glsl_declarations =
+static const gchar *box_bumpmap_glsl_declarations =
   "uniform vec3 pixel_step;\n"
   "uniform vec2 bump_step;\n"
   "uniform sampler2D BumpTex;\n";
-static const gchar *box_blur_glsl_shader =
+static const gchar *box_bumpmap_glsl_shader =
   "vec2 vTexCoord = cogl_tex_coord.st;\n"
   "vec4 displtex = vec4(0.0);\n"
   "if (pixel_step.z > 1.5) {\n"
@@ -55,324 +84,134 @@ static const gchar *box_blur_glsl_shader =
   "  cogl_texel =  displtex;\n"
   "}\n";
 
-static gboolean
-st_background_effect_pre_paint (ClutterEffect *effect)
+/*
+ * Blur effect
+ */
+
+gboolean st_paint_background_blur_effect (StBackgroundBlurEffect *self,
+                                          CoglFramebuffer    *fb,
+                                          ClutterActorBox    *box)
 {
-  StBackgroundEffect *self = ST_BACKGROUND_EFFECT (effect);
-  ClutterEffectClass *parent_class;
-  gfloat width;
-  gfloat height;
-  gfloat posx;
-  gfloat posy;
-  guchar *data;
+  uint8_t *data;
+  unsigned int i;
   guint size;
   guint rowstride;
-  glong new_time;
-  gdouble time_used;
-  ClutterActor *stage;
-  gfloat stage_width;
-  gfloat stage_height;
+  CoglOffscreen *offscreen;
+  CoglError *catch_error = NULL;
+  CoglFramebuffer *fbo;
 
-  if (self->bg_bumpmap == NULL)
-    return FALSE;
-
-  if (!clutter_actor_meta_get_enabled (CLUTTER_ACTOR_META (effect)))
-    return FALSE;
-
-  self->actor = clutter_actor_meta_get_actor (CLUTTER_ACTOR_META (effect));
-  if (self->actor == NULL)
-    return FALSE;
+  self->bg_width = ceil(box->x2 - box->x1);
+  self->bg_height = ceil(box->y2 - box->y1);
+  self->bg_posx = ceil(box->x1);
+  self->bg_posy = ceil(box->y1);
 
   if (!clutter_feature_available (CLUTTER_FEATURE_SHADERS_GLSL))
-  {
-    /* if we don't have support for GLSL shaders then we
-     * forcibly disable the ActorMeta
-     */
-    g_warning ("Unable to use the ShaderEffect: the graphics hardware "
-           "or the current GL driver does not implement support "
-           "for the GLSL shading language.");
-    clutter_actor_meta_set_enabled (CLUTTER_ACTOR_META (effect), FALSE);
-    return FALSE;
-  }
-
-  new_time = clock();
-  time_used = ((double) (new_time - self->old_time)*100) / (double) CLOCKS_PER_SEC;
-  self->old_time = new_time;
-
-  posx = 0.0f;
-  posy = 0.0f;
-
-  width = 0.0f;
-  height = 0.0f;
-
-  stage_width = 0.0f;
-  stage_height = 0.0f;
-
-  clutter_actor_get_transformed_position (self->actor, &posx, &posy);
-  clutter_actor_get_transformed_size (self->actor, &width, &height);
-  self->opacity = clutter_actor_get_paint_opacity (self->actor);
-  stage = clutter_actor_get_stage (self->actor);
-  clutter_actor_get_size (stage, &stage_width, &stage_height);
-
-  if ((posx < 0) || (posy < 0) || ((posx + width) > stage_width) || ((posy + height) > stage_height))
-    return FALSE;
-
-  if  (( posx != self->posx_old)
-       || ( posy != self->posy_old)
-       || ( width != self->width_old)
-       || ( height != self->height_old)
-       || (time_used > 50.0))
-
-  {
-    self->posx_old = posx;
-    self->posy_old = posy;
-    self->width_old = width;
-    self->height_old = height;
-
-    self->bg_posx_i = round(posx)+2;
-    self->bg_posy_i = round(posy)+2;
-    self->bg_width_i = round(width)-4;
-    self->bg_height_i = round(height)-4;
-
-    size = (self->bg_width_i) * (self->bg_height_i) * 4;
-
-    if (((self->opacity == 0xff) || (self->bg_texture == NULL)) && (size > 400))
-      {
-        rowstride = (self->bg_width_i) * 4;
-
-
-        data = g_malloc (size);
-
-        cogl_read_pixels (self->bg_posx_i,
-                          self->bg_posy_i,
-                          self->bg_width_i,
-                          self->bg_height_i,
-                          COGL_READ_PIXELS_COLOR_BUFFER,
-                          COGL_PIXEL_FORMAT_RGBA_8888_PRE,
-                          data);
-
-        if (data != NULL)
-          {
-
-            if (self->bg_texture != NULL)
-              {
-                cogl_handle_unref (self->bg_texture);
-                self->bg_texture = NULL;
-              }
-
-            self->bg_texture = st_cogl_texture_new_from_data_wrapper  (self->bg_width_i,
-                                                                       self->bg_height_i,
-                                                                       COGL_TEXTURE_NO_SLICING,
-                                                                       COGL_PIXEL_FORMAT_RGBA_8888_PRE,
-                                                                       COGL_PIXEL_FORMAT_RGBA_8888_PRE,
-                                                                       rowstride,
-                                                                       data);
-
-            g_free (data);
-
-          }
-      }
-  }
-
-  parent_class = CLUTTER_EFFECT_CLASS (st_background_effect_parent_class);
-
-  if (parent_class->pre_paint (effect))
     {
-      ClutterOffscreenEffect *offscreen_effect =  CLUTTER_OFFSCREEN_EFFECT (effect);
-      CoglHandle fg_texture;
-
-      fg_texture = clutter_offscreen_effect_get_texture (offscreen_effect);
-
-      if (fg_texture != COGL_INVALID_HANDLE)
-        {
-          self->fg_width_i = cogl_texture_get_width (fg_texture);
-          self->fg_height_i = cogl_texture_get_height (fg_texture);
-
-          if ((self->bg_texture != NULL) && (self->opacity == 0xff))
-            {
-
-
-              if (self->pixel_step_uniform0 > -1)
-                {
-                  gfloat pixel_step[3];
-
-                  pixel_step[0] = 1.0f / (self->bg_width_i);
-                  pixel_step[1] = 1.0f / (self->bg_height_i);
-                  pixel_step[2] = 0.0f;
-
-                  cogl_pipeline_set_uniform_float (self->pipeline0,
-                                                   self->pixel_step_uniform0,
-                                                   3,
-                                                   1,
-                                                   pixel_step);
-                }
-
-              if (self->BumpTex_uniform > -1)
-                {
-
-                  cogl_pipeline_set_uniform_1i (self->pipeline0,
-                                                self->BumpTex_uniform,
-                                                1);
-                }
-
-              if (self->bump_step_uniform > -1)
-                {
-                  gfloat bump_step[2];
-
-                  bump_step[0] = 1.0f / (self->bumptex_width_i);
-                  bump_step[1] = 1.0f / (self->bumptex_height_i);
-
-                  cogl_pipeline_set_uniform_float (self->pipeline0,
-                                                   self->bump_step_uniform,
-                                                   2,
-                                                   1,
-                                                   bump_step);
-                }
-
-              if (self->bg_sub_texture != NULL)
-                {
-                  cogl_handle_unref (self->bg_sub_texture);
-                  self->bg_sub_texture = NULL;
-                }
-
-              self->bg_sub_texture = st_cogl_texture_new_with_size_wrapper (self->bg_width_i, self->bg_height_i,
-                                                                            COGL_TEXTURE_NO_SLICING,
-                                                                            COGL_PIXEL_FORMAT_RGBA_8888_PRE);
-
-              cogl_pipeline_set_layer_texture (self->pipeline0, 0, self->bg_texture);
-
-              if (self->pixel_step_uniform1 > -1)
-                {
-                  gfloat pixel_step[3];
-
-                  pixel_step[0] = 1.0f / (self->bg_width_i);
-                  pixel_step[1] = 1.0f / (self->bg_height_i);
-                  pixel_step[2] = 1.0f;
-
-                  cogl_pipeline_set_uniform_float (self->pipeline1,
-                                                   self->pixel_step_uniform1,
-                                                   3,
-                                                   1,
-                                                   pixel_step);
-                }
-
-              if (self->pixel_step_uniform2 > -1)
-                {
-                  gfloat pixel_step[3];
-
-                  pixel_step[0] = 1.0f / (self->fg_width_i);
-                  pixel_step[1] = 1.0f / (self->fg_height_i);
-                  pixel_step[2] = 2.0f;
-
-                  cogl_pipeline_set_uniform_float (self->pipeline3,
-                                                   self->pixel_step_uniform2,
-                                                   3,
-                                                   1,
-                                                   pixel_step);
-                }
-
-            }
-
-          cogl_pipeline_set_layer_texture (self->pipeline2, 0, fg_texture);
-          cogl_pipeline_set_layer_texture (self->pipeline3, 0, fg_texture);
-          cogl_pipeline_set_layer_texture (self->pipeline4, 0, fg_texture);
-
-        }
-      return TRUE;
-    }
-  else
-    {
+      g_message ("Unable to use the ShaderEffect: the graphics hardware "
+                 "or the current GL driver does not implement support "
+                 "for the GLSL shading language.");
       return FALSE;
     }
+
+    for (i = 0; i < self->blur_size; i++)  /* process more blur as multiple repetitions */
+    {
+      /* read and stash the section of background currently displayed under the actor */
+
+      size = (self->bg_width) * (self->bg_height) * 4;
+
+      if (size <= 0)
+          return FALSE;
+
+      rowstride = self->bg_width * 4;
+      data = g_malloc (size);
+
+      cogl_framebuffer_read_pixels (fb, self->bg_posx,
+                            self->bg_posy,
+                            self->bg_width,
+                            self->bg_height,
+                            COGL_PIXEL_FORMAT_RGBA_8888_PRE,
+                            data);
+      if (data != NULL)
+        {
+          if (self->bg_texture != NULL)
+            {
+                cogl_handle_unref (self->bg_texture);
+                self->bg_texture = NULL;
+            }
+
+          self->bg_texture = st_cogl_texture_new_from_data_wrapper (self->bg_width,
+                                                                    self->bg_height,
+                                                                    COGL_TEXTURE_NO_SLICING,
+                                                                    COGL_PIXEL_FORMAT_RGBA_8888_PRE,
+                                                                    COGL_PIXEL_FORMAT_RGBA_8888_PRE,
+                                                                    rowstride,
+                                                                    data);
+
+          offscreen = cogl_offscreen_new_with_texture (self->bg_texture);
+          fbo = COGL_FRAMEBUFFER (offscreen);
+
+/*        if (!cogl_framebuffer_allocate (fbo, &catch_error))
+        {
+          cogl_error_free (catch_error);
+          cogl_object_unref (offscreen);
+          cogl_object_unref (self->bg_texture);
+          return FALSE;
+        } */
+
+          g_free (data);
+        }
+
+      if (self->bg_texture == NULL)
+        {
+          g_message("unable to create background texture");
+          return FALSE;
+        }
+
+      if (self->pixel_step_uniform > -1)
+      {
+        gfloat pixel_step[2];
+
+        pixel_step[0] = 1.0f / (self->bg_width);
+        pixel_step[1] = 1.0f / (self->bg_height);
+
+        cogl_pipeline_set_uniform_float (self->pipeline1,
+                                         self->pixel_step_uniform,
+                                         2,
+                                         1,
+                                         pixel_step);
+      }
+
+      cogl_pipeline_set_layer_texture (self->pipeline1, 0, self->bg_texture);
+
+      cogl_framebuffer_draw_rectangle (fb, self->pipeline1, 0, 0, self->bg_width,self->bg_height);
+
+      cogl_object_unref (offscreen);
+    }
+
+    return TRUE;
+}
+
+static gboolean
+st_background_blur_effect_pre_paint (ClutterEffect *effect)
+{
+  return TRUE;
 }
 
 static void
-st_background_effect_paint_target (ClutterOffscreenEffect *effect)
+st_background_blur_effect_paint_target (ClutterOffscreenEffect *effect)
 {
-  StBackgroundEffect *self = ST_BACKGROUND_EFFECT (effect);
-
-  if ((self->bg_texture != NULL) && (self->opacity == 0xff))
-    {
-      CoglOffscreen *vertical_FBO;
-      cogl_push_source (self->pipeline2);
-      cogl_rectangle (0.0f, 0.0f, (self->fg_width_i), (self->fg_height_i));
-      cogl_pop_source ();
-
-      vertical_FBO = cogl_offscreen_new_to_texture (self->bg_sub_texture);
-      cogl_push_framebuffer ((CoglFramebuffer*)vertical_FBO);
-      cogl_push_source (self->pipeline0);
-      cogl_rectangle (-1.0f, 1.0f, 1.0f, -1.0f);
-      cogl_pop_source ();
-      cogl_pop_framebuffer ();
-      cogl_handle_unref (vertical_FBO);
-
-      cogl_pipeline_set_layer_texture (self->pipeline1, 0, self->bg_sub_texture);
-      cogl_push_source (self->pipeline1);
-      cogl_rectangle (4.0f, 4.0f, (self->bg_width_i) + 4.0f,
-                      (self->bg_height_i) + 4.0f);
-      cogl_pop_source ();
-
-    }
-
-  cogl_pipeline_set_color4ub (self->pipeline3,
-                              0x00,
-                              0x00,
-                              0x00,
-                              0x80);
-
-  cogl_push_source (self->pipeline3);
-  cogl_rectangle (0.0f, 0.0f, (self->fg_width_i), (self->fg_height_i));
-  cogl_pop_source ();
-
-  clutter_actor_queue_redraw (self->actor);
-
-  cogl_pipeline_set_color4ub (self->pipeline4,
-                              self->opacity,
-                              self->opacity,
-                              self->opacity,
-                              self->opacity);
-
-  cogl_push_source (self->pipeline4);
-  cogl_rectangle (0.0f, 0.0f, (self->fg_width_i), (self->fg_height_i));
-  cogl_pop_source ();
-
-  clutter_actor_queue_redraw (self->actor);
-
+  return;
 }
 
 static void
-st_background_effect_dispose (GObject *gobject)
+st_background_blur_effect_dispose (GObject *gobject)
 {
-  StBackgroundEffect *self = ST_BACKGROUND_EFFECT (gobject);
-
-  if (self->pipeline0 != NULL)
-    {
-      cogl_object_unref (self->pipeline0);
-      self->pipeline0 = NULL;
-    }
+  StBackgroundBlurEffect *self = ST_BACKGROUND_BLUR_EFFECT (gobject);
 
   if (self->pipeline1 != NULL)
     {
       cogl_object_unref (self->pipeline1);
       self->pipeline1 = NULL;
-    }
-
-  if (self->pipeline2 != NULL)
-    {
-      cogl_object_unref (self->pipeline2);
-      self->pipeline2 = NULL;
-    }
-
-  if (self->pipeline3 != NULL)
-    {
-      cogl_object_unref (self->pipeline3);
-      self->pipeline3 = NULL;
-    }
-
-  if (self->pipeline4 != NULL)
-    {
-      cogl_object_unref (self->pipeline4);
-      self->pipeline4 = NULL;
     }
 
   if (self->bg_texture != NULL)
@@ -381,10 +220,265 @@ st_background_effect_dispose (GObject *gobject)
       self->bg_texture = NULL;
     }
 
-  if (self->bg_sub_texture != NULL)
+  G_OBJECT_CLASS (st_background_blur_effect_parent_class)->dispose (gobject);
+}
+
+static void
+st_background_blur_effect_class_init (StBackgroundBlurEffectClass *klass)
+{
+  ClutterEffectClass *effect_class = CLUTTER_EFFECT_CLASS (klass);
+  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+  ClutterOffscreenEffectClass *offscreen_class;
+
+  effect_class->pre_paint = st_background_blur_effect_pre_paint;
+  gobject_class->dispose = st_background_blur_effect_dispose;
+
+  offscreen_class = CLUTTER_OFFSCREEN_EFFECT_CLASS (klass);
+  offscreen_class->paint_target = st_background_blur_effect_paint_target;
+}
+
+static void
+st_background_blur_effect_init (StBackgroundBlurEffect *self)
+{
+  CoglContext *ctx;
+  CoglSnippet *snippet;
+  StBackgroundBlurEffectClass *klass = ST_BACKGROUND_BLUR_EFFECT_GET_CLASS (self);
+
+  if (G_UNLIKELY (klass->base_pipeline == NULL))
     {
-      cogl_handle_unref (self->bg_sub_texture);
-      self->bg_sub_texture = NULL;
+      ctx = clutter_backend_get_cogl_context (clutter_get_default_backend ());
+      klass->base_pipeline = cogl_pipeline_new (ctx);
+    }
+
+  self->pipeline1 = cogl_pipeline_copy (klass->base_pipeline);
+
+  snippet = cogl_snippet_new (COGL_SNIPPET_HOOK_TEXTURE_LOOKUP,
+                              box_blur_glsl_declarations,
+                              NULL);
+
+  cogl_snippet_set_replace (snippet, box_blur_glsl_shader);
+  cogl_pipeline_add_layer_snippet (self->pipeline1, 0, snippet);
+  cogl_object_unref (snippet);
+
+  cogl_pipeline_set_layer_wrap_mode (self->pipeline1, 0,
+                                     COGL_MATERIAL_WRAP_MODE_CLAMP_TO_EDGE);
+
+  cogl_pipeline_set_cull_face_mode (self->pipeline1,
+                                    COGL_PIPELINE_CULL_FACE_MODE_NONE);
+
+  cogl_pipeline_set_layer_filters (self->pipeline1, 0,
+                                   COGL_PIPELINE_FILTER_LINEAR,
+                                   COGL_PIPELINE_FILTER_LINEAR);
+
+  cogl_pipeline_set_layer_null_texture (self->pipeline1,
+                                        0,
+                                        COGL_TEXTURE_TYPE_2D);
+
+  self->pixel_step_uniform =
+      cogl_pipeline_get_uniform_location (self->pipeline1, "pixel_step");
+
+  self->bg_texture = NULL;
+}
+
+ClutterEffect *
+st_background_blur_effect_new (void)
+{
+  return g_object_new (ST_TYPE_BACKGROUND_BLUR_EFFECT,
+                       NULL);
+}
+
+/*
+ * Bumpmap effect
+ */
+
+
+static gboolean
+st_background_bumpmap_effect_pre_paint (ClutterEffect *effect)
+{
+  return TRUE;
+}
+
+st_background_bumpmap_effect_paint_target (ClutterOffscreenEffect *effect)
+{
+  return;
+}
+
+gboolean st_paint_background_bumpmap_effect (StBackgroundBumpmapEffect *self,
+                                             CoglFramebuffer    *fb,
+                                             ClutterActorBox    *box)
+{
+  GFile *file;
+  uint8_t *data;
+  guint size;
+  guint rowstride;
+  CoglOffscreen *offscreen;
+  CoglError *catch_error = NULL;
+  CoglFramebuffer *fbo;
+
+  self->bg_width = ceil(box->x2 - box->x1);
+  self->bg_height = ceil(box->y2 - box->y1);
+  self->bg_posx = ceil(box->x1);
+  self->bg_posy = ceil(box->y1);
+
+  if (!clutter_feature_available (CLUTTER_FEATURE_SHADERS_GLSL))
+    {
+      g_message ("Unable to use the ShaderEffect: the graphics hardware "
+                 "or the current GL driver does not implement support "
+                 "for the GLSL shading language.");
+
+      return FALSE;
+    }
+
+    /* read the bumpmap in */
+
+  if (self->bg_bumpmap != NULL)
+    {
+      cogl_handle_unref (self->bg_bumpmap);
+      self->bg_bumpmap = NULL;
+    }
+
+  if (self->bumpmap_path == NULL)
+    {
+      return FALSE;
+    }
+
+  file = g_file_new_for_path (self->bumpmap_path);
+  if (g_file_query_exists (file, NULL))
+    {
+      self->bg_bumpmap = st_cogl_texture_new_from_file_wrapper (self->bumpmap_path,
+                                                                COGL_TEXTURE_NO_SLICING,
+                                                                COGL_PIXEL_FORMAT_RGBA_8888_PRE);
+    }
+
+  g_object_unref (file);
+
+  if (self->bg_bumpmap != NULL)
+    {
+      self->bumptex_width = cogl_texture_get_width (self->bg_bumpmap);
+      self->bumptex_height = cogl_texture_get_height (self->bg_bumpmap);
+
+      cogl_pipeline_set_layer_texture (self->pipeline0, 1, self->bg_bumpmap);
+    }
+  else
+    {
+      cogl_pipeline_set_layer_null_texture (self->pipeline0,
+                                            1,
+                                            COGL_TEXTURE_TYPE_2D);
+    }
+
+    /* read and stash the section of background currently displayed under the actor */
+
+    size = (self->bg_width) * (self->bg_height) * 4;
+
+    if (size <= 0)
+        return FALSE;
+
+    rowstride = self->bg_width * 4;
+    data = g_malloc (size);
+
+    cogl_framebuffer_read_pixels (fb, self->bg_posx,
+                          self->bg_posy,
+                          self->bg_width,
+                          self->bg_height,
+                          COGL_PIXEL_FORMAT_RGBA_8888_PRE,
+                          data);
+    if (data != NULL)
+      {
+        if (self->bg_texture != NULL)
+            {
+                cogl_handle_unref (self->bg_texture);
+                self->bg_texture = NULL;
+            }
+
+        self->bg_texture = st_cogl_texture_new_from_data_wrapper (self->bg_width,
+                                                            self->bg_height,
+                                   COGL_TEXTURE_NO_SLICING,
+                                   COGL_PIXEL_FORMAT_RGBA_8888_PRE,
+                                   COGL_PIXEL_FORMAT_RGBA_8888_PRE,
+                                                   rowstride,
+                                                   data);
+
+        offscreen = cogl_offscreen_new_with_texture (self->bg_texture);
+        fbo = COGL_FRAMEBUFFER (offscreen);
+ /*       if (!cogl_framebuffer_allocate (fbo, &catch_error))
+        {
+          cogl_error_free (catch_error);
+          cogl_object_unref (offscreen);
+          cogl_object_unref (self->bg_texture);
+          return FALSE;
+        } */
+
+        g_free (data);
+      }
+
+    if (self->bg_texture == NULL)
+      {
+        g_message("unable to create background texture");
+        return FALSE;
+      }
+
+    /* set uniforms */
+
+    if (self->pixel_step_uniform0 > -1)
+      {
+       gfloat pixel_step[3];
+
+        pixel_step[0] = 1.0f / (self->bg_width);
+        pixel_step[1] = 1.0f / (self->bg_height);
+        pixel_step[2] = 0.0f;
+
+        cogl_pipeline_set_uniform_float (self->pipeline0,
+                                         self->pixel_step_uniform0,
+                                         3,
+                                         1,
+                                         pixel_step);
+      }
+
+    if (self->BumpTex_uniform > -1)
+      {
+        cogl_pipeline_set_uniform_1i (self->pipeline0,
+                                      self->BumpTex_uniform,
+                                      1);
+      }
+
+     if (self->bump_step_uniform > -1)
+      {
+        gfloat bump_step[2];
+
+        bump_step[0] = 1.0f / (self->bumptex_width);
+        bump_step[1] = 1.0f / (self->bumptex_height);
+
+        cogl_pipeline_set_uniform_float (self->pipeline0,
+                                         self->bump_step_uniform,
+                                         2,
+                                         1,
+                                         bump_step);
+      }
+
+    cogl_pipeline_set_layer_texture (self->pipeline0, 0, self->bg_texture);
+
+    cogl_framebuffer_draw_rectangle (fb, self->pipeline0, 0, 0, self->bg_width,self->bg_height);
+
+    cogl_object_unref (offscreen);
+
+    return TRUE;
+}
+
+static void
+st_background_bumpmap_effect_dispose (GObject *gobject)
+{
+  StBackgroundBumpmapEffect *self = ST_BACKGROUND_BUMPMAP_EFFECT (gobject);
+
+  if (self->pipeline0 != NULL)
+    {
+      cogl_object_unref (self->pipeline0);
+      self->pipeline0 = NULL;
+    }
+
+  if (self->bg_texture != NULL)
+    {
+      cogl_handle_unref (self->bg_texture);
+      self->bg_texture = NULL;
     }
 
   if (self->bg_bumpmap != NULL)
@@ -393,140 +487,44 @@ st_background_effect_dispose (GObject *gobject)
       self->bg_bumpmap = NULL;
     }
 
-  G_OBJECT_CLASS (st_background_effect_parent_class)->dispose (gobject);
+  G_OBJECT_CLASS (st_background_bumpmap_effect_parent_class)->dispose (gobject);
 }
 
 static void
-st_background_effect_set_property (GObject      *gobject,
-                                   guint         prop_id,
-                                   const GValue *value,
-                                   GParamSpec   *pspec)
-{
-  StBackgroundEffect *self = ST_BACKGROUND_EFFECT (gobject);
-  GFile *file;
-
-  switch (prop_id)
-    {
-    case PROP_BUMPMAP:
-
-      self->bumpmap_location = g_value_dup_string (value);
-
-      if (self->bg_bumpmap != NULL)
-        {
-          cogl_handle_unref (self->bg_bumpmap);
-          self->bg_bumpmap = NULL;
-        }
-
-      if (self->bumpmap_location == NULL)
-        {
-          break;
-        }
-
-      file = g_file_new_for_path (g_strdup (self->bumpmap_location));
-      if (g_file_query_exists (file, NULL))
-        {
-          self->bg_bumpmap = st_cogl_texture_new_from_file_wrapper (self->bumpmap_location,
-                                                                    COGL_TEXTURE_NO_SLICING,
-                                                                    COGL_PIXEL_FORMAT_RGBA_8888_PRE);
-        }
-
-      g_object_unref (file);
-
-      if (self->bg_bumpmap != NULL)
-        {
-          self->bumptex_width_i = cogl_texture_get_width (self->bg_bumpmap);
-          self->bumptex_height_i = cogl_texture_get_height (self->bg_bumpmap);
-
-          cogl_pipeline_set_layer_texture (self->pipeline0, 1, self->bg_bumpmap);
-        }
-      else
-        {
-          cogl_pipeline_set_layer_null_texture (self->pipeline0,
-                                                1,
-                                                COGL_TEXTURE_TYPE_2D);
-        }
-
-      break;
-
-    default:
-      G_OBJECT_WARN_INVALID_PROPERTY_ID (gobject, prop_id, pspec);
-      break;
-    }
-}
-
-static void
-st_background_effect_get_property (GObject    *gobject,
-                                   guint       prop_id,
-                                   GValue     *value,
-                                   GParamSpec *pspec)
-{
-  StBackgroundEffect *self = ST_BACKGROUND_EFFECT (gobject);
-
-  switch (prop_id)
-    {
-    case PROP_BUMPMAP:
-      g_value_set_string (value, self->bumpmap_location);
-      break;
-
-    default:
-      G_OBJECT_WARN_INVALID_PROPERTY_ID (gobject, prop_id, pspec);
-      break;
-    }
-}
-
-static void
-st_background_effect_class_init (StBackgroundEffectClass *klass)
+st_background_bumpmap_effect_class_init (StBackgroundBumpmapEffectClass *klass)
 {
   ClutterEffectClass *effect_class = CLUTTER_EFFECT_CLASS (klass);
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
   ClutterOffscreenEffectClass *offscreen_class;
 
-  effect_class->pre_paint = st_background_effect_pre_paint;
-  gobject_class->set_property = st_background_effect_set_property;
-  gobject_class->get_property = st_background_effect_get_property;
-  gobject_class->dispose = st_background_effect_dispose;
-  
+  effect_class->pre_paint = st_background_bumpmap_effect_pre_paint;
+  gobject_class->dispose = st_background_bumpmap_effect_dispose;
+
   offscreen_class = CLUTTER_OFFSCREEN_EFFECT_CLASS (klass);
-  offscreen_class->paint_target = st_background_effect_paint_target;
-
-  obj_props[PROP_BUMPMAP] =
-    g_param_spec_string ("bumpmap",
-                         "Background effect construct prop",
-                         "Set bumpmap path",
-                         "/usr/share/cinnamon/bumpmaps/bumpmap.png",
-                         G_PARAM_READWRITE);
-
-  g_object_class_install_properties (gobject_class, PROP_LAST, obj_props);
+  offscreen_class->paint_target = st_background_bumpmap_effect_paint_target;
 }
 
 static void
-st_background_effect_init (StBackgroundEffect *self)
+st_background_bumpmap_effect_init (StBackgroundBumpmapEffect *self)
 {
   CoglContext *ctx;
   CoglSnippet *snippet;
-  StBackgroundEffectClass *klass = ST_BACKGROUND_EFFECT_GET_CLASS (self);
+  StBackgroundBumpmapEffectClass *klass = ST_BACKGROUND_BUMPMAP_EFFECT_GET_CLASS (self);
 
   if (G_UNLIKELY (klass->base_pipeline == NULL))
     {
       ctx = clutter_backend_get_cogl_context (clutter_get_default_backend ());
-
       klass->base_pipeline = cogl_pipeline_new (ctx);
     }
-    
+
   self->pipeline0 = cogl_pipeline_copy (klass->base_pipeline);
-  self->pipeline1 = cogl_pipeline_copy (klass->base_pipeline);
-  self->pipeline2 = cogl_pipeline_copy (klass->base_pipeline);
-  self->pipeline3 = cogl_pipeline_copy (klass->base_pipeline);
-  self->pipeline4 = cogl_pipeline_copy (klass->base_pipeline);
 
   snippet = cogl_snippet_new (COGL_SNIPPET_HOOK_TEXTURE_LOOKUP,
-                              box_blur_glsl_declarations,
+                              box_bumpmap_glsl_declarations,
                               NULL);
 
-  cogl_snippet_set_replace (snippet, box_blur_glsl_shader);
+  cogl_snippet_set_replace (snippet, box_bumpmap_glsl_shader);
   cogl_pipeline_add_layer_snippet (self->pipeline0, 0, snippet);
-  cogl_pipeline_add_layer_snippet (self->pipeline1, 0, snippet);
-  cogl_pipeline_add_layer_snippet (self->pipeline3, 0, snippet);
   cogl_object_unref (snippet);
 
   cogl_pipeline_set_layer_wrap_mode (self->pipeline0, 0,
@@ -535,31 +533,7 @@ st_background_effect_init (StBackgroundEffect *self)
   cogl_pipeline_set_layer_wrap_mode (self->pipeline0, 1,
                                      COGL_PIPELINE_WRAP_MODE_REPEAT);
 
-  cogl_pipeline_set_layer_wrap_mode (self->pipeline1, 0,
-                                     COGL_MATERIAL_WRAP_MODE_CLAMP_TO_EDGE);
-
-  cogl_pipeline_set_layer_wrap_mode (self->pipeline2, 0,
-                                     COGL_MATERIAL_WRAP_MODE_CLAMP_TO_EDGE);
-
-  cogl_pipeline_set_layer_wrap_mode (self->pipeline3, 0,
-                                     COGL_MATERIAL_WRAP_MODE_CLAMP_TO_EDGE);
-
-  cogl_pipeline_set_layer_wrap_mode (self->pipeline4, 0,
-                                     COGL_MATERIAL_WRAP_MODE_CLAMP_TO_EDGE);
-
   cogl_pipeline_set_cull_face_mode (self->pipeline0,
-                                    COGL_PIPELINE_CULL_FACE_MODE_NONE);
-
-  cogl_pipeline_set_cull_face_mode (self->pipeline1,
-                                    COGL_PIPELINE_CULL_FACE_MODE_NONE);
-
-  cogl_pipeline_set_cull_face_mode (self->pipeline2,
-                                    COGL_PIPELINE_CULL_FACE_MODE_NONE);
-
-  cogl_pipeline_set_cull_face_mode (self->pipeline3,
-                                    COGL_PIPELINE_CULL_FACE_MODE_NONE);
-
-  cogl_pipeline_set_cull_face_mode (self->pipeline4,
                                     COGL_PIPELINE_CULL_FACE_MODE_NONE);
 
   cogl_pipeline_set_layer_filters (self->pipeline0, 0,
@@ -570,39 +544,7 @@ st_background_effect_init (StBackgroundEffect *self)
                                    COGL_PIPELINE_FILTER_NEAREST,
                                    COGL_PIPELINE_FILTER_NEAREST);
 
-  cogl_pipeline_set_layer_filters (self->pipeline1, 0,
-                                   COGL_PIPELINE_FILTER_LINEAR,
-                                   COGL_PIPELINE_FILTER_LINEAR);
-
-  cogl_pipeline_set_layer_filters (self->pipeline2, 0,
-                                   COGL_PIPELINE_FILTER_LINEAR,
-                                   COGL_PIPELINE_FILTER_LINEAR);
-
-  cogl_pipeline_set_layer_filters (self->pipeline3, 0,
-                                   COGL_PIPELINE_FILTER_LINEAR,
-                                   COGL_PIPELINE_FILTER_LINEAR);
-
-  cogl_pipeline_set_layer_filters (self->pipeline4, 0,
-                                   COGL_PIPELINE_FILTER_LINEAR,
-                                   COGL_PIPELINE_FILTER_LINEAR);
-
   cogl_pipeline_set_layer_null_texture (self->pipeline0,
-                                        0,
-                                        COGL_TEXTURE_TYPE_2D);
-
-  cogl_pipeline_set_layer_null_texture (self->pipeline1,
-                                        0,
-                                        COGL_TEXTURE_TYPE_2D);
-
-  cogl_pipeline_set_layer_null_texture (self->pipeline2,
-                                        0,
-                                        COGL_TEXTURE_TYPE_2D);
-
-  cogl_pipeline_set_layer_null_texture (self->pipeline3,
-                                        0,
-                                        COGL_TEXTURE_TYPE_2D);
-  
-  cogl_pipeline_set_layer_null_texture (self->pipeline4,
                                         0,
                                         COGL_TEXTURE_TYPE_2D);
 
@@ -615,73 +557,21 @@ st_background_effect_init (StBackgroundEffect *self)
   self->bump_step_uniform =
     cogl_pipeline_get_uniform_location (self->pipeline0, "bump_step");
 
-  self->pixel_step_uniform1 =
-    cogl_pipeline_get_uniform_location (self->pipeline1, "pixel_step");
-
-  self->pixel_step_uniform2 =
-    cogl_pipeline_get_uniform_location (self->pipeline3, "pixel_step");
-
   cogl_pipeline_set_blend (self->pipeline0,
                            "RGBA = ADD(SRC_COLOR, DST_COLOR*0)",
                            NULL);
 
-  cogl_pipeline_set_blend (self->pipeline1,
-                           "RGBA = ADD (SRC_COLOR*DST_COLOR[A], DST_COLOR*(1-DST_COLOR[A]))",
-                           NULL);
-
-  cogl_pipeline_set_color4ub (self->pipeline1,
-                              0xff,
-                              0xff,
-                              0xff,
-                              0xff);
-
-  cogl_pipeline_set_alpha_test_function (self->pipeline2,
-                                         COGL_PIPELINE_ALPHA_FUNC_LESS,
-                                         0.004f);
-
-  cogl_pipeline_set_color_mask (self->pipeline2,
-                                COGL_COLOR_MASK_ALPHA);
-
-  cogl_pipeline_set_blend (self->pipeline2,
-                           "RGBA = ADD(SRC_COLOR, DST_COLOR*0)",
-                           NULL);
-
-  cogl_pipeline_set_alpha_test_function (self->pipeline3,
-                                         COGL_PIPELINE_ALPHA_FUNC_GEQUAL,
-                                         0.004f);
-    
-  cogl_pipeline_set_color_mask (self->pipeline3,
-                                COGL_COLOR_MASK_ALL);
-
-  cogl_pipeline_set_blend (self->pipeline3,
-                           "RGBA = ADD (SRC_COLOR, DST_COLOR*(1-SRC_COLOR[A]))",
-                           NULL);
-
-  cogl_pipeline_set_alpha_test_function (self->pipeline4,
-                                         COGL_PIPELINE_ALPHA_FUNC_GEQUAL,
-                                         0.004f);
-    
-  cogl_pipeline_set_color_mask (self->pipeline4,
-                                COGL_COLOR_MASK_ALL);
-
-  cogl_pipeline_set_blend (self->pipeline4,
-                           "RGBA = ADD (SRC_COLOR, DST_COLOR*(1-SRC_COLOR[A]))",
-                           NULL);
-
-
   self->bg_texture = NULL;
 
-  self->bg_sub_texture = NULL;
+  self->bumpmap_path = "/usr/share/cinnamon/bumpmaps/frost.png";
 
-  self->bumpmap_location = "/usr/share/cinnamon/bumpmaps/frost.png";
-
-  self->bg_bumpmap = st_cogl_texture_new_from_file_wrapper (self->bumpmap_location,
+  self->bg_bumpmap = st_cogl_texture_new_from_file_wrapper (self->bumpmap_path,
                                                             COGL_TEXTURE_NO_SLICING,
                                                             COGL_PIXEL_FORMAT_RGBA_8888_PRE);
   if (self->bg_bumpmap != NULL)
     {
-      self->bumptex_width_i = cogl_texture_get_width (self->bg_bumpmap);
-      self->bumptex_height_i = cogl_texture_get_height (self->bg_bumpmap);
+      self->bumptex_width = cogl_texture_get_width (self->bg_bumpmap);
+      self->bumptex_height = cogl_texture_get_height (self->bg_bumpmap);
 
       cogl_pipeline_set_layer_texture (self->pipeline0, 1, self->bg_bumpmap);
     }
@@ -695,17 +585,17 @@ st_background_effect_init (StBackgroundEffect *self)
   cogl_pipeline_set_layer_combine (self->pipeline0,1,
                                    "RGBA = REPLACE (PREVIOUS)",
                                    NULL);
-
-  self->old_time = 0;
-
-  self->opacity = 0;
-
 }
 
 ClutterEffect *
-st_background_effect_new ()
+st_background_bumpmap_effect_new (void)
 {
-  return g_object_new (ST_TYPE_BACKGROUND_EFFECT,
+  return g_object_new (ST_TYPE_BACKGROUND_BUMPMAP_EFFECT,
                        NULL);
 }
+
+
+/*
+ *  Common code for effects
+ */
 

--- a/src/st/st-background-effect.c
+++ b/src/st/st-background-effect.c
@@ -92,13 +92,8 @@ gboolean st_paint_background_blur_effect (StBackgroundBlurEffect *self,
                                           CoglFramebuffer    *fb,
                                           ClutterActorBox    *box)
 {
-  uint8_t *data;
   unsigned int i;
-  guint size;
-  guint rowstride;
-  CoglOffscreen *offscreen;
-  CoglError *catch_error = NULL;
-  CoglFramebuffer *fbo;
+
 
   self->bg_width = ceil(box->x2 - box->x1);
   self->bg_height = ceil(box->y2 - box->y1);
@@ -115,6 +110,9 @@ gboolean st_paint_background_blur_effect (StBackgroundBlurEffect *self,
 
     for (i = 0; i < self->blur_size; i++)  /* process more blur as multiple repetitions */
     {
+      uint8_t *data;
+      guint size;
+      guint rowstride;
       /* read and stash the section of background currently displayed under the actor */
 
       size = (self->bg_width) * (self->bg_height) * 4;
@@ -147,17 +145,6 @@ gboolean st_paint_background_blur_effect (StBackgroundBlurEffect *self,
                                                                     rowstride,
                                                                     data);
 
-          offscreen = cogl_offscreen_new_with_texture (self->bg_texture);
-          fbo = COGL_FRAMEBUFFER (offscreen);
-
-/*        if (!cogl_framebuffer_allocate (fbo, &catch_error))
-        {
-          cogl_error_free (catch_error);
-          cogl_object_unref (offscreen);
-          cogl_object_unref (self->bg_texture);
-          return FALSE;
-        } */
-
           g_free (data);
         }
 
@@ -184,8 +171,6 @@ gboolean st_paint_background_blur_effect (StBackgroundBlurEffect *self,
       cogl_pipeline_set_layer_texture (self->pipeline1, 0, self->bg_texture);
 
       cogl_framebuffer_draw_rectangle (fb, self->pipeline1, 0, 0, self->bg_width,self->bg_height);
-
-      cogl_object_unref (offscreen);
     }
 
     return TRUE;
@@ -311,9 +296,6 @@ gboolean st_paint_background_bumpmap_effect (StBackgroundBumpmapEffect *self,
   uint8_t *data;
   guint size;
   guint rowstride;
-  CoglOffscreen *offscreen;
-  CoglError *catch_error = NULL;
-  CoglFramebuffer *fbo;
 
   self->bg_width = ceil(box->x2 - box->x1);
   self->bg_height = ceil(box->y2 - box->y1);
@@ -391,23 +373,12 @@ gboolean st_paint_background_bumpmap_effect (StBackgroundBumpmapEffect *self,
             }
 
         self->bg_texture = st_cogl_texture_new_from_data_wrapper (self->bg_width,
-                                                            self->bg_height,
-                                   COGL_TEXTURE_NO_SLICING,
-                                   COGL_PIXEL_FORMAT_RGBA_8888_PRE,
-                                   COGL_PIXEL_FORMAT_RGBA_8888_PRE,
-                                                   rowstride,
-                                                   data);
-
-        offscreen = cogl_offscreen_new_with_texture (self->bg_texture);
-        fbo = COGL_FRAMEBUFFER (offscreen);
- /*       if (!cogl_framebuffer_allocate (fbo, &catch_error))
-        {
-          cogl_error_free (catch_error);
-          cogl_object_unref (offscreen);
-          cogl_object_unref (self->bg_texture);
-          return FALSE;
-        } */
-
+                                                                  self->bg_height,
+                                                                  COGL_TEXTURE_NO_SLICING,
+                                                                  COGL_PIXEL_FORMAT_RGBA_8888_PRE,
+                                                                  COGL_PIXEL_FORMAT_RGBA_8888_PRE,
+                                                                  rowstride,
+                                                                  data);
         g_free (data);
       }
 
@@ -458,8 +429,6 @@ gboolean st_paint_background_bumpmap_effect (StBackgroundBumpmapEffect *self,
     cogl_pipeline_set_layer_texture (self->pipeline0, 0, self->bg_texture);
 
     cogl_framebuffer_draw_rectangle (fb, self->pipeline0, 0, 0, self->bg_width,self->bg_height);
-
-    cogl_object_unref (offscreen);
 
     return TRUE;
 }

--- a/src/st/st-background-effect.h
+++ b/src/st/st-background-effect.h
@@ -2,70 +2,95 @@
 #define __ST_BACKGROUND_EFFECT_H__
 
 #include <clutter/clutter.h>
+
 G_BEGIN_DECLS
-#define ST_TYPE_BACKGROUND_EFFECT        (st_background_effect_get_type ())
-#define ST_BACKGROUND_EFFECT(obj)        (G_TYPE_CHECK_INSTANCE_CAST ((obj), ST_TYPE_BACKGROUND_EFFECT, StBackgroundEffect))
-#define ST_IS_BACKGROUND_EFFECT(obj)     (G_TYPE_CHECK_INSTANCE_TYPE ((obj), ST_TYPE_BACKGROUND_EFFECT))
+#define ST_TYPE_BACKGROUND_BLUR_EFFECT        (st_background_blur_effect_get_type ())
+#define ST_TYPE_BACKGROUND_BUMPMAP_EFFECT        (st_background_bumpmap_effect_get_type ())
 
-typedef struct _StBackgroundEffect        StBackgroundEffect;
-typedef struct _StBackgroundEffectClass   StBackgroundEffectClass;
+#define ST_BACKGROUND_BLUR_EFFECT(obj)        (G_TYPE_CHECK_INSTANCE_CAST ((obj), ST_TYPE_BACKGROUND_BLUR_EFFECT, StBackgroundBlurEffect))
+#define ST_IS_BACKGROUND_BLUR_EFFECT(obj)     (G_TYPE_CHECK_INSTANCE_TYPE ((obj), ST_TYPE_BACKGROUND_EFFECT))
 
+#define ST_BACKGROUND_BUMPMAP_EFFECT(obj)        (G_TYPE_CHECK_INSTANCE_CAST ((obj), ST_TYPE_BACKGROUND_BUMPMAP_EFFECT, StBackgroundBumpmapEffect))
+#define ST_IS_BACKGROUND_BUMPMAP_EFFECT(obj)     (G_TYPE_CHECK_INSTANCE_TYPE ((obj), ST_TYPE_BACKGROUND_BUMPMAP_EFFECT))
+
+typedef struct _StBackgroundBlurEffect        StBackgroundBlurEffect;
+typedef struct _StBackgroundBlurEffectClass   StBackgroundBlurEffectClass;
+
+typedef struct _StBackgroundBumpmapEffect        StBackgroundBumpmapEffect;
+typedef struct _StBackgroundBumpmapEffectClass   StBackgroundBumpmapEffectClass;
 /* object */
 
-struct _StBackgroundEffect
+struct _StBackgroundBlurEffect
 {
     ClutterOffscreenEffect parent_instance;
 
     ClutterActor *actor;
-    CoglHandle bg_texture;
-    CoglHandle bg_sub_texture;
-    CoglHandle bg_bumpmap;
-    gchar* bumpmap_location;
+    CoglTexture  *bg_texture;
+
+    gint pixel_step_uniform;
+    gint blur_size;
+
+    gint bg_posx;
+    gint bg_posy;
+
+    gint bg_width;
+    gint bg_height;
+
+    CoglPipeline *pipeline1;
+};
+
+struct _StBackgroundBumpmapEffect
+{
+    ClutterOffscreenEffect parent_instance;
+
+    ClutterActor *actor;
+    CoglTexture  *bg_texture;
+    CoglHandle    bg_bumpmap;
+    char         *bumpmap_path;
 
     gint pixel_step_uniform0;
-    gint pixel_step_uniform1;
-    gint pixel_step_uniform2;
     gint BumpTex_uniform;
     gint bump_step_uniform;
+    
+    gint bg_posx;
+    gint bg_posy;
 
-    gint bg_posx_i;
-    gint bg_posy_i;
+    gint bg_width;
+    gint bg_height;
 
-    gint bg_width_i;
-    gint bg_height_i;
-
-    gint fg_width_i;
-    gint fg_height_i;
-
-    gint bumptex_width_i;
-    gint bumptex_height_i;
-
-    gfloat posx_old;
-    gfloat posy_old;
-    gfloat width_old;
-    gfloat height_old;
+    gint bumptex_width;
+    gint bumptex_height;
 
     CoglPipeline *pipeline0;
-    CoglPipeline *pipeline1;
-    CoglPipeline *pipeline2;
-    CoglPipeline *pipeline3;
-    CoglPipeline *pipeline4;
-
-    glong old_time;
-    guint8 opacity;
 };
 
 /* class */
 
-struct _StBackgroundEffectClass
+struct _StBackgroundBlurEffectClass
 {
     ClutterOffscreenEffectClass parent_class;
     CoglPipeline *base_pipeline;
+    gboolean changed;
+};
+struct _StBackgroundBumpmapEffectClass
+{
+    ClutterOffscreenEffectClass parent_class;
+    CoglPipeline *base_pipeline;
+    gboolean changed;
 };
 
-GType   st_background_effect_get_type (void) G_GNUC_CONST;
+GType   st_background_blur_effect_get_type (void) G_GNUC_CONST;
+GType   st_background_bumpmap_effect_get_type (void) G_GNUC_CONST;
 
-ClutterEffect *st_background_effect_new (void);
+ClutterEffect *st_background_blur_effect_new (void);
+ClutterEffect *st_background_bumpmap_effect_new (void);
+
+gboolean st_paint_background_blur_effect (StBackgroundBlurEffect *background_blur_effect,
+                                     CoglFramebuffer     *fb,
+                                     ClutterActorBox *box);
+gboolean st_paint_background_bumpmap_effect (StBackgroundBumpmapEffect *background_blur_effect,
+                                     CoglFramebuffer     *fb,
+                                     ClutterActorBox *box);
 
 G_END_DECLS
 #endif /* __ST_BACKGROUND_EFFECT_H__ */

--- a/src/st/st-theme-node-drawing.c
+++ b/src/st/st-theme-node-drawing.c
@@ -36,6 +36,7 @@
 #include "st-texture-cache.h"
 #include "st-theme-node-private.h"
 #include "st-cogl-wrapper.h"
+#include "st-background-effect.h"
 
 /****
  * Rounded corners
@@ -1986,7 +1987,9 @@ void
 st_theme_node_paint (StThemeNode           *node,
                      CoglFramebuffer       *fb,
                      const ClutterActorBox *box,
-                     guint8                 paint_opacity)
+                     guint8                 paint_opacity,
+                     StBackgroundBlurEffect    *background_blur_effect,
+                     StBackgroundBumpmapEffect *background_bumpmap_effect)
 {
   float width, height;
   ClutterActorBox allocation;
@@ -2029,6 +2032,18 @@ st_theme_node_paint (StThemeNode           *node,
    *    instead of the outside edges of the border (but position the image
    *    such that it's aligned to the outside edges)
    */
+
+
+  /* if there is a background effect then paint it first as a bottom layer
+     i.e. the existing background under the actor will be found, an effect
+     generated and applied to it, and then the new background is written out
+     over the existing background. */
+
+  if (background_blur_effect)
+      st_paint_background_blur_effect (background_blur_effect, fb, box);
+
+  if (background_bumpmap_effect)
+      st_paint_background_bumpmap_effect (background_bumpmap_effect, fb, box);
 
   if (node->box_shadow_material)
     _st_paint_shadow_with_opacity (node->box_shadow,

--- a/src/st/st-theme-node-private.h
+++ b/src/st/st-theme-node-private.h
@@ -71,6 +71,7 @@ struct _StThemeNode {
 
   char *background_image;
   char *background_bumpmap;
+  guint background_blur;
   StBorderImage *border_image;
   StShadow *box_shadow;
   StShadow *background_image_shadow;

--- a/src/st/st-theme-node-transition.c
+++ b/src/st/st-theme-node-transition.c
@@ -298,11 +298,9 @@ setup_framebuffers (StThemeNodeTransition *transition,
                                  priv->offscreen_box.x2,
                                  priv->offscreen_box.y2, 0.0, 1.0);
 
-  st_theme_node_paint (priv->old_theme_node, priv->old_offscreen, allocation, 255);
+  st_theme_node_paint (priv->old_theme_node, priv->old_offscreen, allocation, 255, NULL, NULL);
 
-  st_theme_node_paint (priv->new_theme_node, priv->new_offscreen, allocation, 255);
-
-  return TRUE;
+  st_theme_node_paint (priv->new_theme_node, priv->new_offscreen, allocation, 255, NULL, NULL);
 }
 
 void

--- a/src/st/st-theme-node.c
+++ b/src/st/st-theme-node.c
@@ -1811,6 +1811,7 @@ _st_theme_node_ensure_background (StThemeNode *node)
   node->background_gradient_type = ST_GRADIENT_NONE;
   node->background_position_set = FALSE;
   node->background_size = ST_BACKGROUND_SIZE_AUTO;
+  node->background_blur = 0;
 
   ensure_properties (node);
 
@@ -2070,6 +2071,10 @@ _st_theme_node_ensure_background (StThemeNode *node)
       else if (strcmp (property_name, "-gradient-end") == 0)
         {
           get_color_from_term (node, decl->value, &node->background_gradient_end);
+        }
+      else if (strcmp (property_name, "-blur") == 0)
+        {
+          get_length_from_term_int (node, decl->value, FALSE, &node->background_blur);
         }
     }
 }

--- a/src/st/st-theme-node.h
+++ b/src/st/st-theme-node.h
@@ -27,6 +27,7 @@
 #include "st-border-image.h"
 #include "st-icon-colors.h"
 #include "st-shadow.h"
+#include "st-background-effect.h"
 
 G_BEGIN_DECLS
 
@@ -248,7 +249,9 @@ gboolean st_theme_node_paint_equal    (StThemeNode *node,
 void st_theme_node_paint (StThemeNode            *node,
                           CoglFramebuffer        *framebuffer,
                           const ClutterActorBox  *box,
-                          guint8                  paint_opacity);
+                          guint8                  paint_opacity,
+                          StBackgroundBlurEffect    *background_blur_effect,
+                          StBackgroundBumpmapEffect *background_bumpmap_effect);
 
 void st_theme_node_copy_cached_paint_state (StThemeNode *node,
                                             StThemeNode *other);


### PR DESCRIPTION
This reworks, enables, and extends the previous background effect facility that was turned off last release as it was broken.

There are two possible background effects - bumpmap and blur.  Both are turned on by CSS, and can be layered on each other if desired.
example CSS 

    background-bumpmap: url("/usr/share/cinnamon/bumpmaps/hex.png");
    background-blur: 1px;

Note that the size of the blur is treated as an iteration count.  So background-blur: 1px is the basic effect, while background-blur: 2px  applies the effect again on top of itself, and so on.  The basic blur is relatively mild, twice is stronger, anything above 3 is overkill IMO.
Speeds seem fine with no noticeable speed penalty unless a large blur count is put in for test purposes.

The blur effect is probably the more useful.  The bumpmap effect looks dramatic on a background, but rubbish over something like a text file being edited.

The effect works by snapshotting the screen underneath an actor, applying the effect to it, and then drawing it out as the lowest layer in the process of drawing an actor.  There are no restrictions as to what can be layered on it, though clearly you won't want to put something without transparency over it or the effect would be hidden.

In the screenshots below the bumpmap is shown with nothing layered on it.  The  blur is shown with a semi-transparent background-gradient on top of it.

Still to do:

1) Mask out the corners where there is a border radius.  You can see the effect bleeding outside the border in the images below.
2) Consider other potential effects
3) Optimise

![screenshot from 2018-04-08 13-59-20](https://user-images.githubusercontent.com/6322481/38468146-04112868-3b3a-11e8-8392-dec2b358c101.png)

![screenshot from 2018-04-08 13-58-16](https://user-images.githubusercontent.com/6322481/38468161-2405a7e8-3b3a-11e8-9ac9-47e8b7d26c94.png)
