### PR TITLE
Fix 'Win' button issues in 'Alt + F2' dialog

### DIFF
--- a/js/ui/runDialog.js
+++ b/js/ui/runDialog.js
@@ -212,7 +212,7 @@ __proto__: ModalDialog.ModalDialog.prototype,
             }
             return true;
         }
-        if (symbol == Clutter.Escape) {
+        if (symbol == Clutter.Escape || symbol == Clutter.Super_L || symbol == Clutter.Super_R) {
             this.close();
             return true;
         }


### PR DESCRIPTION
Fix for issue #7461 

Before the user could have the dialog window open and pressing the "Win" key would result in no longer being able to close out the "Alt+F2" dialog window. Added logic that now takes into the account the "Win" key being pressed and closes out the "Alt+F2" dialog window accordingly. 