### PR TITLE
user applet: create our own switch-user-symbolic icon

### DIFF
--- a/files/usr/share/cinnamon/applets/user@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/user@cinnamon.org/applet.js
@@ -92,7 +92,7 @@ MyApplet.prototype = {
 
             if (GLib.getenv("XDG_SEAT_PATH")) {
                 // LightDM
-                item = new PopupMenu.PopupIconMenuItem(_("Switch User"), "system-switch-user", St.IconType.SYMBOLIC);
+                item = new PopupMenu.PopupIconMenuItem(_("Switch User"), "switch-user", St.IconType.SYMBOLIC);
                 item.connect('activate', Lang.bind(this, function() {
                     Util.spawnCommandLine("cinnamon-screensaver-command --lock");
                     Util.spawnCommandLine("dm-tool switch-to-greeter");
@@ -101,7 +101,7 @@ MyApplet.prototype = {
             }
             else if (GLib.file_test("/usr/bin/mdmflexiserver", GLib.FileTest.EXISTS)) {
                 // MDM
-                item = new PopupMenu.PopupIconMenuItem(_("Switch User"), "system-switch-user", St.IconType.SYMBOLIC);
+                item = new PopupMenu.PopupIconMenuItem(_("Switch User"), "switch-user", St.IconType.SYMBOLIC);
                 item.connect('activate', Lang.bind(this, function() {
                     Util.spawnCommandLine("mdmflexiserver");
                 }));
@@ -109,7 +109,7 @@ MyApplet.prototype = {
             }
             else if (GLib.file_test("/usr/bin/gdmflexiserver", GLib.FileTest.EXISTS)) {
                 // GDM
-                item = new PopupMenu.PopupIconMenuItem(_("Switch User"), "system-switch-user", St.IconType.SYMBOLIC);
+                item = new PopupMenu.PopupIconMenuItem(_("Switch User"), "switch-user", St.IconType.SYMBOLIC);
                 item.connect('activate', Lang.bind(this, function() {
                     Util.spawnCommandLine("cinnamon-screensaver-command --lock");
                     Util.spawnCommandLine("gdmflexiserver");

--- a/files/usr/share/cinnamon/applets/user@cinnamon.org/icons/switch-user-symbolic.svg
+++ b/files/usr/share/cinnamon/applets/user@cinnamon.org/icons/switch-user-symbolic.svg
@@ -1,20 +1,92 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg id="svg7384" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://www.w3.org/2000/svg" height="16" width="16" version="1.1" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/">
- <metadata id="metadata90">
-  <rdf:RDF>
-   <cc:Work rdf:about="">
-    <dc:format>image/svg+xml</dc:format>
-    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:title>Gnome Symbolic Icon Theme</dc:title>
-   </cc:Work>
-  </rdf:RDF>
- </metadata>
- <title id="title9167">Gnome Symbolic Icon Theme</title>
- <g id="layer11" transform="translate(-42 -510)">
-  <path id="path21187" style="color:#bebebe;fill:#bebebe" d="m52 342.5a2.5 2.5 0 1 1 -5 0 2.5 2.5 0 1 1 5 0z" transform="translate(-3,171)"/>
-  <path id="path21193" style="color:#bebebe;fill:#bebebe" d="m48 517h-3l0.0467-0.68495c-1.395 0.04-2.047 1.77-2.047 3.18v1.5h6v-1h1v-0.5c0-1.5-0.59314-3.1318-1.9851-3.156z"/>
-  <path id="path21200" style="color:#bebebe;fill:#bebebe" d="m52 342.5a2.5 2.5 0 1 1 -5 0 2.5 2.5 0 1 1 5 0z" transform="translate(4,175)"/>
-  <path id="path21202" style="color:#bebebe;fill:#bebebe" d="m55 521h-3l0.0467-0.68495c-1.583 0.05-2.047 1.64-2.047 2.68v2h7v-2c0-1.0466-0.21771-2.6252-1.9851-2.656z"/>
- </g>
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg7384"
+   height="16"
+   width="16"
+   version="1.1"
+   sodipodi:docname="switch-user-symbolic.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="745"
+     id="namedview10"
+     showgrid="true"
+     inkscape:zoom="1.3037281"
+     inkscape:cx="-145.65527"
+     inkscape:cy="102.76006"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7384">
+    <inkscape:grid
+       type="xygrid"
+       id="grid828" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <title
+     id="title9167">Gnome Symbolic Icon Theme</title>
+  <g
+     id="g840"
+     transform="translate(0,-1.00005)">
+    <path
+       id="path21187"
+       style="color:#bebebe;fill:#bebebe"
+       d="m 8.9994,3.5 a 2.5,2.5 0 1 0 5,0 2.5,2.5 0 1 0 -5,0 z"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path21193"
+       style="color:#bebebe;fill:#bebebe"
+       d="m 9.9994,7 h 3 L 12.9527,6.31505 c 1.395,0.04 2.047,1.77 2.047,3.18 l 3e-4,0.505 c -4,0 -6.1063493,-0.00602 -7.0003,-0.005 v -0.5 c 0,-1.5 0.59314,-3.1318 1.9851,-3.156 z"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccsccscc" />
+  </g>
+  <g
+     id="g836">
+    <path
+       id="path21200"
+       style="color:#bebebe;fill:#bebebe"
+       d="m 1.9994,7.5 a 2.5,2.5 0 1 0 5,0 2.5,2.5 0 1 0 -5,0 z"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path21202"
+       style="color:#bebebe;fill:#bebebe"
+       d="m 2.9994,11 h 3 L 5.9527,10.31505 c 1.583,0.05 2.047,1.64 2.047,2.68 v 2 h -7 v -2 c 0,-1.0466 0.21771,-2.6252 1.9851,-2.656 z"
+       inkscape:connector-curvature="0" />
+  </g>
+  <path
+     inkscape:connector-curvature="0"
+     d="m 14.17245,15.98976 h 0.83984 v -1 c 0.008,-1.67271 0,-5.0000003 0,-5.0000003 0,0 -3.98614,0 -6.0000003,0 V 10.83546 c -0.0954,0.61124 0.3814,1.16164 1.0000003,1.1543 h 1.58594 l -1.6429803,1.64299 -0.64999,0.64998 c -0.65409,0.63582 -0.18523,1.74367 0.7265703,1.71679 0.25979,-0.008 0.50637,-0.11632 0.6875,-0.30273 l 0.62788,-0.62789 1.66508,-1.66508 v 1.58594 c 0,0.68107 0.4492,1 1.16016,1 z"
+     id="path12113-8-6"
+     sodipodi:nodetypes="cccccccccccccccc"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new" />
 </svg>

--- a/files/usr/share/cinnamon/applets/user@cinnamon.org/icons/users-symbolic.svg
+++ b/files/usr/share/cinnamon/applets/user@cinnamon.org/icons/users-symbolic.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg id="svg7384" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://www.w3.org/2000/svg" height="16" width="16" version="1.1" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/">
+ <metadata id="metadata90">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title>Gnome Symbolic Icon Theme</dc:title>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <title id="title9167">Gnome Symbolic Icon Theme</title>
+ <g id="layer11" transform="translate(-42 -510)">
+  <path id="path21187" style="color:#bebebe;fill:#bebebe" d="m52 342.5a2.5 2.5 0 1 1 -5 0 2.5 2.5 0 1 1 5 0z" transform="translate(-3,171)"/>
+  <path id="path21193" style="color:#bebebe;fill:#bebebe" d="m48 517h-3l0.0467-0.68495c-1.395 0.04-2.047 1.77-2.047 3.18v1.5h6v-1h1v-0.5c0-1.5-0.59314-3.1318-1.9851-3.156z"/>
+  <path id="path21200" style="color:#bebebe;fill:#bebebe" d="m52 342.5a2.5 2.5 0 1 1 -5 0 2.5 2.5 0 1 1 5 0z" transform="translate(4,175)"/>
+  <path id="path21202" style="color:#bebebe;fill:#bebebe" d="m55 521h-3l0.0467-0.68495c-1.583 0.05-2.047 1.64-2.047 2.68v2h7v-2c0-1.0466-0.21771-2.6252-1.9851-2.656z"/>
+ </g>
+</svg>


### PR DESCRIPTION
the heads/circles in the system-switch-user-symbolic icon from Adwaita
are not paths and therefore don't change their color

create our own icon based on the Adwaita one