### PR TITLE
Use ints for the menu position

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-looking-glass/cinnamon-looking-glass.py
+++ b/files/usr/share/cinnamon/cinnamon-looking-glass/cinnamon-looking-glass.py
@@ -45,8 +45,8 @@ class MenuButton(Gtk.Button):
         h = parent.get_height()
         extents = parent.get_frame_extents()
         allocation = self.get_allocation()
-        return (x + (extents.width-w)/2 + allocation.x,
-                y + (extents.height-h)-(extents.width-w)/2 + allocation.y,
+        return (x + (extents.width-w)//2 + allocation.x,
+                y + (extents.height-h)-(extents.width-w)//2 + allocation.y,
                 allocation.width,
                 allocation.height)
 


### PR DESCRIPTION
In python3 the / operator returns floats, to maintain the previous behaviour
we need to use the // operator.