### PR TITLE
Notifications: Remove circular reference on notification actors

### DIFF
--- a/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
@@ -249,8 +249,8 @@ MyApplet.prototype = {
     _update_timestamp: function () {
         let actors = this._notificationbin.get_children();
         if (actors) {
-            for (let i = 0; i < actors.length; i++) {
-                let notification = actors[i]._delegate;
+            for (let i = 0; i < this.notifications.length; i++) {
+                let notification = this.notifications[i];
                 let orig_time = notification._timestamp;
                 notification._timeLabel.clutter_text.set_markup(timeify(orig_time));
             }

--- a/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
@@ -247,9 +247,9 @@ MyApplet.prototype = {
     },
 
     _update_timestamp: function () {
-        let actors = this._notificationbin.get_children();
-        if (actors) {
-            for (let i = 0; i < this.notifications.length; i++) {
+        let len = this.notifications.length;
+        if (len > 0) {
+            for (let i = 0; i < len; i++) {
                 let notification = this.notifications[i];
                 let orig_time = notification._timestamp;
                 notification._timeLabel.clutter_text.set_markup(timeify(orig_time));

--- a/js/ui/messageTray.js
+++ b/js/ui/messageTray.js
@@ -453,7 +453,6 @@ Notification.prototype = {
             }));
 
         this.actor = new St.Button({ accessible_role: Atk.Role.NOTIFICATION });
-        this.actor._delegate = this;
         this.actor._parent_container = null;
         this.actor.connect('clicked', Lang.bind(this, this._onClicked));
         this.actor.connect('destroy', Lang.bind(this, this._onDestroy));
@@ -1019,7 +1018,6 @@ Notification.prototype = {
     destroy: function(reason) {
         this._destroyedReason = reason;
         this.actor.destroy();
-        this.actor._delegate = null;
     }
 };
 Signals.addSignalMethods(Notification.prototype);


### PR DESCRIPTION
The applet keeps track of notifications via `this.notifications`, so we can use that to access the `Notification` instances instead of relying on the actor._delegate reference.