### PR TITLE
[WIP] Rework notification image loading

### DIFF
--- a/js/ui/messageTray.js
+++ b/js/ui/messageTray.js
@@ -1840,8 +1840,8 @@ MessageTray.prototype = {
         if (AppletManager.get_role_provider_exists(AppletManager.Roles.NOTIFICATIONS) && !this._notificationRemoved) {
             this.emit('notify-applet-update', notification);
         } else {
-            if (notification.isTransient)
-                notification.destroy(NotificationDestroyedReason.EXPIRED);
+            // if there is no tray applet, the notification expires as soon as it is hidden
+            notification.destroy(NotificationDestroyedReason.EXPIRED);
         }
         this._notification = null;
         this._notificationRemoved = false;

--- a/js/ui/notificationDaemon.js
+++ b/js/ui/notificationDaemon.js
@@ -116,7 +116,7 @@ NotificationDaemon.prototype = {
         Main.statusIconDispatcher.connect('message-icon-added', Lang.bind(this, this._onTrayIconAdded));
         Main.statusIconDispatcher.connect('message-icon-removed', Lang.bind(this, this._onTrayIconRemoved));
 
-// Settings
+        // Settings
         this.settings = new Gio.Settings({ schema_id: "org.cinnamon.desktop.notifications" });
         function setting(self, source, type, camelCase, dashed) {
             function updater() { self[camelCase] = source["get_"+type](dashed); }
@@ -247,20 +247,20 @@ NotificationDaemon.prototype = {
     },
 
     _startExpire: function() {
-         if (this.removeOld && this._expireNotifications.length && !this._expireTimer) {
+        if (this.removeOld && this._expireNotifications.length && !this._expireTimer) {
             this._expireTimer = Mainloop.timeout_add_seconds(Math.max((this._expireNotifications[0].expires-Date.now())/1000, 1), Lang.bind(this, this._expireNotification));
         }
     },
     _stopExpire: function() {
-         if (this._expireTimer == 0) {
+        if (this._expireTimer == 0) {
             return;
         }
-         Mainloop.source_remove(this._expireTimer);
-         this._expireTimer = 0;
+        Mainloop.source_remove(this._expireTimer);
+        this._expireTimer = 0;
     },
     _restartExpire: function() {
-         this._stopExpire();
-         this._startExpire();
+        this._stopExpire();
+        this._startExpire();
     },
     _expireNotification: function() {
         let ndata = this._expireNotifications[0];
@@ -332,7 +332,7 @@ NotificationDaemon.prototype = {
         } else if (timeout == -1) { // Default expiration.
             expires = ndata.expires = Date.now()+this.timeout*1000;
         } else {    // Custom expiration.
-             expires = ndata.expires = Date.now()+timeout;
+            expires = ndata.expires = Date.now()+timeout;
         }
  
         // Does this notification expire?
@@ -434,7 +434,7 @@ NotificationDaemon.prototype = {
                             if (notifications[i] == ndata) {
                                 notifications.splice(i, 1);
                                 break;
-                             }
+                            }
                         }
                         this._restartExpire();
                     }
@@ -601,8 +601,8 @@ Source.prototype = {
 
         this.trayIcon = trayIcon;
         if (this.trayIcon) {
-           this._setSummaryIcon(this.trayIcon);
-           this.useNotificationIcon = false;
+            this._setSummaryIcon(this.trayIcon);
+            this.useNotificationIcon = false;
         }
     },
 


### PR DESCRIPTION
This needs testing.

This reworks external notification image loading so that we can support icon names in the `image-path` and `app_icon` hints as specified by v1.2 of the specification, prevents uncaught errors loading images, and ensures notifications always have a valid icon.

Note that absolute paths aren't actually mentioned by the specification, but support for that format already existed in our code, so I've kept it.

> The "image-data" and "icon_data" hints should be a raw image data structure of signature (iiibiiay) which describes the width, height, rowstride, has alpha, bits per sample, channels and image data respectively.
> 
> The "app_icon" parameter and "image-path" hint should be either an URI (file:// is the only URI schema supported right now) or a name in a freedesktop.org-compliant icon theme (not a GTK+ stock ID).