### PR TITLE
Use standard icon sizes across the panel

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -64,8 +64,7 @@ const Tooltips = imports.ui.tooltips;
 
 const HORIZONTAL_ICON_SIZE = 16; // too bad this can't be defined in theme (cinnamon-app.create_icon_texture returns a clutter actor, not a themable object -
                                  // probably something that could be addressed
-const ICON_HEIGHT_FACTOR = 0.64;
-const VERTICAL_ICON_HEIGHT_FACTOR = 0.75;
+
 const MAX_TEXT_LENGTH = 1000;
 const FLASH_INTERVAL = 500;
 
@@ -676,7 +675,7 @@ class AppMenuButton {
             }
             childBox.x2 = Math.min(childBox.x1 + naturalWidth, box.x2);
         } else {
-            childBox.x1 = box.x1 + Math.max(0, (allocWidth - naturalWidth) / 2);
+            childBox.x1 = box.x1 + Math.floor(Math.max(0, allocWidth - naturalWidth) / 2);
             childBox.x2 = Math.min(childBox.x1 + naturalWidth, box.x2);
         }
         this._iconBox.allocate(childBox, flags);
@@ -728,18 +727,16 @@ class AppMenuButton {
         let tracker = Cinnamon.WindowTracker.get_default();
         let app = tracker.get_window_app(this.metaWindow);
 
-        if (this._applet._scaleMode && this.labelVisible)
-            this.iconSize = Math.round(this._applet._panelHeight * ICON_HEIGHT_FACTOR / global.ui_scale);
-        else if (!this.labelVisible)
-            this.iconSize = Math.round(this._applet._panelHeight * VERTICAL_ICON_HEIGHT_FACTOR / global.ui_scale);
+        if (this.labelVisible && !this._applet._scaleMode)
+            this.icon_size = HORIZONTAL_ICON_SIZE;
         else
-            this.iconSize = HORIZONTAL_ICON_SIZE;
+            this.icon_size = this._applet.icon_size;
 
         let icon = app ?
-            app.create_icon_texture_for_window(this.iconSize, this.metaWindow) :
+            app.create_icon_texture_for_window(this.icon_size, this.metaWindow) :
             new St.Icon({ icon_name: 'application-default-icon',
                 icon_type: St.IconType.FULLCOLOR,
-                icon_size: this.iconSize });
+                icon_size: this.icon_size });
 
         let old_child = this._iconBox.get_child();
         this._iconBox.set_child(icon);
@@ -964,6 +961,7 @@ class CinnamonWindowListApplet extends Applet.Applet {
         this.actor.set_track_hover(false);
         this.actor.set_style_class_name("window-list-box");
         this.orientation = orientation;
+        this.icon_size = Applet.getPanelIconSize(this, St.IconType.FULLCOLOR);
         this.appletEnabled = false;
         //
         // A layout manager is used to cater for vertical panels as well as horizontal
@@ -1029,6 +1027,7 @@ class CinnamonWindowListApplet extends Applet.Applet {
     }
 
     on_panel_height_changed() {
+        this.icon_size = Applet.getPanelIconSize(this, St.IconType.FULLCOLOR);
         this._refreshAllItems();
     }
 

--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -16,11 +16,10 @@ const ModalDialog = imports.ui.modalDialog;
 const Signals = imports.signals;
 const Gettext = imports.gettext;
 
-var COLOR_ICON_HEIGHT_FACTOR = .85;  // Panel height factor for normal color icons
+var COLOR_ICON_HEIGHT_FACTOR = .65;  // Panel height factor for normal color icons
 var PANEL_FONT_DEFAULT_HEIGHT = 11.5; // px
 var PANEL_SYMBOLIC_ICON_DEFAULT_HEIGHT = 1.14 * PANEL_FONT_DEFAULT_HEIGHT; // ems conversion
 var DEFAULT_PANEL_HEIGHT = 25;
-var STD_ICON_SIZES = [16, 24, 32, 48, 64, 96]; // hidpi with largest panel, gets up to 80
 var DEFAULT_ICON_SIZE = 22;
 
 var AllowedLayout = {  // the panel layout that an applet is suitable for
@@ -63,17 +62,19 @@ function getPanelIconSize(applet, icon_type) {
  * Returns: an integer, the icon size
  */
 function toStdIconSize(max_size) {
-    // Standard sizes are equally spaciated by 'halves' of powers of two.
-    // For example next(16) = 16 + 16/2 = 24, next(24) = 24 + 16/2 = 32 and so on.
-    // We substract 8 because the array starts at 16 and it is the 8th 'half'
-    // starting from cero (0, 2, 3, 4, 6, 8, 12 and 16)
-    let idx = Math.floor(Math.log2(max_size) * 2) - 8;
-    if (idx < 0)
-        idx = 0;
-    else if (idx >= STD_ICON_SIZES.length)
-        idx = STD_ICON_SIZES.length - 1;
-
-    return STD_ICON_SIZES[idx];
+    max_size = Math.floor(max_size);
+    if (max_size <= 16)
+        return 16;
+    else if (max_size <= 22)
+        return 22;
+    else if (max_size <= 24)
+        return 24;
+    else if (max_size <= 32)
+        return 32;
+    else if (max_size <= 48)
+        return 48;
+    else // Panel icons reach 32 at most with the largest panel, also on hidpi
+        return 64;
 }
 
 /**


### PR DESCRIPTION
* **window-list: Fix blurry icons in vertical mode**
  Resizing full-color icons doesn't always look good in all sizes.
  IconApplet now uses icons of standard sizes only, that is 16, 22, 24, 32...
  Other applet types that also have icons can get the size used by IconApplets to look crisp and uniform across the panels.
* **panel-launchers: use standard applet's icon size**
* **systray: use standard applet's icon size**