### PR TITLE
chrome: Improve visibility conditions for panels and other chrome w/fullscreen

### DIFF
--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -5,6 +5,7 @@
  * @short_description: The file responsible for managing Cinnamon chrome
  */
 const Clutter = imports.gi.Clutter;
+const Cinnamon = imports.gi.Cinnamon;
 const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
 const Lang = imports.lang;
@@ -606,7 +607,21 @@ Chrome.prototype = {
             let actorData = this._trackedActors[i], visible;
             if (!actorData.isToplevel)
                 continue;
-            else if (this._inOverview)
+            else if (global.stage_input_mode == Cinnamon.StageInputMode.FULLSCREEN) {
+                let monitor = this.findMonitorForActor(actorData.actor);
+
+                if (global.screen.get_n_monitors() == 1 || !monitor.inFullscreen) {
+                    visible = true;
+                } else {
+                    if (Main.modalActorFocusStack.length > 0) {
+                        let modalActor = Main.modalActorFocusStack[Main.modalActorFocusStack.length - 1].actor;
+
+                        if (this.findMonitorForActor(modalActor) == monitor) {
+                            visible = true;
+                        }
+                    }
+                }
+            } else if (this._inOverview)
                 visible = true;
             else if (!actorData.visibleInFullscreen &&
                      this.findMonitorForActor(actorData.actor).inFullscreen)

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -1358,6 +1358,8 @@ function pushModal(actor, timestamp, options) {
     modalActorFocusStack.push(record);
 
     global.stage.set_key_focus(actor);
+
+    layoutManager.updateChrome(true);
     return true;
 }
 
@@ -1413,6 +1415,9 @@ function popModal(actor, timestamp) {
 
     global.end_modal(timestamp);
     global.set_stage_input_mode(Cinnamon.StageInputMode.NORMAL);
+
+    layoutManager.updateChrome(true);
+
     Meta.enable_unredirect_for_screen(global.screen);
 }
 


### PR DESCRIPTION
chrome: Improve visibility conditions for panels and other chrome
when windows are fullscreen and popups or menus are activated.

Intended behavior:

Single monitor setups: Panels are hidden only when a given fullscreen
window for a given monitor actually is the toplevel window for that
monitor.  If a popup is activate (like the Cinnamon menu via shortcut,)
the panels will show while that modal is active.  This prevents a
weird disembodied menu popping out of nowhere.  Further, if a non-
fullscreen window is alt-tabbed to, or otherwise made the focus, the
panels will also return until the fullscreen window is re-focused.

Multi-monitor setups: Same as single monitor, except for modal actor
behavior is different - only the panel(s) on the monitor which currently
hosts the last-added/current modal actor are shown.  This allows, for
instance, the alt-tab popup or menu to be used on your 'work' monitor
without disrupting the view of your 'movie/tv-show' monitor.

Requires muffin patch as well: https://github.com/linuxmint/muffin/pull/317