### PR TITLE
Workspace switcher: fix buttons sizing

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -1362,24 +1362,24 @@ StScrollBar StButton#vhandle:hover {
 /* Controls the styling when using the "Simple buttons" option */
 .panel-top .workspace-switcher,
 .panel-bottom .workspace-switcher {
-    padding-left: 3px;
-    padding-right: 3px;
+    padding: 0 3px;
 }
 
-.panel-left .workspace-switcher
+.panel-left .workspace-switcher,
 .panel-right .workspace-switcher {
-    padding-top: 3px;
-    padding-bottom: 3px;
+    padding: 3px;
 }
 
 .workspace-button {
-    width: 20px;
-    height: 10px;
     color: #cccccc;
     border: 1px;
     border-color: #a6a6a6;
-    padding-top: 2px;
+    padding: 0 8px;
     transition-duration: 300;
+}
+
+.vertical .workspace-button {
+    padding: 4px 0;
 }
 
 .workspace-button:outlined {

--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
@@ -9,6 +9,7 @@ const SignalManager = imports.misc.signalManager;
 const Tooltips = imports.ui.tooltips;
 const Settings = imports.ui.settings;
 const ModalDialog = imports.ui.modalDialog;
+const Pango = imports.gi.Pango;
 
 const MIN_SWITCH_INTERVAL_MS = 220;
 
@@ -186,14 +187,12 @@ SimpleButton.prototype = {
         if (applet.orientation == St.Side.TOP || applet.orientation == St.Side.BOTTOM) {
             this.actor.set_height(applet._panelHeight);
         } else {
-            this.actor.set_height(0.6 * applet._panelHeight);  // factors are completely empirical
-            this.actor.set_width(0.9 * applet._panelHeight);
+            this.actor.set_width(applet._panelHeight);
+            this.actor.add_style_class_name('vertical');
         }
 
-        if (applet.orientation == St.Side.LEFT || applet.orientation == St.Side.RIGHT)
-            this.actor.add_style_class_name('vertical');
-
         let label = new St.Label({ text: (index + 1).toString() });
+        label.clutter_text.set_ellipsize(Pango.EllipsizeMode.NONE);
         this.actor.set_child(label);
     },
 


### PR DESCRIPTION
 * In vertical panels, the width wasn't the full panel width as it
   does in horizontal mode and every applet does in vertical mode.

 * In horizontal panels, if a width wasn't defined in CSS the
   labels were hidden because they ellipsized to zero width.

 * Updated default theme to still look the same as it did.

The horizontal mode issue:
![screenshot from 2016-06-29 13-42-49](https://cloud.githubusercontent.com/assets/10391266/16451280/5be048c6-3e02-11e6-987e-a07dd9603e0f.png)

Fixes #6148 (the vertical mode issue)

Aditionally, fix #7195 and #7456 in vertical panels but with buttons this time.