### PR TITLE
user-applet: fix loading with newer accountsservice

### DIFF
--- a/files/usr/share/cinnamon/applets/user@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/user@cinnamon.org/applet.js
@@ -132,7 +132,7 @@ MyApplet.prototype = {
             this.menu.addMenuItem(item);
 
             this._user = AccountsService.UserManager.get_default().get_user(GLib.get_user_name());
-            this._userLoadedId = this._user.connect('notify::is_loaded', Lang.bind(this, this._onUserChanged));
+            this._userLoadedId = this._user.connect('notify::is-loaded', Lang.bind(this, this._onUserChanged));
             this._userChangedId = this._user.connect('changed', Lang.bind(this, this._onUserChanged));
             this._onUserChanged();
             this.set_show_label_in_vertical_panels(false);


### PR DESCRIPTION
Upstream fixed 'changed' signal being emitted far too often which broke
initial loading of the user info here and exposed this typo. It would
still load and work as usual after the first legitimate changed signal.

fixes: #7471