### PR TITLE
systray: Fix icon resizing

### DIFF
--- a/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
@@ -341,13 +341,7 @@ class CinnamonSystrayApplet extends Applet.Applet {
         }
         icon._rolePosition = position;
 
-        if (this._scaleMode) {
-            this._resizeStatusItem(role, icon);
-        } else {
-            icon.set_pivot_point(0.5, 0.5);
-            icon.set_scale((DEFAULT_ICON_SIZE * global.ui_scale) / icon.width,
-                           (DEFAULT_ICON_SIZE * global.ui_scale) / icon.height);
-        }
+        this._resizeStatusItem(role, icon);
     }
 
     _resizeStatusItem(role, icon) {


### PR DESCRIPTION
This ensures systray icons are always resized, which is needed because some apps use icon sizes that diverge from the resulting size of the current solution for non-scaling mode. This makes the icons a little smaller, but it looks more appropriate for systray icons since they're not launchers.

Also see https://github.com/linuxmint/Cinnamon/commit/c618ff922b6ec4a02645e2867452b0376a5f77d0.

Closes #7588 