### PR TITLE
Optimize parse params. Return defaults if params not defined

### DIFF
--- a/js/misc/params.js
+++ b/js/misc/params.js
@@ -15,10 +15,10 @@
 // Return value: a new object, containing the merged parameters from
 // @params and @defaults
 function parse(params, defaults, allowExtras) {
-    let ret = {}, prop;
+    let ret = {};
 
     if (!params)
-        params = {};
+        return defaults;
 
     for (let prop in params) {
         if (!(prop in defaults) && !allowExtras)


### PR DESCRIPTION
If `params` is `null`, than we can to avoid `for loop` and just return `default`. Result is same.