### PR TITLE
CSD System Settings

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
@@ -187,11 +187,11 @@ class MainWindow:
     def __init__(self):
         self.builder = Gtk.Builder()
         self.builder.add_from_file(config.currentPath + "/cinnamon-settings.ui")
-        self.window = XApp.GtkWindow(window_position=Gtk.WindowPosition.CENTER,
-                                     default_width=800, default_height=600)
+        self.window = self.builder.get_object('MainWind')
         main_box = self.builder.get_object("main_box")
         self.window.add(main_box)
         self.top_bar = self.builder.get_object("top_bar")
+        self.title_lbl = self.builder.get_object("title_lbl")
         self.side_view = {}
         self.main_stack = self.builder.get_object("main_stack")
         self.main_stack.set_transition_type(Gtk.StackTransitionType.CROSSFADE)
@@ -307,6 +307,7 @@ class MainWindow:
 
         # set up larger components.
         self.window.set_title(_("System Settings"))
+        self.title_lbl.set_label(self.window.get_title())
         self.button_back.connect('clicked', self.back_to_icon_view)
 
         self.calculate_bar_heights()

--- a/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.ui
+++ b/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.ui
@@ -1,123 +1,124 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.16.1 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.0"/>
+  <object class="GtkWindow" id="MainWind">
+    <property name="can_focus">False</property>
+    <property name="default_width">800</property>
+    <property name="default_height">600</property>
+    <child type="titlebar">
+      <object class="GtkHeaderBar" id="top_bar">
+        <property name="visible">True</property>
+        <property name="app_paintable">True</property>
+        <property name="can_focus">False</property>
+        <property name="valign">start</property>
+        <property name="show_close_button">True</property>
+        <child type="title">
+          <object class="GtkStack" id="header_stack">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="hexpand">True</property>
+            <child>
+              <object class="GtkBox" id="hbox2">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="border_width">1</property>
+                <child type="center">
+                  <object class="GtkLabel" id="title_lbl">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkEntry" id="search_box">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="halign">start</property>
+                    <property name="invisible_char">●</property>
+                    <property name="width_chars">25</property>
+                    <property name="caps_lock_warning">False</property>
+                    <property name="primary_icon_name">edit-find-symbolic</property>
+                    <property name="secondary_icon_name">edit-clear-symbolic</property>
+                    <property name="placeholder_text">Search...</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="pack_type">end</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="name">side_view</property>
+                <property name="title" translatable="yes">side_view</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="box2">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="border_width">1</property>
+                <child>
+                  <object class="GtkButton" id="button_back">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="focus_on_click">False</property>
+                    <property name="receives_default">True</property>
+                    <child>
+                      <object class="GtkImage" id="image1">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="icon_name">go-previous-symbolic</property>
+                      </object>
+                    </child>
+                    <style>
+                      <class name="raised"/>
+                      <class name="image-button"/>
+                    </style>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkStackSwitcher" id="stack_switcher">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">center</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="name">content_box</property>
+                <property name="title" translatable="yes">content_box</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
       <object class="GtkBox" id="main_box">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
+        <property name="baseline_position">top</property>
         <child>
-          <object class="GtkToolbar" id="top_bar">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="toolbar_style">icons</property>
-            <child>
-              <object class="GtkToolItem" id="toolbutton1">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="valign">center</property>
-                <child>
-                  <object class="GtkStack" id="header_stack">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <child>
-                      <object class="GtkBox" id="hbox2">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="border_width">1</property>
-                        <child>
-                          <object class="GtkEntry" id="search_box">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="halign">start</property>
-                            <property name="invisible_char">●</property>
-                            <property name="width_chars">25</property>
-                            <property name="caps_lock_warning">False</property>
-                            <property name="primary_icon_name">edit-find-symbolic</property>
-                            <property name="secondary_icon_name">edit-clear-symbolic</property>
-                            <property name="placeholder_text">Search...</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="pack_type">end</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="title">side_view</property>
-                        <property name="name">side_view</property>
-                        <property name="position">2</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkBox" id="box2">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="border_width">1</property>
-                        <child>
-                          <object class="GtkButton" id="button_back">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">True</property>
-                            <property name="focus_on_click">False</property>
-                            <child>
-                              <object class="GtkImage" id="image1">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="icon_name">go-previous-symbolic</property>
-                              </object>
-                            </child>
-                            <style>
-                              <class name="raised"/>
-                              <class name="image-button"/>
-                            </style>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkStackSwitcher" id="stack_switcher">
-                            <property name="visible">True</property>
-                            <property name="halign">center</property>
-                            <property name="homogeneous">True</property>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="title">content_box</property>
-                        <property name="name">content_box</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                  </object>
-                </child>
-                <style>
-                  <class name="raised"/>
-                </style>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="homogeneous">False</property>
-              </packing>
-            </child>
-            <style>
-              <class name="primary-toolbar"/>
-            </style>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
+          <placeholder/>
         </child>
         <child>
           <object class="GtkStack" id="main_stack">
@@ -152,9 +153,8 @@
                 </child>
               </object>
               <packing>
-                <property name="title">Hello World</property>
                 <property name="name">side_view_page</property>
-                <property name="position">1</property>
+                <property name="title" translatable="yes">Hi Mint</property>
               </packing>
             </child>
             <child>
@@ -188,7 +188,7 @@
               </object>
               <packing>
                 <property name="name">content_box_page</property>
-                <property name="position">2</property>
+                <property name="position">1</property>
               </packing>
             </child>
           </object>
@@ -199,4 +199,6 @@
           </packing>
         </child>
       </object>
+    </child>
+  </object>
 </interface>


### PR DESCRIPTION
What the changes do:
- Adds a window to the UI file itself, rather than relying on the code to make a window, so that it's better integrated with its header bar
- Adds a header bar, replacing the 'top_bar' control, and merges the 'header_stack' with the center of the header bar, with 'custom title' turned on, so the top toolbar is one with the window controls in the whole of the UI. Still works 100% with the stock System Settings pages
- Adds a label to the main page toolbar, to substitute for the lost title bar text, which has a value equal to the window's title on init
- Turns on expand for the header_stack, to make it stretch all the way around the title bar from left to right.

I'm personally not expecting this to be merged, or even considered in Cinnamon, but given you made the revamped Mint Welcome a Client Side Decorations window, thought this contribution might as well fit in Mint 19.
Also, sorry if it's based on a slightly outdated version of this file, it's based on the latest version that's on the Mint 19 PPA...