### PR TITLE
Simplify getting timestamp in DebugTimers

### DIFF
--- a/js/misc/timers.js
+++ b/js/misc/timers.js
@@ -12,14 +12,12 @@ DebugTimer.prototype = {
     },
 
     start: function() {
-        let date = new Date();
-        this.start_time = date.getTime();
+        this.start_time = Date.now();
         log("Debug timer __" + this.name + "__ started.");
     },
 
     stop: function() {
-        let date = new Date();
-        let diff = date.getTime() - this.start_time;
+        let diff = Date.now() - this.start_time;
         log("Debug timer __" + this.name + "__ stopped at * " + diff.toString() + "ms *")
         this.start_time = 0;
     }


### PR DESCRIPTION
Use static method `Date.now()` instead of `new Date().getTime()`.