### PR TITLE
settings.js: remove 'units' from the list of required properties for …

### DIFF
--- a/js/ui/settings.js
+++ b/js/ui/settings.js
@@ -143,7 +143,6 @@ var SETTINGS_TYPES = {
             "default",
             "min",
             "max",
-            "units",
             "step",
             "description"
         ]


### PR DESCRIPTION
…the spinbutton widget - it isn't actually necessary