### PR TITLE
Fix JS exporter parsing

### DIFF
--- a/js/misc/fileUtils.js
+++ b/js/misc/fileUtils.js
@@ -171,14 +171,14 @@ function createExports({path, dir, meta, type, file, size, JS, returnIndex, reje
         moduleIndex = LoadedModules.length - 1;
     }
 
-    JS = `'use strict';${JS};`;
+    JS = `'use strict';\n${JS};`;
     // Regex matches the top level variable names, and appends them to the module.exports object,
     // mimicking the native CJS importer.
-    const exportsRegex = /^(module\.exports(.?([A-Za-z_$]*))) = ([A-Za-z_;]*)$/gm;
-    const varRegex = /^(const|var|let|function{1,}) ([a-zA-Z_$]*)/gm;
+    const exportsRegex = /^module\.exports(\.[a-zA-Z0-9_$]+)?\s*=/m;
+    const varRegex = /^(const|var|let|function|class)\s+([a-zA-Z0-9_$]+)/gm;
     let match;
 
-    if (!JS.match(exportsRegex)) {
+    if (!exportsRegex.test(JS)) {
         while ((match = varRegex.exec(JS)) != null) {
             if (match.index === varRegex.lastIndex) {
                 varRegex.lastIndex++;


### PR DESCRIPTION
 * Fix exported variable/functions regex. It didn't recognize variables with numbers in the name.
 * Fix module.exports recognition regex and remove clutter. It only recognized some exported variable names, but not numbers nor objects, and it required a space before and after the assignment token (=).
 * Add a new line character after the prepended 'use strict' or otherwise the parser won't recognize exported variables in the first line.
 * Use test instead of match because it's faster in this use case. It only checks until the first occurrence and doesn't generate strings like match.

**Just a note.** 
I wasn't sure if the exports regex was supposed to match things like `module.exports = myVariable`, so I opted for keeping the old behavior and allow it (I was not able to make use of it though). If that is not the expected behavior, please ping me and I'll remove it. I'ts a matter of just removing a `?`.

This will conflict with #7389, but I also added the `class` token that @jaszhix added to the regex. There is no real conflict.