### PR TITLE
add GNOME Apps icons for Gnome Online Accounts

### DIFF
--- a/data/icons/Makefile.am
+++ b/data/icons/Makefile.am
@@ -18,6 +18,12 @@ public_icons = \
     hicolor_actions_scalable_num-lock-off-symbolic.svg \
 	hicolor_apps_scalable_cinnamon-panel-launcher.svg \
     hicolor_apps_scalable_removable-drives.svg \
+    hicolor_apps_scalable_evolution.svg \
+    hicolor_apps_scalable_org.gnome.Calendar.svg \
+    hicolor_apps_scalable_org.gnome.Contacts.svg \
+    hicolor_apps_scalable_org.gnome.Documents.svg \
+    hicolor_apps_scalable_org.gnome.Maps.svg \
+    hicolor_apps_scalable_org.gnome.Photos.svg \
 	hicolor_categories_16x16_cs-desklets.svg \
 	hicolor_categories_16x16_cs-backgrounds.svg \
 	hicolor_categories_scalable_cs-applets.svg \

--- a/data/icons/hicolor_apps_scalable_evolution.svg
+++ b/data/icons/hicolor_apps_scalable_evolution.svg
@@ -1,0 +1,627 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 6.3499994 6.3499994"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="hicolor_apps_scalable_evolution.svg">
+  <defs
+     id="defs2">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient14755-8">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop14757-1" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop14759-3" />
+    </linearGradient>
+    <linearGradient
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715"
+       gradientTransform="matrix(2.774389,0,0,1.969706,-1892.179,-872.8854)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5027-2"
+       xlink:href="#linearGradient5048-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5048-1">
+      <stop
+         id="stop5050-0"
+         offset="0"
+         style="stop-color:black;stop-opacity:0;" />
+      <stop
+         style="stop-color:black;stop-opacity:1;"
+         offset="0.5"
+         id="stop5056-7" />
+      <stop
+         id="stop5052-9"
+         offset="1"
+         style="stop-color:black;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       r="117.14286"
+       fy="486.64789"
+       fx="605.71429"
+       cy="486.64789"
+       cx="605.71429"
+       gradientTransform="matrix(2.774389,0,0,1.969706,-1891.633,-872.8854)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient5029-6"
+       xlink:href="#linearGradient14755-8"
+       inkscape:collect="always" />
+    <radialGradient
+       r="117.14286"
+       fy="486.64789"
+       fx="605.71429"
+       cy="486.64789"
+       cx="605.71429"
+       gradientTransform="matrix(-2.774389,0,0,1.969706,112.7623,-872.8854)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient5031-8"
+       xlink:href="#linearGradient14755-8"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15107-6"
+       id="linearGradient11402-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.854123,0,0,0.853016,4.385014,7.210075)"
+       x1="11.572842"
+       y1="4.7461624"
+       x2="18.475286"
+       y2="26.022909" />
+    <linearGradient
+       id="linearGradient15107-6">
+      <stop
+         id="stop15109-5"
+         offset="0.0000000"
+         style="stop-color:#ffffff;stop-opacity:1.0000000;" />
+      <stop
+         id="stop15111-9"
+         offset="1.0000000"
+         style="stop-color:#e2e2e2;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2136-00"
+       id="linearGradient11404-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.854123,0,0,0.853016,4.385014,7.210075)"
+       x1="2.0618775"
+       y1="15.257116"
+       x2="30.599684"
+       y2="15.257116" />
+    <linearGradient
+       id="linearGradient2136-00">
+      <stop
+         id="stop2138-9"
+         offset="0.0000000"
+         style="stop-color:#989690;stop-opacity:1.0000000;" />
+      <stop
+         id="stop2140-20"
+         offset="1.0000000"
+         style="stop-color:#656460;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient18913-5"
+       id="linearGradient11406-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.971371,0,0,0.733506,5.027433,7.337627)"
+       x1="5.8266134"
+       y1="7.2310905"
+       x2="13.467486"
+       y2="17.876846" />
+    <linearGradient
+       id="linearGradient18913-5">
+      <stop
+         id="stop18915-9"
+         offset="0.0000000"
+         style="stop-color:#ededed;stop-opacity:1.0000000;" />
+      <stop
+         id="stop18917-0"
+         offset="1.0000000"
+         style="stop-color:#c8c8c8;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2166-14"
+       id="linearGradient11408-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.13944,0,0,0.643976,4.995766,7.023296)"
+       x1="10.18424"
+       y1="15.148383"
+       x2="15.310744"
+       y2="29.568739" />
+    <linearGradient
+       id="linearGradient2166-14">
+      <stop
+         id="stop2168-6"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop2170-5"
+         offset="1.0000000"
+         style="stop-color:#dcdcdc;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2152-3"
+       id="linearGradient11410-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.537475,0,0,0.477257,4.995766,7.023296)"
+       x1="8.9156475"
+       y1="37.197018"
+       x2="9.8855038"
+       y2="52.090679" />
+    <linearGradient
+       id="linearGradient2152-3">
+      <stop
+         id="stop2154-8"
+         offset="0.0000000"
+         style="stop-color:#9aa29a;stop-opacity:1.0000000;" />
+      <stop
+         id="stop2156-0"
+         offset="1.0000000"
+         style="stop-color:#b5beb5;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9749-5"
+       id="linearGradient11414-75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.833576,0,0,0.832463,4.73503,7.515565)"
+       x1="11.233107"
+       y1="13.686079"
+       x2="21.111549"
+       y2="24.132717" />
+    <linearGradient
+       id="linearGradient9749-5">
+      <stop
+         id="stop9751-6"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop9753-4"
+         offset="1.0000000"
+         style="stop-color:#ededed;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2274-7"
+       id="linearGradient11416-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.49997,0,0,0.489191,4.995766,7.023296)"
+       x1="8.7803764"
+       y1="37.784683"
+       x2="9.7619219"
+       y2="32.203163" />
+    <linearGradient
+       id="linearGradient2274-7">
+      <stop
+         id="stop2276-6"
+         offset="0.0000000"
+         style="stop-color:#000000;stop-opacity:0.12871288;" />
+      <stop
+         id="stop2278-0"
+         offset="1.0000000"
+         style="stop-color:#000000;stop-opacity:0.0000000;" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient14755-8"
+       id="radialGradient11380-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(1.902215,0.525703)"
+       cx="6.702713"
+       cy="73.615715"
+       fx="6.702713"
+       fy="73.615715"
+       r="7.228416" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient37935-5"
+       id="radialGradient11386-49"
+       gradientUnits="userSpaceOnUse"
+       cx="8.7468252"
+       cy="6.8283234"
+       fx="8.7468252"
+       fy="6.8283234"
+       r="29.889715" />
+    <linearGradient
+       id="linearGradient37935-5">
+      <stop
+         id="stop37937-8"
+         offset="0.0000000"
+         style="stop-color:#9497b3;stop-opacity:1.0000000;" />
+      <stop
+         id="stop37939-73"
+         offset="1.0000000"
+         style="stop-color:#4c4059;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2145-8"
+       id="radialGradient11388-1"
+       gradientUnits="userSpaceOnUse"
+       cx="11.901996"
+       cy="10.045444"
+       fx="11.901996"
+       fy="10.045444"
+       r="29.292715" />
+    <linearGradient
+       id="linearGradient2145-8">
+      <stop
+         style="stop-color:#fffffd;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop2147-6" />
+      <stop
+         style="stop-color:#cbcbc9;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop2149-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient42174-9"
+       id="linearGradient11390-4"
+       gradientUnits="userSpaceOnUse"
+       x1="6.342216"
+       y1="7.7893324"
+       x2="22.218424"
+       y2="25.884274" />
+    <linearGradient
+       id="linearGradient42174-9">
+      <stop
+         style="stop-color:#a0a0a0;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop42176-6" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop42178-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2111-1"
+       id="linearGradient11392-5"
+       gradientUnits="userSpaceOnUse"
+       x1="13.037439"
+       y1="8.3119221"
+       x2="19.359053"
+       y2="17.322744" />
+    <linearGradient
+       id="linearGradient2111-1">
+      <stop
+         style="stop-color:#838383;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop2113-9" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop2115-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2111-1"
+       id="linearGradient11394-7"
+       gradientUnits="userSpaceOnUse"
+       x1="13.037439"
+       y1="-1.5875777"
+       x2="19.359053"
+       y2="7.423245" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2111-1"
+       id="linearGradient11396-5"
+       gradientUnits="userSpaceOnUse"
+       x1="17.987192"
+       y1="3.3621745"
+       x2="24.308804"
+       y2="12.372997" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2111-1"
+       id="linearGradient11398-3"
+       gradientUnits="userSpaceOnUse"
+       x1="8.0876923"
+       y1="3.3621745"
+       x2="14.409305"
+       y2="12.372997" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10653-77"
+       id="radialGradient11400-5"
+       gradientUnits="userSpaceOnUse"
+       cx="11.3292"
+       cy="10.58397"
+       fx="11.3292"
+       fy="10.58397"
+       r="15.532059" />
+    <linearGradient
+       id="linearGradient10653-77">
+      <stop
+         style="stop-color:#f3f4ff;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop10655-2" />
+      <stop
+         style="stop-color:#9193af;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop10657-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2152-3"
+       id="linearGradient1177"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.537475,0,0,0.477257,4.995766,7.023296)"
+       x1="8.9156475"
+       y1="37.197018"
+       x2="9.8855038"
+       y2="52.090679" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2152-3"
+       id="linearGradient1179"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.537475,0,0,0.477257,4.995766,7.023296)"
+       x1="8.9156475"
+       y1="37.197018"
+       x2="9.8855038"
+       y2="52.090679" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.4"
+     inkscape:cx="12.294777"
+     inkscape:cy="13.519817"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1280"
+     inkscape:window-height="746"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid815" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-290.65001)">
+    <g
+       style="display:inline;enable-background:new"
+       id="g12002"
+       transform="matrix(0.13222432,0,0,0.13222432,0.11348873,290.48308)">
+      <g
+         transform="matrix(0.01970535,0,0,0.01960973,36.67354,33.51579)"
+         id="g5022"
+         style="display:inline;opacity:0.58730164">
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.40206185;fill:url(#linearGradient5027-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           id="rect4173"
+           width="1339.6335"
+           height="478.35718"
+           x="-1559.2523"
+           y="-150.69685" />
+        <path
+           inkscape:connector-curvature="0"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.40206185;fill:url(#radialGradient5029-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           d="m -219.61876,-150.68038 c 0,0 0,478.33079 0,478.33079 142.874166,0.90045 345.40022,-107.16966 345.40014,-239.196175 0,-132.026537 -159.436816,-239.134595 -345.40014,-239.134615 z"
+           id="path5058"
+           sodipodi:nodetypes="cccc" />
+        <path
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccc"
+           id="path5018"
+           d="m -1559.2523,-150.68038 c 0,0 0,478.33079 0,478.33079 -142.8742,0.90045 -345.4002,-107.16966 -345.4002,-239.196175 0,-132.026537 159.4368,-239.134595 345.4002,-239.134615 z"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.40206185;fill:url(#radialGradient5031-8);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+      </g>
+      <g
+         id="g11365-0"
+         transform="matrix(1.340124,0,0,1.340124,-5.069189,-7.603523)">
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:url(#linearGradient11402-3);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11404-6);stroke-width:1.11986935;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M 6.5808726,17.231729 V 31.977276 H 30.086157 L 30.047337,17.302485 C 30.045137,16.473694 22.51457,8.4719913 21.125364,8.4719913 h -5.436669 c -1.460536,0 -9.1078244,7.9786497 -9.1078244,8.7597377 z"
+           id="path12723-1"
+           sodipodi:nodetypes="ccczzzz" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:url(#linearGradient11406-5);fill-opacity:1;fill-rule:evenodd;stroke:none"
+           d="M 7.5282401,17.465328 C 7.2820659,17.200418 14.879919,9.0316441 16.028566,9.0316441 h 5.180142 c 1.080765,0 8.681198,8.0853999 8.304249,8.5518439 l -6.717325,8.312126 -7.615504,-0.196039 z"
+           id="path18153-2"
+           sodipodi:nodetypes="czzzccz" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:#000000;fill-opacity:0.14619883;fill-rule:evenodd;stroke:none"
+           d="m 15.140883,25.609036 -4.592796,-5.477783 15.544238,-4.344191 1.840754,3.780413 -4.58841,6.02572"
+           id="path2164-6"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:#000000;fill-opacity:0.14619883;fill-rule:evenodd;stroke:none"
+           d="M 14.648745,25.495465 9.9622552,19.977529 25.39942,15.660107 l 1.987983,3.927642 -4.534872,5.891876"
+           id="path2162-3"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:#000000;fill-opacity:0.14619883;fill-rule:evenodd;stroke:none"
+           d="m 14.951599,25.571179 -4.806948,-5.424245 15.63793,-4.424498 2.001368,4.034718 -4.628564,5.798185"
+           id="path2160-9"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:url(#linearGradient11408-7);fill-opacity:1;fill-rule:evenodd;stroke:none"
+           d="m 14.838029,25.874033 -4.592798,-5.477783 15.477317,-4.317422 1.854139,3.887489 -4.534872,5.891876"
+           id="path15105-4"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:url(#linearGradient1177);fill-opacity:1;fill-rule:evenodd;stroke:none"
+           d="m 16.024558,25.011992 -8.3901392,6.871959 8.7113652,-6.015354 h 5.648238 l 7.778278,5.938872 -7.430282,-6.795477 z"
+           id="path14245-6"
+           sodipodi:nodetypes="ccccccc" />
+        <path
+           inkscape:connector-curvature="0"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1179);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+           d="m 7.5536271,17.383943 7.2127919,8.966494 0.669223,-0.535378 z"
+           id="path14339-0"
+           sodipodi:nodetypes="cccc" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:url(#linearGradient11414-75);stroke-width:1.11929941;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 7.7001745,17.474628 0.018942,13.383348 H 28.966869 L 28.928989,17.547335 C 28.927789,17.115408 22.109043,9.5912909 20.79094,9.5912909 h -4.800856 c -1.369463,0 -8.2905422,7.4333921 -8.2899057,7.8833371 z"
+           id="path15103-4"
+           sodipodi:nodetypes="ccczzzz" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none"
+           d="m 16.3182,25.881574 -7.4791807,5.180189 1.3900717,0.0038 6.26201,-4.302144 5.525323,-0.891149 -5.698224,0.0093 z"
+           id="path17393-7"
+           sodipodi:nodetypes="cccccc" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none"
+           d="m 10.349551,20.380972 0.829836,0.883374 14.274319,-4.311695 1.73158,3.445905 0.403436,-0.445886 -1.847054,-3.88149 z"
+           id="path2174-4"
+           sodipodi:nodetypes="ccccccc" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:url(#linearGradient11416-3);fill-opacity:1;fill-rule:evenodd;stroke:none"
+           d="m 11.527382,21.612342 3.774415,4.042104 0.74953,-0.642454 6.31746,0.02677 0.508609,0.455071 2.489508,-2.971348 C 24.644144,21.639111 11.527382,21.612342 11.527382,21.612342 Z"
+           id="path2272-8"
+           sodipodi:nodetypes="ccccccc" />
+      </g>
+      <g
+         id="g11350-8"
+         transform="matrix(1.307835,0,0,1.307835,-11.62104,-5.417499)">
+        <path
+           inkscape:connector-curvature="0"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient11410-3);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+           d="M 29.838359,17.3583 22.770321,25.574139 23.389829,26.186 Z"
+           id="path14341-7"
+           sodipodi:nodetypes="cccc" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:#fefefe;fill-opacity:1;fill-rule:evenodd;stroke:none"
+           d="m 29.779094,17.314041 -6.303085,8.740435 0.900446,0.79501 z"
+           id="path18921-4"
+           sodipodi:nodetypes="cccc" />
+        <ellipse
+           ry="3.8"
+           rx="13.75"
+           cy="38.700001"
+           cx="12.75"
+           transform="matrix(0.9,0,0,1,21.1,-2)"
+           id="path10689-4"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.57541899;fill:url(#radialGradient11380-8);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.80000001;marker:none" />
+        <circle
+           r="14.910714"
+           cy="16.910715"
+           cx="16.25"
+           style="fill:url(#radialGradient11386-49);fill-opacity:1;fill-rule:evenodd;stroke:#605773;stroke-width:1.62869656;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="path27786-4"
+           transform="matrix(0.704562,0,0,0.704562,20.97029,15.85306)" />
+        <circle
+           r="14.910714"
+           cy="16.910715"
+           cx="16.25"
+           style="fill:url(#radialGradient11388-1);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11390-4);stroke-width:2.37472653;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="path35549-0"
+           transform="matrix(0.46540028,0,0,0.46540028,24.810098,19.85086)" />
+        <circle
+           r="1.21875"
+           cy="17.28125"
+           cx="15.1875"
+           style="fill:#f3f3f3;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.70917851;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+           id="path34778-9"
+           transform="matrix(0.93826444,0,0,0.93826444,18.126596,11.438603)" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#000000;stroke-width:0.63306934;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1"
+           d="M 31.823046,26.54761 29.751878,21.917149"
+           id="path35559-2" />
+        <path
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc"
+           style="fill:none;stroke:#000000;stroke-width:0.9496038;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1"
+           d="m 29.604314,31.540403 1.921439,-2.771874"
+           id="path35561-5" />
+        <circle
+           r="0.61871845"
+           cy="7.6932044"
+           cx="16.705399"
+           style="fill:url(#linearGradient11392-5);fill-opacity:1;fill-rule:evenodd;stroke:none"
+           id="path35563-7"
+           transform="matrix(1.135377,0,0,1.135377,13.35348,13.31414)" />
+        <circle
+           r="0.61871845"
+           cy="7.6932044"
+           cx="16.705399"
+           style="fill:url(#linearGradient11394-7);fill-opacity:1;fill-rule:evenodd;stroke:none"
+           id="path35565-7"
+           transform="matrix(1.135377,0,0,1.135377,13.35348,24.5538)" />
+        <circle
+           r="0.61871845"
+           cy="7.6932044"
+           cx="16.705399"
+           style="fill:url(#linearGradient11396-5);fill-opacity:1;fill-rule:evenodd;stroke:none"
+           id="path35567-2"
+           transform="matrix(1.135377,0,0,1.135377,7.733647,18.93397)" />
+        <circle
+           r="0.61871845"
+           cy="7.6932044"
+           cx="16.705399"
+           style="fill:url(#linearGradient11398-3);fill-opacity:1;fill-rule:evenodd;stroke:none"
+           id="path35569-0"
+           transform="matrix(1.135377,0,0,1.135377,18.97331,18.93397)" />
+        <circle
+           r="14.910714"
+           cy="16.910715"
+           cx="16.25"
+           transform="matrix(0.6267041,0,0,0.6267041,22.235482,17.169706)"
+           id="path10651-6"
+           style="fill:none;stroke:url(#radialGradient11400-5);stroke-width:1.80491161;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/data/icons/hicolor_apps_scalable_org.gnome.Calendar.svg
+++ b/data/icons/hicolor_apps_scalable_org.gnome.Calendar.svg
@@ -1,0 +1,260 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 6.3499994 6.3499994"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="hicolor_apps_scalable_org.gnome.Calendar.svg">
+  <defs
+     id="defs2">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient14991-1">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop14993-0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop14995-0" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       id="filter15152">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.41667205"
+         id="feGaussianBlur15154" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15062"
+       id="linearGradient15138"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0166894,0,0,1.0357267,-4.7619423,-3.1502852)"
+       x1="321.22012"
+       y1="61.649731"
+       x2="321.22012"
+       y2="93.073441" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient15062">
+      <stop
+         style="stop-color:#a6c5ff;stop-opacity:1;"
+         offset="0"
+         id="stop15064" />
+      <stop
+         style="stop-color:#5b8fd9;stop-opacity:1"
+         offset="1"
+         id="stop15066" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient14991-1"
+       id="radialGradient15140-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2448459,0.25992693,-0.41078496,1.9673372,-46.889825,-157.22764)"
+       cx="319.95868"
+       cy="76.5625"
+       fx="319.95868"
+       fy="76.5625"
+       r="20.919315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15042"
+       id="linearGradient15142"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.6979117,0,0,0.72462401,65.717749,85.010976)"
+       x1="352.71368"
+       y1="132.83543"
+       x2="352.71368"
+       y2="142.86761" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient15042">
+      <stop
+         style="stop-color:#f8f8f8;stop-opacity:1"
+         offset="0"
+         id="stop15044" />
+      <stop
+         id="stop15102"
+         offset="0.59251517"
+         style="stop-color:#d9d9da;stop-opacity:1;" />
+      <stop
+         id="stop15050"
+         offset="0.96255541"
+         style="stop-color:#c8c8c8;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a2a2a2;stop-opacity:1"
+         offset="1"
+         id="stop15046" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15054"
+       id="linearGradient15144"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.69782621,0,0,0.72462401,91.593448,85.010976)"
+       x1="317.47461"
+       y1="151.72664"
+       x2="317.47461"
+       y2="143.1402" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient15054">
+      <stop
+         style="stop-color:#f5efef;stop-opacity:1"
+         offset="0"
+         id="stop15056" />
+      <stop
+         style="stop-color:#f1eaea;stop-opacity:1"
+         offset="1"
+         id="stop15058" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.2"
+     inkscape:cx="13.910562"
+     inkscape:cy="11.307643"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1280"
+     inkscape:window-height="746"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid815" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-290.65001)">
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,-79.874211,243.56172)"
+       style="display:inline;enable-background:new"
+       id="g1056">
+      <g
+         id="g15104"
+         transform="matrix(0.48128365,0,0,0.48077366,159.65728,152.43158)">
+        <path
+           transform="matrix(1.0159955,0,0,1,-4.4326989,0)"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.30962345;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;marker:none;filter:url(#filter15152);enable-background:new"
+           d="m 335.57314,61.234387 h -31.1127 c -1.67938,0 -3.62392,0.53033 -3.71231,3.358758 l -2.20971,30.317203 c -0.35356,2.65165 2.47488,4.331028 3.8007,4.331028 h 34.1179 c 3.95019,0 5.12413,-1.762697 5.03814,-4.065863 l -1.94454,-30.493981 c -0.17169,-2.575386 -2.02492,-3.447145 -3.97748,-3.447145 z"
+           id="path15106"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccc" />
+        <path
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient15138);fill-opacity:1;stroke:#204a87;stroke-width:2.0788784;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
+           d="m 338.24391,56.456578 h -35.58838 c -1.7074,0 -3.68439,0.549277 -3.77426,3.478755 l -0.17418,31.400338 c -0.35946,2.746385 2.51619,4.485762 3.86414,4.485762 h 34.6873 c 4.01612,0 5.20965,-1.825672 5.12223,-4.211123 l -0.093,-31.583431 c -0.17455,-2.667397 -2.05871,-3.570301 -4.04386,-3.570301 z"
+           id="path15110"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccc" />
+        <path
+           transform="matrix(1.0183633,0,0,1.0352328,-5.7237342,-2.6322579)"
+           d="m 302.65625,58.939453 c -0.59926,0 -1.01961,0.137731 -1.09766,0.191406 -0.0775,0.0533 -0.18419,-0.03309 -0.21289,0.845703 l -0.15625,31.128907 a 2.4702241,2.4702241 0 0 1 -0.0215,0.310547 c -0.0602,0.456759 0.0923,0.734285 0.51172,1.123046 0.41941,0.388762 1.27209,0.552735 0.88281,0.552735 H 337.25 c 1.63535,0 2.2324,-0.36579 2.40039,-0.525391 0.16799,-0.159601 0.28341,-0.352966 0.25586,-1.099609 a 2.4702241,2.4702241 0 0 1 -0.002,-0.08398 l -0.0937,-31.234374 c -0.0521,-0.733147 -0.18401,-0.808805 -0.34571,-0.929688 -0.16411,-0.122694 -0.58795,-0.279297 -1.21484,-0.279297 z"
+           id="path15177"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#radialGradient15140-8);stroke-width:2.0246911;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
+           inkscape:original="M 302.65625 56.46875 C 300.94885 56.46875 298.96487 56.996395 298.875 59.90625 L 298.71875 91.09375 C 298.35929 93.821738 301.21455 95.5625 302.5625 95.5625 L 337.25 95.5625 C 341.26612 95.5625 342.46242 93.744472 342.375 91.375 L 342.28125 60 C 342.1067 57.350471 340.23515 56.46875 338.25 56.46875 L 302.65625 56.46875 z "
+           inkscape:radius="-2.4699771"
+           sodipodi:type="inkscape:offset" />
+      </g>
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#555555;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new"
+         d="m 322.0046,194.62084 -0.004,-12.59221 h -16.95822 l -0.0521,14.03601 17.01444,-0.0738 z"
+         id="path15114"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient15142);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new"
+         d="m 305.97695,181.03141 0.40352,7.24259 0.8429,0.31031 h 13.26276 l 0.40097,-0.28821 0.13834,-7.32105 z"
+         id="path15116"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path15118"
+         d="m 306.02294,195.03799 0.2364,-5.89187 c 0.31396,-0.0733 0.95402,-0.15839 0.98152,-0.55026 h 13.25323 c 0.0368,0.1403 0.11871,0.19467 0.43581,0.46073 l 0.11561,5.9733 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient15144);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new" />
+      <g
+         id="g15120"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:18.46686172px;line-height:125%;font-family:'Avenir LT 65 Medium';-inkscape-font-specification:'Avenir LT 65 Medium,';text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         transform="matrix(0.49634951,0,0,0.46618061,159.65728,152.43158)">
+        <path
+           id="path15122"
+           style="marker:none"
+           d="m 306.67936,77.249553 c 0.21388,-0.199626 0.42064,-0.413519 0.62029,-0.64168 0.19963,-0.242404 0.37787,-0.491946 0.53473,-0.748628 0.15684,-0.256662 0.27805,-0.527594 0.36361,-0.812795 0.0999,-0.285181 0.14972,-0.584632 0.14973,-0.898353 -10e-6,-0.370737 -0.0713,-0.705837 -0.21389,-1.005299 -0.12834,-0.299438 -0.31372,-0.548981 -0.55612,-0.748627 -0.22816,-0.21388 -0.50622,-0.377866 -0.83418,-0.491955 -0.31373,-0.114065 -0.64882,-0.171101 -1.0053,-0.171115 -0.7415,1.4e-5 -1.35467,0.206777 -1.83948,0.620291 -0.48484,0.41354 -0.79142,0.983922 -0.91975,1.711148 l -2.22449,-0.192505 c 0.0998,-0.670187 0.29232,-1.247698 0.57751,-1.732537 0.29945,-0.499071 0.66306,-0.912598 1.09085,-1.240582 0.44205,-0.327955 0.94113,-0.570367 1.49726,-0.727238 0.57038,-0.156839 1.18354,-0.235267 1.83948,-0.235282 0.65593,1.5e-5 1.2691,0.09271 1.83948,0.278061 0.58465,0.17113 1.09085,0.434932 1.51865,0.791406 0.44204,0.342244 0.78427,0.77716 1.02669,1.30475 0.25666,0.513357 0.38499,1.119388 0.38501,1.818095 -2e-5,0.499095 -0.0784,0.969661 -0.23528,1.411697 -0.14261,0.427797 -0.33512,0.834194 -0.57752,1.219193 -0.24242,0.385016 -0.52048,0.748636 -0.83419,1.090856 -0.31371,0.342238 -0.64168,0.677337 -0.9839,1.0053 l -5.00984,5.254735 -0.004,0.775747 7.19977,-0.09245 0.0445,2.261045 -9.23641,0.143371 v -3.51754"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccccccsccccccccccccsccccccc" />
+        <path
+           id="path15124"
+           style="marker:none"
+           d="m 318.2149,72.048152 -5.29172,0.0474 V 69.78593 h 8.21775 v 1.514283 l -7.93599,15.847416 -2.30607,0.04857"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccc" />
+      </g>
+      <g
+         transform="matrix(0.11603952,0,0,0.11770228,271.70238,176.4255)"
+         id="g15126"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:125%;font-family:'Avenir LT 65 Medium';-inkscape-font-specification:'Avenir LT 65 Medium,';text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#393939;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate">
+        <path
+           inkscape:connector-curvature="0"
+           id="path15128"
+           style="fill:#393939;fill-opacity:1;marker:none"
+           d="m 312.80396,55.857089 h 7.12 v 1.44 h -5.584 v 3.552 h 5.2 v 1.44 h -5.2 v 4.896 h -1.536 v -11.328" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path15130"
+           style="fill:#393939;fill-opacity:1;marker:none"
+           d="m 323.52746,60.849089 h 2.016 c 0.29866,6e-6 0.592,-0.02133 0.88,-0.064 0.29866,-0.05333 0.55999,-0.143993 0.784,-0.272 0.23466,-0.127993 0.42133,-0.309326 0.56,-0.544 0.13866,-0.245326 0.20799,-0.559992 0.208,-0.944 -10e-6,-0.383991 -0.0693,-0.693324 -0.208,-0.928 -0.13867,-0.245324 -0.32534,-0.43199 -0.56,-0.56 -0.22401,-0.12799 -0.48534,-0.213323 -0.784,-0.256 -0.288,-0.05332 -0.58134,-0.07999 -0.88,-0.08 h -2.016 v 3.648 m -1.536,-4.992 h 3.984 c 0.72533,1.1e-5 1.32266,0.101345 1.792,0.304 0.46933,0.192011 0.83733,0.442677 1.104,0.752 0.27733,0.298677 0.46933,0.64001 0.576,1.024 0.10666,0.373342 0.15999,0.736009 0.16,1.088 -1e-5,0.362675 -0.064,0.714674 -0.192,1.056 -0.12801,0.330674 -0.31467,0.634673 -0.56,0.912 -0.23467,0.266673 -0.52801,0.496006 -0.88,0.688 -0.34134,0.181339 -0.72534,0.293339 -1.152,0.336 l 3.216,5.168 h -1.92 l -2.88,-4.992 h -1.712 v 4.992 h -1.536 v -11.328" />
+      </g>
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.52719667;fill:#fdfcfc;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new"
+         d="m 306.04324,195.0159 0.23583,-5.91398 c 0.314,-0.0733 0.90986,-0.22468 0.95948,-0.50606 h 13.25485 c 0.0368,0.1403 0.11872,0.19467 0.43587,0.46073 l 0.1002,5.95121 z"
+         id="path15132"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:round;stroke-opacity:1;marker:none;enable-background:new"
+         d="m 306.5114,181.5 h 13.9772"
+         id="path15134"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/data/icons/hicolor_apps_scalable_org.gnome.Contacts.svg
+++ b/data/icons/hicolor_apps_scalable_org.gnome.Contacts.svg
@@ -1,0 +1,516 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 6.3499994 6.3499994"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="hicolor_apps_scalable_org.gnome.Contacts.svg">
+  <defs
+     id="defs2">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient14991-1">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop14993-0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop14995-0" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7792"
+       inkscape:collect="always"
+       x1="17.353554"
+       x2="28.035534"
+       xlink:href="#linearGradient14991-1"
+       y1="7.9356604"
+       y2="81.759773" />
+    <radialGradient
+       cx="42"
+       cy="15.814279"
+       fx="42"
+       fy="15.814279"
+       gradientTransform="matrix(0.3454607,0,0,0.721158,4.892862,-4.1998389)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient6605"
+       inkscape:collect="always"
+       r="3"
+       xlink:href="#linearGradient6859" />
+    <linearGradient
+       id="linearGradient6859"
+       inkscape:collect="always">
+      <stop
+         id="stop6861"
+         offset="0"
+         style="stop-color:#9ee757;stop-opacity:1" />
+      <stop
+         id="stop6863"
+         offset="1"
+         style="stop-color:#8ae234;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       cx="42.8125"
+       cy="25.727272"
+       fx="42.8125"
+       fy="25.727272"
+       gradientTransform="matrix(0.382744,0,0,0.5019211,3.861375,-1.1630632)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient6600"
+       inkscape:collect="always"
+       r="4.5"
+       xlink:href="#linearGradient6851" />
+    <linearGradient
+       id="linearGradient6851"
+       inkscape:collect="always">
+      <stop
+         id="stop6853"
+         offset="0"
+         style="stop-color:#fdee77;stop-opacity:1" />
+      <stop
+         id="stop6855"
+         offset="1"
+         style="stop-color:#fce94f;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       cx="42.5"
+       cy="36.307945"
+       fx="42.5"
+       fy="36.307945"
+       gradientTransform="matrix(0.3260419,0,0,0.4554235,5.893222,0.5693641)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient6597"
+       inkscape:collect="always"
+       r="4.5"
+       xlink:href="#linearGradient6843" />
+    <linearGradient
+       id="linearGradient6843"
+       inkscape:collect="always">
+      <stop
+         id="stop6845"
+         offset="0"
+         style="stop-color:#fec065;stop-opacity:1" />
+      <stop
+         id="stop6847"
+         offset="1"
+         style="stop-color:#fcaf3e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6647"
+       inkscape:collect="always"
+       x1="42.875"
+       x2="39.919209"
+       xlink:href="#linearGradient14991-1"
+       y1="30.9375"
+       y2="51.062393" />
+    <linearGradient
+       gradientTransform="matrix(0.4165126,0,0,0.4250001,1.63124,1.1624996)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6589"
+       inkscape:collect="always"
+       x1="18.27758"
+       x2="35.660713"
+       xlink:href="#linearGradient6499"
+       y1="15.698529"
+       y2="49.290443" />
+    <linearGradient
+       id="linearGradient6499"
+       inkscape:collect="always">
+      <stop
+         id="stop6501"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1" />
+      <stop
+         id="stop6503"
+         offset="1"
+         style="stop-color:#3465a4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6643"
+       inkscape:collect="always"
+       x1="24.75"
+       x2="24.75"
+       xlink:href="#linearGradient6820"
+       y1="43.927441"
+       y2="36.060127" />
+    <linearGradient
+       id="linearGradient6820"
+       inkscape:collect="always">
+      <stop
+         id="stop6822"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1;" />
+      <stop
+         id="stop6824"
+         offset="1"
+         style="stop-color:#729fcf;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7712">
+      <stop
+         id="stop7714"
+         offset="0"
+         style="stop-color:#888a85;stop-opacity:1;" />
+      <stop
+         id="stop7716"
+         offset="1"
+         style="stop-color:#babdb6;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7750">
+      <stop
+         id="stop7752"
+         offset="0"
+         style="stop-color:#eeeeec;stop-opacity:1;" />
+      <stop
+         id="stop7754"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient14991-1"
+       id="linearGradient1172"
+       gradientUnits="userSpaceOnUse"
+       x1="17.353554"
+       y1="7.9356604"
+       x2="28.035534"
+       y2="81.759773" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient14991-1"
+       id="linearGradient1174"
+       gradientUnits="userSpaceOnUse"
+       x1="42.875"
+       y1="30.9375"
+       x2="39.919209"
+       y2="51.062393" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7712"
+       id="linearGradient904"
+       gradientUnits="userSpaceOnUse"
+       x1="13.064948"
+       y1="14.231973"
+       x2="10.769586"
+       y2="8.7475128" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7712"
+       id="linearGradient906"
+       gradientUnits="userSpaceOnUse"
+       x1="13.064948"
+       y1="14.231973"
+       x2="10.769586"
+       y2="8.7475128" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7750"
+       id="linearGradient908"
+       gradientUnits="userSpaceOnUse"
+       x1="11.813767"
+       y1="11.44004"
+       x2="4.6234279"
+       y2="9.4846621" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.2"
+     inkscape:cx="17.553087"
+     inkscape:cy="9.2200569"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1280"
+     inkscape:window-height="746"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid815" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-290.65001)">
+    <g
+       id="g22"
+       style="display:inline;enable-background:new"
+       transform="matrix(0.26458333,0,0,0.26458333,0.28541616,290.91781)">
+      <g
+         id="g6187"
+         transform="matrix(0.4628899,0,0,0.3760626,-1.047633,1.8041374)">
+        <path
+           d="m 14.345337,8.5060394 c -0.64368,2.2113336 -3.112797,4.0060386 -5.5114231,4.0060386 -2.3986256,0 -3.8229293,-1.794705 -3.1792494,-4.0060386 0.64368,-2.2113336 3.1127974,-4.0060393 5.5114235,-4.0060393 2.398625,0 3.822929,1.7947057 3.179249,4.0060393 z"
+           id="path6189"
+           style="fill:none;fill-opacity:1;stroke:#babdb6;stroke-width:7.19038725;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <ellipse
+           id="path6191"
+           style="fill:none;fill-opacity:1;stroke:#eeeeec;stroke-width:2.39872003;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           transform="matrix(0.8701215,0,-0.3339941,1.1474218,4.7836537,-1.8445527)"
+           cx="9.4575529"
+           cy="9.0207386"
+           rx="4.9939418"
+           ry="3.4913397" />
+      </g>
+      <g
+         id="g7959"
+         transform="translate(40)">
+        <rect
+           height="18.220905"
+           id="rect6193"
+           rx="1.5693029"
+           ry="1.5693029"
+           style="fill:#3465a4;fill-opacity:1;stroke:#204a87;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           width="14"
+           x="-35.5"
+           y="0.47554904" />
+        <path
+           d="m 10.96875,6.515625 c -0.828566,0 -1.453125,0.6245588 -1.453125,1.453125 v 35.0625 c 0,0.828566 0.624559,1.453125 1.453125,1.453125 h 27.0625 c 0.828566,0 1.453125,-0.62456 1.453125,-1.453125 V 7.96875 c 0,-0.8285661 -0.62456,-1.453125 -1.453125,-1.453125 z"
+           id="path7790"
+           inkscape:original="M 10.96875 5.5 C 9.5976699 5.5 8.5 6.5976702 8.5 7.96875 L 8.5 43.03125 C 8.5 44.40233 9.5976702 45.5 10.96875 45.5 L 38.03125 45.5 C 39.40233 45.5 40.5 44.402329 40.5 43.03125 L 40.5 7.96875 C 40.5 6.5976699 39.402329 5.5 38.03125 5.5 L 10.96875 5.5 z "
+           inkscape:radius="-1.016466"
+           sodipodi:type="inkscape:offset"
+           style="opacity:0.2238806;fill:none;fill-opacity:1;stroke:url(#linearGradient1172);stroke-width:2.51192021;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           transform="matrix(0.4008351,0,0,0.3953872,-38.320459,-1.0823724)" />
+      </g>
+      <g
+         id="g6195"
+         transform="matrix(0.4642209,0,0,0.4555227,-1.070651,0.6334319)">
+        <path
+           d="M 14,3 H 39.182408 L 40,3.6961651 V 25 H 14 Z"
+           id="path6197"
+           sodipodi:nodetypes="cccccc"
+           style="fill:#d3d7cf;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 14,3 h 25.65625 c 1.055682,1.1280293 -0.49011,2.2117073 -2,2.1950916 H 12 c 1.501385,0 3.015732,-1.6494088 2,-2.1950916 z"
+           id="path6199"
+           sodipodi:nodetypes="ccccc"
+           style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+           inkscape:connector-curvature="0" />
+      </g>
+      <rect
+         height="4.9999995"
+         id="rect6201"
+         rx="0.54337871"
+         ry="0.55684662"
+         style="fill:url(#radialGradient6605);fill-opacity:1;stroke:#4e9a06;stroke-width:1.00000024;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         width="2.1955814"
+         x="18.304419"
+         y="3.5000002" />
+      <rect
+         height="5"
+         id="rect6207"
+         rx="0.57665509"
+         ry="0.61871845"
+         style="fill:url(#radialGradient6600);fill-opacity:1;stroke:#c4a000;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         width="3.7280617"
+         x="17.771938"
+         y="8.5" />
+      <rect
+         height="4.9999995"
+         id="rect6209"
+         rx="0.54137862"
+         ry="0.61871845"
+         style="fill:url(#radialGradient6597);fill-opacity:1;stroke:#ce5c00;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         width="3.5"
+         x="18"
+         y="13.500001" />
+      <path
+         d="m 39.75,30.492188 c -0.140446,0 -0.257813,0.117367 -0.257812,0.257812 v 7.5 c 0,0.140448 0.117363,0.257812 0.257812,0.257812 h 5.5 c 0.140448,0 0.257812,-0.117363 0.257812,-0.257812 v -7.5 c 0,-0.140448 -0.117363,-0.257812 -0.257812,-0.257812 z"
+         id="path6211"
+         inkscape:original="M 39.75 29.5 C 39.06446 29.5 38.5 30.064461 38.5 30.75 L 38.5 38.25 C 38.5 38.93554 39.064459 39.5 39.75 39.5 L 45.25 39.5 C 45.93554 39.5 46.5 38.935541 46.5 38.25 L 46.5 30.75 C 46.5 30.06446 45.935541 29.5 45.25 29.5 L 39.75 29.5 z "
+         inkscape:radius="-0.99302852"
+         sodipodi:type="inkscape:offset"
+         style="opacity:0.5;fill:none;fill-opacity:1;stroke:url(#linearGradient1174);stroke-width:2.4518249;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         transform="matrix(0.4435981,0,0,0.3750002,0.316285,-1.9375069)" />
+      <path
+         d="m 39.75,30.492188 c -0.140446,0 -0.257813,0.117367 -0.257812,0.257812 v 7.5 c 0,0.140448 0.117363,0.257812 0.257812,0.257812 h 5.5 c 0.140448,0 0.257812,-0.117363 0.257812,-0.257812 v -7.5 c 0,-0.140448 -0.117363,-0.257812 -0.257812,-0.257812 z"
+         id="path6651"
+         inkscape:original="M 39.75 29.5 C 39.06446 29.5 38.5 30.064461 38.5 30.75 L 38.5 38.25 C 38.5 38.93554 39.064459 39.5 39.75 39.5 L 45.25 39.5 C 45.93554 39.5 46.5 38.935541 46.5 38.25 L 46.5 30.75 C 46.5 30.06446 45.935541 29.5 45.25 29.5 L 39.75 29.5 z "
+         inkscape:radius="-0.99302852"
+         sodipodi:type="inkscape:offset"
+         style="opacity:0.5;fill:none;fill-opacity:1;stroke:url(#linearGradient6647);stroke-width:2.4518249;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         transform="matrix(0.4435981,0,0,0.3750002,0.316285,3.0624931)" />
+      <path
+         d="M 3.5,20.5 H 19.03033"
+         id="path7786"
+         sodipodi:nodetypes="cc"
+         style="opacity:0.17537315;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+      <rect
+         height="17"
+         id="rect6221"
+         rx="1.5821517"
+         ry="1.5821517"
+         style="fill:url(#linearGradient6589);fill-opacity:1;stroke:#204a87;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         width="15"
+         x="3.5"
+         y="3.5" />
+      <path
+         d="m 10.96875,6.0039062 c -1.102194,0 -1.9648437,0.8626501 -1.9648438,1.9648438 v 35.0625 c 0,1.102194 0.8626502,1.964844 1.9648438,1.964844 h 27.0625 c 1.102194,0 1.964844,-0.862651 1.964844,-1.964844 V 7.96875 c 0,-1.1021938 -0.862651,-1.9648438 -1.964844,-1.9648438 z"
+         id="path6223"
+         inkscape:original="M 10.96875 5.5 C 9.5976699 5.5 8.5 6.5976702 8.5 7.96875 L 8.5 43.03125 C 8.5 44.40233 9.5976702 45.5 10.96875 45.5 L 38.03125 45.5 C 39.40233 45.5 40.5 44.402329 40.5 43.03125 L 40.5 7.96875 C 40.5 6.5976699 39.402329 5.5 38.03125 5.5 L 10.96875 5.5 z "
+         inkscape:radius="-0.50379127"
+         sodipodi:type="inkscape:offset"
+         style="fill:url(#linearGradient6643);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         transform="matrix(0.4516129,0,0,0.4480666,-0.064516,-0.1629986)" />
+      <path
+         d="m 10.96875,6.515625 c -0.828566,0 -1.453125,0.6245588 -1.453125,1.453125 v 35.0625 c 0,0.828566 0.624559,1.453125 1.453125,1.453125 h 27.0625 c 0.828566,0 1.453125,-0.62456 1.453125,-1.453125 V 7.96875 c 0,-0.8285661 -0.62456,-1.453125 -1.453125,-1.453125 z"
+         id="path6225"
+         inkscape:original="M 10.96875 5.5 C 9.5976699 5.5 8.5 6.5976702 8.5 7.96875 L 8.5 43.03125 C 8.5 44.40233 9.5976702 45.5 10.96875 45.5 L 38.03125 45.5 C 39.40233 45.5 40.5 44.402329 40.5 43.03125 L 40.5 7.96875 C 40.5 6.5976699 39.402329 5.5 38.03125 5.5 L 10.96875 5.5 z "
+         inkscape:radius="-1.016466"
+         sodipodi:type="inkscape:offset"
+         style="opacity:0.46120689;fill:none;fill-opacity:1;stroke:url(#linearGradient7792);stroke-width:2.4133749;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         transform="matrix(0.434238,0,0,0.3953872,0.361169,1.9176276)" />
+      <use
+         height="22"
+         id="use7740"
+         transform="translate(0,12)"
+         width="22"
+         x="0"
+         xlink:href="#g7724"
+         y="0" />
+      <use
+         height="22"
+         id="use7738"
+         transform="translate(0,9)"
+         width="22"
+         x="0"
+         xlink:href="#g7724"
+         y="0" />
+      <use
+         height="22"
+         id="use7732"
+         transform="translate(0,6)"
+         width="22"
+         x="0"
+         xlink:href="#g7724"
+         y="0" />
+      <use
+         height="22"
+         id="use7730"
+         transform="translate(0,3)"
+         width="22"
+         x="0"
+         xlink:href="#g7724"
+         y="0" />
+      <path
+         d="m 10.14932,12.042497 c -2e-6,0.367909 0.07843,0.658047 0.235296,0.870415 0.159875,0.212371 0.37556,0.318555 0.647058,0.318554 0.268472,1e-6 0.48265,-0.106183 0.642534,-0.318554 0.159874,-0.215358 0.239814,-0.505498 0.239818,-0.870415 -4e-6,-0.361923 -0.08145,-0.647574 -0.244343,-0.856957 -0.159885,-0.212365 -0.37557,-0.31855 -0.647059,-0.318553 -0.265464,3e-6 -0.478133,0.106188 -0.638008,0.318553 -0.156867,0.209383 -0.235298,0.495034 -0.235296,0.856957 m 1.855205,1.350489 c -0.0905,0.21237 -0.236808,0.378378 -0.438914,0.498022 -0.199101,0.116654 -0.432886,0.174981 -0.701358,0.17498 -0.518857,10e-7 -0.94118,-0.185448 -1.266968,-0.556347 -0.322778,-0.373889 -0.484166,-0.859947 -0.484163,-1.45817 -3e-6,-0.598222 0.162893,-1.084278 0.488688,-1.458171 0.325789,-0.373886 0.746602,-0.560831 1.262443,-0.560835 0.268472,4e-6 0.502257,0.05983 0.701358,0.179467 0.202106,0.119649 0.348411,0.285656 0.438914,0.498021 v -0.587754 h 0.945701 v 3.109267 c 0.37405,-0.05683 0.668168,-0.234802 0.882353,-0.533914 0.214172,-0.302102 0.32126,-0.687956 0.321267,-1.157563 -7e-6,-0.29911 -0.04375,-0.578778 -0.131222,-0.839009 -0.08749,-0.263214 -0.220218,-0.504 -0.398189,-0.7223555 C 13.337851,9.6137131 12.978877,9.3325481 12.547511,9.1351291 12.11915,8.9377211 11.654595,8.839014 11.153846,8.8390086 10.803917,8.839014 10.469076,8.8853763 10.14932,8.9780957 9.829559,9.0678345 9.533934,9.200939 9.262443,9.37741 8.815985,9.6705445 8.467569,10.050416 8.217194,10.517026 7.969833,10.980653 7.846152,11.48316 7.846154,12.02455 c -2e-6,0.445678 0.079938,0.864434 0.239819,1.256271 0.162894,0.388845 0.39668,0.732824 0.701357,1.031934 0.301657,0.293129 0.647057,0.515968 1.0362,0.668515 0.392152,0.155537 0.80995,0.233307 1.253393,0.233308 0.380086,-10e-7 0.760176,-0.07029 1.140272,-0.210874 0.380084,-0.140583 0.704367,-0.330519 0.972851,-0.569808 l 0.484162,0.726842 c -0.377081,0.290137 -0.788846,0.51148 -1.235294,0.664028 -0.443445,0.155537 -0.894423,0.233306 -1.352941,0.233308 -0.558074,-2e-6 -1.084468,-0.09871 -1.579186,-0.296121 C 9.012063,15.56753 8.571642,15.283373 8.18552,14.909484 7.799395,14.535593 7.505278,14.103378 7.303167,13.612834 7.101055,13.119301 6.999999,12.589873 7,12.02455 6.999999,11.480169 7.102563,10.961211 7.307692,10.467673 7.512819,9.9741428 7.805428,9.5404306 8.18552,9.166536 8.565608,8.7956428 9.007539,8.5084959 9.511312,8.3050936 10.018095,8.101704 10.542982,8.0000064 11.085973,8 c 0.675711,6.4e-6 1.289586,0.1286241 1.841629,0.3858538 0.552029,0.2542513 1.013567,0.6221584 1.384616,1.1037227 0.226236,0.2931347 0.396673,0.6116885 0.511311,0.9556625 0.117639,0.340991 0.176463,0.699925 0.176471,1.076803 -8e-6,0.810596 -0.24586,1.440226 -0.737556,1.888891 -0.491712,0.448669 -1.185528,0.673003 -2.081448,0.673003 h -0.176471 v -0.69095"
+         id="path6289"
+         style="font-style:normal;font-weight:normal;font-size:23.55376053px;font-family:'Bitstream Vera Sans';fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+      <g
+         id="g7724"
+         transform="translate(0,1)">
+        <g
+           id="g6667"
+           style="fill-opacity:1;stroke:url(#linearGradient906);stroke-width:7.1903882;stroke-miterlimit:4;stroke-dasharray:none"
+           transform="matrix(0.4628899,0,0,0.3760626,-1.0476327,0.8353874)">
+          <path
+             d="M 13.627258,10.942098 C 12.110211,12.551235 9.0109564,12.996433 6.7092789,11.935842 5.9191937,11.571779 5.3688822,11.131747 4.9582724,10.535727"
+             id="path6670"
+             sodipodi:nodetypes="csc"
+             style="fill:none;fill-opacity:1;stroke:url(#linearGradient904);stroke-width:7.19616032;stroke-linecap:round;stroke-linejoin:miter;stroke-dashoffset:0;stroke-opacity:1"
+             transform="matrix(0.8701215,0,-0.3339941,1.1474218,4.7836537,-1.8445527)"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g6661"
+           transform="matrix(0.4628899,0,0,0.3760626,-1.0476327,0.8041374)">
+          <path
+             d="M 13.627258,10.942098 A 4.9939418,3.4913397 0 0 1 6.7439241,11.951663 4.9939418,3.4913397 0 0 1 5.2428762,7.1479512"
+             id="path6665"
+             sodipodi:cx="9.4575529"
+             sodipodi:cy="9.0207386"
+             sodipodi:end="3.7077695"
+             sodipodi:open="true"
+             sodipodi:rx="4.9939418"
+             sodipodi:ry="3.4913397"
+             sodipodi:start="0.58274935"
+             sodipodi:type="arc"
+             style="fill:none;fill-opacity:1;stroke:url(#linearGradient908);stroke-width:2.39872003;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             transform="matrix(0.8701215,0,-0.3339941,1.1474218,4.7836537,-1.8445527)" />
+        </g>
+      </g>
+      <ellipse
+         id="path7758"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         transform="matrix(0.9142858,0,0,0.6213592,-0.314286,0.3689322)"
+         cx="5.265625"
+         cy="8.2578125"
+         rx="0.546875"
+         ry="0.8046875" />
+      <ellipse
+         id="path7760"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         transform="matrix(0.9142858,0,0,0.6213592,-0.314286,3.3689322)"
+         cx="5.265625"
+         cy="8.2578125"
+         rx="0.546875"
+         ry="0.8046875" />
+      <ellipse
+         id="path7762"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         transform="matrix(0.9142858,0,0,0.6213592,-0.314286,6.3689322)"
+         cx="5.265625"
+         cy="8.2578125"
+         rx="0.546875"
+         ry="0.8046875" />
+      <ellipse
+         id="path7764"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         transform="matrix(0.9142858,0,0,0.6213592,-0.314286,9.368932)"
+         cx="5.265625"
+         cy="8.2578125"
+         rx="0.546875"
+         ry="0.8046875" />
+      <ellipse
+         id="path7766"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         transform="matrix(0.9142858,0,0,0.6213592,-0.314286,12.368932)"
+         cx="5.265625"
+         cy="8.2578125"
+         rx="0.546875"
+         ry="0.8046875" />
+    </g>
+  </g>
+</svg>

--- a/data/icons/hicolor_apps_scalable_org.gnome.Documents.svg
+++ b/data/icons/hicolor_apps_scalable_org.gnome.Documents.svg
@@ -1,0 +1,859 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 6.3499994 6.3499994"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="hicolor_apps_scalable_org.gnome.Documents.svg">
+  <defs
+     id="defs2">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient14755-8">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop14757-1" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop14759-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient14991-1">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop14993-0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop14995-0" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       height="2.0039842"
+       y="-0.50199205"
+       width="1.1115538"
+       x="-0.05577689"
+       id="filter1-paper-sheet-orig-3"
+       inkscape:collect="always">
+      <feGaussianBlur
+         id="feGaussianBlur1-paper-sheet-orig-2"
+         stdDeviation="0.41832669"
+         inkscape:collect="always" />
+    </filter>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3-paper-sheet-orig-08"
+       id="radialGradient84243"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.94095,0,0,0.730906,375.508,168.164)"
+       cx="-30.314398"
+       cy="34.277431"
+       fx="-30.314398"
+       fy="34.277431"
+       r="18.000002" />
+    <linearGradient
+       id="linearGradient3-paper-sheet-orig-08">
+      <stop
+         style="stop-color: rgb(255, 255, 255); stop-opacity: 1;"
+         offset="0"
+         id="stop6-paper-sheet-orig-1" />
+      <stop
+         style="stop-color: rgb(211, 215, 207); stop-opacity: 1;"
+         offset="1"
+         id="stop7-paper-sheet-orig-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10-paper-sheet-orig-3"
+       id="linearGradient84245"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.485754,0,0,0.488975,331.488,175.793)"
+       x1="-43.860779"
+       y1="61.854836"
+       x2="-54.529251"
+       y2="-0.087501168" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10-paper-sheet-orig-3">
+      <stop
+         style="stop-color: rgb(85, 87, 83); stop-opacity: 1;"
+         offset="0"
+         id="stop15-paper-sheet-orig-7" />
+      <stop
+         style="stop-color: rgb(186, 189, 182); stop-opacity: 1;"
+         offset="1"
+         id="stop16-paper-sheet-orig-8" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient14991-1"
+       id="radialGradient84247"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.46139,0,0,1.40943,-5.84554,-5.46996)"
+       cx="4"
+       cy="5.2999997"
+       fx="4"
+       fy="5.2999997"
+       r="17" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2065-5"
+       id="linearGradient83892"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22885,0,0,0.20994,-28.2475,265.56)"
+       x1="-11.986486"
+       y1="5.9776669"
+       x2="-11.986486"
+       y2="29.726542" />
+    <linearGradient
+       id="linearGradient2065-5"
+       inkscape:collect="always">
+      <stop
+         id="stop2067-7"
+         offset="0"
+         style="stop-color: rgb(85, 87, 83);" />
+      <stop
+         id="stop2069-6"
+         offset="1"
+         style="stop-color: rgb(252, 175, 62);" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4928-0"
+       id="radialGradient83894"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22885,0,0,0.201237,-31.2876,265.391)"
+       cx="-6.0070167"
+       cy="32.837029"
+       fx="-6.0070167"
+       fy="32.837029"
+       r="9.90625" />
+    <linearGradient
+       id="linearGradient4928-0">
+      <stop
+         style="stop-color: rgb(252, 233, 79); stop-opacity: 1;"
+         offset="0"
+         id="stop4930-5" />
+      <stop
+         style="stop-color: rgb(252, 233, 79); stop-opacity: 0;"
+         offset="1"
+         id="stop4932-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4616-1"
+       id="linearGradient83896"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22885,0,0,0.45994,-36.4861,256.81)"
+       x1="25.355263"
+       y1="34.006802"
+       x2="25.355263"
+       y2="32.409008" />
+    <linearGradient
+       id="linearGradient4616-1"
+       inkscape:collect="always">
+      <stop
+         id="stop4618-9"
+         offset="0"
+         style="stop-color: rgb(46, 52, 54); stop-opacity: 1;" />
+      <stop
+         id="stop4620-2"
+         offset="1"
+         style="stop-color: rgb(46, 52, 54); stop-opacity: 0;" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3-paper-sheet-orig-08"
+       id="radialGradient96473"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.90185931,0.08524189,-0.04572996,0.48423403,383.16744,108.90664)"
+       cx="-83.709465"
+       cy="245.51656"
+       fx="-79.833611"
+       fy="254.62349"
+       r="18.000002" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10-paper-sheet-orig-3"
+       id="linearGradient96475"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.07359178,0,0,0.07335495,314.19124,189.91145)"
+       x1="-274.72217"
+       y1="452.54453"
+       x2="-268.20242"
+       y2="322.98654" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3-paper-sheet-orig-08"
+       id="radialGradient96477"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9361091,-0.03547674,0.02666758,1.4553578,442.98649,-199.26036)"
+       cx="-83.651741"
+       cy="242.12727"
+       fx="-79.775887"
+       fy="251.23422"
+       r="18.000002" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10-paper-sheet-orig-3"
+       id="linearGradient96479"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.157303,0,0,0.157303,325.30379,93.333097)"
+       x1="-274.72217"
+       y1="452.54453"
+       x2="-252.41296"
+       y2="280.46585" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient17659-7-4"
+       id="linearGradient96481"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.1586117,0,0,4.7312225,-448.59639,-290.69128)"
+       x1="92.067398"
+       y1="96.875267"
+       x2="130.39951"
+       y2="96.875267" />
+    <linearGradient
+       id="linearGradient17659-7-4"
+       gradientUnits="userSpaceOnUse"
+       x1="106.0254"
+       y1="81.1763"
+       x2="118.3481"
+       y2="98.883202">
+      <stop
+         offset="0"
+         style="stop-color:#da4522;stop-opacity:1;"
+         id="stop17661-4-5" />
+      <stop
+         id="stop17667-2-5"
+         style="stop-color:#953a24;stop-opacity:1;"
+         offset="0.02529254" />
+      <stop
+         id="stop17665-0-3"
+         style="stop-color:#c15236;stop-opacity:1;"
+         offset="0.18952666" />
+      <stop
+         offset="0.94432735"
+         style="stop-color:#6f1f09;stop-opacity:1"
+         id="stop17669-2-4" />
+      <stop
+         offset="1"
+         style="stop-color:#ba310b;stop-opacity:1"
+         id="stop17663-8-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5257-6-1"
+       id="linearGradient96483"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.1548497,0,0,4.7312225,-448.24678,-290.69128)"
+       x1="104.87878"
+       y1="69.006981"
+       x2="117.90468"
+       y2="96.292282" />
+    <linearGradient
+       id="linearGradient5257-6-1">
+      <stop
+         id="stop5259-5-1"
+         offset="0"
+         style="stop-color:#ef2929;stop-opacity:1;" />
+      <stop
+         id="stop5261-9-8"
+         offset="1"
+         style="stop-color:#f68383;stop-opacity:1;" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       id="filter17249-6-6"
+       height="1.3415227"
+       y="-0.17076135"
+       width="2.4514673"
+       x="-0.72573364"
+       inkscape:collect="always">
+      <feGaussianBlur
+         id="feGaussianBlur17251-3-3"
+         stdDeviation="2.0526907"
+         inkscape:collect="always" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient14991-1"
+       id="linearGradient96515"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8929831,0.23927411,0.23927411,1.0641133,-73.039644,-25.570915)"
+       x1="51.5"
+       y1="162.75"
+       x2="51.5"
+       y2="186.29782" />
+    <filter
+       style="color-interpolation-filters:sRGB"
+       id="filter17922-5-7"
+       inkscape:collect="always">
+      <feGaussianBlur
+         id="feGaussianBlur17924-1-1"
+         stdDeviation="2.676031"
+         inkscape:collect="always" />
+    </filter>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient17864-1-3"
+       id="radialGradient96491"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2947354,0,0,1.1522102,-165.70021,-19.580632)"
+       cx="127.97998"
+       cy="83.404785"
+       fx="127.97998"
+       fy="83.404785"
+       r="32.412704" />
+    <linearGradient
+       id="linearGradient17864-1-3">
+      <stop
+         id="stop17866-5-7"
+         offset="0"
+         style="stop-color:#d1f7ab;stop-opacity:1;" />
+      <stop
+         id="stop17868-5-5"
+         offset="1"
+         style="stop-color:#85e923;stop-opacity:1;" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient17317-3-7"
+       id="radialGradient96493"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3828882,0,0,1.2276921,-63.90907,0.6701719)"
+       cx="166.91316"
+       cy="29.169971"
+       fx="166.91316"
+       fy="29.169971"
+       r="49.727314" />
+    <linearGradient
+       id="linearGradient17317-3-7">
+      <stop
+         id="stop17319-0-3"
+         offset="0"
+         style="stop-color:#dde8f4;stop-opacity:1;" />
+      <stop
+         id="stop17321-4-3"
+         offset="1"
+         style="stop-color:#bad0e8;stop-opacity:1;" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient17325-0-5"
+       id="radialGradient96495"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5301685,0,0,2.0151694,-88.007964,-182.26783)"
+       cx="166"
+       cy="149.5"
+       fx="166"
+       fy="149.5"
+       r="49" />
+    <linearGradient
+       id="linearGradient17325-0-5">
+      <stop
+         id="stop17327-9-8"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1;" />
+      <stop
+         id="stop17329-1-7"
+         offset="1"
+         style="stop-color:#3f7ab9;stop-opacity:1;" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient14991-1"
+       id="radialGradient96503"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.4891611,-0.00110812,3.3068698e-4,1.0435292,-134.31974,-43.647512)"
+       cx="55.640617"
+       cy="193.2952"
+       fx="55.640617"
+       fy="193.2952"
+       r="96.546875" />
+    <filter
+       style="color-interpolation-filters:sRGB"
+       id="filter17567-4-5"
+       inkscape:collect="always">
+      <feGaussianBlur
+         id="feGaussianBlur17569-4-9"
+         stdDeviation="0.25808824"
+         inkscape:collect="always" />
+    </filter>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient17767-9-5"
+       id="radialGradient96507"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1277556,0.8124553,-0.402854,0.5591949,21.352022,-49.525404)"
+       cx="91.570328"
+       cy="82.041237"
+       fx="91.570328"
+       fy="82.041237"
+       r="20.859648" />
+    <linearGradient
+       id="linearGradient17767-9-5">
+      <stop
+         style="stop-color:#edc200;stop-opacity:1;"
+         offset="0"
+         id="stop17771-6-8" />
+      <stop
+         style="stop-color:#c4a000;stop-opacity:1;"
+         offset="1"
+         id="stop17769-9-5" />
+    </linearGradient>
+    <inkscape:path-effect
+       effect="spiro"
+       id="path-effect95461-7"
+       is_visible="true" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient14755-8"
+       id="linearGradient4257"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(343,207)"
+       x1="-23.4375"
+       y1="-24.875"
+       x2="-26.453966"
+       y2="-24.144068" />
+    <linearGradient
+       y2="184.5"
+       x2="309.5"
+       y1="179.375"
+       x1="308.52344"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4035"
+       xlink:href="#linearGradient3-paper-sheet-orig-08"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.4"
+     inkscape:cx="7.2516965"
+     inkscape:cy="12.505006"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1280"
+     inkscape:window-height="746"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid815" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-290.65001)">
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,-79.923381,243.54918)"
+       style="display:inline;enable-background:new"
+       id="g1945">
+      <g
+         transform="translate(-397.9998,1.99999)"
+         style="display:inline;enable-background:new"
+         id="use10157">
+        <rect
+           style="opacity:0.29959501;fill:#000000;fill-opacity:1;stroke:none;filter:url(#filter1-paper-sheet-orig-3)"
+           id="rect84233"
+           width="19"
+           height="2"
+           x="702.54419"
+           y="196.51491"
+           rx="1"
+           ry="1" />
+        <g
+           id="g84235"
+           transform="translate(398.044,0.0149083)">
+          <path
+             sodipodi:nodetypes="cccccccscc"
+             id="path84237"
+             d="m 307.46875,177.5 c -1.08496,0 -1.96875,0.88379 -1.96875,1.96875 v 16.0625 c 0,1.08496 0.88379,1.96875 1.96875,1.96875 h 13.0625 c 1.08496,0 1.96875,-0.88379 1.96875,-1.96875 v -0.96875 c 0,-3.40625 0,-5.66929 0,-9.0625 0,-4.84375 -5.05436,-8 -9.5,-8 z"
+             style="display:inline;fill:url(#radialGradient84243);fill-opacity:1;stroke:url(#linearGradient84245);stroke-width:1;stroke-miterlimit:4"
+             inkscape:connector-curvature="0" />
+          <path
+             transform="matrix(0.485754,0,0,0.464926,302.343,176.835)"
+             d="m 8.53125,4.6425781 c -0.5028632,0 -0.8886719,0.3858086 -0.8886719,0.8886719 v 36.9375 c 0,0.502863 0.3858086,0.888672 0.8886719,0.888672 h 30.9375 c 0.502862,0 0.888672,-0.38581 0.888672,-0.888672 V 17.5 c 0,-1.24605 -0.502709,-4.0281 -2.166016,-5.691406 l -5,-5.0000002 C 31.5281,5.1452872 28.74605,4.6425781 27.5,4.6425781 Z"
+             id="path84239"
+             style="display:inline;fill:url(#radialGradient84247);fill-opacity:1;stroke:none"
+             inkscape:original="M 8.53125 3.5 C 7.410033 3.5 6.5 4.4100329 6.5 5.53125 L 6.5 42.46875 C 6.5 43.589967 7.4100329 44.5 8.53125 44.5 L 39.46875 44.5 C 40.589967 44.5 41.5 43.589966 41.5 42.46875 C 41.5 42.46875 41.5 19 41.5 17.5 C 41.5 16 41 13 39 11 C 37 9 36 8 34 6 C 32 4 29 3.5 27.5 3.5 C 26 3.5 8.5312499 3.5 8.53125 3.5 z "
+             inkscape:radius="-1.1427754"
+             sodipodi:type="inkscape:offset" />
+          <path
+             style="display:inline;fill:none;stroke:#ffffff;stroke-width:1;stroke-miterlimit:4"
+             d="m 307.46875,178.5 c -0.53341,0 -0.96875,0.43533 -0.96875,0.96875 v 16.0625 c 0,0.53341 0.43533,0.96875 0.96875,0.96875 h 13.0625 c 0.53341,0 0.96875,-0.43534 0.96875,-0.96875 0,-3.69792 0,-6.42068 0,-10.09375 0,-3.9375 -4.5,-6.9375 -8.46875,-6.9375 z"
+             id="path84241"
+             sodipodi:nodetypes="ccccccscc"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         style="display:inline;enable-background:new"
+         id="g4348"
+         transform="translate(153.0002,-60.00001)"
+         inkscape:export-filename="/home/lapo/Scrivania/use4934.png"
+         inkscape:export-xdpi="90"
+         inkscape:export-ydpi="90">
+        <g
+           transform="translate(190)"
+           id="g6263">
+          <g
+             id="g6265"
+             transform="translate(-80,239)"
+             style="opacity:0.25">
+            <rect
+               ry="0.5"
+               rx="0.5"
+               y="5"
+               x="45"
+               height="1"
+               width="8"
+               id="rect6267"
+               style="display:inline;fill:#000000;fill-opacity:1;stroke:none" />
+            <rect
+               ry="0.5"
+               rx="0.5"
+               y="7"
+               x="45"
+               height="1"
+               width="5"
+               id="rect6269"
+               style="display:inline;fill:#000000;fill-opacity:1;stroke:none" />
+            <rect
+               ry="0.5"
+               rx="0.5"
+               y="9"
+               x="54.01561"
+               height="1"
+               width="2.9843886"
+               id="rect6271"
+               style="display:inline;fill:#000000;fill-opacity:1;stroke:none" />
+            <rect
+               ry="0.5"
+               rx="0.5"
+               y="11"
+               x="54.01561"
+               height="1"
+               width="2.9843886"
+               id="rect6273"
+               style="display:inline;fill:#000000;fill-opacity:1;stroke:none" />
+            <rect
+               ry="0.5"
+               rx="0.5"
+               y="13"
+               x="54.01561"
+               height="1"
+               width="2.9843886"
+               id="rect6275"
+               style="display:inline;fill:#000000;fill-opacity:1;stroke:none" />
+            <rect
+               ry="0.5"
+               rx="0.5"
+               y="15"
+               x="45"
+               height="1"
+               width="12"
+               id="rect6277"
+               style="display:inline;fill:#000000;fill-opacity:1;stroke:none" />
+            <rect
+               ry="0.5"
+               rx="0.5"
+               y="17"
+               x="45"
+               height="1"
+               width="9"
+               id="rect6279"
+               style="display:inline;fill:#000000;fill-opacity:1;stroke:none" />
+          </g>
+          <g
+             id="g6281"
+             transform="translate(0,-20)">
+            <rect
+               ry="0.18369773"
+               rx="0.20544986"
+               y="267.9747"
+               x="-34.998573"
+               height="5.0385695"
+               width="8.0159283"
+               id="rect6283"
+               style="fill:url(#linearGradient83892);fill-opacity:1;stroke:none"
+               inkscape:r_cx="true"
+               inkscape:r_cy="true" />
+            <path
+               inkscape:r_cy="true"
+               inkscape:r_cx="true"
+               id="path6285"
+               d="m -32.805323,269.79491 c -1.182875,0.0688 -2.124013,0.97731 -2.124013,2.07972 0,0.0426 0.0044,0.0827 0.0072,0.12466 h 4.519783 c 0.0028,-0.0419 0.0072,-0.0821 0.0072,-0.12466 0,-1.14722 -1.016489,-2.07972 -2.267043,-2.07972 -0.04885,0 -0.09495,-0.003 -0.143031,0 z"
+               style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient83894);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+               inkscape:connector-curvature="0" />
+            <rect
+               ry="0"
+               rx="0"
+               y="271.9884"
+               x="-34.884148"
+               height="0.91988081"
+               width="7.7808933"
+               id="rect6287"
+               style="fill:url(#linearGradient83896);fill-opacity:1;stroke:none"
+               inkscape:r_cx="true"
+               inkscape:r_cy="true" />
+            <path
+               sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccc"
+               id="path6289"
+               d="m -29.722307,272.69254 c 0,0 -0.127144,-0.64733 -0.127144,-1.04389 0.0035,-0.1809 1.781987,-1.59021 1.786575,-1.80013 l -0.413477,0.33055 -0.289531,-0.7226 0.976081,0.0928 0.457699,-0.41988 -0.518381,0.34911 -0.178281,-0.0371 -0.218737,-0.73188 0.111253,0.71332 -0.807915,-0.0371 0.252845,0.59035 -0.700432,-0.63674 0.740888,0.88626 c 1.8e-5,0.19766 -1.460263,1.40433 -1.457778,1.19626 l -0.60564,-0.7452 -0.05057,-1.00741 0.4577,-0.11997 0.400979,-0.90707 -0.528579,0.83836 -0.412653,-0.0172 -0.923727,-0.71569 -1.268336,-0.44535 1.083565,0.54632 -0.868597,0.0708 h 1.144249 l 0.68655,0.62982 0.08091,1.08791 -1.225158,-1.08791 0.515209,0.56833 -0.744059,0.48137 0.817321,-0.41988 1.292896,1.49396 -0.05057,1.01951 h 0.584844 z"
+               style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none"
+               inkscape:r_cx="true"
+               inkscape:r_cy="true"
+               inkscape:connector-curvature="0" />
+            <path
+               style="display:inline;overflow:visible;visibility:visible;fill:#fef39e;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+               d="m -32.740344,270.77783 c -0.64548,0.0376 -1.159046,0.53331 -1.159046,1.13488 0,0.0232 0.0024,0.0451 0.0039,0.068 h 2.466389 c 0.0015,-0.0229 0.0039,-0.0448 0.0039,-0.068 0,-0.62603 -0.554687,-1.13488 -1.237098,-1.13488 -0.02666,0 -0.05181,-0.002 -0.07805,0 z"
+               id="path6291"
+               inkscape:r_cx="true"
+               inkscape:r_cy="true"
+               inkscape:connector-curvature="0" />
+            <path
+               inkscape:r_cy="true"
+               inkscape:r_cx="true"
+               id="path6293"
+               d="m -32.721818,271.0504 c -0.492277,0.0286 -0.883949,0.40672 -0.883949,0.86551 0,0.0177 0.0018,0.0344 0.003,0.0519 h 1.880997 c 0.0011,-0.0174 0.003,-0.0342 0.003,-0.0519 0,-0.47744 -0.423031,-0.86551 -0.943474,-0.86551 -0.02033,0 -0.03951,-0.001 -0.05953,0 z"
+               style="display:inline;overflow:visible;visibility:visible;fill:#fffbd7;fill-opacity:0.55681799;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+               inkscape:connector-curvature="0" />
+            <path
+               sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccc"
+               id="path6295"
+               d="m -29.722307,272.69254 c 0,0 -0.127144,-0.64733 -0.127144,-1.04389 0.0035,-0.1809 1.781987,-1.59021 1.786575,-1.80013 l -0.413477,0.33055 -0.289531,-0.7226 0.976081,0.0928 0.457699,-0.41988 -0.518381,0.34911 -0.178281,-0.0371 -0.218737,-0.73188 0.111253,0.71332 -0.807915,-0.0371 0.252845,0.59035 -0.700432,-0.63674 0.740888,0.88626 c 1.8e-5,0.19766 -1.460263,1.40433 -1.457778,1.19626 l -0.60564,-0.7452 -0.05057,-1.00741 0.4577,-0.11997 0.400979,-0.90707 -0.528579,0.83836 -0.412653,-0.0172 -0.923727,-0.71569 -1.268336,-0.44535 1.083565,0.54632 -0.868597,0.0708 h 1.144249 l 0.68655,0.62982 0.08091,1.08791 -1.225158,-1.08791 0.515209,0.56833 -0.744059,0.48137 0.817321,-0.41988 1.292896,1.49396 -0.05057,1.01951 h 0.584844 z"
+               style="display:inline;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none"
+               inkscape:r_cx="true"
+               inkscape:r_cy="true"
+               inkscape:connector-curvature="0" />
+          </g>
+        </g>
+        <rect
+           style="display:inline;opacity:0.2;fill:#000000;fill-opacity:1;stroke:none"
+           id="rect6827"
+           width="8"
+           height="1"
+           x="45"
+           y="5"
+           rx="0.5"
+           ry="0.5"
+           transform="translate(110,239)" />
+      </g>
+      <rect
+         transform="matrix(0.99562722,-0.09341542,0.09402501,0.99556984,0,0)"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient96473);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient96475);stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         id="rect96407"
+         width="10.767467"
+         height="10.354057"
+         x="289.01132"
+         y="213.33179" />
+      <g
+         transform="matrix(0.46784797,0,0,0.46631547,163.81887,152.24993)"
+         id="g96409"
+         style="display:inline;enable-background:new">
+        <rect
+           transform="rotate(-15.000001)"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient96477);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient96479);stroke-width:2.14095569;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect96411"
+           width="23.015547"
+           height="22.203333"
+           x="271.48151"
+           y="143.55591" />
+        <g
+           style="display:inline;enable-background:new"
+           id="g96413"
+           transform="matrix(0.0734687,-0.01968588,0.01968588,0.0734687,301.23832,68.081587)">
+          <g
+             inkscape:label="Layer 1"
+             id="g96415"
+             style="display:inline" />
+          <g
+             inkscape:label="overlay"
+             id="g96417"
+             style="display:inline">
+            <path
+               id="path96419"
+               d="m 220.75419,118.6257 c -11.07557,-23.75546 -48.6303,-41.246794 -93.29351,-41.246794 -44.663269,0 -67.375973,13.334917 -78.451509,37.090384 l -18.174468,4.15641 v 39.26887 c -0.834501,23.73077 42.886857,46.9906 96.247547,46.9906 53.36581,0 96.47483,-22.72066 96.47483,-53.51618 l 0.52439,-32.74329 z"
+               style="fill:url(#linearGradient96481);fill-opacity:1;fill-rule:nonzero;stroke:none"
+               sodipodi:nodetypes="cscccsccc"
+               inkscape:connector-curvature="0" />
+            <path
+               id="path96421"
+               d="m 223.94054,118.6257 c 0,30.80026 -43.22344,55.76219 -96.55033,55.76219 -53.326938,0 -96.555507,-24.96193 -96.555507,-55.76219 0,-30.800255 43.233735,-55.762185 96.555507,-55.762185 53.32689,0 96.55033,24.96193 96.55033,55.762185 z"
+               style="fill:url(#linearGradient96483);fill-opacity:1;fill-rule:nonzero;stroke:none"
+               inkscape:connector-curvature="0" />
+            <path
+               inkscape:transform-center-y="-27.143788"
+               inkscape:transform-center-x="-46.727316"
+               id="path96423"
+               d="M 223.14048,111.58313 C 217.94505,76.267705 159.05935,65.023685 148.0996,65.344785 l -24.41375,54.280915 95.44963,-8.04214 z"
+               style="fill:#729fcf;fill-rule:nonzero;stroke:none"
+               sodipodi:nodetypes="ccccc"
+               inkscape:connector-curvature="0" />
+            <path
+               inkscape:transform-center-x="5.807534"
+               inkscape:transform-center-y="-28.186395"
+               id="path96425"
+               d="M 125.21414,119.26931 83.567273,68.851075 c 18.139497,-6.522124 47.501287,-6.940108 64.825407,-5.172341 z"
+               style="fill:#73d216;fill-rule:nonzero;stroke:none"
+               sodipodi:nodetypes="cccc"
+               inkscape:connector-curvature="0" />
+            <rect
+               ry="129.58655"
+               rx="51.382633"
+               y="138.22687"
+               x="218.21046"
+               height="30.791634"
+               width="3.6568708"
+               id="rect96429"
+               style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.19411765;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;marker:none;filter:url(#filter17249-6-6);enable-background:accumulate" />
+            <path
+               sodipodi:nodetypes="ccccc"
+               id="path96433"
+               d="m 41.5,144.375 8.703596,38.70712 c 18.830836,13.56295 32.802461,17.45609 47.366997,22.52912 L 88.956725,167.30316 C 72.447174,167.99285 52.899452,153.20591 41.5,144.375 Z"
+               style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.22941176;fill:url(#linearGradient96515);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;marker:none;enable-background:accumulate"
+               inkscape:connector-curvature="0" />
+            <path
+               inkscape:transform-center-x="5.807534"
+               inkscape:transform-center-y="-28.186395"
+               id="path96437"
+               d="M 125.21414,117.76321 83.567273,67.344978 C 101.70677,60.822854 131.06856,60.40487 148.39268,62.172637 Z"
+               style="opacity:0.46470588;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;filter:url(#filter17922-5-7)"
+               sodipodi:nodetypes="cccc"
+               inkscape:connector-curvature="0" />
+            <path
+               sodipodi:nodetypes="cccc"
+               style="fill:url(#radialGradient96491);fill-opacity:1;fill-rule:nonzero;stroke:none"
+               d="M 120.36144,120.26677 83.567273,48.344978 c 18.139497,-6.522124 41.937447,-11.62347 59.261567,-9.855703 z"
+               id="path96439"
+               inkscape:transform-center-y="-28.186395"
+               inkscape:transform-center-x="5.807534"
+               inkscape:connector-curvature="0" />
+            <path
+               sodipodi:nodetypes="cccc"
+               style="fill:url(#radialGradient96493);fill-opacity:1;fill-rule:nonzero;stroke:none"
+               d="M 222.14048,70.58313 C 216.94505,35.267705 159.05935,25.023685 148.0996,25.344785 l -15.5194,53.40974 z"
+               id="path96441"
+               inkscape:transform-center-x="-46.727316"
+               inkscape:transform-center-y="-27.143788"
+               inkscape:connector-curvature="0" />
+            <path
+               sodipodi:nodetypes="ccccc"
+               id="path96443"
+               d="M 131.95403,79.178109 120.80881,121.06951 223,112 222,70 Z"
+               style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.91176471;fill:url(#radialGradient96495);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;marker:none;enable-background:accumulate"
+               inkscape:connector-curvature="0" />
+            <path
+               style="opacity:0.51057404;fill:url(#radialGradient96503);fill-opacity:1;fill-rule:nonzero;stroke:none"
+               d="m 30.898891,116.625 c 0,0 -0.0625,1.33055 -0.0625,2 0,30.80026 43.235563,55.75 96.562499,55.75 53.32689,0 96.53124,-24.94974 96.53125,-55.75 0,-0.66945 -0.022,-1.33626 -0.0625,-2 -1.82281,29.87369 -43.30522,33.70421 -95.47303,33.70421 -52.167851,0 -81.533156,-11.32182 -97.495719,-33.70421 z"
+               id="path96451"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="cssscsc" />
+            <path
+               sodipodi:nodetypes="ccc"
+               id="path96455"
+               d="m 218.79289,137.01777 c -11.14484,11.8155 -20.92519,17.97443 -33,25.5 13.09871,-5.60365 25.50593,-13.08369 33,-25.5 z"
+               style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.34117647;fill:#fcfcfc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;marker:none;filter:url(#filter17567-4-5);enable-background:accumulate"
+               inkscape:connector-curvature="0" />
+            <g
+               transform="matrix(0.7,0,0,0.7,18.3,42.6)"
+               style="opacity:0.82352941"
+               id="g96459" />
+            <path
+               sodipodi:nodetypes="ccccc"
+               id="path96461"
+               d="M 120.46051,120.10444 74.611648,76.451918 81.949664,49.55415 128.36289,93.127112 Z"
+               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient96507);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;marker:none;enable-background:accumulate"
+               inkscape:connector-curvature="0" />
+          </g>
+        </g>
+        <path
+           style="display:inline;fill:none;stroke:#babdb6;stroke-width:2.14095569px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+           d="m 309.4375,85.249995 12.5,-3.5"
+           id="path96471"
+           inkscape:path-effect="#path-effect95461-7"
+           inkscape:original-d="m 309.4375,85.249995 12.5,-3.5"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+      </g>
+      <g
+         style="display:inline;enable-background:new"
+         id="use10167"
+         transform="translate(0.0462,2.08368)">
+        <path
+           sodipodi:nodetypes="ccccc"
+           id="path84225"
+           d="m 313,179 c 3.35588,0.55242 3.73483,0.76516 3.73483,5.26516 3.5,0 4.09071,0.67421 5.26517,1.73484 0,-0.51002 0,0.0616 0,-0.5 -0.49895,-5.60501 -4.64984,-6.19121 -9,-6.5 z"
+           style="display:inline;opacity:0.48987899;fill:url(#linearGradient4257);fill-opacity:1;stroke:none"
+           inkscape:connector-curvature="0" />
+        <path
+           sodipodi:nodetypes="cccssc"
+           id="path84227"
+           d="m 313,178 c 3.2233,1.08275 4.98928,1.91735 5.03347,5.00314 2.26256,0 3.16773,2.05235 3.96653,3.99686 0,-0.51002 0,-0.93837 0,-1.5 0,-2.24796 -1.15018,-4.08414 -2.875,-5.40625 C 317.40018,178.77164 315.10449,178 313,178 Z"
+           style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         transform="translate(1)"
+         id="g4930"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;fill:none;stroke:#7c7e79;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+           d="m 308,180 v 5 l 1,1 1,-1 v -4"
+           id="path4024-6-7"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           style="display:inline;fill:none;stroke:#babdb6;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+           d="M 309.06434,180 H 307 v 5 l 1,1"
+           id="path4024-6-7-5"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccc" />
+        <path
+           style="display:inline;fill:none;stroke:url(#linearGradient4035);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;enable-background:new"
+           d="m 310,179.5 h -2.5 v 5 l 1,1 1,-1 V 182"
+           id="path4024-6"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccc" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/data/icons/hicolor_apps_scalable_org.gnome.Maps.svg
+++ b/data/icons/hicolor_apps_scalable_org.gnome.Maps.svg
@@ -1,0 +1,955 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 6.3499994 6.3499994"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="hicolor_apps_scalable_org.gnome.Maps.svg">
+  <defs
+     id="defs2">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient19627"
+       id="linearGradient60725"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.18806711,0,0,0.18806711,294.30841,42.135348)"
+       x1="187.19313"
+       y1="217.48814"
+       x2="187.19313"
+       y2="169.05244" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient19627">
+      <stop
+         style="stop-color:#56604f;stop-opacity:1;"
+         offset="0"
+         id="stop19629" />
+      <stop
+         style="stop-color:#acb5a5;stop-opacity:1"
+         offset="1"
+         id="stop19631" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:collect="always"
+       id="filter14901-4"
+       x="-0.16474384"
+       width="1.3294877"
+       y="-0.25184977"
+       height="1.5036995">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="4.5647773"
+         id="feGaussianBlur14903-2" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:collect="always"
+       id="filter14891-9"
+       x="-0.43938461"
+       width="1.8787692"
+       y="-0.48604494"
+       height="1.9720899">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="11.442308"
+         id="feGaussianBlur14893-5" />
+    </filter>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15009-5-5-5"
+       id="radialGradient60727"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.5539568,-0.28776979,0.08055218,0.71490062,-210.91814,106.248)"
+       cx="157.63728"
+       cy="224.31822"
+       fx="157.63728"
+       fy="224.31822"
+       r="34.75" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient15009-5-5-5">
+      <stop
+         style="stop-color:#383e34;stop-opacity:1"
+         offset="0"
+         id="stop15011-5-4-5" />
+      <stop
+         style="stop-color:#84917c;stop-opacity:1"
+         offset="1"
+         id="stop15013-7-5-8" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:collect="always"
+       id="filter14879-1"
+       x="-0.10637733"
+       width="1.2127547"
+       y="-0.11767404"
+       height="1.2353481">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="2.7702429"
+         id="feGaussianBlur14881-6" />
+    </filter>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15009-5-5-5"
+       id="radialGradient60729"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7482014,-0.08633094,0.03548389,0.71854885,-73.791411,73.675366)"
+       cx="81.881546"
+       cy="250.70465"
+       fx="81.881546"
+       fy="250.70465"
+       r="34.75" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15009-5-5-5"
+       id="radialGradient60731"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7482014,-0.08633094,0.03548389,0.71854885,-73.791411,73.675366)"
+       cx="88.25"
+       cy="218.765"
+       fx="88.25"
+       fy="218.765"
+       r="34.75" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient14931-2"
+       id="linearGradient60733"
+       gradientUnits="userSpaceOnUse"
+       x1="31.5"
+       y1="198.5"
+       x2="102.875"
+       y2="179.625" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient14931-2">
+      <stop
+         style="stop-color:#dfe2dc;stop-opacity:1;"
+         offset="0"
+         id="stop14933-0" />
+      <stop
+         style="stop-color:#e8eae5;stop-opacity:1"
+         offset="1"
+         id="stop14935-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient60637"
+       id="linearGradient60735"
+       gradientUnits="userSpaceOnUse"
+       x1="105.5"
+       y1="189"
+       x2="156.5"
+       y2="195.5" />
+    <linearGradient
+       id="linearGradient60637"
+       inkscape:collect="always">
+      <stop
+         id="stop60639"
+         offset="0"
+         style="stop-color:#8e9884;stop-opacity:1" />
+      <stop
+         id="stop60641"
+         offset="1"
+         style="stop-color:#9ea896;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15083-5"
+       id="linearGradient60737"
+       gradientUnits="userSpaceOnUse"
+       x1="156.875"
+       y1="225.43954"
+       x2="216.63115"
+       y2="190.93932" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient15083-5">
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1;"
+         offset="0"
+         id="stop15085-3" />
+      <stop
+         id="stop15091-5"
+         offset="0.93942225"
+         style="stop-color:#d4d9d1;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e2e6e0;stop-opacity:1"
+         offset="0.97525775"
+         id="stop15093-9" />
+      <stop
+         style="stop-color:#d4d8d0;stop-opacity:1"
+         offset="1"
+         id="stop15087-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15144-7"
+       id="linearGradient60739"
+       gradientUnits="userSpaceOnUse"
+       x1="155.375"
+       y1="213.56454"
+       x2="214.88115"
+       y2="190.93932" />
+    <linearGradient
+       id="linearGradient15144-7"
+       inkscape:collect="always">
+      <stop
+         id="stop15146-9"
+         offset="0"
+         style="stop-color:#d3d7cf;stop-opacity:1;" />
+      <stop
+         style="stop-color:#d4d9d1;stop-opacity:1;"
+         offset="0.93942225"
+         id="stop15148-2" />
+      <stop
+         id="stop15150-2"
+         offset="0.9662649"
+         style="stop-color:#dfe3dc;stop-opacity:1" />
+      <stop
+         id="stop15152-8"
+         offset="1"
+         style="stop-color:#d4d8d0;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient14755-8"
+       id="radialGradient60741"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.57798165,0,82.135321)"
+       cx="149.375"
+       cy="194.625"
+       fx="149.375"
+       fy="194.625"
+       r="13.625" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient14755-8">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop14757-1" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop14759-3" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:collect="always"
+       id="filter14775-3"
+       x="-0.22232293"
+       width="1.4446458"
+       y="-0.38465393"
+       height="1.7693079">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="2.5242915"
+         id="feGaussianBlur14777-8" />
+    </filter>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient14991-1"
+       id="radialGradient60743"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1300813,-0.29268293,0.18141561,0.70046584,-44.497769,83.733214)"
+       cx="80.25"
+       cy="187.73877"
+       fx="80.25"
+       fy="187.73877"
+       r="30.75" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient14991-1">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop14993-0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop14995-0" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient14991-1"
+       id="radialGradient60745"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3698405,-0.25999171,0.08949165,0.47151232,-84.160613,153.72842)"
+       cx="180.5"
+       cy="194.48077"
+       fx="180.5"
+       fy="194.48077"
+       r="35.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient20635-6-1"
+       id="linearGradient60747"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(507.9375,53.736825)"
+       x1="180"
+       y1="211.5"
+       x2="177.09375"
+       y2="148" />
+    <linearGradient
+       id="linearGradient20635-6-1"
+       inkscape:collect="always">
+      <stop
+         id="stop20637-6-6"
+         offset="0"
+         style="stop-color:#d7c574;stop-opacity:1" />
+      <stop
+         style="stop-color:#cfbb62;stop-opacity:1;"
+         offset="0.38609564"
+         id="stop20789-0-8" />
+      <stop
+         id="stop20791-4-6"
+         offset="0.83725142"
+         style="stop-color:#c6af4e;stop-opacity:1;" />
+      <stop
+         id="stop20639-8-4"
+         offset="1"
+         style="stop-color:#dfd39d;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient20627-8-0"
+       id="linearGradient60749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(507.9375,53.736825)"
+       x1="49.75"
+       y1="218.75"
+       x2="98.59375"
+       y2="217" />
+    <linearGradient
+       id="linearGradient20627-8-0"
+       inkscape:collect="always">
+      <stop
+         id="stop20629-8-6"
+         offset="0"
+         style="stop-color:#ded9c4;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8d022;stop-opacity:1;"
+         offset="0.17803359"
+         id="stop22486-6-5" />
+      <stop
+         id="stop20631-9-6"
+         offset="1"
+         style="stop-color:#ebe3c1;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient20104-9-1-6"
+       id="linearGradient60751"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(507.9375,53.736825)"
+       x1="126.7462"
+       y1="210.79668"
+       x2="149.73004"
+       y2="150.20921" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient20104-9-1-6">
+      <stop
+         style="stop-color:#826a00;stop-opacity:1;"
+         offset="0"
+         id="stop20106-9-6-9" />
+      <stop
+         style="stop-color:#d9b100;stop-opacity:1"
+         offset="1"
+         id="stop20108-6-6-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient20114-7-2-5-2-9"
+       id="linearGradient60753"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(507.9375,68.736825)"
+       x1="113.81474"
+       y1="157.29919"
+       x2="175.08"
+       y2="155.54919" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient20114-7-2-5-2-9">
+      <stop
+         style="stop-color:#888a85;stop-opacity:1;"
+         offset="0"
+         id="stop20116-5-2-3-4-0" />
+      <stop
+         style="stop-color:#a4a5a1;stop-opacity:1"
+         offset="1"
+         id="stop20118-4-5-6-9-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient22395-8-5"
+       id="linearGradient60755"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(507.9375,53.736825)"
+       x1="98.5"
+       y1="173.5"
+       x2="112.75"
+       y2="169.25" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient22395-8-5">
+      <stop
+         style="stop-color:#bdbdbd;stop-opacity:1;"
+         offset="0"
+         id="stop22397-0-6" />
+      <stop
+         style="stop-color:#cdcdcd;stop-opacity:1"
+         offset="1"
+         id="stop22399-6-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient22448-2-3"
+       id="linearGradient60757"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(507.9375,68.736825)"
+       x1="153.18974"
+       y1="179.54919"
+       x2="182.08"
+       y2="175.54919" />
+    <linearGradient
+       id="linearGradient22448-2-3"
+       inkscape:collect="always">
+      <stop
+         id="stop22450-9-1"
+         offset="0"
+         style="stop-color:#b9bab7;stop-opacity:1" />
+      <stop
+         id="stop22452-7-4"
+         offset="1"
+         style="stop-color:#c7c7c5;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient20114-7-2-5-2-9"
+       id="linearGradient60759"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(507.9375,68.736825)"
+       x1="130.81474"
+       y1="175.54919"
+       x2="182.08"
+       y2="175.54919" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient20114-7-2-5-2-9"
+       id="linearGradient60761"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(507.9375,53.736825)"
+       x1="130.81474"
+       y1="175.54919"
+       x2="182.08"
+       y2="175.54919" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient20765-9-0"
+       id="linearGradient60763"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(507.9375,53.736825)"
+       x1="153.70734"
+       y1="234.46004"
+       x2="195.16147"
+       y2="224.82571" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient20765-9-0">
+      <stop
+         style="stop-color:#a2a2a2;stop-opacity:1"
+         offset="0"
+         id="stop20767-1-3" />
+      <stop
+         style="stop-color:#b6b6b6;stop-opacity:1"
+         offset="1"
+         id="stop20769-3-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient22799-6-7"
+       id="linearGradient60767"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(507.9375,53.736825)"
+       x1="118"
+       y1="159.375"
+       x2="103.25"
+       y2="169.875" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient22799-6-7">
+      <stop
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0"
+         id="stop22801-7-5" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.37280703"
+         offset="1"
+         id="stop22803-5-9" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient14755-8"
+       id="radialGradient60769"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.57798165,0,82.135321)"
+       cx="149.375"
+       cy="194.625"
+       fx="149.375"
+       fy="194.625"
+       r="13.625" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient14670-0"
+       id="radialGradient60771"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27434839,0,0,0.4367642,286.54047,15.723175)"
+       cx="125.57332"
+       cy="122.20717"
+       fx="125.57332"
+       fy="122.20717"
+       r="31.25" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient14670-0">
+      <stop
+         style="stop-color:#f57676;stop-opacity:1"
+         offset="0"
+         id="stop14672-2" />
+      <stop
+         style="stop-color:#ed1212;stop-opacity:1"
+         offset="1"
+         id="stop14674-7" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient14971-4"
+       id="radialGradient60773"
+       gradientUnits="userSpaceOnUse"
+       cx="129.25"
+       cy="129.83951"
+       fx="129.25"
+       fy="129.83951"
+       r="34.93745" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient14971-4">
+      <stop
+         style="stop-color:#fabebe;stop-opacity:1;"
+         offset="0"
+         id="stop14973-7" />
+      <stop
+         style="stop-color:#fabebe;stop-opacity:0;"
+         offset="1"
+         id="stop14975-2" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient14745-0"
+       id="radialGradient60775"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7826226,0,0,1.7826226,-100.09062,-90.782804)"
+       cx="127.8913"
+       cy="115.99819"
+       fx="127.8913"
+       fy="115.99819"
+       r="31.25" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient14745-0">
+      <stop
+         style="stop-color:#ff4141;stop-opacity:1"
+         offset="0"
+         id="stop14747-5" />
+      <stop
+         style="stop-color:#cc0000;stop-opacity:1"
+         offset="1"
+         id="stop14749-3" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient14991-1"
+       id="radialGradient60777"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0999298,0,0,0.4738253,-14.938489,37.028868)"
+       cx="149.48978"
+       cy="49.24028"
+       fx="149.48978"
+       fy="49.24028"
+       r="34.5" />
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:collect="always"
+       id="filter14695-8"
+       x="-0.062560327"
+       width="1.1251206"
+       y="-0.14522643"
+       height="1.290453">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.670246"
+         id="feGaussianBlur14697-2" />
+    </filter>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient14991-1"
+       id="radialGradient60779"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.8045963,-1.2769439,0.30783453,0.91717895,-449.00342,197.05045)"
+       cx="143.82129"
+       cy="146.03168"
+       fx="143.82129"
+       fy="146.03168"
+       r="43.284622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient59587"
+       id="linearGradient60781"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.806396,0,0,0.99764631,-259.73652,-0.76319855)"
+       x1="322"
+       y1="60"
+       x2="322"
+       y2="62" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient59587">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop59589" />
+      <stop
+         style="stop-color:#d3d3d3;stop-opacity:1"
+         offset="1"
+         id="stop59591" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient20765-9-0"
+       id="linearGradient4842"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(507.9375,53.736825)"
+       x1="153.70734"
+       y1="234.46004"
+       x2="195.16147"
+       y2="224.82571" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15.839192"
+     inkscape:cx="9.7481261"
+     inkscape:cy="9.982649"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1280"
+     inkscape:window-height="746"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid815" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-290.65001)">
+    <g
+       style="display:inline;enable-background:new"
+       id="g60643"
+       transform="matrix(0.14235262,0,0,0.14235262,-42.289194,283.47899)">
+      <path
+         sodipodi:nodetypes="cccccccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path60645"
+         d="m 304.11206,68.566894 -0.0314,10.453932 -3.49382,10.817129 0.60332,1.5791 1.5909,0.147282 9.64638,0.105751 -0.0179,-3.30548 0.89222,-4.346395 10.37433,4.839243 1.6447,-0.759097 2.35755,2.381168 9.06756,-2.347636 c 2.46424,-0.903555 2.33914,-3.817211 1.44786,-5.094177 l -3.22711,-6.433441 0.0722,-8.140936 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#dfe3dc;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient60725);stroke-width:2.77456808;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.41563798;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter14901-4);enable-background:accumulate"
+         d="m 162.75,221 c 0,1 13.3569,36.48053 13.3569,36.48053 L 233.73404,237.66423 219.5,211 Z"
+         id="path60647"
+         inkscape:connector-curvature="0"
+         transform="matrix(0.18318623,0,0,0.19291513,295.0081,40.702592)"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.57613172;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter14891-9);enable-background:accumulate"
+         d="M 40.5,259.5 92,253 l 16.72382,-15.48379 48.37747,17.82072 67.28921,-17.02221 -24.00508,-55.53111 -4.2061,-33.6108 -49.47348,16.68222 -34.5762,-15.70031 -44.37964,17.29503 4.715359,26.62994 z"
+         id="path60649"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccccc"
+         transform="matrix(0.18581336,0,0,0.18581336,294.60932,42.587796)" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient60727);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="m 159.51748,234.07446 15.63066,18.80752 54.88837,-13.48593 c 3.75,-1.25 4.08849,-17.77105 3.08849,-21.02105 -1,-3.25 -7.125,-11.125 -7.125,-11.125 z"
+         id="path60651"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccscc"
+         transform="matrix(0.18581336,0,0,0.18581336,294.60932,42.587796)" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path60653"
+         d="m 40.5,260 51.5,-6.5 11,-50 -44.5,13 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter14879-1);enable-background:accumulate"
+         transform="matrix(0.18581336,0,0,0.18581336,294.60932,42.587796)" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient60729);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="m 42,259.125 9.375,-14 45,-11 -2.25,14.25 c 0,0 -1.369796,2.9545 -4.375,3.75 z"
+         id="path60655"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccc"
+         transform="matrix(0.18581336,0,0,0.18581336,294.60932,42.587796)" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient60731);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="M 34,253 42.576192,264.55477 92.8191,263.28651 103.5,209.75 l -40,3.75 z"
+         id="path60657"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccc"
+         transform="matrix(0.18581336,0,0,0.18581336,294.60932,42.587796)" />
+      <path
+         sodipodi:nodetypes="ccccccc"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient60733);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="m 113.04292,141.57724 -59.661058,-0.4601 1.871307,51.78841 L 31.5,254.5 91,219 107.5,179.5 Z"
+         id="path60659"
+         inkscape:connector-curvature="0"
+         transform="matrix(0.18581336,0,0,0.18581336,294.60932,42.587796)" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path60661"
+         d="m 112.5,142.5 34.5,16.5 5.5,35.5 4,54 -62.986423,-29.03014 C 91.763577,218.59486 91,219 91,219 l 16.5,-39.5 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient60735);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         sodipodi:nodetypes="cccccccc"
+         transform="matrix(0.18581336,0,0,0.18581336,294.60932,42.587796)" />
+      <path
+         sodipodi:nodetypes="ccccccccc"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient60737);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="m 197,144.25 c -0.625,-1.875 -2.35891,-3.35022 -3.73391,-2.72522 L 147,159 l 5.5,35.5 4,54 69.93663,-32.35683 c 3,-1.375 5.68837,-0.14317 5.68837,-0.14317 L 212.5,184.5 Z"
+         id="path60663"
+         inkscape:connector-curvature="0"
+         transform="matrix(0.18581336,0,0,0.18581336,294.60932,42.587796)" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path60665"
+         d="m 212.47224,144.25 c -0.625,-1.875 -2.35891,-3.35022 -3.73391,-2.72522 L 154.95715,143.52776 152.5,194.5 l 0.5,4.75 59,-15.875 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient60739);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         sodipodi:nodetypes="ccccccc"
+         transform="matrix(0.18581336,0,0,0.18581336,294.60932,42.587796)" />
+      <ellipse
+         ry="7.875"
+         rx="13.625"
+         cy="194.625"
+         cx="149.375"
+         id="path60667"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.34979428;fill:url(#radialGradient60741);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter14775-3);enable-background:accumulate"
+         transform="matrix(0.31558777,0,0,0.31558777,275.22427,17.330452)" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#edefeb;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         d="m 112,142.5 -5,36.75 -16.625,40.125 c 0.985394,-0.62285 1.767773,-0.52728 2.421875,-0.15625 L 107.75,179.5 113,142.875 Z"
+         id="path60669"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc"
+         transform="matrix(0.18581336,0,0,0.18581336,294.60932,42.587796)" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.40329219;fill:url(#radialGradient60743);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         d="M 61.007392,195.94194 107.5,180 l -12,27.5 -48.770796,16.80113 z"
+         id="path60671"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc"
+         transform="matrix(0.18581336,0,0,0.18581336,294.60932,42.587796)" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.40329219;fill:url(#radialGradient60745);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         d="M 212,183.5 153,199.625 155.5,235.5 223,202 Z"
+         id="path60673"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc"
+         transform="matrix(0.18581336,0,0,0.18581336,294.60932,42.587796)" />
+      <g
+         id="g60675"
+         style="display:inline;enable-background:new"
+         transform="matrix(0.18065222,0,0,0.18065222,203.95073,33.323959)">
+        <path
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient60747);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+           d="m 661.21653,280.28102 c 0,0 -0.16843,-1.60312 0.94374,-2.02195 1.31476,-0.49514 1.85186,0.8486 1.85186,0.8486 l 26.92537,-11.37085 c 14.5022,-4.46222 20.98455,-14.45537 21.09238,-25.24907 0.006,-0.62384 0.55367,-1.25036 0.51763,-1.87865 -0.0262,-0.45656 -0.62595,-0.91404 -0.67417,-1.37211 -0.066,-0.62718 0.40992,-1.38046 0.30314,-2.00892 -0.0614,-0.36154 -0.69206,-0.59814 -0.76682,-0.95964 -0.34854,-1.68537 2.34158,-5.64182 1.71069,-7.30508 l -1.35919,-30.68122 -19.86571,0.40776 0.31389,34.31877 c 0.71026,1.98875 1.13802,4.13892 1.12275,6.31292 -10e-4,0.20968 -0.46995,0.76046 -0.0169,0.62956 0,0 -0.93629,3.19056 -0.0482,0.69362 -0.46671,5.04696 -0.30396,7.34407 -7.8748,10.63574 l -21.86213,9.35686 c 0,0 -0.31603,-0.94463 -1.51903,-0.74673 -1.3222,0.2175 -1.11884,1.44794 -1.11884,1.44794 z"
+           id="path60677"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="csccccccscccccccccscc" />
+        <path
+           sodipodi:nodetypes="ccccccccccc"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient60749);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+           d="m 612.9375,238.38368 -16.84898,8.1404 0.85052,-6.76255 2.13898,-34.41117 -14.83686,-1.62746 0.55229,40.71824 -2.79113,7.67308 -24.40607,12.92821 -12.86502,30.42443 63.20627,-42.73004 z"
+           id="path60679"
+           inkscape:connector-curvature="0" />
+        <path
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient60751);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+           d="m 660.4375,262.04243 0.76517,18.28279 c -7.89969,-5.94207 -15.72727,-12.15628 -24.09494,-15.7584 l -2.97112,20.59528 -11.15249,-4.86108 3.41276,-21.30895 c -6.14682,-3.03548 -11.4057,-4.51144 -17.95938,-6.25525 l 5.9754,-14.59725 c 17.25655,5.18877 30.3536,13.661 46.0246,23.90286 z"
+           id="path60681"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccc" />
+        <path
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient60753);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+           d="m 635.02589,248.76455 1.41161,-11.02773 1,-30.5 -16.75,-8.5 -4.75,34.5 -2,6 c 7.12881,2.34073 13.73494,5.14295 21.08839,9.52773 z"
+           id="path60683"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccc" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path60685"
+           d="m 596.4375,247.23682 4.75,-8.75 2,-31.75 16.52145,-3.10726 -3.77145,29.60726 -2,6 z"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient60755);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+           sodipodi:nodetypes="ccccccc" />
+        <path
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient60757);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+           d="m 667.39008,245.70024 -4.94975,-13.78857 22.62741,-7.42462 6.62268,15.62421 -6.97622,11.95295 -21.56071,9.19407 -0.93306,-13.65534 z"
+           id="path60687"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccccc" />
+        <path
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient60759);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+           d="m 660.05385,263.37792 c -7.39932,-4.02395 -13.48444,-10.84143 -21.3016,-13.61182 v -10.42982 l 20.68288,9.63433 z"
+           id="path60689"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#686965;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+           d="m 658.55124,233.17511 2.12132,13.08148 -22.62741,-10.25305 0.35355,-12.37437 z"
+           id="path60691"
+           inkscape:connector-curvature="0" />
+        <path
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient60761);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+           d="m 651.48018,278.42995 0.7071,12.02081 11.31372,5.83364 -1.85616,-11.93242 z"
+           id="path60693"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4842);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+           d="m 674.8147,278.07639 2.82843,12.02082 25.45584,-11.93243 -3.8007,-11.13692 z"
+           id="path60695"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="path60697"
+           d="m 669.77657,280.10933 2.2097,11.49049 -8.48527,4.68458 -1.85616,-11.93242 z"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient60763);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+        <path
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.30452677;fill:url(#linearGradient60767);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+           d="m 603.4375,206.73682 17,-3.59654 19,4.09654 -4.25,32.75 -19.25,-8.5 -15,7 z"
+           id="path60699"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccc" />
+      </g>
+      <path
+         transform="translate(7.95968e-6)"
+         inkscape:connector-curvature="0"
+         id="path60701"
+         d="m 336.24998,82.8125 -2.78394,-5.769641 -0.0161,-7.898218 H 305.1331"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ffffff;stroke-width:1.85864747;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         sodipodi:nodetypes="ccc" />
+      <path
+         transform="translate(7.95968e-6)"
+         inkscape:connector-curvature="0"
+         id="path60703"
+         d="m 327.44088,89.022795 9.654,-2.661817 0.0734,-3.183534"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.31275719;fill:none;stroke:#ffffff;stroke-width:1.85864747;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         sodipodi:nodetypes="cc" />
+      <path
+         transform="translate(7.95968e-6)"
+         inkscape:connector-curvature="0"
+         id="path60705"
+         d="m 311.70356,90.341055 -8.63215,0.123238 -1.47039,-1.208386"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.31275719;fill:none;stroke:#ffffff;stroke-width:1.85864747;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         sodipodi:nodetypes="cc" />
+      <g
+         transform="matrix(0.9828742,0,0,0.96619268,4.9296821,2.3944823)"
+         id="g60709">
+        <ellipse
+           ry="7.875"
+           rx="13.625"
+           cy="194.625"
+           cx="149.375"
+           transform="matrix(0.18581336,0,0,0.18581336,294.60932,42.587796)"
+           id="path60711"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.34979428;fill:url(#radialGradient60769);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+        <path
+           sodipodi:nodetypes="szsss"
+           inkscape:connector-curvature="0"
+           id="path60713"
+           d="m 330.57338,60.92906 c 0,6.931317 -6.7376,18.828437 -8.57338,18.686515 -1.83579,-0.141922 -8.57339,-11.613274 -8.57339,-18.686515 0,-4.755166 3.83844,-8.609989 8.57339,-8.609989 4.73495,0 8.57338,3.854823 8.57338,8.609989 z"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient60771);fill-opacity:1;fill-rule:nonzero;stroke:#a40000;stroke-width:1.9072876;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate" />
+        <circle
+           r="31.25"
+           cy="96.75"
+           cx="129.25"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.62551437;fill:url(#radialGradient60773);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+           id="path60715"
+           transform="matrix(0.20513795,0,0,0.20513795,295.52078,42.578946)" />
+        <circle
+           r="31.25"
+           cy="96.75"
+           cx="129.25"
+           transform="matrix(0.19235431,0,0,0.192,297.12714,42.424001)"
+           id="path60717"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient60775);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+        <path
+           transform="matrix(0.18581336,0,0,0.18581336,294.60932,42.587796)"
+           inkscape:connector-curvature="0"
+           id="path60719"
+           d="m 149.48978,55.151966 c -17.69399,0 -32.0378,11.056095 -32.0378,24.694481 0,0.983974 0.0869,1.953955 0.23216,2.907864 1.8761,-12.260479 15.39495,-21.764248 31.80564,-21.764248 16.41069,0 29.95856,9.503769 31.83466,21.764248 0.1452,-0.953909 0.20314,-1.92389 0.20314,-2.907864 0,-13.638386 -14.34381,-24.694481 -32.0378,-24.694481 z"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4526749;fill:url(#radialGradient60777);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter14695-8);enable-background:accumulate" />
+        <path
+           transform="matrix(0.16803736,0,0,0.16803736,297.22958,44.818958)"
+           sodipodi:type="inkscape:offset"
+           inkscape:radius="-5.7784467"
+           inkscape:original="M 322 52.435547 C 317.30558 52.435547 313.5 56.258195 313.5 60.972656 C 313.5 67.985351 320.17993 79.35734 322 79.498047 C 323.82007 79.638754 330.5 67.844642 330.5 60.972656 C 330.5 56.258195 326.69442 52.435547 322 52.435547 z "
+           xlink:href="#path14659-9"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.48148151;fill:none;stroke:url(#radialGradient60779);stroke-width:10.89258289;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="path60721"
+           inkscape:href="#path14659-9"
+           d="m 322,58.214844 c -1.55751,0 -2.7207,1.152981 -2.7207,2.757812 0,1.586316 1.19876,5.514703 2.72851,8.69336 1.51822,-3.225404 2.71289,-7.219808 2.71289,-8.69336 0,-1.604831 -1.16319,-2.757812 -2.7207,-2.757812 z m 2.7207,16.091797 c 0.17271,0.211206 0.38791,0.468747 0.36524,0.447265 -0.0167,-0.01581 -0.0297,-0.220196 -0.36524,-0.447265 z" />
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient60781);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+           id="rect60723"
+           width="3.612792"
+           height="5.7988191"
+           x="320.22946"
+           y="57.287346" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/data/icons/hicolor_apps_scalable_org.gnome.Photos.svg
+++ b/data/icons/hicolor_apps_scalable_org.gnome.Photos.svg
@@ -1,0 +1,1950 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 6.3499994 6.3499994"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="hicolor_apps_scalable_org.gnome.Photos.svg">
+  <defs
+     id="defs2">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient14755-8">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop14757-1" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop14759-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient14991-1">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop14993-0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop14995-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8576-1">
+      <stop
+         id="stop8578-2"
+         offset="0"
+         style="stop-color:#e6e6e3;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e6e6e3;stop-opacity:1;"
+         offset="0.007958"
+         id="stop8580-8" />
+      <stop
+         id="stop8582-8"
+         offset="0.04157639"
+         style="stop-color:#53534a;stop-opacity:1" />
+      <stop
+         style="stop-color:#b3b3aa;stop-opacity:1"
+         offset="0.06549367"
+         id="stop8584-6" />
+      <stop
+         id="stop8586-2"
+         offset="0.07798523"
+         style="stop-color:#b5b5b5;stop-opacity:1" />
+      <stop
+         style="stop-color:#bcbcb6;stop-opacity:1"
+         offset="0.9102242"
+         id="stop8588-3" />
+      <stop
+         id="stop8590-2"
+         offset="0.9475261"
+         style="stop-color:#9c9c90;stop-opacity:1" />
+      <stop
+         id="stop8592-3"
+         offset="0.96348912"
+         style="stop-color:#65655b;stop-opacity:1" />
+      <stop
+         id="stop8594-0"
+         offset="0.9781549"
+         style="stop-color:#e6e6e3;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e6e6e3;stop-opacity:1;"
+         offset="0.98914403"
+         id="stop8596-8" />
+      <stop
+         id="stop8598-5"
+         offset="1"
+         style="stop-color:#d6d6d1;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient39496">
+      <stop
+         style="stop-color:#323232;stop-opacity:1"
+         offset="0"
+         id="stop39498" />
+      <stop
+         style="stop-color:#9b9b9b;stop-opacity:1"
+         offset="1"
+         id="stop39500" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient39160">
+      <stop
+         id="stop39162"
+         offset="0"
+         style="stop-color:#7c8b90;stop-opacity:1" />
+      <stop
+         style="stop-color:#232829;stop-opacity:1"
+         offset="0.05599762"
+         id="stop39164" />
+      <stop
+         id="stop39166"
+         offset="0.14188343"
+         style="stop-color:#596367;stop-opacity:1" />
+      <stop
+         style="stop-color:#16191a;stop-opacity:1"
+         offset="0.43734261"
+         id="stop39168" />
+      <stop
+         id="stop39170"
+         offset="0.93562192"
+         style="stop-color:#424a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#191d1e;stop-opacity:1"
+         offset="0.95929426"
+         id="stop39172" />
+      <stop
+         id="stop39174"
+         offset="1"
+         style="stop-color:#5e6c6d;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient39529">
+      <stop
+         style="stop-color:#e6e6e3;stop-opacity:1;"
+         offset="0"
+         id="stop39531" />
+      <stop
+         id="stop39533"
+         offset="0.01827126"
+         style="stop-color:#e6e6e3;stop-opacity:1;" />
+      <stop
+         style="stop-color:#53534a;stop-opacity:1"
+         offset="0.06514955"
+         id="stop39535" />
+      <stop
+         id="stop39537"
+         offset="0.12884656"
+         style="stop-color:#b3b3aa;stop-opacity:1" />
+      <stop
+         style="stop-color:#b5b5b5;stop-opacity:1"
+         offset="0.16638461"
+         id="stop39539" />
+      <stop
+         id="stop39541"
+         offset="0.78499174"
+         style="stop-color:#bcbcb6;stop-opacity:1" />
+      <stop
+         style="stop-color:#9c9c90;stop-opacity:1"
+         offset="0.86207336"
+         id="stop39543" />
+      <stop
+         style="stop-color:#65655b;stop-opacity:1"
+         offset="0.92076278"
+         id="stop39545" />
+      <stop
+         style="stop-color:#e6e6e3;stop-opacity:1;"
+         offset="0.9781549"
+         id="stop39547" />
+      <stop
+         id="stop39549"
+         offset="0.98914403"
+         style="stop-color:#e6e6e3;stop-opacity:1;" />
+      <stop
+         style="stop-color:#d6d6d1;stop-opacity:1"
+         offset="1"
+         id="stop39551" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8344">
+      <stop
+         style="stop-color:#ff0606;stop-opacity:1"
+         offset="0"
+         id="stop8346" />
+      <stop
+         style="stop-color:#cc0000;stop-opacity:1"
+         offset="1"
+         id="stop8348" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient39571">
+      <stop
+         style="stop-color:#eeeeee;stop-opacity:1;"
+         offset="0"
+         id="stop39573" />
+      <stop
+         style="stop-color:#1c1c1c;stop-opacity:1"
+         offset="1"
+         id="stop39575" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10785">
+      <stop
+         style="stop-color:#525252;stop-opacity:1"
+         offset="0"
+         id="stop10787" />
+      <stop
+         id="stop10797"
+         offset="0.27999729"
+         style="stop-color:#3a3a3a;stop-opacity:1;" />
+      <stop
+         id="stop10795"
+         offset="0.75750965"
+         style="stop-color:#080808;stop-opacity:1;" />
+      <stop
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         offset="1"
+         id="stop10789" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath15654">
+      <circle
+         r="20.875"
+         cy="183.625"
+         cx="180.375"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:new"
+         id="path15656"
+         transform="translate(253.75,41.5)" />
+    </clipPath>
+    <linearGradient
+       id="linearGradient10663">
+      <stop
+         id="stop10665"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1" />
+      <stop
+         id="stop10667"
+         offset="1"
+         style="stop-color:#321d4b;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient15542">
+      <stop
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0"
+         id="stop15544" />
+      <stop
+         id="stop15550"
+         offset="0.68263459"
+         style="stop-color:#000000;stop-opacity:0" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1"
+         offset="1"
+         id="stop15546" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10669"
+       inkscape:collect="always">
+      <stop
+         id="stop10671"
+         offset="0"
+         style="stop-color:#858585;stop-opacity:1" />
+      <stop
+         id="stop10673"
+         offset="1"
+         style="stop-color:#36d548;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient15471">
+      <stop
+         style="stop-color:#bcf1c2;stop-opacity:1;"
+         offset="0"
+         id="stop15473" />
+      <stop
+         style="stop-color:#bcf1c2;stop-opacity:0;"
+         offset="1"
+         id="stop15475" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10675">
+      <stop
+         style="stop-color:#eeb5f3;stop-opacity:1"
+         offset="0"
+         id="stop10677" />
+      <stop
+         style="stop-color:#6c6c6c;stop-opacity:1"
+         offset="1"
+         id="stop10679" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient16893">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop16895" />
+      <stop
+         id="stop16901"
+         offset="0.85363209"
+         style="stop-color:#d6d6d6;stop-opacity:1;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop16897" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient17282">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop17284" />
+      <stop
+         id="stop17288"
+         offset="0.41722602"
+         style="stop-color:#fafafb;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e3e7ea;stop-opacity:1"
+         offset="0.57299733"
+         id="stop17290" />
+      <stop
+         style="stop-color:#dde2e3;stop-opacity:1"
+         offset="1"
+         id="stop17286" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient40062">
+      <stop
+         id="stop40066"
+         offset="0"
+         style="stop-color:#9f9f99;stop-opacity:1" />
+      <stop
+         id="stop40064"
+         offset="1"
+         style="stop-color:#32322f;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient17104-4">
+      <stop
+         style="stop-color:#ebebe9;stop-opacity:1;"
+         offset="0"
+         id="stop17106-3" />
+      <stop
+         id="stop17112-7"
+         offset="0.1"
+         style="stop-color:#98988d;stop-opacity:1" />
+      <stop
+         style="stop-color:#fafaf9;stop-opacity:1"
+         offset="0.23101276"
+         id="stop17114-7" />
+      <stop
+         style="stop-color:#ececea;stop-opacity:1"
+         offset="1"
+         id="stop17108-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient17440">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop17442" />
+      <stop
+         style="stop-color:#e3e7ea;stop-opacity:1"
+         offset="1"
+         id="stop17444" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient17260"
+       inkscape:collect="always">
+      <stop
+         id="stop17262"
+         offset="0"
+         style="stop-color:#e8ebec;stop-opacity:1" />
+      <stop
+         style="stop-color:#c1c8cb;stop-opacity:1;"
+         offset="0.06380612"
+         id="stop17270" />
+      <stop
+         id="stop17278"
+         offset="0.12657583"
+         style="stop-color:#808e95;stop-opacity:1" />
+      <stop
+         style="stop-color:#7f8e94;stop-opacity:1"
+         offset="0.37353063"
+         id="stop17268" />
+      <stop
+         style="stop-color:#b3bcbf;stop-opacity:1;"
+         offset="0.76234901"
+         id="stop17266" />
+      <stop
+         id="stop17280"
+         offset="0.85740942"
+         style="stop-color:#b1bbbe;stop-opacity:1;" />
+      <stop
+         id="stop17264"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient16808">
+      <stop
+         style="stop-color:#ededed;stop-opacity:0"
+         offset="0"
+         id="stop16810" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop16812" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient16676">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop16678" />
+      <stop
+         style="stop-color:#9ea9ac;stop-opacity:1"
+         offset="1"
+         id="stop16680" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient17596">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop17598" />
+      <stop
+         id="stop17602"
+         offset="0.43527859"
+         style="stop-color:#f6f7f8;stop-opacity:1" />
+      <stop
+         style="stop-color:#bbc4c6;stop-opacity:1"
+         offset="1"
+         id="stop17600" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient17606">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.1124498"
+         offset="0"
+         id="stop17608" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop17610" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath16743">
+      <ellipse
+         ry="6.5"
+         rx="18.625"
+         cy="83.5"
+         cx="69.125"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient16747);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new"
+         id="path16745" />
+    </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient16818">
+      <stop
+         style="stop-color:#e8ebec;stop-opacity:1"
+         offset="0"
+         id="stop16820" />
+      <stop
+         style="stop-color:#b0babd;stop-opacity:1"
+         offset="1"
+         id="stop16822" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient38593"
+       inkscape:collect="always">
+      <stop
+         style="stop-color:#364679;stop-opacity:1"
+         offset="0"
+         id="stop38595" />
+      <stop
+         style="stop-color:#252a2c;stop-opacity:1"
+         offset="1"
+         id="stop38597" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath2919">
+      <circle
+         r="20.875"
+         cy="183.625"
+         cx="180.375"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:new"
+         id="path2917"
+         transform="translate(253.75,41.5)" />
+    </clipPath>
+    <linearGradient
+       id="linearGradient15393">
+      <stop
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0"
+         id="stop15395" />
+      <stop
+         style="stop-color:#7f4ebb;stop-opacity:1"
+         offset="1"
+         id="stop15397" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient15411">
+      <stop
+         style="stop-color:#f69ff9;stop-opacity:1;"
+         offset="0"
+         id="stop15413" />
+      <stop
+         style="stop-color:#f69ff9;stop-opacity:0;"
+         offset="1"
+         id="stop15415" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient15740-9">
+      <stop
+         style="stop-color:#633c92;stop-opacity:1"
+         offset="0"
+         id="stop15742-0" />
+      <stop
+         style="stop-color:#28183b;stop-opacity:1"
+         offset="1"
+         id="stop15744-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient15503">
+      <stop
+         style="stop-color:#e191ea;stop-opacity:1;"
+         offset="0"
+         id="stop15505" />
+      <stop
+         style="stop-color:#e191ea;stop-opacity:0;"
+         offset="1"
+         id="stop15507" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient15461">
+      <stop
+         style="stop-color:#36d548;stop-opacity:1;"
+         offset="0"
+         id="stop15463" />
+      <stop
+         style="stop-color:#36d548;stop-opacity:0;"
+         offset="1"
+         id="stop15465" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient15521"
+       inkscape:collect="always">
+      <stop
+         id="stop15523"
+         offset="0"
+         style="stop-color:#eeb5f3;stop-opacity:1" />
+      <stop
+         id="stop15525"
+         offset="1"
+         style="stop-color:#3465a4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient15615">
+      <stop
+         style="stop-color:#f2f8e8;stop-opacity:1;"
+         offset="0"
+         id="stop15617" />
+      <stop
+         style="stop-color:#9af403;stop-opacity:0.39819005"
+         offset="1"
+         id="stop15619" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       id="filter39510-3"
+       x="-0.071343876"
+       width="1.1426877"
+       y="-0.95886165"
+       height="2.9177234">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.2485178"
+         id="feGaussianBlur39512-6" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8576-1"
+       id="linearGradient40290"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0905489,0,0,0.09246892,301.2741,172.56789)"
+       x1="36.498711"
+       y1="112.25"
+       x2="256.00525"
+       y2="112.25" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient39496"
+       id="linearGradient40292"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.46274701,0,0,0.46164613,166.47178,153.2593)"
+       x1="339.62497"
+       y1="90.763611"
+       x2="339.62497"
+       y2="57.771545" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient39160"
+       id="linearGradient40294"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.08547078,0,0,0.08461405,301.85892,173.73388)"
+       x1="34.75"
+       y1="231.375"
+       x2="256.52762"
+       y2="231.375" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient39529"
+       id="linearGradient40296"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.08642334,0,0,0.0867132,301.81765,173.70479)"
+       x1="36.498711"
+       y1="112.25"
+       x2="256.00525"
+       y2="112.25" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8344"
+       id="radialGradient40298"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2523819,0,0,1.2523819,-22.935203,-33.85073)"
+       cx="90.875"
+       cy="134.12505"
+       fx="90.875"
+       fy="134.12505"
+       r="13.875" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient39571"
+       id="linearGradient40300"
+       gradientUnits="userSpaceOnUse"
+       x1="176.29088"
+       y1="165.48108"
+       x2="176.29088"
+       y2="192.81148" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10785"
+       id="radialGradient40302"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.95119233,0.21061255,-0.47025708,2.1238284,91.97632,-239.41355)"
+       cx="175.62187"
+       cy="171.32021"
+       fx="175.62187"
+       fy="171.32021"
+       r="21.375" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient16893"
+       id="radialGradient40324"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.029347,-5.3962876e-8,8.260055e-8,1.003209,-1.9580017,-0.28980923)"
+       cx="66.71875"
+       cy="90.3125"
+       fx="66.71875"
+       fy="90.3125"
+       r="19.25" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient17282"
+       id="radialGradient40326"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5563912,-0.03604779,-0.00529576,2.0555043,-38.236792,-78.452491)"
+       cx="67.898262"
+       cy="86.272835"
+       fx="67.898262"
+       fy="86.272835"
+       r="18.625" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient40062"
+       id="radialGradient40328"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.002182,-1.5774099e-7,2.3151909e-7,1.8842617,-0.37517912,-77.834109)"
+       cx="171.93018"
+       cy="88.021606"
+       fx="171.93018"
+       fy="88.021606"
+       r="23.947815" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient17104-4"
+       id="linearGradient40330"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1913531,0,-0.25441284,1.6951358,-7.6844848,-58.99859)"
+       x1="159"
+       y1="86.559517"
+       x2="163.1875"
+       y2="85.622017" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient17440"
+       id="radialGradient40336"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.13798092,-0.00523632,5.8665853e-4,0.2032083,296.09623,162.61396)"
+       cx="110.99965"
+       cy="108.66787"
+       fx="110.99965"
+       fy="108.66787"
+       r="106.35328" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient17260"
+       id="linearGradient40338"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-0.25)"
+       x1="102.1046"
+       y1="92.889481"
+       x2="131.6454"
+       y2="92.889481" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient16808"
+       id="radialGradient40340"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.77167517,0,0,0.24485756,63.532955,71.962584)"
+       cx="65.885239"
+       cy="119.35288"
+       fx="65.885239"
+       fy="119.35288"
+       r="18.625" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient16676"
+       id="radialGradient40342"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.0826935,0.13842865,-0.05858083,1.1836401,-136.96218,-41.292905)"
+       cx="68.462334"
+       cy="98.513252"
+       fx="68.462334"
+       fy="98.513252"
+       r="18.625" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient17596"
+       id="radialGradient40344"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5637867,-0.01894703,-4.1323233e-4,0.5771077,-39.175776,38.038046)"
+       cx="69.515709"
+       cy="77.769203"
+       fx="69.515709"
+       fy="77.769203"
+       r="18.625" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient17606"
+       id="linearGradient40346"
+       gradientUnits="userSpaceOnUse"
+       x1="73.470085"
+       y1="91.126183"
+       x2="73.470085"
+       y2="77.166534" />
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath16743-2">
+      <ellipse
+         ry="6.5"
+         rx="18.625"
+         cy="83.5"
+         cx="69.125"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient16747);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new"
+         id="path16745-5" />
+    </clipPath>
+    <filter
+       inkscape:collect="always"
+       id="filter17616-4">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.36008676"
+         id="feGaussianBlur17618-7" />
+    </filter>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient16818"
+       id="radialGradient40348"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0543342,0,0,0.31669925,-4.3854446,62.958879)"
+       cx="116.625"
+       cy="104.37531"
+       fx="116.625"
+       fy="104.37531"
+       r="14.770405" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient16808"
+       id="radialGradient40350"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8136035,0,0,0.23099845,62.599524,73.088069)"
+       cx="65.885239"
+       cy="119.35288"
+       fx="65.885239"
+       fy="119.35288"
+       r="18.625" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient14991-1"
+       id="radialGradient40352"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.0554715,4.7566277e-8,0,0.61404585,-142.62716,27.30629)"
+       cx="69.389023"
+       cy="102.06567"
+       fx="69.389023"
+       fy="102.06567"
+       r="18.625" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient17282"
+       id="radialGradient40354"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.0803592,-0.08956605,-0.01476832,1.9704686,-72.996079,-67.482415)"
+       cx="67.898262"
+       cy="86.272835"
+       fx="67.898262"
+       fy="86.272835"
+       r="18.625" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient14991-1"
+       id="radialGradient40356"
+       gradientUnits="userSpaceOnUse"
+       cx="176.85715"
+       cy="167.21986"
+       fx="176.85715"
+       fy="167.21986"
+       r="21.375" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient14991-1"
+       id="radialGradient40360"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6134673,0,0,1.6134673,-109.12049,-123.08654)"
+       cx="177.875"
+       cy="200.64076"
+       fx="177.875"
+       fy="200.64076"
+       r="21.375" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient38593"
+       id="radialGradient40362"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.34606359,-0.24871539,1.1303072,1.572714,-95.261765,-63.884544)"
+       cx="189"
+       cy="193.625"
+       fx="189"
+       fy="193.625"
+       r="21.375" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient14991-1"
+       id="radialGradient40304"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9091335,0,0,1.9091335,-122.33527,-111.88024)"
+       cx="134.5625"
+       cy="123.0625"
+       fx="134.5625"
+       fy="123.0625"
+       r="8.6875" />
+    <filter
+       inkscape:collect="always"
+       id="filter10697-7">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.72109684"
+         id="feGaussianBlur10699-8" />
+    </filter>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath15654-6">
+      <circle
+         r="20.875"
+         cy="183.625"
+         cx="180.375"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:new"
+         id="path15656-8"
+         transform="translate(253.75,41.5)" />
+    </clipPath>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10663"
+       id="radialGradient40306"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.564021,0,0,1.564021,-101.59428,-100.04322)"
+       cx="180.125"
+       cy="177.375"
+       fx="180.125"
+       fy="177.375"
+       r="20.875" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15542"
+       id="radialGradient40308"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1377876,0,0,1.1377876,-24.853435,-25.596062)"
+       cx="180.375"
+       cy="185.76465"
+       fx="180.375"
+       fy="185.76465"
+       r="20.875" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10669"
+       id="radialGradient40310"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1573291,0,0,0.61172259,-68.025181,83.362171)"
+       cx="432.37497"
+       cy="208.3804"
+       fx="432.37497"
+       fy="208.3804"
+       r="11.138502" />
+    <filter
+       inkscape:collect="always"
+       id="filter15457-0"
+       x="-0.082570113"
+       width="1.1651402"
+       y="-0.18319967"
+       height="1.3663994">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.65779447"
+         id="feGaussianBlur15459-6" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       id="filter15686-8"
+       x="-0.38776687"
+       width="1.7755337"
+       y="-0.42889094"
+       height="1.8577819">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.0502019"
+         id="feGaussianBlur15688-9" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       id="filter15443-2"
+       x="-0.14448161"
+       width="1.2889632"
+       y="-0.17075099"
+       height="1.341502">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.39130435"
+         id="feGaussianBlur15445-6" />
+    </filter>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15471"
+       id="radialGradient40312"
+       gradientUnits="userSpaceOnUse"
+       cx="435.9375"
+       cy="216.1875"
+       fx="435.9375"
+       fy="216.1875"
+       r="1.3125" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15471"
+       id="radialGradient40314"
+       gradientUnits="userSpaceOnUse"
+       cx="435.9375"
+       cy="216.1875"
+       fx="435.9375"
+       fy="216.1875"
+       r="1.3125" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15471"
+       id="radialGradient40316"
+       gradientUnits="userSpaceOnUse"
+       cx="435.9375"
+       cy="216.1875"
+       fx="435.9375"
+       fy="216.1875"
+       r="1.3125" />
+    <filter
+       inkscape:collect="always"
+       id="filter15495-9"
+       x="-0.25458264"
+       width="1.5091653"
+       y="-0.25458264"
+       height="1.5091653">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.27844975"
+         id="feGaussianBlur15497-5" />
+    </filter>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10675"
+       id="radialGradient40318"
+       gradientUnits="userSpaceOnUse"
+       cx="435.9375"
+       cy="216.1875"
+       fx="435.9375"
+       fy="216.1875"
+       r="1.3125" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient14991-1"
+       id="radialGradient40756"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6134673,0,0,1.6134673,-109.12049,-123.08654)"
+       cx="177.875"
+       cy="200.64076"
+       fx="177.875"
+       fy="200.64076"
+       r="21.375" />
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3357">
+      <circle
+         r="20.875"
+         cy="183.625"
+         cx="180.375"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:new"
+         id="path3355"
+         transform="translate(253.75,41.5)" />
+    </clipPath>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15393"
+       id="radialGradient40758"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.564021,0,0,1.564021,-101.59428,-100.04322)"
+       cx="180.125"
+       cy="177.375"
+       fx="180.125"
+       fy="177.375"
+       r="20.875" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15542"
+       id="radialGradient40760"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1377876,0,0,1.1377876,-24.853435,-25.596062)"
+       cx="180.375"
+       cy="185.76465"
+       fx="180.375"
+       fy="185.76465"
+       r="20.875" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15411"
+       id="radialGradient40762"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2658115,0,0,0.66388716,-115.39543,76.530778)"
+       cx="434.125"
+       cy="245.10072"
+       fx="434.125"
+       fy="245.10072"
+       r="17.875" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15740-9"
+       id="radialGradient40764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99979252,0.01748073,-0.02372975,0.99956485,5.2414361,-7.4763272)"
+       cx="433.46475"
+       cy="228.13098"
+       fx="433.46475"
+       fy="228.13098"
+       r="13.78125" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15740-9"
+       id="radialGradient40766"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99979252,0.01748073,-0.02372975,0.99956485,5.2414361,-7.4763272)"
+       cx="433.46475"
+       cy="228.13098"
+       fx="433.46475"
+       fy="228.13098"
+       r="13.78125" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15740-9"
+       id="radialGradient40768"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99979252,0.01748073,-0.02372975,0.99956485,5.2414361,-7.4763272)"
+       cx="433.46475"
+       cy="228.13098"
+       fx="433.46475"
+       fy="228.13098"
+       r="13.78125" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15503"
+       id="radialGradient40770"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.7540107,0,53.856283)"
+       cx="434.75894"
+       cy="229.38165"
+       fx="434.75894"
+       fy="229.38165"
+       r="11.6875" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient14755-8"
+       id="radialGradient40772"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.8926646,0,23.452785)"
+       cx="434.5"
+       cy="218.5"
+       fx="434.5"
+       fy="218.5"
+       r="8.1006193" />
+    <filter
+       inkscape:collect="always"
+       id="filter15583-6">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.37391999"
+         id="feGaussianBlur15585-1" />
+    </filter>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15461"
+       id="radialGradient40774"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1573291,0,0,0.61172259,-68.025181,83.362171)"
+       cx="432.37497"
+       cy="208.3804"
+       fx="432.37497"
+       fy="208.3804"
+       r="11.138502" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15471"
+       id="radialGradient40776"
+       gradientUnits="userSpaceOnUse"
+       cx="435.9375"
+       cy="216.1875"
+       fx="435.9375"
+       fy="216.1875"
+       r="1.3125" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15471"
+       id="radialGradient40778"
+       gradientUnits="userSpaceOnUse"
+       cx="435.9375"
+       cy="216.1875"
+       fx="435.9375"
+       fy="216.1875"
+       r="1.3125" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15471"
+       id="radialGradient40780"
+       gradientUnits="userSpaceOnUse"
+       cx="435.9375"
+       cy="216.1875"
+       fx="435.9375"
+       fy="216.1875"
+       r="1.3125" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15521"
+       id="radialGradient40782"
+       gradientUnits="userSpaceOnUse"
+       cx="435.9375"
+       cy="216.1875"
+       fx="435.9375"
+       fy="216.1875"
+       r="1.3125" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15615"
+       id="radialGradient40784"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5621799,0.41858494,-1.0458455,3.9031476,100.15995,-631.84865)"
+       cx="175.4375"
+       cy="192.46379"
+       fx="175.4375"
+       fy="192.46379"
+       r="4.5625" />
+    <filter
+       inkscape:collect="always"
+       id="filter15639-9"
+       x="-0.58531517"
+       width="2.1706305"
+       y="-0.41554978"
+       height="1.8310996">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="2.2254171"
+         id="feGaussianBlur15641-0" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient17104-4"
+       id="linearGradient2261"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.1888551,0,0.25387938,2.16129,369.22747,-100.96704)"
+       x1="159"
+       y1="86.559517"
+       x2="163.1875"
+       y2="85.622017" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient17104-4"
+       id="linearGradient2263"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.1888551,0,0.25387938,2.16129,369.22747,-100.96704)"
+       x1="159"
+       y1="86.559517"
+       x2="163.1875"
+       y2="85.622017" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.4"
+     inkscape:cx="13.632838"
+     inkscape:cy="13.716278"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1280"
+     inkscape:window-height="746"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid815" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-290.65001)">
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,-79.906631,244.09448)"
+       style="display:inline;enable-background:new"
+       id="g2134">
+      <rect
+         transform="matrix(0.4843708,0,0,0.44465184,159.1022,155.27315)"
+         ry="3.5139852"
+         rx="3.2258344"
+         y="88.75"
+         x="299.375"
+         height="3.125"
+         width="42"
+         id="rect40080"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;marker:none;filter:url(#filter39510-3);enable-background:new" />
+      <path
+         sodipodi:nodetypes="cccccccssssssczccc"
+         inkscape:connector-curvature="0"
+         id="path40082"
+         d="m 308.86915,180.45658 c 0.25877,-1.18913 3.75227,-1.27716 4.0116,0.002 l 2.73968,4.5e-4 0.051,0.18495 3.45784,-0.0117 0.0397,-0.17628 h 1.54229 c 0.62585,-0.21111 0.9505,-0.14744 1.66936,-0.16322 1.42306,-0.0313 2.1194,0.4777 2.1194,0.86828 v 13.6338 c 0,0.39061 -1.14592,0.70509 -2.56931,0.70509 h -14.75948 c -1.42339,0 -2.65951,-0.31448 -2.65951,-0.70509 v -7.61237 c -0.41973,0 -0.97211,-0.16884 -1.00379,-0.85688 -0.0316,-0.68805 0.65613,-0.9487 1.00379,-0.95889 v -4.20566 c 0.61851,-0.82177 2.76112,-0.5476 4.35743,-0.70453 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient40290);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient40292);stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:new" />
+      <path
+         sodipodi:nodetypes="sccccssssssss"
+         inkscape:connector-curvature="0"
+         id="path40084"
+         d="m 307.42521,180.77799 h 7.98084 l 0.0373,0.16922 3.27933,-6.4e-4 0.0272,-0.16958 2.60705,0.002 c 1.34356,6.5e-4 2.4252,0.28775 2.4252,0.64517 v 11.93061 c 0,0.35742 -1.08164,0.64516 -2.42522,0.64516 H 307.42517 C 306.08167,193.99992 305,193.71218 305,193.35476 v -11.9306 c 0,-0.35743 1.08167,-0.64517 2.42524,-0.64517 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient40294);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new" />
+      <path
+         sodipodi:nodetypes="cccccssssssc"
+         inkscape:connector-curvature="0"
+         id="path40086"
+         d="m 307.44336,180.55807 h 8.03306 l 0.0592,0.32384 h 3.29361 l 0.0324,-0.32384 h 2.62627 c 1.35357,0 2.4433,0.53393 2.4433,1.19715 0,0.66326 -0.808,1.19716 -2.4433,1.19716 h -14.04443 c -1.35359,0 -2.46158,0.41362 -2.44329,-1.19716 0.0113,-0.96265 0.86671,-1.19715 2.44325,-1.19715 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient40296);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new"
+         d="m 305.00002,181.63455 v 2.59506 c 0,0.3663 0.55581,0.77039 2.46754,0.77039 h 14.06541 c 2.01347,0 2.27059,-0.40409 2.27059,-0.77039 l -0.021,-2.81403 c -0.15002,0.2596 -0.70738,0.80879 -2.06596,0.80879 h -14.24906 c -1.35854,0 -2.31748,-0.26517 -2.46755,-0.58982 z"
+         id="path40088"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccssccssc" />
+      <path
+         sodipodi:nodetypes="cccscc"
+         inkscape:connector-curvature="0"
+         id="path40090"
+         d="m 323.64482,186.08669 c 0,0 -0.25705,0.43231 -0.92927,0.41266 h -11.58619 c 0,0 -0.20348,1.0934 -1.72311,1.06315 -1.51491,-0.0302 -1.875,-1.15625 -1.875,-1.15625 l -1,0.0312"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.19678716;fill:#3d4447;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;filter:url(#filter16757-8);enable-background:new" />
+      <path
+         sodipodi:nodetypes="cccscccc"
+         inkscape:connector-curvature="0"
+         id="path40092"
+         d="m 323.66457,184.97015 -0.83012,0.55024 -11.67994,-0.059 c -0.2586,0.77163 -1.06006,1.12077 -1.72227,1.12077 -0.5125,0 -1.54508,-0.40313 -1.54508,-1.12077 l -1.43309,-0.0196 C 305.90712,185.41409 305.5,185.00946 305.5,185.00946 l 0.0387,3.10487"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;filter:url(#filter16757-8);enable-background:new" />
+      <circle
+         r="13.875"
+         cy="129.125"
+         cx="91.125"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient40298);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new"
+         id="path40094"
+         transform="matrix(0.10810818,0,0,0.10898656,299.64864,170.41492)" />
+      <g
+         transform="matrix(0.09320585,0,0,0.09210154,300.64953,172.86397)"
+         id="g40096">
+        <circle
+           r="21.375"
+           cy="179.625"
+           cx="177.875"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient40300);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.23782039;marker:none;enable-background:new"
+           id="path40098"
+           transform="matrix(2.7606631,0,0,2.7937637,-310.26526,-332.06033)" />
+        <g
+           transform="translate(191.6935)"
+           id="g40100" />
+        <circle
+           r="34.75"
+           cy="180.5"
+           cx="181.75"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:1;marker:none;enable-background:new"
+           id="path40102"
+           transform="translate(-3.25,-0.75)" />
+        <circle
+           r="21.375"
+           cy="179.625"
+           cx="177.875"
+           transform="matrix(2.2651266,0,0,2.4209276,-222.49828,-261.97598)"
+           id="path40104"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient40302);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.39130434;marker:none;enable-background:new" />
+      </g>
+      <g
+         id="g40148"
+         transform="matrix(0.06541232,0,0,0.0563446,302.7334,176.30555)"
+         style="opacity:0.62248996">
+        <ellipse
+           ry="7.875"
+           rx="20.0625"
+           cy="93.375"
+           cx="67.4375"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.55063653;marker:none;enable-background:new"
+           id="path40150"
+           transform="matrix(1.0882447,0,0,1.1601146,-6.5760037,-20.983578)" />
+        <ellipse
+           ry="7.875"
+           rx="20.0625"
+           cy="93.375"
+           cx="67.4375"
+           transform="matrix(1.3515024,0,0,1.4732754,32.469646,-52.691109)"
+           id="path40152"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.55063653;marker:none;enable-background:new" />
+      </g>
+      <g
+         id="g40154"
+         transform="matrix(0.0733754,0,0,0.07250606,302.20186,174.6392)">
+        <path
+           sodipodi:nodetypes="ccccccsccscscccccccccccccccccccccccccccccccccsccccccccccccccccccccccccccccccccscccccsccsccccccccccccccsc"
+           inkscape:connector-curvature="0"
+           id="path40156"
+           d="m 65.78125,83.1875 -0.0625,0.0625 c -0.316978,0.004 -0.624776,0.02253 -0.9375,0.03125 l -0.09375,-0.0625 c -0.661695,0.02387 -1.29744,0.07882 -1.9375,0.125 V 83.375 c -0.337029,0.02084 -0.669713,0.03625 -1,0.0625 -0.311442,0.02475 -0.632482,0.06432 -0.9375,0.09375 C 60.498603,83.566926 49.68208,83.959772 49.375,84 l -1.8125,0.375 c -0.121408,0.02512 -0.117495,5.065445 -0.09375,5.1875 -0.0068,0.08058 -0.03125,0.168218 -0.03125,0.25 0,0.112106 0.01517,0.233012 0.03125,0.34375 l 0.1875,0.03125 c 0.04583,0.08704 0.09852,0.164298 0.15625,0.25 L 47.53125,90.5 c 0.06967,0.226673 0.17772,0.468236 0.3125,0.6875 l 0.6875,0.03125 c 0.05933,0.05169 0.123761,0.105239 0.1875,0.15625 l -0.625,0.15625 c 0.17032,0.216296 0.394011,0.418081 0.625,0.625 h 1.21875 c 0.02801,0.01525 0.06532,0.01608 0.09375,0.03125 L 49.125,92.53125 c 0.267761,0.204462 0.550245,0.400929 0.875,0.59375 l 1.40625,-0.09375 -0.84375,0.40625 c 0.356707,0.186778 0.747763,0.358226 1.15625,0.53125 L 53.0625,93.8125 52.40625,94.25 c 0.437044,0.165589 0.922872,0.319035 1.40625,0.46875 L 55.0625,94.5 54.625,94.96875 c 0.505082,0.13993 1.017267,0.252806 1.5625,0.375 l 1.15625,-0.28125 -0.21875,0.5 c 0.562874,0.111249 1.121897,0.189528 1.71875,0.28125 L 59.875,95.5 V 96 c 0.604027,0.07913 1.212349,0.12916 1.84375,0.1875 l 0.8125,-0.375 0.21875,0.46875 c 0.64006,0.04619 1.275805,0.101141 1.9375,0.125 l 0.65625,-0.4375 0.4375,0.46875 c 0.32326,0.0055 0.641496,0 0.96875,0 0.327254,0 0.64549,0.0057 0.96875,0 l 0.4375,-0.46875 0.65625,0.4375 c 0.661695,-0.02389 1.29744,-0.07882 1.9375,-0.125 l 0.21875,-0.46875 0.8125,0.375 C 72.412651,96.12915 73.020973,96.079131 73.625,96 v -0.5 l 1.03125,0.34375 c 0.596853,-0.09172 1.155876,-0.170001 1.71875,-0.28125 l -0.21875,-0.5 1.15625,0.28125 c 0.545232,-0.122194 1.057417,-0.23507 1.5625,-0.375 L 78.4375,94.5 l 1.25,0.21875 c 0.483378,-0.149715 0.969205,-0.303161 1.40625,-0.46875 l -0.65625,-0.4375 1.34375,0.15625 c 0.408485,-0.173024 0.799543,-0.344472 1.15625,-0.53125 L 82.09375,93.03125 83.5,93.125 c 0.324754,-0.192821 0.607238,-0.389288 0.875,-0.59375 l -1,-0.375 h 1.40625 c 0.230989,-0.206919 0.45468,-0.408704 0.625,-0.625 l -0.390625,-0.296875 c 0.01704,-0.01427 0.155175,-0.01693 0.0625,-0.03125 L 85.65625,91.1875 c 0.13478,-0.219264 0.242828,-0.460827 0.3125,-0.6875 L 85.828125,90.34375 C 85.893675,90.274465 85.72034,90.163556 85.75,90.109375 l 0.28125,0.04687 c 0.01611,-0.110738 0.03125,-0.231644 0.03125,-0.34375 0,-0.112106 -0.01509,-0.233011 -0.03125,-0.34375 L 85.75,89.421875 c 0.22923,-0.128195 0.03125,-0.167852 0.03125,-0.25 l 0.1875,-0.04687 0.0625,-5.84375 c 0,0 -6.231571,1.658288 -6.34375,1.625 -0.26774,-0.07945 -0.53024,-0.175474 -0.8125,-0.25 -0.06189,-0.01715 -0.124821,-0.04559 -0.1875,-0.0625 -0.440769,-0.113227 -0.902141,-0.211789 -1.375,-0.3125 -0.310827,-0.0662 -0.644979,-0.126995 -0.96875,-0.1875 L 76.375,84.0625 C 75.812126,83.951249 75.253103,83.872976 74.65625,83.78125 L 74.5625,83.8125 c -0.31156,-0.045 -0.61701,-0.08516 -0.9375,-0.125 V 83.625 C 73.020973,83.54587 72.412651,83.495846 71.78125,83.4375 L 71.6875,83.5 C 71.389007,83.47408 71.085536,83.42773 70.78125,83.40625 L 70.75,83.34375 c -0.64006,-0.04617 -1.275805,-0.101141 -1.9375,-0.125 l -0.125,0.0625 c -0.297505,-0.01043 -0.604681,0.0062 -0.90625,0 l -0.0625,-0.09375 c -0.32326,-0.0055 -0.641496,0 -0.96875,0 -0.327254,0 -0.64549,-0.0055 -0.96875,0 z"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#6e6e6e;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;enable-background:new" />
+        <path
+           d="m 68.78125,90.156249 v 6.21875 l 1.934091,-0.09375 0.06591,-6.25 z m 17.1875,-5.96875 v 6.34375 l -0.26477,0.78125 -0.0477,-6.375 z m -0.625,1.0625 v 6.28125 l -0.54602,0.6875 -0.0477,-6.3125 z m -1.03125,0.9375 v 6.28125 l -0.85852,0.6875 -0.0477,-6.3125 z m -1.46875,1 v 6.28125 l -1.01477,0.5 -0.0477,-6.3125 z M 81,88.031249 v 6.28125 l -1.42102,0.4375 -0.0477,-6.3125 z m -2.25,0.6875 v 6.28125 l -1.42102,0.4375 -0.0477,-6.3125 z m -5.124999,1.03125 v 6.21875 l -1.746591,0.28125 -0.06591,-6.25 z m 2.656249,-0.46875 v 6.28125 l -1.65625,0.28125 -0.0625,-6.3125 z m -28.8125,-5.09375 v 6.34375 l 0.264773,0.78125 0.04773,-6.375 z m 0.625,1.0625 v 6.28125 l 0.546023,0.6875 0.04773,-6.3125 z m 1.03125,0.9375 v 6.28125 l 0.858523,0.6875 0.04773,-6.3125 z m 1.46875,1 v 6.28125 l 1.014773,0.5 0.04773,-6.3125 z m 1.84375,0.84375 v 6.28125 l 1.421023,0.4375 0.04773,-6.3125 z m 2.25,0.6875 v 6.28125 l 1.421023,0.4375 0.04773,-6.3125 z m 11.09375,1.46875 v 6.21875 l 1.809091,0.03125 0.06591,-6.25 z m -3.0625,-0.125 v 6.21875 l 1.840341,0.125 0.06591,-6.25 z m -2.90625,-0.3125 v 6.21875 l 1.746591,0.28125 0.06591,-6.25 z m -2.65625,-0.46875 v 6.28125 l 1.65625,0.28125 0.0625,-6.3125 z"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient40324);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;enable-background:new"
+           id="path40158"
+           inkscape:connector-curvature="0" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path40160"
+           d="m 66.749989,76.973039 c -0.326724,0 -0.646711,6.52e-4 -0.969447,0.0062 l -0.430866,0.467398 -0.646298,-0.436648 c -0.660625,0.02383 -1.299872,0.05844 -1.938896,0.104549 l -0.215434,0.479698 -0.825825,-0.393598 c -0.630381,0.05825 -1.246083,0.130099 -1.849132,0.2091 v 0.485847 l -1.005353,-0.344399 c -0.595887,0.09159 -1.179452,0.19028 -1.741416,0.30135 l 0.233386,0.479697 -1.148975,-0.289049 c -0.544351,0.121998 -1.075575,0.253893 -1.579841,0.393598 l 0.448817,0.46125 -1.25669,-0.2214 c -0.482596,0.149474 -0.946025,0.308227 -1.382361,0.473548 l 0.646297,0.430497 -1.346454,-0.153747 c -0.407825,0.172744 -0.792846,0.354724 -1.148975,0.541197 l 0.843779,0.393599 -1.400313,-0.07997 c -0.324231,0.192508 -0.612356,0.392416 -0.879685,0.596548 l 1.005353,0.344399 h -1.418266 c -0.230615,0.206582 -0.440349,0.4175 -0.610393,0.633447 l 1.148975,0.282898 -1.400315,0.0738 c -0.134562,0.218908 -0.235639,0.437893 -0.305195,0.664198 l 1.274645,0.2214 -1.36441,0.147598 c -0.01607,0.110561 -0.01795,0.220175 -0.01795,0.332099 0,0.111924 0.0019,0.221539 0.01795,0.332099 l 1.36441,0.147599 -1.274645,0.221401 c 0.06955,0.226305 0.170633,0.445288 0.305195,0.664198 l 1.400315,0.0738 -1.148975,0.282899 c 0.170044,0.215946 0.379778,0.426864 0.610393,0.633447 h 1.418266 l -1.005353,0.344398 c 0.267329,0.204132 0.555454,0.40404 0.879685,0.596549 l 1.400313,-0.07997 -0.843779,0.393601 c 0.356129,0.186474 0.74115,0.368453 1.148975,0.541197 l 1.346454,-0.153749 -0.646297,0.430497 c 0.436336,0.165321 0.899765,0.324076 1.382361,0.473549 l 1.25669,-0.221398 -0.448817,0.461249 c 0.504266,0.139702 1.03549,0.271599 1.579841,0.393597 l 1.148975,-0.289048 -0.233386,0.479698 c 0.561964,0.111069 1.145529,0.209772 1.741416,0.301346 l 1.005353,-0.344398 v 0.485847 c 0.603049,0.07901 1.218751,0.150854 1.849132,0.2091 l 0.825825,-0.393596 0.215434,0.479697 c 0.639024,0.04611 1.278271,0.08072 1.938896,0.104549 l 0.646298,-0.436649 0.430866,0.4674 c 0.322736,0.0055 0.642723,0.0062 0.969447,0.0062 0.326724,0 0.646711,-4.66e-4 0.969447,-0.0062 l 0.430866,-0.4674 0.646298,0.436649 c 0.660625,-0.02385 1.299872,-0.05844 1.938896,-0.104549 l 0.215434,-0.479697 0.825825,0.393596 c 0.630381,-0.05825 1.246083,-0.130097 1.849132,-0.2091 v -0.485847 l 1.005353,0.344398 c 0.595887,-0.09158 1.179452,-0.190277 1.741416,-0.301346 l -0.233386,-0.479698 1.148976,0.289048 c 0.54435,-0.121998 1.075574,-0.253895 1.579841,-0.393597 l -0.448818,-0.461249 1.25669,0.221398 c 0.482596,-0.149473 0.946023,-0.308228 1.382362,-0.473549 l -0.646298,-0.430497 1.346456,0.153749 c 0.407823,-0.172744 0.792844,-0.354723 1.148973,-0.541197 l -0.843778,-0.393601 1.400313,0.07997 c 0.32423,-0.192509 0.612356,-0.392417 0.879686,-0.596549 l -1.005355,-0.344398 h 1.418266 c 0.230615,-0.206583 0.440349,-0.417501 0.610393,-0.633447 l -1.148975,-0.282899 1.400315,-0.0738 c 0.134562,-0.21891 0.235637,-0.437893 0.305195,-0.664198 l -1.274644,-0.221401 1.364409,-0.147599 c 0.01609,-0.11056 0.01792,-0.220175 0.01792,-0.332099 0,-0.111924 -0.0018,-0.221538 -0.01792,-0.332099 l -1.364409,-0.147598 1.274644,-0.2214 c -0.06955,-0.226305 -0.170633,-0.44529 -0.305195,-0.664198 l -1.400315,-0.0738 1.148975,-0.282898 c -0.170044,-0.215947 -0.379778,-0.426865 -0.610393,-0.633447 h -1.418266 l 1.005355,-0.344399 c -0.26733,-0.204171 -0.555456,-0.404079 -0.879686,-0.596587 l -1.400313,0.07997 0.843778,-0.393601 c -0.356129,-0.186473 -0.74115,-0.368453 -1.148973,-0.541197 l -1.346456,0.153749 0.646298,-0.430498 c -0.436339,-0.165325 -0.899766,-0.324078 -1.382362,-0.473552 l -1.25669,0.2214 0.448818,-0.461249 C 78.36382,78.297034 77.832596,78.165138 77.288246,78.04314 l -1.148976,0.289049 0.233386,-0.479697 C 75.810692,77.741421 75.227127,77.64272 74.63124,77.551142 l -1.005353,0.344399 v -0.485848 c -0.603049,-0.07901 -1.218751,-0.150847 -1.849132,-0.209099 l -0.825825,0.393598 -0.215434,-0.479697 c -0.639024,-0.04609 -1.278271,-0.08073 -1.938896,-0.104549 l -0.646298,0.436648 -0.430866,-0.467398 c -0.322736,-0.0055 -0.642723,-0.0062 -0.969447,-0.0062 z"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient40326);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.55063653;marker:none;enable-background:new" />
+      </g>
+      <g
+         id="g40162"
+         transform="matrix(0.08586683,0,0,0.0757837,302.30394,174.57139)">
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="path40164"
+           d="m 148.0523,78.996815 h 47.52668 l 0.29901,18.049575 h -47.89563 z"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient40328);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.55063653;marker:none;filter:url(#filter16757-8);enable-background:new" />
+        <ellipse
+           ry="1.5625"
+           rx="3.4375"
+           cy="87.5625"
+           cx="182.6875"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.55063653;marker:none;filter:url(#filter16757-8);enable-background:new"
+           id="path40166"
+           transform="matrix(2.3247463,0,0,2.7306413,-252.74579,-152.6676)" />
+        <ellipse
+           ry="1.5625"
+           rx="3.4375"
+           cy="87.5625"
+           cx="182.6875"
+           transform="matrix(1.9670931,0,0,2.2366265,-187.407,-112.9952)"
+           id="path40168"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient40330);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.39318216;marker:none;filter:url(#filter16757-8);enable-background:new" />
+        <g
+           clip-path="none"
+           id="g40170"
+           transform="translate(-6.10467)">
+          <path
+             sodipodi:nodetypes="cscccsccc"
+             inkscape:connector-curvature="0"
+             id="path40172"
+             d="m 200.45155,93.616606 c 0,0 0.77842,-0.585956 0.73819,-1.148184 -0.0571,-0.7989 0.19868,-1.914281 -1.21478,-1.88032 l -5.93136,-0.007 0.0831,-15.479248 4.67206,-0.123484 c 3.44573,-0.09107 3.17399,3.095707 3.17399,3.095707 l 0.0621,15.542543 z"
+             style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient2261);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.55063653;marker:none;filter:url(#filter16757-8);enable-background:new"
+             clip-path="none" />
+        </g>
+        <g
+           transform="matrix(-1,0,0,1,349.88904,0)"
+           id="g40174"
+           clip-path="none">
+          <path
+             clip-path="none"
+             style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient2263);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.55063653;marker:none;filter:url(#filter16757-8);enable-background:new"
+             d="m 200.45155,93.616606 c 0,0 0.77842,-0.585956 0.73819,-1.148184 -0.0571,-0.7989 0.19868,-1.914281 -1.21478,-1.88032 l -5.93136,-0.007 0.0831,-15.479248 4.67206,-0.123484 c 3.44573,-0.09107 3.17399,3.095707 3.17399,3.095707 l 0.0621,15.542543 z"
+             id="path40176"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cscccsccc" />
+        </g>
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#343431;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter16757-8);enable-background:new"
+           id="rect40178"
+           width="1.0390625"
+           height="1.0625"
+           x="319.99219"
+           y="131.99219"
+           transform="matrix(7.9913144,0,0,9.0247878,-2409.2382,-1103.2504)" />
+        <rect
+           y="87.95108"
+           x="187.56439"
+           height="9.5888367"
+           width="8.3034754"
+           id="rect40180"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#343431;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter16757-8);enable-background:new" />
+      </g>
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient40336);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.55063653;marker:none;filter:url(#filter16757-8);enable-background:new"
+         d="m 305.0104,181.242 c -0.0998,0.69457 0.49889,1.758 2.65164,1.758 h 13.69948 c 2.27587,0 2.4878,-1.1317 2.4385,-1.68314 -0.43349,0.46143 -1.06362,0.8322 -2.26763,0.82903 l -14.34429,-0.0378 c -1.07155,0 -1.95216,-0.0562 -2.1777,-0.86595 z"
+         id="path40182"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccsccc" />
+      <g
+         id="g40184"
+         transform="matrix(0.12459214,0,0,0.12311595,296.26494,169.47291)">
+        <path
+           sodipodi:nodetypes="cscccc"
+           inkscape:connector-curvature="0"
+           id="path40186"
+           d="m 131.24745,93.17657 c 0,2.946928 -6.43477,5.335883 -14.37245,5.335883 -7.93768,0 -14.37245,-2.388955 -14.37245,-5.335883 l 0.024,-3.761282 c 5.92362,-1.083512 24.76402,-2.408931 28.68965,0.08894 z"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient40338);fill-opacity:1;fill-rule:nonzero;stroke:url(#radialGradient40340);stroke-width:7.87914085;marker:none;enable-background:new" />
+        <path
+           transform="matrix(0.77181208,0,0,0.81027362,63.52349,22.092153)"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient40342);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new"
+           d="m 87.75,83.5 c 0,3.589851 -8.338697,6.5 -18.625,6.5 -1.638298,0 -3.227192,-0.07382 -4.74086,-0.212453 -0.451666,-0.04137 -1.949351,2.22553 -2.386934,2.172862 -2.294524,-0.276172 -5.519718,-1.3215 -7.309283,-1.867316 C 54.049947,89.898511 55.636757,87.99203 55.080008,87.76913 52.227558,86.627121 50.5,85.133968 50.5,83.5 50.5,79.910149 58.838697,77 69.125,77 79.411303,77 87.75,79.910149 87.75,83.5 Z"
+           id="path40188"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sssssssss" />
+        <ellipse
+           ry="6.5"
+           rx="18.625"
+           cy="83.5"
+           cx="69.125"
+           transform="matrix(0.5986146,0,0,0.52908864,75.500102,45.349421)"
+           id="path40190"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1566265;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new" />
+        <ellipse
+           ry="6.5"
+           rx="18.625"
+           cy="83.5"
+           cx="69.125"
+           clip-path="url(#clipPath16743-2)"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient40344);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient40346);stroke-width:8.85361671;stroke-opacity:1;marker:none;filter:url(#filter17616-4);enable-background:new"
+           id="path40192"
+           transform="matrix(0.62173444,0,0,0.60969687,73.901936,38.511654)" />
+        <path
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#b2bcbf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.55063653;marker:none;filter:url(#filter16757-8);enable-background:new"
+           d="m 105.5625,94.968749 0.1875,4.34375 1.15618,0.281556 0.6369,-0.15659 0.0455,0.310909 1.48819,0.366616 0.68051,-0.0975 0.0701,0.28245 1.73512,0.40321 -0.0625,-4.109375 -1.43385,-0.331238 -0.29575,-0.454289 -0.6559,0.154887 -1.23674,-0.316959 -0.3153,-0.463924 -0.72705,0.134899 z"
+           id="path40194"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccccccccccc" />
+        <path
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#86949a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.55063653;marker:none;filter:url(#filter16757-8);enable-background:new"
+           d="m 113.0625,94.8125 -1.6875,1.875 0.17187,3.9375 1.79688,-1.96875 z"
+           id="path40196"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#86949a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.55063653;marker:none;filter:url(#filter16757-8);enable-background:new"
+           d="m 109.125,95.984374 c 0,0 -0.0625,4.156246 0,4.124996 0.0625,-0.0312 0.64063,-0.0625 0.64063,-0.0625 v -4.234371 z"
+           id="path40198"
+           inkscape:connector-curvature="0" />
+        <path
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#86949a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.55063653;marker:none;filter:url(#filter16757-8);enable-background:new"
+           d="m 106.85938,95.312499 0.0937,4.328125 0.57812,-0.171875 v -4.28125 z"
+           id="path40200"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         style="fill:#b5b5b5;fill-opacity:1"
+         id="g40202"
+         transform="matrix(0.05878954,0,0,0.058093,304.30177,178.19503)">
+        <ellipse
+           ry="8.485281"
+           rx="4.8171649"
+           cy="136.03961"
+           cx="19.312855"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#555753;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.36723092;marker:none;filter:url(#filter16757-8);enable-background:new"
+           id="path40204"
+           transform="matrix(1.4771982,0,0,2.190837,-9.1975756,-163.34521)" />
+        <path
+           sodipodi:nodetypes="cscssccccsssss"
+           inkscape:connector-curvature="0"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#888a85;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.55063653;marker:none;filter:url(#filter16757-8);enable-background:new"
+           d="m 2.0345725,123.24512 c -5.2638925,0.073 -10.0270858,5.33998 -10.0270858,11.60623 0,6.20492 4.6858713,11.05474 9.8782949,11.22378 0,0.0876 0.074939,0.13241 0.1487909,0.13241 H 18.445704 c 0.07385,0 0.140918,-0.0452 0.148791,-0.13241 1.682021,-7.94066 1.505093,-16.33601 -0.148791,-22.83001 H 2.1461657 Z m 1.5664051,5.60815 c 2.6147908,0 4.7241108,2.5482 4.7241108,5.6523 0,3.10411 -2.10932,5.60815 -4.7241108,5.60815 -2.61479075,0 -4.7241111,-2.50404 -4.7241111,-5.60815 0,-3.1041 2.10932035,-5.6523 4.7241111,-5.6523 z"
+           id="path40206" />
+      </g>
+      <g
+         transform="matrix(0.11691937,0,0,0.10841766,307.93331,171.07736)"
+         id="g40208">
+        <path
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient40348);fill-opacity:1;fill-rule:nonzero;stroke:url(#radialGradient40350);stroke-width:8.58092976;marker:none;enable-background:new"
+           d="m 133.9932,91.863117 c 0,2.78013 -6.78438,5.033868 -15.15335,5.033868 -8.36897,0 -15.15337,-2.253738 -15.15337,-5.033868 l 0.0253,-2.310179 c 6.24547,-1.022185 26.10956,-2.272584 30.24849,0.0839 z"
+           id="path40210"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cscccc" />
+        <ellipse
+           ry="6.5"
+           rx="18.625"
+           cy="83.5"
+           cx="69.125"
+           transform="matrix(0.83216922,0,0,0.76441155,61.659204,26.51204)"
+           id="path40212"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient40352);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new" />
+        <ellipse
+           ry="6.5"
+           rx="18.625"
+           cy="83.5"
+           cx="69.125"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient40354);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.6043182;marker:none;enable-background:new"
+           id="path40214"
+           transform="matrix(0.83216922,0,0,0.76441155,61.659204,25.804491)" />
+      </g>
+      <g
+         id="g40216"
+         transform="matrix(0.6959887,0,0,0.69369941,78.403953,89.741351)">
+        <circle
+           r="21.375"
+           cy="179.625"
+           cx="177.875"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.36546188;fill:url(#radialGradient40356);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.23782039;marker:none;enable-background:new"
+           id="path40218"
+           transform="matrix(0.30409367,0,0,0.32276408,289.40934,84.800815)" />
+        <circle
+           r="21.375"
+           cy="179.625"
+           cx="177.875"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.21686748;fill:url(#radialGradient40360);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.23782039;marker:none;enable-background:new"
+           id="path40222"
+           transform="matrix(0.19941026,0,0,0.1976979,307.9954,108.34768)" />
+        <g
+           id="g40224"
+           transform="matrix(0.22248424,0,0,0.22057355,303.72415,104.04207)"
+           style="display:inline;enable-background:new">
+          <circle
+             r="21.375"
+             cy="179.625"
+             cx="177.875"
+             transform="matrix(1.3595805,0,0,1.3758832,-62.90033,-66.864528)"
+             id="path40226"
+             style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient40362);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.23782039;marker:none;enable-background:new" />
+        </g>
+      </g>
+      <path
+         d="m 309,184.48153 h 1.0172 V 185 H 309 Z m 0,-0.44724 h 0.49302 V 185 H 309 Z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:0.77828058;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter16757-8);enable-background:new"
+         id="path40286"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccc" />
+      <ellipse
+         ry="0.72920388"
+         rx="0.629767"
+         cy="71.471924"
+         cx="298.47641"
+         id="path40288"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter16757-8);enable-background:new"
+         transform="matrix(0.44738105,0,0,0.44465184,170.90345,154.22909)" />
+      <g
+         transform="matrix(0.10390539,0,0,0.10267431,298.91185,171.32031)"
+         id="g40106">
+        <circle
+           r="8.6875"
+           cy="117.3125"
+           cx="134.8125"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient40304);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter10697-7);enable-background:new"
+           id="path40108" />
+        <g
+           id="g40110"
+           transform="matrix(1.4358974,0,0,1.4358974,-58.253203,-162.39102)">
+          <g
+             transform="matrix(0.23353293,0,0,0.23353293,33.11751,142.17589)"
+             clip-path="url(#clipPath15654-6)"
+             id="g40112">
+            <circle
+               r="20.875"
+               cy="183.625"
+               cx="180.375"
+               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient40306);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:new"
+               id="path40114"
+               transform="translate(253.75,41.5)" />
+            <circle
+               r="20.875"
+               cy="183.625"
+               cx="180.375"
+               transform="translate(253.75,41.5)"
+               id="path40116"
+               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient40308);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:new" />
+            <g
+               transform="translate(0,6)"
+               id="g40118" />
+            <g
+               transform="matrix(1.6142312,0,0,1.6142312,-266.72989,-129.0727)"
+               id="g40120">
+              <ellipse
+                 ry="8.8125"
+                 rx="11.6875"
+                 cy="218.9375"
+                 cx="435.0625"
+                 style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#191025;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:new"
+                 id="path40122"
+                 transform="matrix(0.82352941,0,0,1,76.213235,4)" />
+              <circle
+                 r="5.5"
+                 cy="218.5"
+                 cx="434.5"
+                 transform="matrix(0.89521013,0,0,0.89521013,45.531166,23.965053)"
+                 id="path40124"
+                 style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:new" />
+              <path
+                 sodipodi:nodetypes="cssscscc"
+                 inkscape:connector-curvature="0"
+                 style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient40310);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;filter:url(#filter15457-0);enable-background:new"
+                 d="m 424.58196,217.89188 c -0.007,-0.13515 -0.0168,-0.26536 -0.0168,-0.40215 0,-4.53716 4.34257,-8.77776 9.62229,-8.77776 5.27973,0 9.4973,4.2406 9.4973,8.77776 0,0.13679 -0.009,0.267 -0.0168,0.40215 -0.2474,-4.34766 -4.48503,-6.62561 -9.60557,-6.62561 -5.12056,0 -9.23319,2.27795 -9.48059,6.62561 z"
+                 id="path40126" />
+              <g
+                 transform="matrix(0.8813906,0,0,0.8813906,53.848934,25.653047)"
+                 id="g40128">
+                <ellipse
+                   ry="2.75"
+                   rx="3.25"
+                   cy="224.25"
+                   cx="449.5"
+                   style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c2c2c2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;filter:url(#filter15686-8);enable-background:new"
+                   id="path40130"
+                   transform="matrix(1.1582075,-0.27647923,0,1.1582075,-91.614292,75.799371)" />
+                <ellipse
+                   ry="2.75"
+                   rx="3.25"
+                   cy="224.25"
+                   cx="449.5"
+                   transform="matrix(0.68852991,-0.16436106,0,0.68852991,119.5058,130.72746)"
+                   id="path40132"
+                   style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;filter:url(#filter15443-2);enable-background:new" />
+              </g>
+              <circle
+                 r="1.3125"
+                 cy="216.1875"
+                 cx="435.9375"
+                 transform="translate(0,0.125)"
+                 id="path40134"
+                 style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient40312);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:new" />
+              <circle
+                 r="1.3125"
+                 cy="216.1875"
+                 cx="435.9375"
+                 transform="matrix(2.1428571,0,0,1,-499.58929,5.625)"
+                 style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient40314);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:new"
+                 id="path40136" />
+              <circle
+                 r="1.3125"
+                 cy="216.1875"
+                 cx="435.9375"
+                 id="path40138"
+                 style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient40316);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;filter:url(#filter15495-9);enable-background:new"
+                 transform="matrix(2.2783632,0,0,1.8444445,-559.16152,-172.43334)" />
+            </g>
+            <circle
+               r="1.3125"
+               cy="216.1875"
+               cx="435.9375"
+               id="path40140"
+               style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.59036147;fill:url(#radialGradient40318);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;filter:url(#filter15495-9);enable-background:new"
+               transform="matrix(7.493765,0,0,7.5561904,-2832.4578,-1398.5463)" />
+          </g>
+        </g>
+        <ellipse
+           ry="1.125"
+           rx="0.0625"
+           cy="107.125"
+           cx="125.8125"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#6c6c6c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new"
+           id="path40142" />
+      </g>
+      <g
+         id="g40694"
+         transform="matrix(0.5114622,0,0,0.53868378,141.61361,111.7436)">
+        <circle
+           r="21.375"
+           cy="179.625"
+           cx="177.875"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.21686748;fill:url(#radialGradient40756);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.23782039;marker:none;enable-background:new"
+           id="path40696"
+           transform="matrix(0.19941026,0,0,0.1976979,307.9954,108.34768)" />
+        <g
+           id="g40698"
+           transform="matrix(0.22248424,0,0,0.22057355,303.72415,104.04207)"
+           style="display:inline;enable-background:new" />
+        <g
+           id="g40700"
+           clip-path="url(#clipPath15654-6)"
+           transform="matrix(0.24600577,0,0,0.22599566,237.33949,93.391177)"
+           style="display:inline;enable-background:new">
+          <circle
+             r="20.875"
+             cy="183.625"
+             cx="180.375"
+             transform="translate(253.75,41.5)"
+             id="path40702"
+             style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient40758);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:new" />
+          <circle
+             r="20.875"
+             cy="183.625"
+             cx="180.375"
+             style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient40760);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:new"
+             id="path40704"
+             transform="translate(253.75,41.5)" />
+          <path
+             sodipodi:nodetypes="cssscscc"
+             inkscape:connector-curvature="0"
+             id="path40706"
+             d="m 416.28125,224.25 c -0.0144,0.29405 -0.0312,0.57738 -0.0312,0.875 0,9.87209 8.00291,17.875 17.875,17.875 9.87209,0 17.875,-8.00291 17.875,-17.875 0,-0.29762 -0.0169,-0.58095 -0.0312,-0.875 -0.54795,11.20559 -7.26928,17.75 -17.84375,17.75 -11.69947,0 -17.38117,-8.29024 -17.84375,-17.75 z"
+             style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient40762);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:new" />
+          <g
+             id="g40708"
+             transform="translate(0,6)">
+            <ellipse
+               ry="10.96875"
+               rx="13.78125"
+               cy="217.09375"
+               cx="433.09375"
+               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#5d388a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:new"
+               id="path40710"
+               transform="matrix(1.1466993,0,0,1.3361824,-62.597034,-73.170584)" />
+            <ellipse
+               ry="10.96875"
+               rx="13.78125"
+               cy="217.09375"
+               cx="433.09375"
+               transform="matrix(1.1466993,0,0,1.3361824,-62.597034,-73.545584)"
+               id="path40712"
+               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient40764);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:new" />
+            <ellipse
+               ry="10.96875"
+               rx="13.78125"
+               cy="217.09375"
+               cx="433.09375"
+               transform="matrix(1.1466993,0,0,1.3361824,-62.597034,-75.045584)"
+               id="path40714"
+               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#5d388a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:new" />
+            <ellipse
+               ry="10.96875"
+               rx="13.78125"
+               cy="217.09375"
+               cx="433.09375"
+               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient40766);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:new"
+               id="path40716"
+               transform="matrix(1.1466993,0,0,1.3361824,-62.597034,-75.420584)" />
+            <ellipse
+               ry="10.96875"
+               rx="13.78125"
+               cy="217.09375"
+               cx="433.09375"
+               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#5d388a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:new"
+               id="path40718"
+               transform="matrix(1.1466993,0,0,1.3361824,-62.597034,-77.170584)" />
+            <ellipse
+               ry="10.96875"
+               rx="13.78125"
+               cy="217.09375"
+               cx="433.09375"
+               transform="matrix(1.1466993,0,0,1.3361824,-62.597034,-77.545584)"
+               id="path40720"
+               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient40768);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:new" />
+          </g>
+          <g
+             id="g40722"
+             transform="translate(0,-3)">
+            <ellipse
+               ry="8.8125"
+               rx="11.6875"
+               cy="218.9375"
+               cx="435.0625"
+               transform="matrix(0.82352941,0,0,1,76.213235,4)"
+               id="path40724"
+               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#191025;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:new" />
+            <ellipse
+               ry="8.8125"
+               rx="11.6875"
+               cy="218.9375"
+               cx="435.0625"
+               transform="matrix(0.82352941,0,0,1,76.213235,0.5)"
+               id="path40726"
+               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient40770);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:new" />
+            <ellipse
+               ry="8.8125"
+               rx="11.6875"
+               cy="218.9375"
+               cx="435.0625"
+               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#191025;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:new"
+               id="path40728"
+               transform="matrix(0.82352941,0,0,1,76.213235,0)" />
+            <circle
+               r="5.5"
+               cy="218.5"
+               cx="434.5"
+               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:new"
+               id="path40730"
+               transform="matrix(1.1363636,0,0,1.1363636,-59.25,-31.545455)" />
+            <circle
+               r="5.5"
+               cy="218.5"
+               cx="434.5"
+               transform="matrix(3.2691675,0,0,1.9290405,-986.20332,-206.87037)"
+               id="path40732"
+               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient40772);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;filter:url(#filter15583-6);enable-background:new" />
+            <path
+               transform="matrix(1.6902415,0,0,1.6902415,-299.65104,-147.22983)"
+               id="path40734"
+               d="m 424.58196,217.89188 c -0.007,-0.13515 -0.0168,-0.26536 -0.0168,-0.40215 0,-4.53716 4.34257,-8.77776 9.62229,-8.77776 5.27973,0 9.4973,4.2406 9.4973,8.77776 0,0.13679 -0.009,0.267 -0.0168,0.40215 -0.2474,-4.34766 -4.48503,-6.62561 -9.60557,-6.62561 -5.12056,0 -9.23319,2.27795 -9.48059,6.62561 z"
+               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient40774);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;filter:url(#filter15457-0);enable-background:new"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="cssscscc" />
+            <g
+               id="g40736"
+               transform="matrix(1.6049394,0,0,1.6049394,-256.89419,-125.84524)">
+              <ellipse
+                 ry="2.75"
+                 rx="3.25"
+                 cy="224.25"
+                 cx="449.5"
+                 transform="matrix(1.1582075,-0.27647923,0,1.1582075,-91.614292,75.799371)"
+                 id="path40738"
+                 style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#88fc95;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;filter:url(#filter15686-8);enable-background:new" />
+              <ellipse
+                 ry="2.75"
+                 rx="3.25"
+                 cy="224.25"
+                 cx="449.5"
+                 style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;filter:url(#filter15443-2);enable-background:new"
+                 id="path40740"
+                 transform="matrix(0.68852991,-0.16436106,0,0.68852991,119.5058,130.72746)" />
+            </g>
+            <circle
+               r="1.3125"
+               cy="216.1875"
+               cx="435.9375"
+               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient40776);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:new"
+               id="path40742"
+               transform="translate(0,0.125)" />
+            <circle
+               r="1.3125"
+               cy="216.1875"
+               cx="435.9375"
+               id="path40744"
+               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient40778);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:new"
+               transform="matrix(2.1428571,0,0,1,-499.58929,5.625)" />
+            <circle
+               r="1.3125"
+               cy="216.1875"
+               cx="435.9375"
+               transform="matrix(3.9523809,0,0,1.8444445,-1288.9286,-172.43334)"
+               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient40780);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;filter:url(#filter15495-9);enable-background:new"
+               id="path40746" />
+          </g>
+          <circle
+             r="1.3125"
+             cy="216.1875"
+             cx="435.9375"
+             transform="matrix(5.7373015,0,0,7.5561904,-2066.7495,-1398.5463)"
+             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.59036147;fill:url(#radialGradient40782);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;filter:url(#filter15495-9);enable-background:new"
+             id="path40748" />
+          <circle
+             r="1.3125"
+             cy="216.1875"
+             cx="435.9375"
+             id="path40750"
+             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.24899597;fill:#499ef8;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;filter:url(#filter15495-9);enable-background:new"
+             transform="matrix(10.722713,0,0,7.5561904,-4240.0773,-1405.5463)" />
+        </g>
+        <path
+           transform="matrix(0.21927317,0,0,0.25056504,304.79772,97.717401)"
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="path40752"
+           d="m 174.125,182.625 c 1.34416,1.17916 2.10534,0.81834 3.125,0.375 l 1.125,12.25 c -4.17383,0.70093 -6.75,-0.25 -9.125,-2.375 z"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.86345382;fill:url(#radialGradient40784);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;filter:url(#filter15639-9);enable-background:new" />
+        <circle
+           r="4.515625"
+           cy="79.203125"
+           cx="326.35938"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#000000;stroke-width:1.50520718;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;filter:url(#filter16757-8);enable-background:new"
+           id="path40754"
+           transform="matrix(1.2989437,0,0,1.2333025,-80.033138,46.663751)" />
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
these icons are the official icons of the gnome apps (sources):

* https://github.com/GNOME/gnome-contacts/blob/master/data/icons/hicolor/org.gnome.Contacts.svg
* https://github.com/GNOME/gnome-calendar/blob/master/data/icons/org.gnome.Calendar.svg
* https://github.com/GNOME/gnome-documents/blob/master/data/icons/hicolor_org.gnome.Documents.svg
* https://github.com/GNOME/gnome-maps/blob/master/data/icons/org.gnome.Maps.svg
* https://github.com/GNOME/gnome-photos/blob/master/data/icons/hicolor_org.gnome.Photos.svg
* https://github.com/GNOME/evolution/blob/master/data/icons/hicolor_apps_scalable_evolution.svg