### PR TITLE
Notification clearing on app focus + blacklist + limit

### DIFF
--- a/js/ui/messageTray.js
+++ b/js/ui/messageTray.js
@@ -32,7 +32,6 @@ var LONGER_HIDE_TIMEOUT = 0.6;
 
 var MAX_SOURCE_TITLE_WIDTH = 180;
 
-
 // We delay hiding of the tray if the mouse is within MOUSE_LEFT_ACTOR_THRESHOLD
 // range from the point where it left the tray.
 var MOUSE_LEFT_ACTOR_THRESHOLD = 20;
@@ -1040,6 +1039,7 @@ function Source(title) {
 
 Source.prototype = {
     ICON_SIZE: 24,
+    MAX_NOTIFICATIONS: 10,
 
     _init: function(title) {
         this.title = title;
@@ -1119,6 +1119,10 @@ Source.prototype = {
 
     _updateCount: function() {
         let count = this.notifications.length;
+        if (count > this.MAX_NOTIFICATIONS) {
+            let oldestNotif = this.notifications.shift();
+            oldestNotif.destroy();
+        }
         this._setCount(count, count > 1);
     },
 

--- a/js/ui/notificationDaemon.js
+++ b/js/ui/notificationDaemon.js
@@ -13,6 +13,10 @@ const MessageTray = imports.ui.messageTray;
 const Params = imports.misc.params;
 const Mainloop = imports.mainloop;
 
+// don't automatically clear these apps' notifications on window focus
+// lowercase only
+const AUTOCLEAR_BLACKLIST = ['chromium', 'firefox', 'google chrome'];
+
 let nextNotificationId = 1;
 
 // Should really be defined in Gio.js
@@ -121,6 +125,11 @@ NotificationDaemon.prototype = {
         }
         setting(this, this.settings, "boolean", "removeOld", "remove-old");
         setting(this, this.settings, "int", "timeout", "timeout");
+
+        Cinnamon.WindowTracker.get_default().connect('notify::focus-app',
+            Lang.bind(this, this._onFocusAppChanged));
+        Main.overview.connect('hidden',
+            Lang.bind(this, this._onFocusAppChanged));
     },
 
    // Create an icon for a notification from icon string/path.
@@ -518,6 +527,24 @@ NotificationDaemon.prototype = {
             Config.PACKAGE_VERSION,
             '1.2'
         ];
+    },
+
+    _onFocusAppChanged: function() {
+        let tracker = Cinnamon.WindowTracker.get_default();
+        if (!tracker.focus_app)
+            return;
+
+        let name = tracker.focus_app.get_name();
+        if (name && AUTOCLEAR_BLACKLIST.includes(name.toLowerCase()))
+            return;
+
+        for (let i = 0; i < this._sources.length; i++) {
+            let source = this._sources[i];
+            if (source.app == tracker.focus_app) {
+                source.destroyNonResidentNotifications();
+                return;
+            }
+        }
     },
 
     _emitNotificationClosed: function(id, reason) {


### PR DESCRIPTION
- Reverts #7252 and adds a blacklist which includes chrome, chromium, and firefox
- Limits notifications to 10 per source. When a new notification is added and 10 notifications exist, the oldest notification is dismissed.

More details in the first commit.