### PR TITLE
 Make the key binding setting for Show Desklets global

### DIFF
--- a/files/usr/share/cinnamon/applets/show-desklets@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/show-desklets@cinnamon.org/applet.js
@@ -1,7 +1,6 @@
 const Applet = imports.ui.applet;
 const Panel = imports.ui.panel;
 const Main = imports.ui.main;
-const Settings = imports.ui.settings;
 
 // ES2015 class syntax can be used for Cinnamon 3.8+
 class CinnamonShowDeskletsApplet extends Applet.IconApplet {
@@ -12,48 +11,17 @@ class CinnamonShowDeskletsApplet extends Applet.IconApplet {
         this.set_applet_tooltip(_('Show Desklets'));
         this._applet_context_menu.addMenuItem(
             new Panel.SettingsLauncher(_('Add Desklets'), 'desklets', 'list-add')
-        )
-
-        this.state = {};
-        this.settings = new Settings.AppletSettings(this.state, __meta.uuid, instance_id);
-        this.settings.bind('showKey', 'showKey', () => {
-            this.unbindShowKey();
-            this.bindShowKey();
-        });
-
-        global.settings.connect('changed::panel-edit-mode', () => this.onPanelEditModeChanged());
-        this.bindShowKey();
-    }
-
-    bindShowKey() {
-        Main.keybindingManager.addHotKey('show-desklet-key', this.state.showKey, () => this.on_applet_clicked());
-    }
-
-    unbindShowKey() {
-        Main.keybindingManager.removeHotKey('show-desklet-key');
-    }
-
-    onPanelEditModeChanged() {
-        if (global.settings.get_boolean('panel-edit-mode')
-            && Main.deskletContainer.isModal) {
-            Main.deskletContainer.lower();
-        }
+        );
     }
 
     on_applet_clicked() {
-        if (Main.deskletContainer.isModal) {
-            Main.deskletContainer.lower();
-        } else {
-            Main.deskletContainer.raise();
-        }
+        Main.deskletContainer.toggle();
     }
 
     on_applet_removed_from_panel() {
         if (Main.deskletContainer.isModal) {
             Main.deskletContainer.lower();
         }
-        this.unbindShowKey();
-        this.settings.finalize();
     }
 }
 

--- a/files/usr/share/cinnamon/applets/show-desklets@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/show-desklets@cinnamon.org/settings-schema.json
@@ -1,7 +1,0 @@
-{
-    "showKey": {
-        "type": "keybinding",
-        "description": "Show desklets shortcut",
-        "default": "<Super>Tab::"
-    }
-}

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_keyboard.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_keyboard.py
@@ -52,6 +52,7 @@ KEYBINDINGS = [
     # General
     [_("Toggle Scale"), MUFFIN_KEYBINDINGS_SCHEMA, "switch-to-workspace-down", "general"],
     [_("Toggle Expo"), MUFFIN_KEYBINDINGS_SCHEMA, "switch-to-workspace-up", "general"],
+    [_("Show Desklets"), CINNAMON_SCHEMA, "show-desklets", "general"],
     [_("Cycle through open windows"), MUFFIN_KEYBINDINGS_SCHEMA, "switch-windows", "general"],
     [_("Cycle backwards through open windows"), MUFFIN_KEYBINDINGS_SCHEMA, "switch-windows-backward", "general"],
     [_("Cycle through open windows of the same application"), MUFFIN_KEYBINDINGS_SCHEMA, "switch-group", "general"],

--- a/js/ui/deskletManager.js
+++ b/js/ui/deskletManager.js
@@ -422,8 +422,11 @@ DeskletContainer.prototype = {
         this.stageEventIds = [];
 
         this.keybindingSettings = new Gio.Settings({ schema_id: KEYBINDING_SCHEMA });
-        let keyBinding = this.keybindingSettings.get_strv(SHOW_DESKLETS_KEY);
-        Main.keybindingManager.addHotKeyArray(SHOW_DESKLETS_KEY, keyBinding, () => this.toggle());
+        Main.keybindingManager.addHotKeyArray(
+            SHOW_DESKLETS_KEY,
+            this.keybindingSettings.get_strv(SHOW_DESKLETS_KEY),
+            () => this.toggle()
+        );
         global.settings.connect('changed::panel-edit-mode', () => {
             if (this.isModal) {
                 this.lower();

--- a/js/ui/deskletManager.js
+++ b/js/ui/deskletManager.js
@@ -36,6 +36,8 @@ var deskletChangeKey = 0;
 const ENABLED_DESKLETS_KEY = 'enabled-desklets';
 const DESKLET_SNAP_KEY = 'desklet-snap';
 const DESKLET_SNAP_INTERVAL_KEY = 'desklet-snap-interval';
+const KEYBINDING_SCHEMA = 'org.cinnamon.desktop.keybindings';
+const SHOW_DESKLETS_KEY = 'show-desklets';
 
 function initEnabledDesklets() {
     for (let i = 0; i < definitions.length; i++) {
@@ -418,6 +420,15 @@ DeskletContainer.prototype = {
 
         this.isModal = false;
         this.stageEventIds = [];
+
+        this.keybindingSettings = new Gio.Settings({ schema_id: KEYBINDING_SCHEMA });
+        let keyBinding = this.keybindingSettings.get_strv(SHOW_DESKLETS_KEY);
+        Main.keybindingManager.addHotKeyArray(SHOW_DESKLETS_KEY, keyBinding, () => this.toggle());
+        global.settings.connect('changed::panel-edit-mode', () => {
+            if (this.isModal) {
+                this.lower();
+            }
+        });
     },
 
     /**
@@ -601,5 +612,13 @@ DeskletContainer.prototype = {
     lower: function() {
         this.actor.get_parent().set_child_below_sibling(this.actor, global.window_group);
         this.unsetModal();
+    },
+
+    toggle: function() {
+        if (this.isModal) {
+            this.lower();
+        } else {
+            this.raise();
+        }
     }
 };

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -337,6 +337,7 @@ function start() {
 
     slideshowManager = new SlideshowManager.SlideshowManager();
 
+    keybindingManager = new Keybindings.KeybindingManager();
     deskletContainer = new DeskletManager.DeskletContainer();
 
     // Set up stage hierarchy to group all UI actors under one container.
@@ -416,7 +417,6 @@ function start() {
 
     placesManager = new PlacesManager.PlacesManager();
 
-    keybindingManager = new Keybindings.KeybindingManager();
     magnifier = new Magnifier.Magnifier();
 
     Meta.later_add(Meta.LaterType.BEFORE_REDRAW, _checkWorkspaces);


### PR DESCRIPTION
Moved keybindingManager before deskletContainer's initialization in main.js to prevent a TypeError.

Depends on https://github.com/linuxmint/cinnamon-desktop/pull/115