### PR TITLE
[WIP] Simplify separators

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -47,13 +47,7 @@ StScrollBar StButton#hhandle:hover,
 StScrollBar StButton#vhandle:hover {
     background-color: rgba(204,204,204,0.5);
 }
-.separator {
-    -gradient-height: 2px;
-    -gradient-start: rgba(85,85,85,1);
-    -gradient-end: #555555;
-    -margin-horizontal: 1.5em;
-    height: 1em;
-}
+
 .slider {
     height: 1em;
     min-width: 15em;
@@ -190,12 +184,12 @@ StScrollBar StButton#vhandle:hover {
 .popup-combobox-item {
     spacing: 1em;
 }
-.popup-separator-menu-item {
-    -gradient-height: 2px;
-    -gradient-start: rgba(85,85,85,1);
-    -gradient-end: #555555;
-    -margin-horizontal: 1.5em;
-    height: 1em;
+
+.separator,
+.popup-menu-item.separator {
+    background-color: #555555;
+    height: 2px;
+    margin: .4em 1.75em;
 }
 .popup-alternating-menu-item:alternate {
     font-weight: bold;

--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -1,6 +1,5 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
-const Cairo = imports.cairo;
 const Mainloop = imports.mainloop;
 const Clutter = imports.gi.Clutter;
 const Gtk = imports.gi.Gtk;
@@ -486,31 +485,8 @@ var PopupSeparatorMenuItem = class PopupSeparatorMenuItem extends PopupBaseMenuI
     _init () {
         super._init.call(this, { reactive: false });
 
-        this._drawingArea = new St.DrawingArea({ style_class: 'popup-separator-menu-item' });
-        this.addActor(this._drawingArea, { span: -1, expand: true });
-        this._signals.connect(this._drawingArea, 'repaint', Lang.bind(this, this._onRepaint));
-    }
-
-    _onRepaint(area) {
-        let cr = area.get_context();
-        let themeNode = area.get_theme_node();
-        let [width, height] = area.get_surface_size();
-        let margin = themeNode.get_length('-margin-horizontal');
-        let gradientHeight = themeNode.get_length('-gradient-height');
-        let startColor = themeNode.get_color('-gradient-start');
-        let endColor = themeNode.get_color('-gradient-end');
-
-        let gradientWidth = (width - margin * 2);
-        let gradientOffset = (height - gradientHeight) / 2;
-        let pattern = new Cairo.LinearGradient(margin, gradientOffset, width - margin, gradientOffset + gradientHeight);
-        pattern.addColorStopRGBA(0, startColor.red / 255, startColor.green / 255, startColor.blue / 255, startColor.alpha / 255);
-        pattern.addColorStopRGBA(0.5, endColor.red / 255, endColor.green / 255, endColor.blue / 255, endColor.alpha / 255);
-        pattern.addColorStopRGBA(1, startColor.red / 255, startColor.green / 255, startColor.blue / 255, startColor.alpha / 255);
-        cr.setSource(pattern);
-        cr.rectangle(margin, gradientOffset, gradientWidth, gradientHeight);
-        cr.fill();
-
-        cr.$dispose();
+        this.actor.add_style_class_name('separator');
+        this.actor.style = 'padding: 0'; // Prevent themes from having to reset this
     }
 }
 

--- a/js/ui/separator.js
+++ b/js/ui/separator.js
@@ -1,38 +1,8 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
-
-const Cairo = imports.cairo;
-const Lang = imports.lang;
 const St = imports.gi.St;
 
-function Separator() {
-    this._init();
-}
-
-Separator.prototype = {
-    _init: function() {
-        this.actor = new St.DrawingArea({ style_class: 'separator' });
-        this.actor.connect('repaint', Lang.bind(this, this._onRepaint));
-    },
-
-    _onRepaint: function(area) {
-        let cr = area.get_context();
-        let themeNode = area.get_theme_node();
-        let [width, height] = area.get_surface_size();
-        let margin = themeNode.get_length('-margin-horizontal');
-        let gradientHeight = themeNode.get_length('-gradient-height');
-        let startColor = themeNode.get_color('-gradient-start');
-        let endColor = themeNode.get_color('-gradient-end');
-
-        let gradientWidth = (width - margin * 2);
-        let gradientOffset = (height - gradientHeight) / 2;
-        let pattern = new Cairo.LinearGradient(margin, gradientOffset, width - margin, gradientOffset + gradientHeight);
-        pattern.addColorStopRGBA(0, startColor.red / 255, startColor.green / 255, startColor.blue / 255, startColor.alpha / 255);
-        pattern.addColorStopRGBA(0.5, endColor.red / 255, endColor.green / 255, endColor.blue / 255, endColor.alpha / 255);
-        pattern.addColorStopRGBA(1, startColor.red / 255, startColor.green / 255, startColor.blue / 255, startColor.alpha / 255);
-        cr.setSource(pattern);
-        cr.rectangle(margin, gradientOffset, gradientWidth, gradientHeight);
-        cr.fill();
-
-        cr.$dispose();
+class Separator {
+    constructor() {
+        this.actor = new St.Widget({ style_class: 'separator' });
     }
-};
+}


### PR DESCRIPTION
Now that margins are implemented there's no need to do custom painting.
This also allows the separator to extend up to the menu's full with.

This makes ~many~ theme's separators invisible ~(those who don't define a background color).~ They need to do something like this:
```diff
+.popup-menu-item.separator {
+    background-color: #555555;
+    height: 1px;
+    margin: .5em 1em;
+}
 
-.popup-separator-menu-item {
+.popup-separator-menu-item { /* Cinnamon < 4.0 */
     -gradient-height: 1px;
     -gradient-start: #555555;
     -gradient-end: #555555;
     -margin-horizontal: 1em;
     height: 1em;
 }
```
---

**EDIT:** I have changed the commit to use the `separator` class instead of the old `popup-separator-menu-item` class. The vast majority of themes needed to change anyways, and it was hard to keep compatibility with both implementations in the same theme.