### PR TITLE
PEP8ify

### DIFF
--- a/files/usr/bin/cinnamon-json-makepot
+++ b/files/usr/bin/cinnamon-json-makepot
@@ -18,8 +18,8 @@ args = sys.argv[1:]
 if '-h' in args:
     print("cinnamon-json-makepot is deprecated - please use cinnamon-xlet-makepot instead\ntype cinnamon-xlet-makepot -h for usage information.")
     quit()
-elif '-i' not in args and '--install' not in args and
-     '-r' not in args and '--remove' not in args:
+if '-i' not in args and '--install' not in args and \
+   '-r' not in args and '--remove' not in args:
     potfile = args.pop()
     if '-j' in args:
         args.remove('-j')

--- a/files/usr/bin/cinnamon-killer-daemon
+++ b/files/usr/bin/cinnamon-killer-daemon
@@ -8,8 +8,8 @@ import os
 import syslog
 
 import gi
-gi.require_version('Keybinder', '3.0')
-gi.require_version('Gtk', '3.0')
+gi.require_version('Keybinder', '3.0')  # noqa
+gi.require_version('Gtk', '3.0')  # noqa
 from gi.repository import Keybinder
 from gi.repository import Gtk, Gio
 
@@ -50,6 +50,7 @@ class KillerDaemon:
     def restart_cinnamon(self, keystring, data):
         os.system("nemo -n &")  # restart nemo if it's not running already
         os.system("cinnamon --replace &")  # restart Cinnamon whether it's running or not (can be handy in case of a DE freeze)
+
 
 if __name__ == '__main__':
     daemon = KillerDaemon()

--- a/files/usr/bin/cinnamon-launcher
+++ b/files/usr/bin/cinnamon-launcher
@@ -3,16 +3,16 @@
 """ Launches or restarts cinnamon
 """
 
-FALLBACK_COMMAND = "metacity"
-FALLBACK_ARGS = ("--replace",)
-
 import os
 import sys
 import gettext
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version('Gtk', '3.0')  # noqa
 from gi.repository import Gtk
+
+FALLBACK_COMMAND = "metacity"
+FALLBACK_ARGS = ("--replace",)
 
 gettext.install("cinnamon", "/usr/share/locale")
 
@@ -28,6 +28,7 @@ elif os.path.exists("/usr/bin/tint2"):
     panel_process_name = "tint2"
     panel_cmd = "killall tint2; tint2 &"
 
+
 def confirm_restart():
     d = Gtk.MessageDialog(parent=None, flags=0, message_type=Gtk.MessageType.WARNING, buttons=Gtk.ButtonsType.YES_NO)
     d.set_keep_above(True)
@@ -37,6 +38,7 @@ def confirm_restart():
     resp = d.run()
     d.destroy()
     return (resp == Gtk.ResponseType.YES)
+
 
 if __name__ == "__main__":
     cinnamon_pid = os.fork()

--- a/files/usr/bin/cinnamon-menu-editor
+++ b/files/usr/bin/cinnamon-menu-editor
@@ -7,7 +7,7 @@ Usage:  cinnamon-menu-editor
 
 import sys
 
-sys.path.insert(0, '/usr/share/cinnamon/cinnamon-menu-editor')
+sys.path.insert(0, '/usr/share/cinnamon/cinnamon-menu-editor')  # noqa
 from cme import MainWindow
 
 
@@ -16,11 +16,12 @@ def main():
         from MenuEditor import config
         datadir = config.pkgdatadir
         version = config.VERSION
-    except:
+    except Exception:
         datadir = '.'
         version = '0.9'
     app = MainWindow.MainWindow(datadir, version)
     app.run()
+
 
 if __name__ == '__main__':
     main()

--- a/files/usr/bin/cinnamon-preview-gtk-theme
+++ b/files/usr/bin/cinnamon-preview-gtk-theme
@@ -8,7 +8,7 @@ Usage:  cinnamon-preview-gtk-theme theme-name
 import sys
 
 import gi
-gi.require_version("Gtk", "3.0")
+gi.require_version("Gtk", "3.0")  # noqa
 from gi.repository import Gtk
 
 if __name__ == '__main__':

--- a/files/usr/bin/cinnamon-subprocess-wrapper
+++ b/files/usr/bin/cinnamon-subprocess-wrapper
@@ -14,7 +14,7 @@ if __name__ == "__main__":
     try:
         result = subprocess.check_output(sys.argv[2:])
         success = True
-    except:
+    except Exception:
         result = ""
         success = False
 

--- a/files/usr/bin/cinnamon-xlet-makepot
+++ b/files/usr/bin/cinnamon-xlet-makepot
@@ -25,7 +25,7 @@ files which contain translations for the extracted strings.
 
 try:
     import polib
-except:
+except Exception:
     print("""\
 
 Module "polib" not available.
@@ -34,6 +34,7 @@ You will need to install this module using your distribution's package manager
 (in debian-based syatems "apt-get install python3-polib")
 """)
     quit()
+
 
 def scan_json(dir, pot_path):
     append = os.path.exists(pot_path)
@@ -65,6 +66,7 @@ def scan_json(dir, pot_path):
     else:
         pot_file.save(fpath=pot_path)
 
+
 def extract_settings_strings(data, dir, pot_file, parent=""):
     for key in data.keys():
         if key in ("description", "tooltip", "units", "title"):
@@ -89,6 +91,7 @@ def extract_settings_strings(data, dir, pot_file, parent=""):
         except AttributeError:
             pass
 
+
 def extract_metadata_strings(data, dir, pot_file):
     for key in data:
         if key in ("name", "description", "comments"):
@@ -104,6 +107,7 @@ def extract_metadata_strings(data, dir, pot_file):
             for value in values:
                 save_entry(value.strip(), comment, pot_file)
 
+
 def save_entry(msgid, comment, pot_file):
     if not msgid.strip():
         return
@@ -117,6 +121,7 @@ def save_entry(msgid, comment, pot_file):
     else:
         entry = polib.POEntry(msgid=msgid, comment=comment)
         pot_file.append(entry)
+
 
 def remove_empty_folders(path):
     if not os.path.isdir(path):
@@ -136,6 +141,7 @@ def remove_empty_folders(path):
         print('Removing empty folder:', path)
         os.rmdir(path)
 
+
 def do_install(uuid, dir):
     podir = os.path.join(dir, "po")
     files_installed = 0
@@ -151,6 +157,7 @@ def do_install(uuid, dir):
         print('Nothing to install')
     else:
         print('installed %i files' % files_installed)
+
 
 def do_remove(uuid):
     files_removed = 0
@@ -168,25 +175,26 @@ def do_remove(uuid):
     else:
         print('removed %i files' % files_removed)
 
+
 def scan_xlet():
     parser = argparse.ArgumentParser(description=USAGE_DESCRIPTION, epilog=USAGE_EPILOG, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('-j', '--skip-js', action='store_false', dest='js', default=True,
-        help='If this option is not included, javascript files will be scanned for translatable strings.')
+                        help='If this option is not included, javascript files will be scanned for translatable strings.')
     parser.add_argument('-p', '--skip-python', action='store_false', dest='python', default=True,
-        help='If this option is not included, python files will be scanned for translatable strings.')
+                        help='If this option is not included, python files will be scanned for translatable strings.')
     parser.add_argument('-i', '--install', action='store_true', dest='install', default=False,
-        help=('Compiles and installs any .po files contained in a po folder to the system locale store. '
-              'Use this option to test your translations locally before uploading to Spices. '
-              'It will use the applet, desklet, or extension UUID as the translation domain.'))
+                        help=('Compiles and installs any .po files contained in a po folder to the system locale store. '
+                              'Use this option to test your translations locally before uploading to Spices. '
+                              'It will use the applet, desklet, or extension UUID as the translation domain.'))
     parser.add_argument('-r', '--remove', action='store_true', dest='remove', default=False,
-        help=('The opposite of install, removes translations from the store. Again, it uses the UUID '
-              'to find the correct files to remove.'))
+                        help=('The opposite of install, removes translations from the store. Again, it uses the UUID '
+                              'to find the correct files to remove.'))
     parser.add_argument('-k', '--keyword', dest='keyword', default='_',
-        help='Change the variable name gettext is assigned to in your files. The default is _.')
+                        help='Change the variable name gettext is assigned to in your files. The default is _.')
     parser.add_argument('-o', '--potfile', dest='out_file', default=None,
-        help=('Use this option to specify the location for the generated .pot file. By default '
-              '<uuid>/po/<uuid>.pot is used. This is where translators are expecting to find the pot '
-              'file, so you should only use this option if you want the pot file elsewhere for your own use.'))
+                        help=('Use this option to specify the location for the generated .pot file. By default '
+                              '<uuid>/po/<uuid>.pot is used. This is where translators are expecting to find the pot '
+                              'file, so you should only use this option if you want the pot file elsewhere for your own use.'))
     parser.add_argument('dir', help='the path to the applet/desklet/extension directory')
 
     args = parser.parse_args()
@@ -218,7 +226,7 @@ def scan_xlet():
     os.chdir(dir)
     if args.js or args.python:
         try:
-            output = subprocess.check_output(["xgettext", "--version"])
+            subprocess.check_output(["xgettext", "--version"])
         except OSError:
             print("xgettext not found, you may need to install the gettext package")
             quit()

--- a/files/usr/bin/xlet-settings
+++ b/files/usr/bin/xlet-settings
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
-import os, sys
+import os
+import sys
 
 if len(sys.argv) < 3:
     print("usage:\n    xlet-settings <xlet_type> <uuid>\nor\n    xlet-settings <xlet_type> <uuid> <instance_id>")


### PR DESCRIPTION
Update scripts to match the pep8 guidelines
(https://www.python.org/dev/peps/pep-0008)

 - multiple imports in the same line
 - module level import not at top of file
 - bare except used: this is dangerous and should be avoided
 - missing whitespace around arithmetic operator
 - expected 2 blank lines after class or function definition, found 1
 - continuation line under-indented for visual indent
 - local variable is assigned to but never used