### PR TITLE
Sync the logic in cs_startup with cinnamon-session

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_startup.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_startup.py
@@ -212,10 +212,7 @@ class AutostartApp():
             self.save_done_success()
             return False
 
-        if self.system_position:
-            use_path = os.path.join(self.system_position, self.basename)
-        else:
-            use_path = self.path
+        use_path = self.path
 
         key_file = GLib.KeyFile.new()
 

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_startup.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_startup.py
@@ -546,7 +546,7 @@ class AutostartBox(Gtk.Box):
             AUTOSTART_APPS[key] = app
 
             app.basename = os.path.basename(app.app)
-            app.dir = os.path.basename(app.app)
+            app.dir = os.path.dirname(app.app)
             app.hidden = False
             app.no_display = False
             app.enabled = True

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_startup.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_startup.py
@@ -14,9 +14,11 @@ try:
     ENVIRON = os.environ['XDG_CURRENT_DESKTOP']
 except:
     ENVIRON = ""
+
 D_GROUP = "Desktop Entry"
 DEFAULT_ICON = "system-run"
 AUTOSTART_APPS = []
+
 
 def list_header_func(row, before, user_data):
     if before and not row.get_header():
@@ -150,7 +152,7 @@ class AutostartApp():
         if only_show_in:
             found = False
             for i in only_show_in:
-                if i == ENVIRON:
+                if i in ('GNOME', 'X-Cinnamon'):
                     found = True
                     break
             if not found:


### PR DESCRIPTION
cinnamon-session also starts the autostart desktop files that are OnlyIn
GNOME, and drops all the ones that are set listed in
org.cinnamon.SessionManager autostart-blacklist gsetting.