### PR TITLE
applet, desklet, popupMenu: Migrate to class syntax

### DIFF
--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -33,15 +33,9 @@ var AllowedLayout = {  // the panel layout that an applet is suitable for
  * #MenuItem
  * @short_description: Deprecated. Use #PopupMenu.PopupIconMenuItem instead.
  */
-function MenuItem(label, icon, callback) {
-    this._init(label, icon, callback);
-}
-
-MenuItem.prototype = {
-    __proto__ : PopupMenu.PopupIconMenuItem.prototype,
-
-    _init: function(label, icon, callback) {
-        PopupMenu.PopupIconMenuItem.prototype._init.call(this, label, icon, St.IconType.SYMBOLIC);
+var MenuItem = class MenuItem extends PopupMenu.PopupIconMenuItem {
+    _init(label, icon, callback) {
+        super._init(label, icon, St.IconType.SYMBOLIC);
         this.connect('activate', callback);
     }
 }
@@ -54,34 +48,21 @@ MenuItem.prototype = {
  *
  * Inherits: PopupMenu.PopupMenu
  */
-function AppletContextMenu(launcher, orientation) {
-    this._init(launcher, orientation);
-}
-
-AppletContextMenu.prototype = {
-    __proto__: PopupMenu.PopupMenu.prototype,
-
-    /**
-     * _init:
-     * @launcher (Applet.Applet): The applet that contains the context menu
-     * @orientation (St.Side): The orientation of the applet
-     *
-     * Constructor function
-     */
-    _init: function(launcher, orientation) {
-        PopupMenu.PopupMenu.prototype._init.call(this, launcher.actor, orientation);
+var AppletContextMenu = class AppletContextMenu extends PopupMenu.PopupMenu {
+    _init(launcher, orientation) {
+        super._init(launcher.actor, orientation);
         Main.uiGroup.add_actor(this.actor);
         this.actor.hide();
         this.connect("open-state-changed", Lang.bind(this, this._onOpenStateChanged, launcher.actor));
         launcher.connect("orientation-changed", Lang.bind(this, function(a, orientation) {
             this.setArrowSide(orientation);
         }));
-    },
+    }
 
-    _onOpenStateChanged: function(menu, open, sourceActor) {
+    _onOpenStateChanged(menu, open, sourceActor) {
         sourceActor.change_style_pseudo_class("checked", open);
     }
-};
+}
 
 /**
  * #AppletPopupMenu:
@@ -91,12 +72,7 @@ AppletContextMenu.prototype = {
  *
  * Inherits: PopupMenu.PopupMenu
  */
-function AppletPopupMenu(launcher, orientation) {
-    this._init(launcher, orientation);
-}
-
-AppletPopupMenu.prototype = {
-    __proto__: PopupMenu.PopupMenu.prototype,
+var AppletPopupMenu = class AppletPopupMenu extends PopupMenu.PopupMenu {
 
     /**
      * _init:
@@ -105,8 +81,8 @@ AppletPopupMenu.prototype = {
      *
      * Constructor function
      */
-    _init: function(launcher, orientation) {
-        PopupMenu.PopupMenu.prototype._init.call(this, launcher.actor, orientation);
+    _init(launcher, orientation) {
+        super._init(launcher.actor, orientation);
         Main.uiGroup.add_actor(this.actor);
         this.actor.hide();
         this.launcher = launcher;
@@ -116,17 +92,17 @@ AppletPopupMenu.prototype = {
         } else if (launcher._applet) {
             launcher._applet.connect("orientation-changed", Lang.bind(this, this._onOrientationChanged));
         }
-    },
+    }
 
-    _onOrientationChanged: function(a, orientation) {
+    _onOrientationChanged(a, orientation) {
         this.setArrowSide(orientation);
-    },
+    }
 
-    _onOpenStateChanged: function(menu, open, sourceActor) {
+    _onOpenStateChanged(menu, open, sourceActor) {
         if (!sourceActor._applet_context_menu.isOpen)
             sourceActor.actor.change_style_pseudo_class("checked", open);
     }
-};
+}
 
 /**
  * #Applet
@@ -156,11 +132,7 @@ AppletPopupMenu.prototype = {
  *
  * Base applet class that other applets can inherit
  */
-function Applet(orientation, panelHeight, instance_id) {
-    this._init(orientation, panelHeight, instance_id);
-}
-
-Applet.prototype = {
+var Applet = class Applet {
 
     /**
      * _init:
@@ -168,7 +140,12 @@ Applet.prototype = {
      * @panelHeight (int): height of the panel containing the applet
      * @instance_id (int): instance id of the applet
      */
-    _init: function(orientation, panel_height, instance_id) {
+
+    constructor() {
+        return this._init.apply(this, arguments);
+    }
+
+    _init(orientation, panel_height, instance_id) {
 
         this.actor = new St.BoxLayout({ style_class: 'applet-box',
                                         reactive: true,
@@ -237,47 +214,47 @@ Applet.prototype = {
         this._panelEditModeChangedId = global.settings.connect('changed::panel-edit-mode', Lang.bind(this, function() {
             this._setAppletReactivity();
         }));
-    },
+    }
 
     /* FIXME:  This makes no sense - inhibit flag should = panel edit mode, right?
      *         Needs fixed in dnd.js also, it expects this backwards logic right now
      */
 
-    _setAppletReactivity: function() {
+    _setAppletReactivity() {
         this._draggable.inhibit = !global.settings.get_boolean('panel-edit-mode');
-    },
+    }
 
-    _onDragBegin: function() {
+    _onDragBegin() {
         this._dragging = true;
         this._applet_tooltip.hide();
         this._applet_tooltip.preventShow = true;
         Main.panelManager.resetPanelDND();
-    },
+    }
 
-    _onDragEnd: function() {
+    _onDragEnd() {
         this._dragging = false;
         this._applet_tooltip.preventShow = false;
-    },
+    }
 
-    _onDragCancelled: function() {
+    _onDragCancelled() {
         this._dragging = false;
         this._applet_tooltip.preventShow = false;
-    },
+    }
 
-    getDragActor: function() {
+    getDragActor() {
         let clone = new Clutter.Clone({ source: this.actor });
         clone.width = this.actor.width;
         clone.height = this.actor.height;
         return clone;
-    },
+    }
 
     // Returns the original actor that should align with the actor
     // we show as the item is being dragged.
-    getDragActorSource: function() {
+    getDragActorSource() {
         return this.actor;
-    },
+    }
 
-    _onButtonPressEvent: function (actor, event) {
+    _onButtonPressEvent (actor, event) {
         if (!this._applet_enabled) {
             return false;
         }
@@ -303,7 +280,7 @@ Applet.prototype = {
             }
         }
         return true;
-    },
+    }
 
     /**
      * set_applet_tooltip:
@@ -311,12 +288,12 @@ Applet.prototype = {
      *
      * Sets the tooltip of the applet
      */
-    set_applet_tooltip: function (text) {
+    set_applet_tooltip (text) {
         if (text != this._applet_tooltip_text) {
             this._applet_tooltip_text = text;
             this._applet_tooltip.set_text(text);
         }
-    },
+    }
 
     /**
      * set_applet_enabled:
@@ -325,12 +302,12 @@ Applet.prototype = {
      * Sets whether the applet is enabled or not. A disabled applet sets its
      * padding to 0px and doesn't react to clicks
      */
-    set_applet_enabled: function (enabled) {
+    set_applet_enabled (enabled) {
         if (enabled != this._applet_enabled) {
             this._applet_enabled = enabled;
             this.actor.visible = enabled;
         }
-    },
+    }
 
     /**
      * on_applet_clicked:
@@ -340,9 +317,9 @@ Applet.prototype = {
      *
      * This is meant to be overridden in individual applets.
      */
-    on_applet_clicked: function(event) {
+    on_applet_clicked(event) {
         // Implemented by Applets
-    },
+    }
 
     /**
      * on_applet_middle_clicked:
@@ -352,9 +329,9 @@ Applet.prototype = {
      *
      * This is meant to be overridden in individual applets.
      */
-    on_applet_middle_clicked: function(event) {
+    on_applet_middle_clicked(event) {
         // Implemented by Applets
-    },
+    }
 
 
     /**
@@ -366,11 +343,11 @@ Applet.prototype = {
      *
      * This is meant to be overridden in individual applets
      */
-    on_applet_instances_changed: function() {
+    on_applet_instances_changed() {
 
-    },
+    }
 
-    on_applet_added_to_panel_internal: function(userEnabled) {
+    on_applet_added_to_panel_internal(userEnabled) {
         if (userEnabled) {
             Mainloop.timeout_add(300, Lang.bind(this, function() {
                 let [x, y] = this.actor.get_transformed_position();
@@ -384,7 +361,7 @@ Applet.prototype = {
         this.on_applet_added_to_panel(userEnabled);
 
         Main.AppletManager.callAppletInstancesChanged(this._uuid);
-    },
+    }
 
     /**
      * on_applet_added_to_panel:
@@ -393,8 +370,8 @@ Applet.prototype = {
      *
      * This is meant to be overridden in individual applets.
      */
-    on_applet_added_to_panel: function(userEnabled) {
-    },
+    on_applet_added_to_panel(userEnabled) {
+    }
 
     /**
      * on_applet_removed_from_panel:
@@ -403,8 +380,8 @@ Applet.prototype = {
      *
      * This is meant to be overridden in individual applets.
      */
-    on_applet_removed_from_panel: function(deleteConfig) {
-    },
+    on_applet_removed_from_panel(deleteConfig) {
+    }
 
     /**
      * on_applet_reloaded:
@@ -417,12 +394,12 @@ Applet.prototype = {
     },
 
     // should only be called by appletManager
-    _onAppletRemovedFromPanel: function(deleteConfig) {
+    _onAppletRemovedFromPanel(deleteConfig) {
         global.settings.disconnect(this._panelEditModeChangedId);
         this.on_applet_removed_from_panel(deleteConfig);
 
         Main.AppletManager.callAppletInstancesChanged(this._uuid);
-    },
+    }
 
     /**
      * setOrientationInternal:
@@ -431,7 +408,7 @@ Applet.prototype = {
      * Sets the orientation of the St.BoxLayout.
      *
      */
-    setOrientationInternal: function (orientation) {
+    setOrientationInternal (orientation) {
         if (orientation == St.Side.LEFT || orientation == St.Side.RIGHT) {
             this.actor.add_style_class_name('vertical');
             this.actor.set_important(true);
@@ -441,7 +418,7 @@ Applet.prototype = {
             this.actor.remove_style_class_name('vertical');
             this.actor.set_vertical(false);
         }
-    },
+    }
 
     /**
      * setOrientation:
@@ -451,12 +428,12 @@ Applet.prototype = {
      *
      * This function should only be called by appletManager
      */
-    setOrientation: function (orientation) {
+    setOrientation (orientation) {
         this.setOrientationInternal(orientation);
         this.on_orientation_changed(orientation);
         this.emit("orientation-changed", orientation);
         this.finalizeContextMenu();
-    },
+    }
 
     /**
      * setAllowedLayout:
@@ -466,9 +443,9 @@ Applet.prototype = {
      * AllowedLayout.HORIZONTAL, AllowedLayout.VERTICAL, and
      * AllowedLayout.BOTH.
      */
-    setAllowedLayout: function (layout) {
+    setAllowedLayout (layout) {
         this._allowedLayout = layout;
-    },
+    }
 
     /**
      * getAllowedLayout:
@@ -477,9 +454,9 @@ Applet.prototype = {
      *
      * Returns (Applet.AllowedLayout): The allowed layout of the applet
      */
-    getAllowedLayout: function() {
+    getAllowedLayout() {
         return this._allowedLayout;
-    },
+    }
 
     /**
      * on_orientation_changed:
@@ -489,9 +466,9 @@ Applet.prototype = {
      *
      * This is meant to be overridden in individual applets.
      */
-    on_orientation_changed: function(orientation) {
+    on_orientation_changed(orientation) {
         // Implemented by Applets
-    },
+    }
 
     /**
      * setPanelHeight:
@@ -499,22 +476,22 @@ Applet.prototype = {
      *
      * Sets the panel height property of the applet.
      */
-    setPanelHeight: function (panel_height) {
+    setPanelHeight (panel_height) {
         if (panel_height && panel_height > 0) {
             this._panelHeight = panel_height;
         }
         this._scaleMode = this.panel.scaleMode;
         this.on_panel_height_changed_internal();
-    },
+    }
 
     /**
      * on_panel_height_changed_internal:
      *
      * This function is called when the panel containing the applet changes height
      */
-    on_panel_height_changed_internal: function() {
+    on_panel_height_changed_internal() {
         this.on_panel_height_changed();
-    },
+    }
 
     /**
      * on_panel_height_changed:
@@ -523,11 +500,11 @@ Applet.prototype = {
      *
      * This is meant to be overridden in individual applets.
      */
-    on_panel_height_changed: function() {
+    on_panel_height_changed() {
         // Implemented byApplets
-    },
+    }
 
-    finalizeContextMenu: function () {
+    finalizeContextMenu () {
 
         // Add default context menus if we're in panel edit mode, ensure their removal if we're not
         let items = this._applet_context_menu._getMenuItems();
@@ -573,10 +550,10 @@ Applet.prototype = {
         if (items.indexOf(this.context_menu_item_remove) == -1) {
             this._applet_context_menu.addMenuItem(this.context_menu_item_remove);
         }
-    },
+    }
 
     // translation
-    _: function(str) {
+    _(str) {
         // look into the text domain first
         let translated = Gettext.dgettext(this._uuid, str);
 
@@ -585,7 +562,7 @@ Applet.prototype = {
             return translated;
         // else, use the default cinnamon domain
         return _(str);
-    },
+    }
 
     /**
      * highlight:
@@ -593,15 +570,15 @@ Applet.prototype = {
      *
      * Turns on/off the highlight of the applet
      */
-    highlight: function(highlight) {
+    highlight(highlight) {
         this.actor.change_style_pseudo_class("highlight", highlight);
-    },
+    }
 
-    openAbout: function() {
+    openAbout() {
         new ModalDialog.SpicesAboutDialog(this._meta, "applets");
-    },
+    }
 
-    configureApplet: function() {
+    configureApplet() {
         Util.spawnCommandLine("xlet-settings applet " + this._uuid + " " + this.instance_id);
     }
 };
@@ -617,12 +594,7 @@ Signals.addSignalMethods(Applet.prototype);
  *
  * Inherits: Applet.Applet
  */
-function IconApplet(orientation, panel_height, instance_id) {
-    this._init(orientation, panel_height, instance_id);
-}
-
-IconApplet.prototype = {
-    __proto__: Applet.prototype,
+var IconApplet = class IconApplet extends Applet {
 
     /**
      * _init:
@@ -630,15 +602,15 @@ IconApplet.prototype = {
      * @panelHeight (int): height of the panel containing the applet
      * @instance_id (int): instance id of the applet
      */
-    _init: function(orientation, panel_height, instance_id) {
-        Applet.prototype._init.call(this, orientation, panel_height, instance_id);
+    _init(orientation, panel_height, instance_id) {
+        super._init(orientation, panel_height, instance_id);
 
         this._applet_icon_box = new St.Bin(); // https://developer.gnome.org/st/stable/StBin.htm
 
         this._applet_icon_box.set_fill(true,true);
         this._applet_icon_box.set_alignment(St.Align.MIDDLE,St.Align.MIDDLE);
         this.actor.add(this._applet_icon_box);
-    },
+    }
 
     /**
      * set_applet_icon_name:
@@ -648,13 +620,13 @@ IconApplet.prototype = {
      *
      * The icon will be full color
      */
-    set_applet_icon_name: function (icon_name) {
+    set_applet_icon_name (icon_name) {
         this._ensureIcon();
 
         this._applet_icon.set_icon_name(icon_name);
         this._applet_icon.set_icon_type(St.IconType.FULLCOLOR);
         this._setStyle();
-    },
+    }
 
     /**
      * set_applet_icon_symbolic_name:
@@ -664,13 +636,13 @@ IconApplet.prototype = {
      *
      * The icon will be symbolic
      */
-    set_applet_icon_symbolic_name: function (icon_name) {
+    set_applet_icon_symbolic_name (icon_name) {
         this._ensureIcon();
 
         this._applet_icon.set_icon_name(icon_name);
         this._applet_icon.set_icon_type(St.IconType.SYMBOLIC);
         this._setStyle();
-    },
+    }
 
     /**
      * set_applet_icon_path:
@@ -680,7 +652,7 @@ IconApplet.prototype = {
      *
      * The icon will be full color
      */
-    set_applet_icon_path: function (icon_path) {
+    set_applet_icon_path (icon_path) {
         this._ensureIcon();
 
         try {
@@ -691,7 +663,7 @@ IconApplet.prototype = {
         } catch (e) {
             global.log(e);
         }
-    },
+    }
 
     /**
      * set_applet_icon_symbolic_path:
@@ -701,7 +673,7 @@ IconApplet.prototype = {
      *
      * The icon will be symbolic
      */
-    set_applet_icon_symbolic_path: function(icon_path) {
+    set_applet_icon_symbolic_path(icon_path) {
         this._ensureIcon();
 
         try {
@@ -712,16 +684,16 @@ IconApplet.prototype = {
         } catch (e) {
             global.log(e);
         }
-    },
+    }
 
-    _ensureIcon: function() {
+    _ensureIcon() {
         if (!this._applet_icon || !(this._applet_icon instanceof St.Icon))
             this._applet_icon = new St.Icon({ reactive: true, track_hover: true, style_class: 'applet-icon'});
 
         this._applet_icon_box.set_child(this._applet_icon);
-    },
+    }
 
-    _setStyle: function() {
+    _setStyle() {
 
         let symb_scaleup = ((this._panelHeight / DEFAULT_PANEL_HEIGHT) * PANEL_SYMBOLIC_ICON_DEFAULT_HEIGHT) / global.ui_scale;
         let fullcolor_scaleup = this._panelHeight * COLOR_ICON_HEIGHT_FACTOR / global.ui_scale;
@@ -746,14 +718,14 @@ IconApplet.prototype = {
                                                 -1);
                                                 this._applet_icon.set_style_class_name('system-status-icon');
         }
-    },
+    }
 
-    on_panel_height_changed_internal: function() {
+    on_panel_height_changed_internal() {
         if (this._applet_icon)
             this._setStyle();
         this.on_panel_height_changed();
     }
-};
+}
 
 /**
  * #TextApplet:
@@ -764,12 +736,7 @@ IconApplet.prototype = {
  *
  * Inherits: Applet.Applet
  */
-function TextApplet(orientation, panel_height, instance_id) {
-    this._init(orientation, panel_height, instance_id);
-}
-
-TextApplet.prototype = {
-    __proto__: Applet.prototype,
+var TextApplet = class TextApplet extends Applet {
 
     /**
      * _init:
@@ -780,8 +747,8 @@ TextApplet.prototype = {
      * Note that suitability for display in a vertical panel is handled by having applets declare
      * they work OK, handled elsewhere
      */
-    _init: function(orientation, panel_height, instance_id) {
-        Applet.prototype._init.call(this, orientation, panel_height, instance_id);
+    _init(orientation, panel_height, instance_id) {
+        super._init(orientation, panel_height, instance_id);
         this._applet_label = new St.Label({ reactive: true,
                                             track_hover: true,
                                             style_class: 'applet-label'});
@@ -793,7 +760,7 @@ TextApplet.prototype = {
         this.actor.add(this._layoutBin, { y_align: St.Align.MIDDLE,
                                           y_fill: false });
         this.actor.set_label_actor(this._applet_label);
-    },
+    }
 
     /**
      * set_applet_label:
@@ -801,13 +768,13 @@ TextApplet.prototype = {
      *
      * Sets the text of the actor to @text
      */
-    set_applet_label: function (text) {
+    set_applet_label (text) {
         this._applet_label.set_text(text);
-    },
-
-    on_applet_added_to_panel: function() {
     }
-};
+
+    on_applet_added_to_panel() {
+    }
+}
 
 /**
  * #TextIconApplet:
@@ -820,12 +787,7 @@ TextApplet.prototype = {
  * Note that suitability for display in a vertical panel is handled by having applets declare
  * they work OK, handled elsewhere
  */
-function TextIconApplet(orientation, panel_height, instance_id) {
-    this._init(orientation, panel_height, instance_id);
-}
-
-TextIconApplet.prototype = {
-    __proto__: IconApplet.prototype,
+var TextIconApplet = class TextIconApplet extends IconApplet {
 
     /**
      * _init:
@@ -833,8 +795,8 @@ TextIconApplet.prototype = {
      * @panelHeight (int): height of the panel containing the applet
      * @instance_id (int): instance id of the applet
      */
-    _init: function(orientation, panel_height, instance_id) {
-        IconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
+    _init(orientation, panel_height, instance_id) {
+        super._init(orientation, panel_height, instance_id);
         this._applet_label = new St.Label({ reactive: true,
                                             track_hover: true,
                                             style_class: 'applet-label'});
@@ -848,7 +810,7 @@ TextIconApplet.prototype = {
         this.actor.set_label_actor(this._applet_label);
 
         this.show_label_in_vertical_panels = true;
-    },
+    }
 
     /**
      * set_show_label_in_vertical_panels:
@@ -856,9 +818,9 @@ TextIconApplet.prototype = {
      *
      * Sets whether to show the label in vertical panels
      */
-    set_show_label_in_vertical_panels: function (show) {
+    set_show_label_in_vertical_panels (show) {
         this.show_label_in_vertical_panels = show;
-    },
+    }
 
     /**
      * set_applet_label:
@@ -866,7 +828,7 @@ TextIconApplet.prototype = {
      *
      * Sets the text of the actor to @text
      */
-    set_applet_label: function (text) {
+    set_applet_label (text) {
         this._applet_label.set_text(text);
 
         if ((this._orientation == St.Side.LEFT || this._orientation == St.Side.RIGHT) && (this.show_label_in_vertical_panels == false)) {
@@ -882,7 +844,7 @@ TextIconApplet.prototype = {
                 this.hide_applet_label(false);
             }
         }
-    },
+    }
 
     /**
      * set_applet_enabled:
@@ -891,7 +853,7 @@ TextIconApplet.prototype = {
      * Sets whether the applet is enabled or not. A disabled applet sets its
      * padding to 0px and doesn't react to clicks
      */
-    set_applet_enabled: function (enabled) {
+    set_applet_enabled (enabled) {
         if (enabled != this._applet_enabled) {
             this._applet_enabled = enabled;
             this.actor.visible = enabled;
@@ -899,7 +861,7 @@ TextIconApplet.prototype = {
                 this._applet_icon.visible = enabled;
             }
         }
-    },
+    }
 
     /**
      * hide_applet_label:
@@ -909,48 +871,48 @@ TextIconApplet.prototype = {
      * function to hide applet labels when an applet is placed in a vertical
      * panel
      */
-    hide_applet_label: function (hide) {
+    hide_applet_label (hide) {
         if (hide) {
             this.hideLabel();
         } else {
             this.showLabel();
         }
-    },
+    }
     /**
      * hideLabel:
      *
      * Hides the applet label
      */
-    hideLabel: function () {
+    hideLabel () {
         this._applet_label.hide();
         this._layoutBin.hide();
-    },
+    }
     /**
      * showLabel:
      *
      * Shows the applet label
      */
-    showLabel: function () {
+    showLabel () {
         this._applet_label.show();
         this._layoutBin.show();
-    },
+    }
     /**
      * hide_applet_icon:
      *
      * Hides the icon of the applet
      */
-    hide_applet_icon: function () {
+    hide_applet_icon () {
         this._applet_icon_box.child = null;
-    },
+    }
 
-    on_applet_added_to_panel: function() {
+    on_applet_added_to_panel() {
 
-    },
+    }
 
     /**
      * Override setOrientation, to recall set_applet_label
      */
-    setOrientation: function (orientation) {
+    setOrientation (orientation) {
         this.setOrientationInternal(orientation);
         this.on_orientation_changed(orientation);
         this.emit("orientation-changed", orientation);
@@ -958,4 +920,4 @@ TextIconApplet.prototype = {
         this._orientation = orientation;
         this.set_applet_label(this._applet_label.get_text());
     }
-};
+}

--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -390,8 +390,8 @@ var Applet = class Applet {
      *
      * This is meant to be overridden in individual applets.
      */
-    on_applet_reloaded: function(deleteConfig) {
-    },
+    on_applet_reloaded(deleteConfig) {
+    }
 
     // should only be called by appletManager
     _onAppletRemovedFromPanel(deleteConfig) {

--- a/js/ui/desklet.js
+++ b/js/ui/desklet.js
@@ -32,19 +32,19 @@ const DESKLET_DESTROY_TIME = 0.5;
  *
  * #Desklet is a base class in which other desklets can inherit
  */
-function Desklet(metadata, desklet_id){
-    this._init(metadata, desklet_id);
-}
-
-Desklet.prototype = {
+var Desklet = class Desklet {
     /**
      * _init:
      * @metadata (dictionary): the metadata of the desklet
      * @desklet_id (int): instance id of the desklet
-     * 
+     *
      * Constructor function
      */
-    _init: function(metadata, desklet_id){
+    constructor() {
+        return this._init.apply(this, arguments);
+    }
+
+    _init(metadata, desklet_id) {
         this.metadata = metadata;
         this.instance_id = desklet_id;
         this.actor = new St.BoxLayout({reactive: true, track_hover: true, vertical: true});
@@ -78,7 +78,7 @@ Desklet.prototype = {
 
         this._drag_end_ids = {"drag-end": 0, "drag-cancelled": 0};
         this._draggable = DND.makeDraggable(this.actor, {restoreOnSuccess: true}, Main.deskletContainer.actor);
-    },
+    }
 
     /**
      * setHeader:
@@ -86,9 +86,9 @@ Desklet.prototype = {
      *
      * Sets the header text of the desklet to @header
      */
-    setHeader: function(header){
+    setHeader(header){
         this._header_label.set_text(header);
-    },
+    }
 
     /**
      * setContent:
@@ -98,17 +98,17 @@ Desklet.prototype = {
      *
      * Sets the content actor of the desklet as @actor
      */
-    setContent: function(actor, params){
+    setContent(actor, params){
         this.content.set_child(actor);
-    },
+    }
 
     /**
      * on_desklet_removed:
      *
      * Callback when desklet is removed. To be overridden by individual desklets
      */
-    on_desklet_removed: function(deleteConfig) {
-    },
+    on_desklet_removed(deleteConfig) {
+    }
 
     /**
      * on_desklet_reloaded:
@@ -123,7 +123,7 @@ Desklet.prototype = {
      *
      * Destroys the actor with an fading animation
      */
-    destroy: function(deleteConfig){
+    destroy(deleteConfig){
         Tweener.addTween(this.actor,
                          { opacity: 0,
                            transition: 'linear',
@@ -137,22 +137,22 @@ Desklet.prototype = {
         this._menu = null;
         this._menuManager = null;
         this.emit('destroy');
-    },
+    }
 
-    _updateDecoration: function(){
+    _updateDecoration(){
         let dec = global.settings.get_int('desklet-decorations');
         let preventDecorations = this.metadata['prevent-decorations'];
         if (preventDecorations == true){
             dec = 0;
         }
-                      
+
         switch(dec){
         case 0:
-            this._header.hide();    
-            this.content.style_class = 'desklet';        
+            this._header.hide();
+            this.content.style_class = 'desklet';
             break;
         case 1:
-            this._header.hide();            
+            this._header.hide();
             this.content.style_class = 'desklet-with-borders';
             break;
         case 2:
@@ -160,13 +160,13 @@ Desklet.prototype = {
             this.content.style_class = 'desklet-with-borders-and-header';
             break;
         }
-    },
+    }
 
-    on_desklet_clicked: function(event) {
-        // Implemented by Desklets        
-    },
+    on_desklet_clicked(event) {
+        // Implemented by Desklets
+    }
 
-    on_desklet_added_to_desktop_internal: function(userEnabled) {
+    on_desklet_added_to_desktop_internal(userEnabled) {
         if (userEnabled) {
             Mainloop.timeout_add(300, Lang.bind(this, function() {
                 let [x, y] = this.actor.get_transformed_position();
@@ -178,7 +178,7 @@ Desklet.prototype = {
         }
 
         this.on_desklet_added_to_desktop(userEnabled);
-    },
+    }
 
     /**
      * on_desklet_added_to_desktop:
@@ -187,10 +187,10 @@ Desklet.prototype = {
      *
      * This is meant to be overridden in individual applets.
      */
-    on_desklet_added_to_desktop: function(userEnabled) {
-    },
+    on_desklet_added_to_desktop(userEnabled) {
+    }
 
-    _onButtonReleaseEvent: function(actor, event) {
+    _onButtonReleaseEvent(actor, event) {
         if (event.get_button() == 3) {
             this._menu.toggle();
         } else {
@@ -199,46 +199,46 @@ Desklet.prototype = {
             }
             this.on_desklet_clicked(event);
         }
-    },
-    
-    _trackMouse: function() {
+    }
+
+    _trackMouse() {
         if(!Main.layoutManager.isTrackingChrome(this.actor)) {
             Main.layoutManager.addChrome(this.actor, {doNotAdd: true});
             this._isTracked = true;
         }
-    },
-    
-    _untrackMouse: function() {
+    }
+
+    _untrackMouse() {
         if(Main.layoutManager.isTrackingChrome(this.actor)) {
             Main.layoutManager.untrackChrome(this.actor);
             this._isTracked = false;
         }
-    },
+    }
 
-    _onRemoveDesklet: function(){
+    _onRemoveDesklet(){
         DeskletManager.removeDesklet(this._uuid, this.instance_id);
-    },
-    
-    finalizeContextMenu: function() {
+    }
+
+    finalizeContextMenu() {
         this.context_menu_separator = new PopupMenu.PopupSeparatorMenuItem();
         if (this._menu._getMenuItems().length > 0) {
             this._menu.addMenuItem(this.context_menu_separator);
         }
-        
+
         this.context_menu_item_about = new PopupMenu.PopupMenuItem(_("About..."))
         this.context_menu_item_about.connect("activate", Lang.bind(this, this.openAbout));
         this._menu.addMenuItem(this.context_menu_item_about);
-        
-        if (!this._meta["hide-configuration"] && GLib.file_test(this._meta["path"] + "/settings-schema.json", GLib.FileTest.EXISTS)) {            
+
+        if (!this._meta["hide-configuration"] && GLib.file_test(this._meta["path"] + "/settings-schema.json", GLib.FileTest.EXISTS)) {
             this.context_menu_item_configure = new PopupMenu.PopupMenuItem(_("Configure..."));
             this.context_menu_item_configure.connect("activate", Lang.bind(this, this.configureDesklet));
             this._menu.addMenuItem(this.context_menu_item_configure);
         }
-        
+
         this.context_menu_item_remove = new PopupMenu.PopupMenuItem(_("Remove this desklet"));
         this.context_menu_item_remove.connect("activate", Lang.bind(this, this._onRemoveDesklet));
-        this._menu.addMenuItem(this.context_menu_item_remove);            
-    },
+        this._menu.addMenuItem(this.context_menu_item_remove);
+    }
 
     /**
      * highlight:
@@ -246,16 +246,16 @@ Desklet.prototype = {
      *
      * Turns on/off the highlight of the desklet
      */
-    highlight: function(highlight) {
+    highlight(highlight) {
         this.content.change_style_pseudo_class("highlight", highlight);
-    },
+    }
 
-    openAbout: function() {
+    openAbout() {
         new ModalDialog.SpicesAboutDialog(this._meta, "desklets");
-    },
+    }
 
-    configureDesklet: function() {
+    configureDesklet() {
         Util.spawnCommandLine("xlet-settings desklet " + this._uuid + " " + this.instance_id);
     }
-};
+}
 Signals.addSignalMethods(Desklet.prototype);

--- a/js/ui/desklet.js
+++ b/js/ui/desklet.js
@@ -115,8 +115,8 @@ var Desklet = class Desklet {
      *
      * Callback when desklet is reloaded. To be overridden by individual desklets
      */
-    on_desklet_reloaded: function() {
-    },
+    on_desklet_reloaded() {
+    }
 
     /**
      * destroy:

--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -93,12 +93,12 @@ function arrowIcon(side) {
     return arrow;
 }
 
-function PopupBaseMenuItem(params) {
-    this._init(params);
-}
+var PopupBaseMenuItem = class PopupBaseMenuItem {
+    constructor() {
+        return this._init.apply(this, arguments);
+    }
 
-PopupBaseMenuItem.prototype = {
-    _init: function (params) {
+    _init(params) {
         params = Params.parse (params, { reactive: true,
                                          activate: true,
                                          hover: true,
@@ -142,18 +142,18 @@ PopupBaseMenuItem.prototype = {
             this._signals.connect(this.actor, 'key-focus-in', Lang.bind(this, this._onKeyFocusIn));
             this._signals.connect(this.actor, 'key-focus-out', Lang.bind(this, this._onKeyFocusOut));
         }
-    },
+    }
 
-    _onStyleChanged: function (actor) {
+    _onStyleChanged(actor) {
         this._spacing = Math.round(actor.get_theme_node().get_length('spacing'));
-    },
+    }
 
-    _onButtonReleaseEvent: function (actor, event) {
+    _onButtonReleaseEvent(actor, event) {
         this.activate(event, false);
         return true;
-    },
+    }
 
-    _onKeyPressEvent: function (actor, event) {
+    _onKeyPressEvent(actor, event) {
         let symbol = event.get_key_symbol();
 
         if (symbol == Clutter.KEY_space || symbol == Clutter.KEY_Return) {
@@ -161,25 +161,25 @@ PopupBaseMenuItem.prototype = {
             return true;
         }
         return false;
-    },
+    }
 
-    _onKeyFocusIn: function (actor) {
+    _onKeyFocusIn(actor) {
         this.setActive(true);
-    },
+    }
 
-    _onKeyFocusOut: function (actor) {
+    _onKeyFocusOut(actor) {
         this.setActive(false);
-    },
+    }
 
-    _onHoverChanged: function (actor) {
+    _onHoverChanged(actor) {
         this.setActive(actor.hover);
-    },
+    }
 
-    activate: function (event, keepMenu) {
+    activate(event, keepMenu) {
         this.emit('activate', event, keepMenu);
-    },
+    }
 
-    setActive: function (active) {
+    setActive(active) {
         let activeChanged = active != this.active;
 
         if (activeChanged) {
@@ -189,9 +189,9 @@ PopupBaseMenuItem.prototype = {
 
             this.emit('active-changed', active);
         }
-    },
+    }
 
-    setSensitive: function(sensitive) {
+    setSensitive(sensitive) {
         if (!this._activatable)
             return;
         if (this.sensitive == sensitive)
@@ -203,19 +203,19 @@ PopupBaseMenuItem.prototype = {
 
         this.actor.change_style_pseudo_class('insensitive', !sensitive);
         this.emit('sensitive-changed', sensitive);
-    },
+    }
 
-    destroy: function() {
+    destroy() {
         this._signals.disconnectAllSignals();
         this.actor.destroy();
         this.emit('destroy');
-    },
+    }
 
     // adds an actor to the menu item; @params can contain %span
     // (column span; defaults to 1, -1 means "all the remaining width", 0 means "no new column after this actor"),
     // %expand (defaults to #false), and %align (defaults to
     // #St.Align.START)
-    addActor: function(child, params) {
+    addActor(child, params) {
         params = Params.parse(params, { span: 1,
                                         expand: false,
                                         align: St.Align.START });
@@ -223,23 +223,23 @@ PopupBaseMenuItem.prototype = {
         this._children.push(params);
         this._signals.connect(this.actor, 'destroy', this._removeChild.bind(this, child));
         this.actor.add_actor(child);
-    },
+    }
 
-    _removeChild: function(child) {
+    _removeChild(child) {
         for (let i = 0; i < this._children.length; i++) {
             if (this._children[i].actor == child) {
                 this._children.splice(i, 1);
                 return;
             }
         }
-    },
+    }
 
-    removeActor: function(child) {
+    removeActor(child) {
         this.actor.remove_actor(child);
         this._removeChild(child);
-    },
+    }
 
-    setShowDot: function(show) {
+    setShowDot(show) {
         if (show) {
             if (this._dot)
                 return;
@@ -256,9 +256,9 @@ PopupBaseMenuItem.prototype = {
             this._dot = null;
             this.actor.remove_accessible_state (Atk.StateType.CHECKED);
         }
-    },
+    }
 
-    _onRepaintDot: function(area) {
+    _onRepaintDot(area) {
         let cr = area.get_context();
         let [width, height] = area.get_surface_size();
         let color = area.get_theme_node().get_foreground_color();
@@ -272,11 +272,11 @@ PopupBaseMenuItem.prototype = {
         cr.fill();
 
         cr.$dispose();
-    },
+    }
 
     // This returns column widths in logical order (i.e. from the dot
     // to the image), not in visual order (left to right)
-    getColumnWidths: function() {
+    getColumnWidths() {
         let widths = [];
         for (let i = 0, col = 0; i < this._children.length; i++) {
             let child = this._children[i];
@@ -294,13 +294,13 @@ PopupBaseMenuItem.prototype = {
             }
         }
         return widths;
-    },
+    }
 
-    setColumnWidths: function(widths) {
+    setColumnWidths(widths) {
         this._columnWidths = widths;
-    },
+    }
 
-    _getPreferredWidth: function(actor, forHeight, alloc) {
+    _getPreferredWidth(actor, forHeight, alloc) {
         let width = 0;
         if (this._columnWidths) {
             for (let i = 0; i < this._columnWidths.length; i++) {
@@ -318,9 +318,9 @@ PopupBaseMenuItem.prototype = {
             }
         }
         alloc.min_size = alloc.natural_size = width;
-    },
+    }
 
-    _getPreferredHeight: function(actor, forWidth, alloc) {
+    _getPreferredHeight(actor, forWidth, alloc) {
         let height = 0, x = 0, minWidth, childWidth;
         for (let i = 0; i < this._children.length; i++) {
             let child = this._children[i];
@@ -344,9 +344,9 @@ PopupBaseMenuItem.prototype = {
                 height = natural;
         }
         alloc.min_size = alloc.natural_size = height;
-    },
+    }
 
-    _allocate: function(actor, box, flags) {
+    _allocate(actor, box, flags) {
         let height = box.y2 - box.y1;
         let direction = this.actor.get_direction();
 
@@ -469,41 +469,29 @@ PopupBaseMenuItem.prototype = {
                 x -= availWidth + this._spacing;
         }
     }
-};
+}
 Signals.addSignalMethods(PopupBaseMenuItem.prototype);
 
-function PopupMenuItem() {
-    this._init.apply(this, arguments);
-}
-
-PopupMenuItem.prototype = {
-    __proto__: PopupBaseMenuItem.prototype,
-
-    _init: function (text, params) {
-        PopupBaseMenuItem.prototype._init.call(this, params);
+var PopupMenuItem = class PopupMenuItem extends PopupBaseMenuItem {
+    _init (text, params) {
+        super._init.call(this, params);
 
         this.label = new St.Label({ text: text });
         this.addActor(this.label);
         this.actor.label_actor = this.label;
     }
-};
-
-function PopupSeparatorMenuItem() {
-    this._init();
 }
 
-PopupSeparatorMenuItem.prototype = {
-    __proto__: PopupBaseMenuItem.prototype,
-
-    _init: function () {
-        PopupBaseMenuItem.prototype._init.call(this, { reactive: false });
+var PopupSeparatorMenuItem = class PopupSeparatorMenuItem extends PopupBaseMenuItem {
+    _init () {
+        super._init.call(this, { reactive: false });
 
         this._drawingArea = new St.DrawingArea({ style_class: 'popup-separator-menu-item' });
         this.addActor(this._drawingArea, { span: -1, expand: true });
         this._signals.connect(this._drawingArea, 'repaint', Lang.bind(this, this._onRepaint));
-    },
+    }
 
-    _onRepaint: function(area) {
+    _onRepaint(area) {
         let cr = area.get_context();
         let themeNode = area.get_theme_node();
         let [width, height] = area.get_surface_size();
@@ -524,22 +512,16 @@ PopupSeparatorMenuItem.prototype = {
 
         cr.$dispose();
     }
-};
+}
 
 const PopupAlternatingMenuItemState = {
     DEFAULT: 0,
     ALTERNATIVE: 1
 }
 
-function PopupAlternatingMenuItem() {
-    this._init.apply(this, arguments);
-}
-
-PopupAlternatingMenuItem.prototype = {
-    __proto__: PopupBaseMenuItem.prototype,
-
-    _init: function(text, alternateText, params) {
-        PopupBaseMenuItem.prototype._init.call(this, params);
+var PopupAlternatingMenuItem = class PopupAlternatingMenuItem extends PopupBaseMenuItem {
+    _init(text, alternateText, params) {
+        super._init.call(this, params);
         this.actor.add_style_class_name('popup-alternating-menu-item');
 
         this._text = text;
@@ -549,9 +531,9 @@ PopupAlternatingMenuItem.prototype = {
         this.addActor(this.label);
 
         this._signals.connect(this.actor, 'notify::mapped', Lang.bind(this, this._onMapped));
-    },
+    }
 
-    _onMapped: function() {
+    _onMapped() {
         if (this.actor.mapped) {
             this._capturedEventId = global.stage.connect('captured-event',
                                                          Lang.bind(this, this._onCapturedEvent));
@@ -562,9 +544,9 @@ PopupAlternatingMenuItem.prototype = {
                 this._capturedEventId = 0;
             }
         }
-    },
+    }
 
-    _setState: function(state) {
+    _setState(state) {
         if (this.state != state) {
             if (state == PopupAlternatingMenuItemState.ALTERNATIVE && !this._canAlternate())
                 return;
@@ -572,9 +554,9 @@ PopupAlternatingMenuItem.prototype = {
             this.state = state;
             this._updateLabel();
         }
-    },
+    }
 
-    _updateStateFromModifiers: function() {
+    _updateStateFromModifiers() {
         let [x, y, mods] = global.get_pointer();
         let state;
 
@@ -585,9 +567,9 @@ PopupAlternatingMenuItem.prototype = {
         }
 
         this._setState(state);
-    },
+    }
 
-    _onCapturedEvent: function(actor, event) {
+    _onCapturedEvent(actor, event) {
         if (event.type() != Clutter.EventType.KEY_PRESS &&
             event.type() != Clutter.EventType.KEY_RELEASE)
             return false;
@@ -598,9 +580,9 @@ PopupAlternatingMenuItem.prototype = {
             this._updateStateFromModifiers();
 
         return false;
-    },
+    }
 
-    _updateLabel: function() {
+    _updateLabel() {
         if (this.state == PopupAlternatingMenuItemState.ALTERNATIVE) {
             this.actor.add_style_pseudo_class('alternate');
             this.label.set_text(this._alternateText);
@@ -608,15 +590,15 @@ PopupAlternatingMenuItem.prototype = {
             this.actor.remove_style_pseudo_class('alternate');
             this.label.set_text(this._text);
         }
-    },
+    }
 
-    _canAlternate: function() {
+    _canAlternate() {
         if (this.state == PopupAlternatingMenuItemState.DEFAULT && !this._alternateText)
             return false;
         return true;
-    },
+    }
 
-    updateText: function(text, alternateText) {
+    updateText(text, alternateText) {
         this._text = text;
         this._alternateText = alternateText;
 
@@ -625,17 +607,11 @@ PopupAlternatingMenuItem.prototype = {
 
         this._updateLabel();
     }
-};
-
-function PopupSliderMenuItem() {
-    this._init.apply(this, arguments);
 }
 
-PopupSliderMenuItem.prototype = {
-    __proto__: PopupBaseMenuItem.prototype,
-
-    _init: function(value) {
-        PopupBaseMenuItem.prototype._init.call(this, { activate: false });
+var PopupSliderMenuItem = class PopupSliderMenuItem extends PopupBaseMenuItem {
+    _init(value) {
+        super._init.call(this, { activate: false });
 
         this._signals.connect(this.actor, 'key-press-event', Lang.bind(this, this._onKeyPressEvent));
 
@@ -653,17 +629,17 @@ PopupSliderMenuItem.prototype = {
         this._releaseId = this._motionId = 0;
         this._dragging = false;
         this._mark_position = 0; // 0 means no mark
-    },
+    }
 
-    setValue: function(value) {
+    setValue(value) {
         if (isNaN(value))
             throw TypeError('The slider value must be a number');
 
         this._value = Math.max(Math.min(value, 1), 0);
         this._slider.queue_repaint();
-    },
+    }
 
-    _sliderRepaint: function(area) {
+    _sliderRepaint(area) {
         let cr = area.get_context();
         let themeNode = area.get_theme_node();
         let [width, height] = area.get_surface_size();
@@ -724,9 +700,9 @@ PopupSliderMenuItem.prototype = {
         }
 
         cr.$dispose();
-    },
+    }
 
-    _startDragging: function(actor, event) {
+    _startDragging(actor, event) {
         if (this._dragging) // don't allow two drags at the same time
             return;
 
@@ -742,9 +718,9 @@ PopupSliderMenuItem.prototype = {
         let absX, absY;
         [absX, absY] = event.get_coords();
         this._moveHandle(absX, absY);
-    },
+    }
 
-    _endDragging: function() {
+    _endDragging() {
         if (this._dragging) {
             this._signals.disconnect('button-release-event', this._slider);
             this._signals.disconnect('motion-event', this._slider);
@@ -755,9 +731,9 @@ PopupSliderMenuItem.prototype = {
             this.emit('drag-end');
         }
         return true;
-    },
+    }
 
-    _onScrollEvent: function (actor, event) {
+    _onScrollEvent (actor, event) {
         let direction = event.get_scroll_direction();
 
         if (direction == Clutter.ScrollDirection.DOWN) {
@@ -769,16 +745,16 @@ PopupSliderMenuItem.prototype = {
 
         this._slider.queue_repaint();
         this.emit('value-changed', this._value);
-    },
+    }
 
-    _motionEvent: function(actor, event) {
+    _motionEvent(actor, event) {
         let absX, absY;
         [absX, absY] = event.get_coords();
         this._moveHandle(absX, absY);
         return true;
-    },
+    }
 
-    _moveHandle: function(absX, absY) {
+    _moveHandle(absX, absY) {
         let relX, relY, sliderX, sliderY;
         [sliderX, sliderY] = this._slider.get_transformed_position();
         relX = absX - sliderX;
@@ -798,17 +774,17 @@ PopupSliderMenuItem.prototype = {
         this._value = newvalue;
         this._slider.queue_repaint();
         this.emit('value-changed', this._value);
-    },
+    }
 
     get value() {
         return this._value;
-    },
+    }
 
-    set_mark: function (value) {
+    set_mark (value) {
         this._mark_position = value;
-    },
+    }
 
-    _onKeyPressEvent: function (actor, event) {
+    _onKeyPressEvent (actor, event) {
         let key = event.get_key_symbol();
         if (key == Clutter.KEY_Right || key == Clutter.KEY_Left) {
             let delta = key == Clutter.KEY_Right ? 0.1 : -0.1;
@@ -820,14 +796,14 @@ PopupSliderMenuItem.prototype = {
         }
         return false;
     }
-};
-
-function Switch() {
-    this._init.apply(this, arguments);
 }
 
-Switch.prototype = {
-    _init: function(state) {
+var Switch = class Switch {
+    constructor() {
+        return this._init.apply(this, arguments);
+    }
+
+    _init(state) {
         this.actor = new St.Bin({ style_class: 'toggle-switch' ,
                                   accessible_role: Atk.Role.CHECK_BOX});
         // Translators: this MUST be either "toggle-switch-us"
@@ -837,28 +813,22 @@ Switch.prototype = {
         // simply result in invisible toggle switches.
         this.actor.add_style_class_name("toggle-switch-us");
         this.setToggleState(state);
-    },
+    }
 
-    setToggleState: function(state) {
+    setToggleState(state) {
         if (this.actor.is_finalized()) return;
         this.actor.change_style_pseudo_class('checked', state);
         this.state = state;
-    },
+    }
 
-    toggle: function() {
+    toggle() {
         this.setToggleState(!this.state);
     }
-};
-
-function PopupSwitchMenuItem() {
-    this._init.apply(this, arguments);
 }
 
-PopupSwitchMenuItem.prototype = {
-    __proto__: PopupBaseMenuItem.prototype,
-
-    _init: function(text, active, params) {
-        PopupBaseMenuItem.prototype._init.call(this, params);
+var PopupSwitchMenuItem = class PopupSwitchMenuItem extends PopupBaseMenuItem {
+    _init(text, active, params) {
+        super._init.call(this, params);
 
         this.label = new St.Label({ text: text });
         this._statusLabel = new St.Label({ text: '', style_class: 'popup-inactive-menu-item' });
@@ -871,44 +841,39 @@ PopupSwitchMenuItem.prototype = {
         this._statusBin = new St.Bin({ x_align: St.Align.END });
         this.addActor(this._statusBin, { expand: true, span: -1, align: St.Align.END });
         this._statusBin.child = this._switch.actor;
-    },
+    }
 
-    setStatus: function(text) {
+    setStatus(text) {
         if (text != null) {
             this._statusLabel.set_text(text);
         } else {
             this._statusLabel.set_text('');
         }
-    },
+    }
 
-    activate: function(event) {
+    activate(event) {
         if (this._switch.actor.mapped) {
             this.toggle();
         }
 
         PopupBaseMenuItem.prototype.activate.call(this, event, true);
-    },
+    }
 
-    toggle: function() {
+    toggle() {
         this._switch.toggle();
         this.emit('toggled', this._switch.state);
-    },
+    }
 
     get state() {
         return this._switch.state;
-    },
+    }
 
-    setToggleState: function(state) {
+    setToggleState(state) {
         this._switch.setToggleState(state);
     }
-};
-
-function PopupSwitchIconMenuItem() {
-    this._init.apply(this, arguments);
 }
 
-PopupSwitchIconMenuItem.prototype = {
-    __proto__: PopupBaseMenuItem.prototype,
+var PopupSwitchIconMenuItem = class PopupSwitchIconMenuItem extends PopupBaseMenuItem {
 
     /**
      * _init:
@@ -919,8 +884,8 @@ PopupSwitchIconMenuItem.prototype = {
      * or #St.IconType.FULLCOLOR)
      * @params (JSON): parameters to pass to %PopupMenu.PopupBaseMenuItem._init
      */
-    _init: function(text, active, iconName, iconType, params) {
-        PopupBaseMenuItem.prototype._init.call(this, params);
+    _init(text, active, iconName, iconType, params) {
+        super._init.call(this, params);
 
         this.label = new St.Label({ text: text });
         this._statusLabel = new St.Label({ text: '', style_class: 'popup-inactive-menu-item' });
@@ -938,7 +903,7 @@ PopupSwitchIconMenuItem.prototype = {
         this._statusBin = new St.Bin({ x_align: St.Align.END });
         this.addActor(this._statusBin, { expand: true, span: -1, align: St.Align.END });
         this._statusBin.child = this._switch.actor;
-    },
+    }
 
     /**
      * setIconSymbolicName:
@@ -946,10 +911,10 @@ PopupSwitchIconMenuItem.prototype = {
      *
      * Changes the icon to a symbolic icon with name @iconName.
      */
-    setIconSymbolicName: function (iconName) {
+    setIconSymbolicName (iconName) {
         this._icon.set_icon_name(iconName);
         this._icon.set_icon_type(St.IconType.SYMBOLIC);
-    },
+    }
 
     /**
      * setIconName:
@@ -957,40 +922,40 @@ PopupSwitchIconMenuItem.prototype = {
      *
      * Changes the icon to a full color icon with name @iconName.
      */
-    setIconName: function (iconName) {
+    setIconName (iconName) {
         this._icon.set_icon_name(iconName);
         this._icon.set_icon_type(St.IconType.FULLCOLOR);
-    },
+    }
 
-    setStatus: function(text) {
+    setStatus(text) {
         if (text != null) {
             this._statusLabel.set_text(text);
         } else {
             this._statusLabel.set_text('');
         }
-    },
+    }
 
-    activate: function(event) {
+    activate(event) {
         if (this._switch.actor.mapped) {
             this.toggle();
         }
 
         PopupBaseMenuItem.prototype.activate.call(this, event, true);
-    },
+    }
 
-    toggle: function() {
+    toggle() {
         this._switch.toggle();
         this.emit('toggled', this._switch.state);
-    },
+    }
 
     get state() {
         return this._switch.state;
-    },
+    }
 
-    setToggleState: function(state) {
+    setToggleState(state) {
         this._switch.setToggleState(state);
     }
-};
+}
 
 /**
  * #PopupIconMenuItem:
@@ -1003,12 +968,8 @@ PopupSwitchIconMenuItem.prototype = {
  * on the right, make your own menu item (by copy and pasting the code found
  * below) because PopupImageMenuItem is deprecated and may disappear any time.
  */
-function PopupIconMenuItem() {
-    this._init.apply(this, arguments);
-}
 
-PopupIconMenuItem.prototype = {
-    __proto__: PopupBaseMenuItem.prototype,
+var PopupIconMenuItem = class PopupIconMenuItem extends PopupBaseMenuItem {
 
     /**
      * _init:
@@ -1018,8 +979,8 @@ PopupIconMenuItem.prototype = {
      * or #St.IconType.FULLCOLOR)
      * @params (JSON): parameters to pass to %PopupMenu.PopupBaseMenuItem._init
      */
-    _init: function (text, iconName, iconType, params) {
-        PopupBaseMenuItem.prototype._init.call(this, params);
+    _init (text, iconName, iconType, params) {
+        super._init.call(this, params);
 
         this.label = new St.Label({text: text});
         this._icon = new St.Icon({ style_class: 'popup-menu-icon',
@@ -1027,7 +988,7 @@ PopupIconMenuItem.prototype = {
             icon_type: iconType});
         this.addActor(this._icon, {span: 0});
         this.addActor(this.label);
-    },
+    }
 
     /**
      * setIconSymbolicName:
@@ -1035,10 +996,10 @@ PopupIconMenuItem.prototype = {
      *
      * Changes the icon to a symbolic icon with name @iconName.
      */
-    setIconSymbolicName: function (iconName) {
+    setIconSymbolicName (iconName) {
         this._icon.set_icon_name(iconName);
         this._icon.set_icon_type(St.IconType.SYMBOLIC);
-    },
+    }
 
     /**
      * setIconName:
@@ -1046,22 +1007,16 @@ PopupIconMenuItem.prototype = {
      *
      * Changes the icon to a full color icon with name @iconName.
      */
-    setIconName: function (iconName) {
+    setIconName (iconName) {
         this._icon.set_icon_name(iconName);
         this._icon.set_icon_type(St.IconType.FULLCOLOR);
     }
 }
 
 // Deprecated. Do not use
-function PopupImageMenuItem() {
-    this._init.apply(this, arguments);
-}
-
-PopupImageMenuItem.prototype = {
-    __proto__: PopupBaseMenuItem.prototype,
-
-    _init: function (text, iconName, params) {
-        PopupBaseMenuItem.prototype._init.call(this, params);
+var PopupImageMenuItem = class PopupImageMenuItem extends PopupBaseMenuItem {
+    _init (text, iconName, params) {
+        super._init.call(this, params);
 
         this.label = new St.Label({ text: text });
         this.addActor(this.label);
@@ -1069,9 +1024,9 @@ PopupImageMenuItem.prototype = {
         this.addActor(this._icon, { align: St.Align.END });
 
         this.setIcon(iconName);
-    },
+    }
 
-    setIcon: function(name) {
+    setIcon(name) {
         this._icon.icon_name = name;
     }
 };
@@ -1086,14 +1041,12 @@ PopupImageMenuItem.prototype = {
  * a radio button or empty.
  */
 function PopupIndicatorMenuItem() {
-    this._init.apply(this, arguments);
+    return this._init.apply(this, arguments);
 }
 
-PopupIndicatorMenuItem.prototype = {
-    __proto__: PopupBaseMenuItem.prototype,
-
-    _init: function(text, params) {
-        PopupBaseMenuItem.prototype._init.call(this, params);
+var PopupIndicatorMenuItem = class PopupIndicatorMenuItem extends PopupBaseMenuItem {
+    _init(text, params) {
+        super._init.call(this, params);
         this.actor._delegate = this;
         this._displayIcon = false;
 
@@ -1107,27 +1060,27 @@ PopupIndicatorMenuItem.prototype = {
         this.addActor(this._ornament, {span: 0});
         this.addActor(this.label);
         this.addActor(this._accel, { align: St.Align.END });
-    },
+    }
 
-    setAccel: function(accel) {
+    setAccel(accel) {
         this._accel.set_text(accel);
-    },
+    }
 
-    haveIcon: function() {
+    haveIcon() {
         return ((this._icon)&&((this._icon.icon_name && this._icon.icon_name != "") || (this._icon.gicon)));
-    },
+    }
 
-    setIconName: function(name) {
+    setIconName(name) {
         if (this._icon)
             this._icon.icon_name = name;
-    },
+    }
 
-    setGIcon: function(gicon) {
+    setGIcon(gicon) {
         if (this._icon)
             this._icon.gicon = gicon;
-    },
+    }
 
-    setOrnament: function(ornamentType, state) {
+    setOrnament(ornamentType, state) {
         switch (ornamentType) {
         case OrnamentType.CHECK:
             if ((this._ornament.child)&&(!(this._ornament.child._delegate instanceof CheckBox.CheckButton))) {
@@ -1156,9 +1109,9 @@ PopupIndicatorMenuItem.prototype = {
             this._icon = null;
             break;
         }
-    },
+    }
 
-    destroy: function() {
+    destroy() {
         if (this.actor) {
             PopupMenuItem.prototype.destroy.call(this);
             this.actor = null;
@@ -1176,12 +1129,13 @@ PopupIndicatorMenuItem.prototype = {
  * getItemById and handleEvent. All instances of this class need to have a unique
  * id to represent a menu item.
  */
-function PopupMenuAbstractItem() {
-    throw new TypeError('Trying to instantiate abstract class PopupMenuAbstractItem');
-}
 
-PopupMenuAbstractItem.prototype = {
-    _init: function(id, childrenIds, params) {
+var PopupMenuAbstractItem = class PopupMenuAbstractItem {
+    constructor() {
+        return this._init.apply(this, arguments);
+    }
+
+    _init(id, childrenIds, params) {
         this._id = id;
         this._childrenIds = childrenIds;
         if (!this._childrenIds)
@@ -1223,133 +1177,133 @@ PopupMenuAbstractItem.prototype = {
         this._type = params.type;
         this._action = params.action;
         this._paramType = params.paramType;
-    },
+    }
 
-    getItemById: function(id) {throw new Error('Trying to use abstract function getItemById');},
-    handleEvent: function(event, params) {throw new Error('Trying to use abstract function handleEvent');},
+    getItemById(id) {throw new Error('Trying to use abstract function getItemById');}
+    handleEvent(event, params) {throw new Error('Trying to use abstract function handleEvent');}
     //FIXME: Will be intresting this function? We don't use it anyway...
-    //is_root: function() {throw new Error('Trying to use abstract function is_root');},
+    //is_root() {throw new Error('Trying to use abstract function is_root');},
 
-    isVisible: function() {
+    isVisible() {
         return this._visible;
-    },
+    }
 
-    setVisible: function(visible) {
+    setVisible(visible) {
         if (this._visible != visible) {
             this._visible = visible;
             this._updateVisible();
         }
-    },
+    }
 
-    isSensitive: function() {
+    isSensitive() {
         return this._sensitive;
-    },
+    }
 
-    setSensitive: function(sensitive) {
+    setSensitive(sensitive) {
         if (this._sensitive != sensitive) {
             this._sensitive = sensitive;
             this._updateSensitive();
         }
-    },
+    }
 
-    getLabel: function() {
+    getLabel() {
         return this._label;
-    },
+    }
 
-    setLabel: function(label) {
+    setLabel(label) {
         if (this._label != label) {
             this._label = label;
             this._updateLabel();
         }
-    },
+    }
 
-    getAction: function() {
+    getAction() {
         return this._action;
-    },
+    }
 
-    setAction: function(action) {
+    setAction(action) {
         if (this._action != action) {
             this._action = action;
         }
-    },
+    }
 
-    getParamType: function() {
+    getParamType() {
         return this._paramType;
-    },
+    }
 
-    setParamType: function(paramType) {
+    setParamType(paramType) {
         if (this._paramType != paramType) {
             this._paramType = paramType;
         }
-    },
+    }
 
-    getFactoryType: function() {
+    getFactoryType() {
         return this._type;
-    },
+    }
 
-    setFactoryType: function(type) {
+    setFactoryType(type) {
         if ((type) && (this._type != type)) {
             this._type = type;
             this._updateType();
         }
-    },
+    }
 
-    getIconName: function() {
+    getIconName() {
         return this._iconName;
-    },
+    }
 
-    setIconName: function(iconName) {
+    setIconName(iconName) {
         if (this._iconName != iconName) {
             this._iconName = iconName;
             this._updateImage();
         }
-    },
+    }
 
-    getGdkIcon: function() {
+    getGdkIcon() {
         return this._iconData;
-    },
+    }
 
-    setGdkIcon: function(iconData) {
+    setGdkIcon(iconData) {
         if (this._iconData != iconData) {
             this._iconData = iconData;
             this._updateImage();
         }
-    },
+    }
 
-    getToggleType: function() {
+    getToggleType() {
         return this._toggleType;
-    },
+    }
 
-    setToggleType: function(toggleType) {
+    setToggleType(toggleType) {
         if (this._toggleType != toggleType) {
             this._toggleType = toggleType;
             this._updateOrnament();
         }
-    },
+    }
 
-    getToggleState: function() {
+    getToggleState() {
         return this._toggleState;
-    },
+    }
 
-    setToggleState: function(toggleState) {
+    setToggleState(toggleState) {
         if (this._toggleState != toggleState) {
             this._toggleState = toggleState;
             this._updateOrnament();
         }
-    },
+    }
 
-    getAccel: function() {
+    getAccel() {
         return this._accel;
-    },
+    }
 
-    setAccel: function(accel) {
+    setAccel(accel) {
         if (this._accel != accel) {
             this._accel = accel;
             this._updateAccel();
         }
-    },
+    }
 
-    setShellItem: function(shellItem, handlers) {
+    setShellItem(shellItem, handlers) {
         if (this.shellItem != shellItem) {
             if (this.shellItem) {
                 // FIXME: This create problems, why?
@@ -1395,18 +1349,18 @@ PopupMenuAbstractItem.prototype = {
                 }
             }
         }
-    },
+    }
 
-    _updateLabel: function() {
+    _updateLabel() {
         if ((this.shellItem)&&(this.shellItem.label)) {
             let label = this.getLabel();
             // The separator item might not even have a hidden label
             if (this.shellItem.label)
                 this.shellItem.label.set_text(label);
         }
-    },
+    }
 
-    _updateOrnament: function() {
+    _updateOrnament() {
         // Separators and alike might not have gotten the setOrnament function
         if ((this.shellItem)&&(this.shellItem.setOrnament)) {
             if (this.getToggleType() == "checkmark") {
@@ -1417,18 +1371,18 @@ PopupMenuAbstractItem.prototype = {
                 this.shellItem.setOrnament(OrnamentType.NONE);
             }
         }
-    },
+    }
 
-    _updateAccel: function() {
+    _updateAccel() {
         if ((this.shellItem)&&(this.shellItem._accel)) {
             let accel = this.getAccel();
             if (accel) {
                 this.shellItem._accel.set_text(accel);
             }
         }
-    },
+    }
 
-    _updateImage: function() {
+    _updateImage() {
         // Might be missing on submenus / separators
         if ((this.shellItem)&&(this.shellItem._icon)) {
             let iconName = this.getIconName();
@@ -1451,50 +1405,50 @@ PopupMenuAbstractItem.prototype = {
                 }
             }
         }
-    },
+    }
 
-    _updateVisible: function() {
+    _updateVisible() {
         if (this.shellItem) {
             this.shellItem.actor.visible = this.isVisible();
         }
-    },
+    }
 
-    _updateSensitive: function() {
+    _updateSensitive() {
         if ((this.shellItem)&&(this.shellItem.setSensitive)) {
             this.shellItem.setSensitive(this.isSensitive());
         }
-    },
+    }
 
-    _updateType: function() {
+    _updateType() {
         this.emit('type-changed');
-    },
+    }
 
-    getShellItem: function() {
+    getShellItem() {
         return this.shellItem;
-    },
+    }
 
-    getId: function() {
+    getId() {
         return this._id;
-    },
+    }
 
-    getChildrenIds: function() {
+    getChildrenIds() {
         // Clone it!
         return this._childrenIds.concat();
-    },
+    }
 
-    getChildren: function() {
+    getChildren() {
         return this._childrenIds.map(child_id => this.getItemById(child_id));
-    },
+    }
 
-    getParent: function() {
+    getParent() {
         return this.parent;
-    },
+    }
 
-    setParent: function(parent) {
+    setParent(parent) {
         this.parent = parent;
-    },
+    }
 
-    addChild: function(pos, child_id) {
+    addChild(pos, child_id) {
         let factoryItem = this.getItemById(child_id);
         if (factoryItem) {
             // If our item is previusly assigned, so destroy first the shell item.
@@ -1503,9 +1457,9 @@ PopupMenuAbstractItem.prototype = {
             this._childrenIds.splice(pos, 0, child_id);
             this.emit('child-added', factoryItem, pos);
         }
-    },
+    }
 
-    removeChild: function(child_id) {
+    removeChild(child_id) {
         // Find it
         let pos = -1;
         for (let i = 0; i < this._childrenIds.length; ++i) {
@@ -1530,9 +1484,9 @@ PopupMenuAbstractItem.prototype = {
         if (this._childrenIds.length == 0) {
             this.emit('childs-empty');
         }
-    },
+    }
 
-    moveChild: function(child_id, newpos) {
+    moveChild(child_id, newpos) {
         // Find the old position
         let oldpos = -1;
         for (let i = 0; i < this._childrenIds.length; ++i) {
@@ -1552,23 +1506,23 @@ PopupMenuAbstractItem.prototype = {
             this._childrenIds.splice(newpos, 0, child_id);
             this.emit('child-moved', this.getItemById(child_id), oldpos, newpos);
         }
-    },
+    }
 
     // handlers = { "signal": handler }
-    connectAndRemoveOnDestroy: function(handlers) {
+    connectAndRemoveOnDestroy(handlers) {
         /*for (let signal in handlers) {
             this._externalSignalsHandlers.connect(this, signal, handlers[signal]);
         }*/
         this._connectAndSaveId(this, handlers, this._externalSignalsHandlers);
-    },
+    }
 
-    destroyShellItem: function() {
+    destroyShellItem() {
         this._destroyShellItem(this.shellItem);
-    },
+    }
 
     // We try to not crash cinnamon if a shellItem will be destroyed and has the focus,
     // then we are moving the focus to the source actor.
-    _destroyShellItem: function(shellItem) {
+    _destroyShellItem(shellItem) {
         if (shellItem) {
             let focus = global.stage.key_focus;
             if (shellItem.close)
@@ -1585,37 +1539,37 @@ PopupMenuAbstractItem.prototype = {
             }
             shellItem.destroy();
         }
-    },
+    }
 
     // handlers = { "signal": handler }
-    _connectAndSaveId: function(target, handlers , idArray) {
+    _connectAndSaveId(target, handlers , idArray) {
         idArray = typeof idArray != 'undefined' ? idArray : [];
         for (let signal in handlers) {
             idArray.push(target.connect(signal, handlers[signal]));
         }
         return idArray;
-    },
+    }
 
-    _disconnectSignals: function(obj, signals_handlers) {
+    _disconnectSignals(obj, signals_handlers) {
         if ((obj)&&(signals_handlers)) {
             for (let pos in signals_handlers)
                 obj.disconnect(signals_handlers[pos]);
         }
-    },
+    }
 
-    _onActivate: function(shellItem, event, keepMenu) {
+    _onActivate(shellItem, event, keepMenu) {
         this.handleEvent("clicked");
-    },
+    }
 
-    _onOpenStateChanged: function(menu, open) {
+    _onOpenStateChanged(menu, open) {
         if (open) {
             this.handleEvent("opened");
         } else {
             this.handleEvent("closed");
         }
-    },
+    }
 
-    _onShellItemDestroyed: function(shellItem) {
+    _onShellItemDestroyed(shellItem) {
         if ((this.shellItem)&&(this.shellItem == shellItem)) {
             this.shellItem = null;
             /*if (this._internalSignalsHandlers) {
@@ -1634,9 +1588,9 @@ PopupMenuAbstractItem.prototype = {
         } else {
             global.logWarning("We are not connected with any shellItem");
         }
-    },
+    }
 
-    _onShellMenuDestroyed: function(shellMenu) {
+    _onShellMenuDestroyed(shellMenu) {
         /*if (this._shellMenuSignalsHandlers) {
             this._shellMenuSignalsHandlers.disconnectAllSignals();
             this._shellMenuSignalsHandlers = null;
@@ -1645,9 +1599,9 @@ PopupMenuAbstractItem.prototype = {
             this._disconnectSignals(shellMenu, this._shellMenuSignalsHandlers);
             this._shellMenuSignalsHandlers = null;
         }
-    },
+    }
 
-    destroy: function() {
+    destroy() {
         if (this._externalSignalsHandlers) {
             // Emit the destroy signal first, to allow the external listener know about it,
             // then, disconnect the listener handler.
@@ -1684,17 +1638,17 @@ Signals.addSignalMethods(PopupMenuAbstractItem.prototype);
  * This is a base popup menu class for more sophisticated popup menus to
  * inherit. This cannot be instantiated.
  */
-function PopupMenuBase() {
-    throw new TypeError('Trying to instantiate abstract class PopupMenuBase');
-}
 
-PopupMenuBase.prototype = {
+var PopupMenuBase = class PopupMenuBase {
+    constructor() {
+        return this._init.apply(this, arguments);
+    }
     /**
      * _init:
      * @sourceActor (St.Widget): the actor that owns the popup menu
      * @styleClass (string): (optional) the style class of the popup menu
      */
-    _init: function(sourceActor, styleClass) {
+    _init(sourceActor, styleClass) {
         this.sourceActor = sourceActor;
 
         this._signals = new SignalManager.SignalManager(null);
@@ -1713,7 +1667,7 @@ PopupMenuBase.prototype = {
 
         this._activeMenuItem = null;
         this._childMenus = [];
-    },
+    }
 
     /**
      * addAction:
@@ -1725,13 +1679,13 @@ PopupMenuBase.prototype = {
      *
      * Returns (PopupMenu.PopupMenuItem): the menu item created.
      */
-    addAction: function(title, callback) {
+    addAction(title, callback) {
         let menuItem = new PopupMenuItem(title);
         this.addMenuItem(menuItem);
         this._signals.connect(menuItem, 'activate', (menuItem, event) => { callback(event) });
 
         return menuItem;
-    },
+    }
 
     /**
      * addSettingsAction:
@@ -1744,12 +1698,12 @@ PopupMenuBase.prototype = {
      *
      * Returns (PopupMenu.PopupMenuItem): the menu item created.
      */
-    addSettingsAction: function(title, module) {
+    addSettingsAction(title, module) {
         let menuItem = this.addAction(title, function() {
                            Util.spawnCommandLine("cinnamon-settings " + module);
                        });
         return menuItem;
-    },
+    }
 
     /**
      * addCommandlineAction:
@@ -1761,12 +1715,12 @@ PopupMenuBase.prototype = {
      *
      * Returns (PopupMenu.PopupMenuItem): the menu item created.
      */
-    addCommandlineAction: function(title, cmd) {
+    addCommandlineAction(title, cmd) {
         let menuItem = this.addAction(title, function() {
                            Util.spawnCommandLine(cmd);
                        });
         return menuItem
-    },
+    }
 
     /**
      * isChildMenu:
@@ -1774,9 +1728,9 @@ PopupMenuBase.prototype = {
      *
      * Returns: whether @menu is a submenu of this menu.
      */
-    isChildMenu: function(menu) {
+    isChildMenu(menu) {
         return this._childMenus.indexOf(menu) != -1;
-    },
+    }
 
     /**
      * addChildMenu:
@@ -1784,7 +1738,7 @@ PopupMenuBase.prototype = {
      *
      * Makes @menu a submenu of this menu.
      */
-    addChildMenu: function(menu) {
+    addChildMenu(menu) {
         if (this.isChildMenu(menu))
             return;
 
@@ -1796,7 +1750,7 @@ PopupMenuBase.prototype = {
          * Emitted when an menu is added as a submenu.
          */
         this.emit('child-menu-added', menu);
-    },
+    }
 
     /**
      * removeChildMenu:
@@ -1804,7 +1758,7 @@ PopupMenuBase.prototype = {
      *
      * Removes @menu from the current menu if it is a child.
      */
-    removeChildMenu: function(menu) {
+    removeChildMenu(menu) {
         let index = this._childMenus.indexOf(menu);
 
         if (index == -1)
@@ -1818,9 +1772,9 @@ PopupMenuBase.prototype = {
          *
          * Emitted when an submenu is removed.
          */
-    },
+    }
 
-    _connectSubMenuSignals: function(object, menu) {
+    _connectSubMenuSignals(object, menu) {
         /**
          * SIGNAL:activate
          * @menuItem (PopupBaseMenuItem): the item activated
@@ -1848,9 +1802,9 @@ PopupMenuBase.prototype = {
             this._activeMenuItem = submenuItem;
             this.emit('active-changed', submenuItem);
         });
-    },
+    }
 
-    _connectItemSignals: function(menuItem) {
+    _connectItemSignals(menuItem) {
         this._signals.connect(menuItem, 'active-changed', (menuItem, active) => {
             if (active && this._activeMenuItem != menuItem) {
                 if (this._activeMenuItem)
@@ -1892,9 +1846,9 @@ PopupMenuBase.prototype = {
                 this._activeMenuItem = null;
             this.length--;
         });
-    },
+    }
 
-    _updateSeparatorVisibility: function(menuItem) {
+    _updateSeparatorVisibility(menuItem) {
         let children = this.box.get_children();
 
         let index = children.indexOf(menuItem.actor);
@@ -1925,7 +1879,7 @@ PopupMenuBase.prototype = {
         }
 
         menuItem.actor.show();
-    },
+    }
 
     /**
      * addMenuItem:
@@ -1936,7 +1890,7 @@ PopupMenuBase.prototype = {
      *
      * Adds the @menuItem to the menu.
      */
-    addMenuItem: function(menuItem, position) {
+    addMenuItem(menuItem, position) {
         let before_item = null;
         if (position == undefined) {
             this.box.add(menuItem.actor);
@@ -1988,7 +1942,7 @@ PopupMenuBase.prototype = {
             throw TypeError("Invalid argument to PopupMenuBase.addMenuItem()");
 
         this.length++;
-    },
+    }
 
     /**
      * getColumnWidths:
@@ -1998,7 +1952,7 @@ PopupMenuBase.prototype = {
      * internally and shouldn't be fiddled with unless you are implementing
      * other popup menu items.
      */
-    getColumnWidths: function() {
+    getColumnWidths() {
         let columnWidths = [];
         let items = this.box.get_children();
         for (let i = 0; i < items.length; i++) {
@@ -2013,7 +1967,7 @@ PopupMenuBase.prototype = {
             }
         }
         return columnWidths;
-    },
+    }
 
     /**
      * setColumnWidths:
@@ -2022,13 +1976,13 @@ PopupMenuBase.prototype = {
      * Sets the widths of each column according to @widths so that things can
      * align.
      */
-    setColumnWidths: function(widths) {
+    setColumnWidths(widths) {
         let items = this.box.get_children();
         for (let i = 0; i < items.length; i++) {
             if (items[i].maybeGet("_delegate") instanceof PopupBaseMenuItem || items[i].maybeGet("_delegate") instanceof PopupMenuBase)
                 items[i]._delegate.setColumnWidths(widths);
         }
-    },
+    }
 
     // Because of the above column-width funniness, we need to do a
     // queue-relayout on every item whenever the menu itself changes
@@ -2036,22 +1990,22 @@ PopupMenuBase.prototype = {
     // menuitems will in turn call queue_relayout on their parent, the
     // menu, but that call will be a no-op since the menu already
     // has a relayout queued, so we won't get stuck in a loop.
-    _menuQueueRelayout: function() {
+    _menuQueueRelayout() {
         this.box.get_children().forEach(actor => actor.queue_relayout());
-    },
+    }
 
-    addActor: function(actor) {
+    addActor(actor) {
         this.box.add(actor);
-    },
+    }
 
-    _getMenuItems: function() {
+    _getMenuItems() {
         return this.box.get_children().reduce((children, actor) => {
             if (actor._delegate &&
                 (actor._delegate instanceof PopupBaseMenuItem || actor._delegate instanceof PopupMenuSection))
                 children.push(actor._delegate);
             return children;
         }, []);
-    },
+    }
 
     get firstMenuItem() {
         let items = this._getMenuItems();
@@ -2059,36 +2013,36 @@ PopupMenuBase.prototype = {
             return items[0];
         else
             return null;
-    },
+    }
 
     get numMenuItems() {
         return this._getMenuItems().length;
-    },
+    }
 
     /**
      * removeAll:
      *
      * Clears everything inside the menu.
      */
-    removeAll: function() {
+    removeAll() {
         let children = this._getMenuItems();
         for (let i = 0; i < children.length; i++) {
             let item = children[i];
             item.destroy();
         }
-    },
+    }
 
     /**
      * toggle:
      *
      * Toggles the open/close state of the menu.
      */
-    toggle: function() {
+    toggle() {
         if (this.isOpen)
             this.close(true);
         else
             this.open(true);
-    },
+    }
 
     /**
      * toggle_with_options:
@@ -2098,20 +2052,20 @@ PopupMenuBase.prototype = {
      *
      * Toggles the open/close state of the menu with extra parameters
      */
-    toggle_with_options: function (animate, onComplete) {
+    toggle_with_options (animate, onComplete) {
         if (this.isOpen) {
             this.close(animate, onComplete);
         } else {
             this.open(animate, onComplete);
         }
-    },
+    }
 
     /**
      * destroy:
      *
      * Destroys the popup menu completely.
      */
-    destroy: function() {
+    destroy() {
         this._signals.disconnectAllSignals();
         this.removeAll();
         this.actor.destroy();
@@ -2134,27 +2088,15 @@ Signals.addSignalMethods(PopupMenuBase.prototype);
  * @slidePosition (number): Position relative to the @sourceActor of the menu upon which the menu will be centered
  * (if possible). If -1, the menu will be centered on the @sourceActor. See %shiftToPosition for more details.
  */
-function PopupMenu() {
-    // orientation used to be passed as the third argument, but now we only have 2 args so if we get 3, we assume
-    // that it's old code and only grab the ones we need
-    if (arguments.length > 2) {
-        this._init(arguments[0], arguments[2]);
-    }
-    else {
-        this._init.apply(this, arguments);
-    }
-}
 
-PopupMenu.prototype = {
-    __proto__: PopupMenuBase.prototype,
-
+var PopupMenu = class PopupMenu extends PopupMenuBase {
     /**
      * _init:
      * @sourceActor (St.Widget): the actor that owns the popup menu
      * @orientation (St.Side): the side of the menu that will be attached to @sourceActor. See %setOrientation() for details
      */
-    _init: function(sourceActor, orientation) {
-        PopupMenuBase.prototype._init.call (this, sourceActor, 'popup-menu-content');
+    _init(sourceActor, orientation) {
+        super._init.call(this, sourceActor, 'popup-menu-content');
 
         this.paint_count = 0;
         this.animating = false;
@@ -2176,7 +2118,7 @@ PopupMenu.prototype = {
 
         global.focus_manager.add_group(this.actor);
         this.actor.reactive = true;
-    },
+    }
 
     /**
      * setArrowSide:
@@ -2185,9 +2127,9 @@ PopupMenu.prototype = {
      * Sets the orientation of the @sourceActor with respect to the menu. This function is deprecated and kept
      * for compatibility with older code. Please use %setOrientation instead.
      */
-    setArrowSide: function(side) {
+    setArrowSide(side) {
         this.setOrientation(side);
-    },
+    }
 
     /**
      * setOrientation:
@@ -2196,9 +2138,9 @@ PopupMenu.prototype = {
      * Sets the orientation of the @sourceActor with respect to the menu. For example, if you use St.Side.TOP,
      * the menu will try to place itself below the @sourcActor unless there is not enough room for it.
      */
-    setOrientation: function(orientation) {
+    setOrientation(orientation) {
         this._orientation = orientation;
-    },
+    }
 
     /**
      * setCustomStyleClass:
@@ -2206,14 +2148,14 @@ PopupMenu.prototype = {
      *
      * Adds a custom class name to the menu which allows it to be styled separately from other menus.
      */
-    setCustomStyleClass: function(className) {
+    setCustomStyleClass(className) {
         this.customStyleClass = className;
         if (this.actor.get_style_class_name()) {
             this.actor.set_style_class_name(this.actor.get_style_class_name() + " " + className);
         } else {
             this.actor.set_style_class_name(className);
         }
-    },
+    }
 
     /**
      * setSourceAlignment:
@@ -2223,7 +2165,7 @@ PopupMenu.prototype = {
      * Since the boxpointer was removed from the menu, this function now does nothing. Please do not use this
      * function in new code.
      */
-    setSourceAlignment: function(alignment) {},
+    setSourceAlignment(alignment) {}
 
     /**
      * open:
@@ -2231,7 +2173,7 @@ PopupMenu.prototype = {
      *
      * Opens the popup menu
      */
-    open: function(animate) {
+    open(animate) {
         if (this.isOpen)
             return;
 
@@ -2366,7 +2308,7 @@ PopupMenu.prototype = {
         }
 
         this.emit('open-state-changed', true);
-    },
+    }
 
     /**
      * close:
@@ -2374,7 +2316,7 @@ PopupMenu.prototype = {
      *
      * Closes the popup menu.
      */
-    close: function(animate) {
+    close(animate) {
         if (!this.isOpen)
             return;
 
@@ -2441,7 +2383,7 @@ PopupMenu.prototype = {
             this.actor.hide();
         }
         this.emit('open-state-changed', false);
-    },
+    }
 
     /**
      * shiftToPosition:
@@ -2456,11 +2398,11 @@ PopupMenu.prototype = {
      * along the x axis. If you have set the @slidePosition using this function and then wish to return to centering
      * the menu on the center of the @sourceActor, you can do so by setting it to -1.
      */
-    shiftToPosition: function(slidePosition) {
+    shiftToPosition(slidePosition) {
         this._slidePosition = slidePosition;
         let [xPos, yPos] = this._calculatePosition();
         this.actor.set_position(xPos, yPos);
-    },
+    }
 
     /**
      * setMaxHeight:
@@ -2474,7 +2416,7 @@ PopupMenu.prototype = {
      * of the menu is higher then the screen; it's useful if part of the menu
      * is scrollable so the minimum height is smaller than the natural height.
      */
-    setMaxHeight: function() {
+    setMaxHeight() {
         let monitor = Main.layoutManager.findMonitorForActor(this.sourceActor)
 
         let maxHeight = monitor.height;
@@ -2497,9 +2439,9 @@ PopupMenu.prototype = {
 
         this.actor.style = 'max-height: ' + Math.floor(maxHeight / global.ui_scale) + 'px; ' +
                            'max-width: ' + Math.floor(maxWidth / global.ui_scale) + 'px;';
-    },
+    }
 
-    _calculatePosition: function() {
+    _calculatePosition() {
         if (!this.actor.visible) {
             this.box.show();
         }
@@ -2583,38 +2525,38 @@ PopupMenu.prototype = {
         if (this.customStyleClass) styleClasses.push(this.customStyleClass);
         this.actor.set_style_class_name(styleClasses.join(" "));
         return [Math.round(xPos), Math.round(yPos)];
-    },
+    }
 
-    _boxGetPreferredWidth: function (actor, forHeight, alloc) {
+    _boxGetPreferredWidth (actor, forHeight, alloc) {
         let columnWidths = this.getColumnWidths();
         this.setColumnWidths(columnWidths);
 
         // Now they will request the right sizes
         [alloc.min_size, alloc.natural_size] = this.box.get_preferred_width(forHeight);
-    },
+    }
 
-    _boxGetPreferredHeight: function (actor, forWidth, alloc) {
+    _boxGetPreferredHeight (actor, forWidth, alloc) {
         [alloc.min_size, alloc.natural_size] = this.box.get_preferred_height(forWidth);
-    },
+    }
 
-    _boxAllocate: function (actor, box, flags) {
+    _boxAllocate (actor, box, flags) {
         this.box.allocate(box, flags);
         if (!this.animating && this.sourceActor.get_stage() != null) {
             let [xPos, yPos] = this._calculatePosition();
             this.actor.set_position(xPos, yPos);
         }
-    },
+    }
 
-    _onKeyPressEvent: function(actor, event) {
+    _onKeyPressEvent(actor, event) {
         if (event.get_key_symbol() == Clutter.Escape) {
             this.close(true);
             return true;
         }
 
         return false;
-    },
+    }
 
-    on_paint: function(actor) {
+    on_paint(actor) {
         if (this.paint_count < 2 || this.animating) {
             this.paint_count++;
             return;
@@ -2627,7 +2569,7 @@ PopupMenu.prototype = {
         this.paint_count = 0;
         Main.popup_rendering_actor = null;
     }
-};
+}
 
 /**
  * #PopupSubMenu
@@ -2645,12 +2587,8 @@ PopupMenu.prototype = {
  *
  * Inherits: PopupMenu.PopupMenuBase
  */
-function PopupSubMenu() {
-    this._init.apply(this, arguments);
-}
 
-PopupSubMenu.prototype = {
-    __proto__: PopupMenuBase.prototype,
+var PopupSubMenu = class PopupSubMenu extends PopupMenuBase {
 
     /**
      * _init:
@@ -2659,8 +2597,8 @@ PopupSubMenu.prototype = {
      * #PopupSubMenuMenuItem. When the submenu opens, the arrow is rotated by
      * pi/2 clockwise to denote the status of the submenu.
      */
-    _init: function(sourceActor, sourceArrow) {
-        PopupMenuBase.prototype._init.call(this, sourceActor);
+    _init(sourceActor, sourceArrow) {
+        super._init.call(this, sourceActor);
         this.unmapId = 0;
 
         if (sourceArrow) {
@@ -2694,9 +2632,9 @@ PopupSubMenu.prototype = {
         this.actor.clip_to_allocation = true;
         this._signals.connect(this.actor, 'key-press-event', Lang.bind(this, this._onKeyPressEvent));
         this.actor.hide();
-    },
+    }
 
-    _getTopMenu: function() {
+    _getTopMenu() {
         let actor = this.actor.get_parent();
         while (actor) {
             if (actor._delegate && actor._delegate instanceof PopupMenu)
@@ -2706,9 +2644,9 @@ PopupSubMenu.prototype = {
         }
 
         return null;
-    },
+    }
 
-    _needsScrollbar: function() {
+    _needsScrollbar() {
         let topMenu = this._getTopMenu();
         if(!topMenu)
             return false;
@@ -2717,7 +2655,7 @@ PopupSubMenu.prototype = {
 
         let topMaxHeight = topThemeNode.get_max_height();
         return topMaxHeight >= 0 && topNaturalHeight >= topMaxHeight;
-    },
+    }
 
     /**
      * open:
@@ -2725,7 +2663,7 @@ PopupSubMenu.prototype = {
      *
      * Opens the submenu
      */
-    open: function(animate) {
+    open(animate) {
         if (this.isOpen)
             return;
 
@@ -2774,7 +2712,7 @@ PopupSubMenu.prototype = {
                 this._arrow.rotation_angle_z = targetAngle;
             this.emit('open-state-changed', true);
         }
-    },
+    }
 
     /**
      * close:
@@ -2782,7 +2720,7 @@ PopupSubMenu.prototype = {
      *
      * Closes the submenu
      */
-    close: function(animate) {
+    close(animate) {
         if (!this.isOpen)
             return;
 
@@ -2819,11 +2757,11 @@ PopupSubMenu.prototype = {
                 this.isOpen = false;
                 this.emit('open-state-changed', false);
             }
-    },
+    }
 
     //Closes the submenu after it has been unmapped. Used to prevent size changes
     //when the parent is closing at the same time and may be tweening.
-    closeAfterUnmap: function() {
+    closeAfterUnmap() {
         if (this.isOpen && this.actor.mapped) {
             if (!this.unmapId) {
                 this.unmapId = this.actor.connect("notify::mapped", () => {
@@ -2835,9 +2773,9 @@ PopupSubMenu.prototype = {
         } else {
             this.close(false);
         }
-    },
+    }
 
-    _onKeyPressEvent: function(actor, event) {
+    _onKeyPressEvent(actor, event) {
         // Move focus back to parent menu if the user types Left.
 
         if (this.isOpen && event.get_key_symbol() == Clutter.KEY_Left) {
@@ -2865,36 +2803,23 @@ PopupSubMenu.prototype = {
  *
  * Inherits: PopupMenu.PopupMenuBase
  */
-function PopupMenuSection() {
-    this._init.apply(this, arguments);
-}
-
-PopupMenuSection.prototype = {
-    __proto__: PopupMenuBase.prototype,
-
-    _init: function() {
-        PopupMenuBase.prototype._init.call(this);
+var PopupMenuSection = class PopupMenuSection extends PopupMenuBase {
+    _init() {
+        super._init.call(this);
 
         this.actor = this.box;
         this.actor._delegate = this;
         this.isOpen = true;
-    },
+    }
 
     // deliberately ignore any attempt to open() or close()
-    open: function(animate) { },
-    close: function() { },
-
+    open(animate) { }
+    close() { }
 }
 
-function PopupSubMenuMenuItem() {
-    this._init.apply(this, arguments);
-}
-
-PopupSubMenuMenuItem.prototype = {
-    __proto__: PopupBaseMenuItem.prototype,
-
-    _init: function(text) {
-        PopupBaseMenuItem.prototype._init.call(this);
+var PopupSubMenuMenuItem = class PopupSubMenuMenuItem extends PopupBaseMenuItem {
+    _init(text) {
+        super._init.call(this);
 
         this._triangle = null;
 
@@ -2920,18 +2845,18 @@ PopupSubMenuMenuItem.prototype = {
 
         this.menu = new PopupSubMenu(this.actor, this._triangle);
         this._signals.connect(this.menu, 'open-state-changed', Lang.bind(this, this._subMenuOpenStateChanged));
-    },
+    }
 
-    _subMenuOpenStateChanged: function(menu, open) {
+    _subMenuOpenStateChanged(menu, open) {
         this.actor.change_style_pseudo_class('open', open);
-    },
+    }
 
-    destroy: function() {
+    destroy() {
         this.menu.destroy();
         PopupBaseMenuItem.prototype.destroy.call(this);
-    },
+    }
 
-    _onKeyPressEvent: function(actor, event) {
+    _onKeyPressEvent(actor, event) {
         let symbol = event.get_key_symbol();
 
         if (symbol == Clutter.KEY_Right) {
@@ -2944,26 +2869,20 @@ PopupSubMenuMenuItem.prototype = {
         }
 
         return PopupBaseMenuItem.prototype._onKeyPressEvent.call(this, actor, event);
-    },
+    }
 
-    activate: function(event) {
+    activate(event) {
         this.menu.open(true);
-    },
+    }
 
-    _onButtonReleaseEvent: function(actor) {
+    _onButtonReleaseEvent(actor) {
         this.menu.toggle();
     }
-};
-
-function PopupComboMenu() {
-    this._init.apply(this, arguments);
 }
 
-PopupComboMenu.prototype = {
-    __proto__: PopupMenuBase.prototype,
-
-    _init: function(sourceActor) {
-        PopupMenuBase.prototype._init.call(this,
+var PopupComboMenu = class PopupComboMenu extends PopupMenuBase {
+    _init(sourceActor) {
+        super._init.call(this,
                                            sourceActor, 'popup-combo-menu');
         this.actor = this.box;
         this.actor._delegate = this;
@@ -2971,24 +2890,24 @@ PopupComboMenu.prototype = {
         this._signals.connect(this.actor, 'key-focus-in', Lang.bind(this, this._onKeyFocusIn));
         this._activeItemPos = -1;
         global.focus_manager.add_group(this.actor);
-    },
+    }
 
-    _onKeyPressEvent: function(actor, event) {
+    _onKeyPressEvent(actor, event) {
         if (event.get_key_symbol() == Clutter.Escape) {
             this.close(true);
             return true;
         }
 
         return false;
-    },
+    }
 
-    _onKeyFocusIn: function(actor) {
+    _onKeyFocusIn(actor) {
         let items = this._getMenuItems();
         let activeItem = items[this._activeItemPos];
         activeItem.actor.grab_key_focus();
-    },
+    }
 
-    open: function() {
+    open() {
         if (this.isOpen)
             return;
 
@@ -3014,9 +2933,9 @@ PopupComboMenu.prototype = {
         this.savedFocusActor = global.stage.get_key_focus();
         global.stage.set_key_focus(this.actor);
         this.emit('open-state-changed', true);
-    },
+    }
 
-    close: function() {
+    close() {
         if (!this.isOpen)
             return;
 
@@ -3033,35 +2952,29 @@ PopupComboMenu.prototype = {
         }
         this.emit('open-state-changed', false);
         global.stage.set_key_focus(this.savedFocusActor);
-    },
+    }
 
-    setActiveItem: function(position) {
+    setActiveItem(position) {
         this._activeItemPos = position;
-    },
+    }
 
-    setItemVisible: function(position, visible) {
+    setItemVisible(position, visible) {
         if (!visible && position == this._activeItemPos) {
             log('Trying to hide the active menu item.');
             return;
         }
 
         this._getMenuItems()[position].actor.visible = visible;
-    },
+    }
 
-    getItemVisible: function(position) {
+    getItemVisible(position) {
         return this._getMenuItems()[position].actor.visible;
     }
-};
-
-function PopupComboBoxMenuItem() {
-    this._init.apply(this, arguments);
 }
 
-PopupComboBoxMenuItem.prototype = {
-    __proto__: PopupBaseMenuItem.prototype,
-
-    _init: function (params) {
-        PopupBaseMenuItem.prototype._init.call(this, params);
+var PopupComboBoxMenuItem = class PopupComboBoxMenuItem extends PopupBaseMenuItem {
+    _init (params) {
+        super._init.call(this, params);
 
         this._itemBox = new Cinnamon.Stack();
 
@@ -3084,9 +2997,9 @@ PopupComboBoxMenuItem.prototype = {
 
         this._activeItemPos = -1;
         this._items = [];
-    },
+    }
 
-    _getTopMenu: function() {
+    _getTopMenu() {
         let actor = this.actor.get_parent();
         while (actor) {
             if (actor._delegate &&
@@ -3098,9 +3011,9 @@ PopupComboBoxMenuItem.prototype = {
         }
 
         return null;
-    },
+    }
 
-    _onScrollEvent: function(actor, event) {
+    _onScrollEvent(actor, event) {
         if (this._activeItemPos == -1)
             return;
 
@@ -3125,18 +3038,18 @@ PopupComboBoxMenuItem.prototype = {
 
         this.setActiveItem(position);
         this.emit('active-item-changed', position);
-    },
+    }
 
-    activate: function(event) {
+    activate(event) {
         let topMenu = this._getTopMenu();
         if (!topMenu)
             return;
 
         topMenu.addChildMenu(this._menu);
         this._menu.toggle();
-    },
+    }
 
-    addMenuItem: function(menuItem, position) {
+    addMenuItem(menuItem, position) {
         if (position === undefined)
             position = this._menu.numMenuItems;
 
@@ -3160,14 +3073,14 @@ PopupComboBoxMenuItem.prototype = {
 
         this._signals.connect(menuItem, 'activate',
                         this._itemActivated.bind(this, position));
-    },
+    }
 
-    checkAccessibleLabel: function() {
+    checkAccessibleLabel() {
         let activeItem = this._menu.getActiveItem();
         this.actor.label_actor = activeItem.label;
-    },
+    }
 
-    setActiveItem: function(position) {
+    setActiveItem(position) {
         let item = this._items[position];
         if (!item)
             return;
@@ -3179,13 +3092,13 @@ PopupComboBoxMenuItem.prototype = {
             this._items[i].visible = (i == this._activeItemPos);
 
         this.checkAccessibleLabel();
-    },
+    }
 
-    setItemVisible: function(position, visible) {
+    setItemVisible(position, visible) {
         this._menu.setItemVisible(position, visible);
-    },
+    }
 
-    _itemActivated: function(menuItem, event, position) {
+    _itemActivated(menuItem, event, position) {
         this.setActiveItem(position);
         this.emit('active-item-changed', position);
     }
@@ -3200,17 +3113,16 @@ PopupComboBoxMenuItem.prototype = {
  * class to more details. To initialize the construction you need to provide the root
  * instance of your abstract menu items.
  */
-function PopupMenuFactory() {
-    this._init.apply(this, arguments);
-}
+var PopupMenuFactory = class PopupMenuFactory {
+    constructor() {
+        return this._init.apply(this, arguments);
+    }
 
-PopupMenuFactory.prototype = {
-
-    _init: function() {
+    _init() {
         this._menuLikend = new Array();
-    },
+    }
 
-    _createShellItem: function(factoryItem, launcher, orientation) {
+    _createShellItem(factoryItem, launcher, orientation) {
         // Decide whether it's a submenu or not
         let shellItem = null;
         let item_type = factoryItem.getFactoryType();
@@ -3225,17 +3137,17 @@ PopupMenuFactory.prototype = {
         else if (item_type == FactoryClassTypes.MenuItemClass)
             shellItem = new PopupIndicatorMenuItem("FIXME");
         return shellItem;
-    },
+    }
 
-    getShellMenu: function(factoryMenu) {
+    getShellMenu(factoryMenu) {
         let index = this._menuLikend.indexOf(factoryMenu);
         if (index != -1) {
             return factoryMenu.getShellItem();
         }
         return null;
-    },
+    }
 
-    buildShellMenu: function(client, launcher, orientation) {
+    buildShellMenu(client, launcher, orientation) {
         let factoryMenu = client.getRoot();
         if (!(factoryMenu instanceof PopupMenuAbstractItem)) {
             throw new Error("MenuFactory: can't construct an instance of \
@@ -3249,11 +3161,11 @@ PopupMenuFactory.prototype = {
         let shellItem = this._createShellItem(factoryMenu, launcher, orientation);
         this._attachToMenu(shellItem, factoryMenu);
         return shellItem;
-    },
+    }
 
     // This will attach the root factoryItem to an already existing menu that will be used as the root menu.
     // it will also connect the factoryItem to be automatically destroyed when the menu dies.
-    _attachToMenu: function(shellItem, factoryItem) {
+    _attachToMenu(shellItem, factoryItem) {
         // Cleanup: remove existing childs (just in case)
         shellItem.removeAll();
 
@@ -3270,16 +3182,16 @@ PopupMenuFactory.prototype = {
         factoryItem.connectAndRemoveOnDestroy({
             'destroy'           : Lang.bind(this, this._onDestroyMainMenu)
         });
-    },
+    }
 
-    _onDestroyMainMenu: function(factoryItem) {
+    _onDestroyMainMenu(factoryItem) {
         let index = this._menuLikend.indexOf(factoryItem);
         if (index != -1) {
             this._menuLikend.splice(index, 1);
         }
-    },
+    }
 
-    _createItem: function(factoryItem) {
+    _createItem(factoryItem) {
         // Don't allow to override previusly preasigned items, destroy the shell item first.
         factoryItem.destroyShellItem();
         let shellItem = this._createShellItem(factoryItem);
@@ -3294,9 +3206,9 @@ PopupMenuFactory.prototype = {
             'child-moved':        Lang.bind(this, this._onChildMoved)
         });
         return shellItem;
-    },
+    }
 
-    _createChildrens: function(factoryItem) {
+    _createChildrens(factoryItem) {
         if (factoryItem) {
             let shellItem = factoryItem.getShellItem();
             if (shellItem instanceof PopupSubMenuMenuItem) {
@@ -3313,9 +3225,9 @@ PopupMenuFactory.prototype = {
                 }
             }
         }
-    },
+    }
 
-    _onChildAdded: function(factoryItem, child, position) {
+    _onChildAdded(factoryItem, child, position) {
         let shellItem = factoryItem.getShellItem();
         if (shellItem) {
             if (shellItem instanceof PopupSubMenuMenuItem) {
@@ -3330,9 +3242,9 @@ PopupMenuFactory.prototype = {
         } else {
             global.logWarning("Tried to add a child shell item to non existing shell item.");
         }
-    },
+    }
 
-    _onChildMoved: function(factoryItem, child, oldpos, newpos) {
+    _onChildMoved(factoryItem, child, oldpos, newpos) {
         let shellItem = factoryItem.getShellItem();
         if (shellItem) {
             if (shellItem instanceof PopupSubMenuMenuItem) {
@@ -3347,14 +3259,14 @@ PopupMenuFactory.prototype = {
         } else {
             global.logWarning("Tried to move a child shell item in non existing shell item.");
         }
-    },
+    }
 
     // FIXME: If this function it is applied, this mean that our old shell Item
     // is not valid right now, so we can destroy it with all the obsolete submenu
     // structure and then create again for the new factoryItems source. Anyway
     // there are a lot of possible scenarios when this was called, sure we are
     // missing some of them.
-    _onTypeChanged: function(factoryItem) {
+    _onTypeChanged(factoryItem) {
         let shellItem = factoryItem.getShellItem();
         let factoryItemParent = factoryItem.getParent();
         let parentMenu = null;
@@ -3384,12 +3296,12 @@ PopupMenuFactory.prototype = {
             let newShellItem = this._createItem(factoryItem);
             parentMenu.addMenuItem(newShellItem, pos);
         }
-    },
+    }
 
     // FIXME: This is a HACK. We're really getting into the internals of the PopupMenu implementation.
     // First, find our wrapper. Children tend to lie. We do not trust the old positioning.
     // Will be better add this function inside the PopupMenuBase class?
-    _moveItemInMenu: function(menu, factoryItem, newpos) {
+    _moveItemInMenu(menu, factoryItem, newpos) {
         let shellItem = factoryItem.getShellItem();
         if (shellItem) {
             let family = menu._getMenuItems();
@@ -3410,17 +3322,17 @@ PopupMenuFactory.prototype = {
             }
         }
     }
-};
+}
 
 /* Basic implementation of a menu manager.
  * Call addMenu to add menus
  */
-function PopupMenuManager(owner) {
-    this._init(owner);
-}
+var PopupMenuManager = class PopupMenuManager {
+    constructor() {
+        return this._init.apply(this, arguments);
+    }
 
-PopupMenuManager.prototype = {
-    _init: function(owner) {
+    _init(owner) {
         this._owner = owner;
         this.grabbed = false;
 
@@ -3434,9 +3346,9 @@ PopupMenuManager.prototype = {
         this._preGrabInputMode = null;
         this._grabbedFromKeynav = false;
         this._signals = new SignalManager.SignalManager(null);
-    },
+    }
 
-    addMenu: function(menu, position) {
+    addMenu(menu, position) {
         this._signals.connect(menu, 'open-state-changed', this._onMenuOpenState, this);
         this._signals.connect(menu, 'child-menu-added', this._onChildMenuAdded, this);
         this._signals.connect(menu, 'child-menu-removed', this._onChildMenuRemoved, this);
@@ -3454,9 +3366,9 @@ PopupMenuManager.prototype = {
             this._menus.push(menu);
         else
             this._menus.splice(position, 0, menu);
-    },
+    }
 
-    removeMenu: function(menu) {
+    removeMenu(menu) {
         if (menu == this._activeMenu)
             this._closeMenu();
 
@@ -3471,9 +3383,9 @@ PopupMenuManager.prototype = {
             this._signals.disconnect(null, menu.sourceActor);
 
         this._menus.splice(position, 1);
-    },
+    }
 
-    _grab: function() {
+    _grab() {
         if (!Main.pushModal(this._owner.actor)) {
             return;
         }
@@ -3484,9 +3396,9 @@ PopupMenuManager.prototype = {
         this._signals.connect(global.stage, 'notify::key-focus', this._onKeyFocusChanged, this);
 
         this.grabbed = true;
-    },
+    }
 
-    _ungrab: function() {
+    _ungrab() {
         if (!this.grabbed) {
             return;
         }
@@ -3495,9 +3407,9 @@ PopupMenuManager.prototype = {
 
         this.grabbed = false;
         Main.popModal(this._owner.actor);
-    },
+    }
 
-    _onMenuOpenState: function(menu, open) {
+    _onMenuOpenState(menu, open) {
         if (open) {
             if (this._activeMenu && this._activeMenu.isChildMenu(menu)) {
                 this._menuStack.push(this._activeMenu);
@@ -3542,18 +3454,18 @@ PopupMenuManager.prototype = {
                     focus.grab_key_focus();
             }
         }
-    },
+    }
 
-    _onChildMenuAdded: function(menu, childMenu) {
+    _onChildMenuAdded(menu, childMenu) {
         this.addMenu(childMenu);
-    },
+    }
 
-    _onChildMenuRemoved: function(menu, childMenu) {
+    _onChildMenuRemoved(menu, childMenu) {
         this.removeMenu(childMenu);
-    },
+    }
 
     // change the currently-open menu without dropping grab
-    _changeMenu: function(newMenu) {
+    _changeMenu(newMenu) {
         if (this._activeMenu) {
             // _onOpenMenuState will drop the grab if it sees
             // this._activeMenu being closed; so clear _activeMenu
@@ -3566,9 +3478,9 @@ PopupMenuManager.prototype = {
             newMenu.open(false);
         } else
             newMenu.open(true);
-    },
+    }
 
-    _onMenuSourceEnter: function(menu) {
+    _onMenuSourceEnter(menu) {
         if (!this.grabbed || menu == this._activeMenu)
             return false;
 
@@ -3583,9 +3495,9 @@ PopupMenuManager.prototype = {
 
         this._changeMenu(menu);
         return false;
-    },
+    }
 
-    _onKeyFocusChanged: function() {
+    _onKeyFocusChanged() {
         if (!this.grabbed || !this._activeMenu || DND.isDragging())
             return;
 
@@ -3601,25 +3513,24 @@ PopupMenuManager.prototype = {
         }
 
         this._closeMenu();
-    },
+    }
 
-    _onMenuDestroy: function(menu) {
+    _onMenuDestroy(menu) {
         this.removeMenu(menu);
-    },
+    }
 
-    _activeMenuContains: function(actor) {
-
+    _activeMenuContains(actor) {
         return !actor.is_finalized()
                 && this._activeMenu != null
                 && (this._activeMenu.actor.contains(actor) ||
                     (this._activeMenu.sourceActor && this._activeMenu.sourceActor.contains(actor)));
-    },
+    }
 
-    _eventIsOnActiveMenu: function(event) {
+    _eventIsOnActiveMenu(event) {
         return this._activeMenuContains(event.get_source());
-    },
+    }
 
-    _shouldBlockEvent: function(event) {
+    _shouldBlockEvent(event) {
         let src = event.get_source();
 
         if (src.is_finalized() || (this._activeMenu != null && this._activeMenu.actor.contains(src)))
@@ -3628,9 +3539,9 @@ PopupMenuManager.prototype = {
         return (this._menus.find(x => x.sourceActor &&
                                       !x.blockSourceEvents &&
                                       x.sourceActor.contains(src)) === undefined);
-    },
+    }
 
-    _onEventCapture: function(actor, event) {
+    _onEventCapture(actor, event) {
         if (!this.grabbed)
             return false;
 
@@ -3667,16 +3578,16 @@ PopupMenuManager.prototype = {
         }
 
         return true;
-    },
+    }
 
-    _closeMenu: function() {
+    _closeMenu() {
         if (this._activeMenu != null)
             this._activeMenu.close(true);
-    },
+    }
 
-    destroy: function() {
+    destroy() {
         this._signals.disconnectAllSignals();
         this.emit('destroy');
     }
-};
+}
 Signals.addSignalMethods(PopupMenuManager.prototype);

--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -1040,9 +1040,6 @@ var PopupImageMenuItem = class PopupImageMenuItem extends PopupBaseMenuItem {
  * the item. The default ornament is an icon,  but can be replace for a check button,
  * a radio button or empty.
  */
-function PopupIndicatorMenuItem() {
-    return this._init.apply(this, arguments);
-}
 
 var PopupIndicatorMenuItem = class PopupIndicatorMenuItem extends PopupBaseMenuItem {
     _init(text, params) {
@@ -1542,7 +1539,7 @@ var PopupMenuAbstractItem = class PopupMenuAbstractItem {
     }
 
     // handlers = { "signal": handler }
-    _connectAndSaveId(target, handlers , idArray) {
+    _connectAndSaveId(target, handlers, idArray) {
         idArray = typeof idArray != 'undefined' ? idArray : [];
         for (let signal in handlers) {
             idArray.push(target.connect(signal, handlers[signal]));


### PR DESCRIPTION
This updates some of the Cinnamon APIs to the newer class syntax. Since third party xlets have not switched to class syntax yet, there is a tricky part to it, so it looks different than the approach in #7389. 

When updating function constructors in the middle of the prototype chain, we have to account for child classes (xlets) still using function constructors calling `_init` directly. This wasn't a problem for the Cinnamon xlet refactoring because they're at the end of the prototype chain, and don't need to worry about other classes calling their `_init` methods. As a result, `_init` needs to be maintained as the constructor function for all APIs. Only the root class at the beginning of the prototype chain needs to have an actual constructor for initializing the instance.