### PR TITLE
proper keybindings names

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_keyboard.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_keyboard.py
@@ -50,8 +50,8 @@ CATEGORIES = [
 KEYBINDINGS = [
     #   KB Label                        Schema                  Key name               Array?  Category
     # General
-    [_("Toggle Scale"), MUFFIN_KEYBINDINGS_SCHEMA, "switch-to-workspace-down", "general"],
-    [_("Toggle Expo"), MUFFIN_KEYBINDINGS_SCHEMA, "switch-to-workspace-up", "general"],
+    [_("Toggle Scale"), MUFFIN_KEYBINDINGS_SCHEMA, "show-scale", "general"],
+    [_("Toggle Expo"), MUFFIN_KEYBINDINGS_SCHEMA, "show-expo", "general"],
     [_("Cycle through open windows"), MUFFIN_KEYBINDINGS_SCHEMA, "switch-windows", "general"],
     [_("Cycle backwards through open windows"), MUFFIN_KEYBINDINGS_SCHEMA, "switch-windows-backward", "general"],
     [_("Cycle through open windows of the same application"), MUFFIN_KEYBINDINGS_SCHEMA, "switch-group", "general"],
@@ -120,6 +120,8 @@ KEYBINDINGS = [
     [_("Move window to up monitor"), MUFFIN_KEYBINDINGS_SCHEMA, "move-to-monitor-up", "win-monitors"],
     [_("Move window to down monitor"), MUFFIN_KEYBINDINGS_SCHEMA, "move-to-monitor-down", "win-monitors"],
     # Workspaces
+    [_("Switch to top workspace"), MUFFIN_KEYBINDINGS_SCHEMA, "switch-to-workspace-up", "workspaces"],
+    [_("Switch to down workspace"), MUFFIN_KEYBINDINGS_SCHEMA, "switch-to-workspace-down", "workspaces"],
     [_("Switch to left workspace"), MUFFIN_KEYBINDINGS_SCHEMA, "switch-to-workspace-left", "workspaces"],
     [_("Switch to right workspace"), MUFFIN_KEYBINDINGS_SCHEMA, "switch-to-workspace-right", "workspaces"],
     # Workspaces - Direct Nav

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -979,11 +979,11 @@ WindowManager.prototype = {
     },
 
     _showWorkspaceSwitcher : function(display, screen, window, binding) {
-        if (binding.get_name() == 'switch-to-workspace-up') {
+        if (binding.get_name() == 'show-expo') {
             Main.expo.toggle();
             return;
         }
-        if (binding.get_name() == 'switch-to-workspace-down') {
+        if (binding.get_name() == 'show-scale') {
             Main.overview.toggle();
             return;
         }
@@ -991,7 +991,11 @@ WindowManager.prototype = {
         if (screen.n_workspaces == 1)
             return;
 
-        if (binding.get_name() == 'switch-to-workspace-left') {
+        if (binding.get_name() == 'switch-to-workspace-up') {
+           this.actionMoveWorkspaceUp();
+        } else if (binding.get_name() == 'switch-to-workspace-down') {
+           this.actionMoveWorkspaceDown();
+        } else if (binding.get_name() == 'switch-to-workspace-left') {
            this.actionMoveWorkspaceLeft();
         } else if (binding.get_name() == 'switch-to-workspace-right') {
            this.actionMoveWorkspaceRight();


### PR DESCRIPTION
Hi, I think that keybinding names right now dont make sense - I have been using workspace grid and after latest update cant switch up and down - because the shortcuts are being hijacked by expo/scale. 

I have not tested this properly and I am not that familiar with the codebase to see if this is breaking something else. 

Best regards, 
Visgean. 