### PR TITLE
Fix some issues with the download refactoring in Spices.py

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
@@ -366,8 +366,9 @@ class Spice_Harvester(GObject.Object):
                 os.remove(outfile)
             except OSError:
                 pass
-            if not isinstance(e, KeyboardInterrupt):
+            if not isinstance(e, KeyboardInterrupt) and not self.download_manager.abort_status:
                 self.errorMessage(_("An error occurred while trying to access the server. Please try again in a little while."), e)
+            self.abort()
             return None
 
         return outfile
@@ -379,7 +380,7 @@ class Spice_Harvester(GObject.Object):
         count = 0
         blockSize = 1024 * 8
         try:
-            with urlopen(url) as urlobj:
+            with urlopen(url, timeout=15) as urlobj:
                 assert urlobj.getcode() == 200
 
                 totalSize = int(urlobj.info()['content-length'])
@@ -394,7 +395,6 @@ class Spice_Harvester(GObject.Object):
                     f.write(data)
                     ui_thread_do(reporthook, count, blockSize, totalSize)
         except Exception as e:
-            self.abort()
             f.close()
             raise e
 

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
@@ -295,7 +295,7 @@ class Spice_Harvester(GObject.Object):
 
     # updates any progress bars with the download progress
     def _update_progress(self, count, blockSize, totalSize):
-        if self.download_manager.busy():
+        if self.download_manager.busy() and self.download_total_files > 1:
             total = self.download_total_files
             current = total - self.download_manager.get_n_jobs()
             fraction = float(current) / float(total)


### PR DESCRIPTION
* Use `with lock` instead of `lock.acquire` to ensure a lock always gets removed.
* When updating the download progress use the total downloads to calculate the fraction only when there is more than one download. This prevents a divide-by-zero under certain circumstances, and gives more meaningfull progress information.