### PR TITLE
Menu applet: don't hardcode favorites button padding

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -1038,7 +1038,7 @@ StScrollBar StButton#vhandle:hover {
 .menu-background {
 }
 .menu-favorites-box {
-    padding: 10px;
+    padding: 0.8em;
     border: 1px solid #666;
     border-radius: 8px;
     background-gradient-direction: vertical;
@@ -1047,10 +1047,7 @@ StScrollBar StButton#vhandle:hover {
     transition-duration: 300;
 }
 .menu-favorites-button {
-    padding-top: 10px;
-    padding-left: 10px;
-    padding-right: 10px;
-    padding-bottom: 10px;
+    padding: 0.8em;
 }
 .menu-favorites-button:hover {
     color: white;
@@ -1060,16 +1057,7 @@ StScrollBar StButton#vhandle:hover {
     box-shadow: inset 0px 0px 1px 1px rgba(255,255,255,0.06);
     border-radius: 4px;
 }
-.menu-places-box {
-    padding: 10px;
-    border: 0px solid #666;
-}
-.menu-places-button {
-    padding-top: 10px;
-    padding-left: 10px;
-    padding-right: 10px;
-    padding-bottom: 10px;
-}
+
 .menu-categories-box {
     padding-top: 10px;
     padding-left: 30px;

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -857,7 +857,6 @@ class FavoritesButton extends GenericApplicationButton {
         let icon_size = 0.6 * real_size / global.ui_scale;
         if (icon_size > MAX_FAV_ICON_SIZE)
             icon_size = MAX_FAV_ICON_SIZE;
-        this.actor.style = "padding-top: "+(icon_size / 3)+"px;padding-bottom: "+(icon_size / 3)+"px;";
 
         this.actor.add_style_class_name('menu-favorites-button');
         let icon = app.create_icon_texture(icon_size);
@@ -901,7 +900,6 @@ class SystemButton extends PopupMenu.PopupBaseMenuItem {
         let icon_size = 0.6 * real_size / global.ui_scale;
         if (icon_size > MAX_FAV_ICON_SIZE)
             icon_size = MAX_FAV_ICON_SIZE;
-        this.actor.style = "padding-top: "+(icon_size / 3)+"px;padding-bottom: "+(icon_size / 3)+"px;";
         this.actor.add_style_class_name('menu-favorites-button');
 
         let iconObj = new St.Icon({icon_name: icon, icon_size: icon_size, icon_type: St.IconType.FULLCOLOR});


### PR DESCRIPTION
Let the theme define both horizontal and vertical paddings.
This means more easy theming and less calculations.

Themes don't have to do anything because, although it was ignored, most of them already defined the vertical padding they wanted, Mint-Y being one of the exceptions.