### PR TITLE
Workspace switcher: fix blurry #panelRight's applets in visual mode

### DIFF
--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
@@ -78,8 +78,9 @@ WorkspaceGraph.prototype = {
         if (applet.orientation == St.Side.LEFT || applet.orientation == St.Side.RIGHT)
             height = height / this.sizeRatio;
 
-        this.actor.set_size(this.sizeRatio * height, height);
-        this.graphArea.set_size(this.sizeRatio * height, height);
+        let width = Math.round(this.sizeRatio * height);
+        this.actor.set_size(width, height);
+        this.graphArea.set_size(width, height);
         this.graphArea.connect('repaint', Lang.bind(this, this.onRepaint));
         if (index == global.screen.get_active_workspace_index()) {
             this.actor.add_style_pseudo_class('active');


### PR DESCRIPTION
With simple buttons:
![screenshot from 2018-04-12 12-20-47](https://user-images.githubusercontent.com/10391266/38671551-0ac606f0-3e4c-11e8-9a34-2f2bf82d88ce.png)

In visual mode:
![screenshot from 2018-04-12 12-21-09](https://user-images.githubusercontent.com/10391266/38671550-0a93db1c-3e4c-11e8-9f8e-c8d9d61e4aa8.png)

After this patch:
![screenshot from 2018-04-12 12-23-26](https://user-images.githubusercontent.com/10391266/38671694-5b26b68a-3e4c-11e8-8008-124f89149b56.png)