### PR TITLE
fileUtils: Fix module exporter bug, fix line numbers in stack traces being incorrect

### DIFF
--- a/js/misc/fileUtils.js
+++ b/js/misc/fileUtils.js
@@ -171,11 +171,11 @@ function createExports({path, dir, meta, type, file, size, JS, returnIndex, reje
         moduleIndex = LoadedModules.length - 1;
     }
 
-    JS = `'use strict';\n${JS};`;
+    JS = `'use strict';${JS};`;
     // Regex matches the top level variable names, and appends them to the module.exports object,
     // mimicking the native CJS importer.
     const exportsRegex = /^module\.exports(\.[a-zA-Z0-9_$]+)?\s*=/m;
-    const varRegex = /^(const|var|let|function|class)\s+([a-zA-Z0-9_$]+)/gm;
+    const varRegex = /^(?:'use strict';){0,}(const|var|let|function|class)\s+([a-zA-Z0-9_$]+)/gm;
     let match;
 
     if (!exportsRegex.test(JS)) {

--- a/js/misc/fileUtils.js
+++ b/js/misc/fileUtils.js
@@ -202,7 +202,7 @@ function createExports({path, dir, meta, type, file, size, JS, returnIndex, reje
 
     // Return the exports object containing all of our top level namespaces, and include the sourceURL so
     // Spidermonkey includes the file names in stack traces.
-    JS += `return exports;//# sourceURL=${path}`;
+    JS += `return module.exports;//# sourceURL=${path}`;
 
     try {
         // Create the function returning module.exports and return it to Extension so it can be called by the


### PR DESCRIPTION
This fixes a bug when module.exports is overwritten with a new object, breaking the reference to the exports variable in the xlet scope, resulting in the module returning undefined.

Also re-approaches the fix for variables on the first line in a file being ignored because the solution in #7477 causes the line numbers in stack traces to be offset by 1.