### PR TITLE
Spices.py: fix file permissions durring install

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
@@ -611,6 +611,11 @@ class Spice_Harvester(GObject.Object):
         contents = os.listdir(folder)
 
         if not self.themes:
+            # ensure proper file permissions
+            for root, dirs, files in os.walk(folder):
+                for file in files:
+                    os.chmod(os.path.join(root, file), 0o755)
+
             # Install spice localization files, if any
             if 'po' in contents:
                 po_dir = os.path.join(folder, 'po')


### PR DESCRIPTION
Because the files are zipped, and then unziped, the execute bit is getting lost when xlets are installed through cinnamon-settings, which in turn causes certain included scripts to not run. This sets the permissions manually on all files to ensure that everything has the necessary permissions.