### PR TITLE
[WIP] Allow custom widgets in xlet settings

### DIFF
--- a/files/usr/bin/cinnamon-menu-editor
+++ b/files/usr/bin/cinnamon-menu-editor
@@ -6,12 +6,15 @@ Usage:  cinnamon-menu-editor
 """
 
 import sys
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
 
-sys.path.insert(0, '/usr/share/cinnamon/cinnamon-menu-editor')  # noqa
-from cme import MainWindow
+sys.path.append('/usr/share/cinnamon/cinnamon-menu-editor')  # noqa
+from cme.MainWindow import MainWindow
 
 
-def main():
+if __name__ == '__main__':
     try:
         from MenuEditor import config
         datadir = config.pkgdatadir
@@ -19,9 +22,5 @@ def main():
     except Exception:
         datadir = '.'
         version = '0.9'
-    app = MainWindow.MainWindow(datadir, version)
-    app.run()
-
-
-if __name__ == '__main__':
-    main()
+    app = MainWindow(datadir, version)
+    Gtk.main()

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1288,10 +1288,6 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         Main.keybindingManager.removeHotKey("overlay-key-" + this.instance_id);
     }
 
-    _launch_editor() {
-        Util.spawnCommandLine("cinnamon-menu-editor");
-    }
-
     on_applet_clicked(event) {
         this.menu.toggle_with_options(this.enableAnimation);
     }

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/cme.py
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/cme.py
@@ -1,0 +1,12 @@
+#!/usr/bin/python3
+
+import sys
+sys.path.append('/usr/share/cinnamon/cinnamon-menu-editor/')
+from cme.MainWindow import CMEContent as Content
+
+class MenuEditorPage(SettingsPage):
+    def __init__(self, info, settings):
+        SettingsPage.__init__(self)
+
+        self.pack_start(Content(), True, True, 0)
+

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/settings-schema.json
@@ -1,7 +1,7 @@
 {
     "layout" : {
         "type" : "layout",
-        "pages" : ["panel", "menu"],
+        "pages" : ["panel", "menu", "edit-menu-items"],
         "panel" : {
             "type" : "page",
             "title" : "Panel",
@@ -11,6 +11,12 @@
             "type" : "page",
             "title" : "Menu",
             "sections" : ["menu-layout", "menu-behave"]
+        },
+        "edit-menu-items" : {
+            "type" : "custom",
+            "title" : "Edit",
+            "file" : "cme.py",
+            "widget" : "MenuEditorPage"
         },
         "panel-appear" : {
             "type" : "section",
@@ -25,7 +31,7 @@
         "menu-layout" : {
             "type" : "section",
             "title" : "Layout and content",
-            "keys" : ["show-category-icons", "show-application-icons", "favbox-show", "show-places", "menu-editor-button"]
+            "keys" : ["show-category-icons", "show-application-icons", "favbox-show", "show-places"]
         },
         "menu-behave" : {
             "type" : "section",
@@ -116,11 +122,5 @@
     "default": false,
     "description": "Use menu animations",
     "tooltip": "Allow the menu to animate on open and close"
- },
-  "menu-editor-button" : {
-    "type" : "button",
-    "description" : "Open the menu editor",
-    "callback" : "_launch_editor",
-    "tooltip" : "Press this button to customize your menu entries."
  }
 }

--- a/files/usr/share/cinnamon/applets/settings-example@cinnamon.org/CustomWidget.py
+++ b/files/usr/share/cinnamon/applets/settings-example@cinnamon.org/CustomWidget.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python3
+
+import random
+
+class MyWidget(SettingsWidget):
+    def __init__(self, info, key, settings):
+        SettingsWidget.__init__(self)
+        self.key = key
+        self.settings = settings
+        self.info = info
+
+        self.pack_start(Gtk.Label(_(info['description']), halign=Gtk.Align.START), True, True, 0)
+        self.entry = Gtk.Entry()
+        self.settings.bind('custom-widget', self.entry, 'text', Gio.SettingsBindFlags.DEFAULT)
+        self.button = Gtk.Button(_("Random"))
+        self.button.connect('clicked', self.button_pressed)
+        self.pack_end(self.button, False, False, 0)
+        self.pack_end(self.entry, False, False, 0)
+
+    def button_pressed(self, *args):
+        self.entry.set_text(str(random.randint(0, 9)))

--- a/files/usr/share/cinnamon/applets/settings-example@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/settings-example@cinnamon.org/settings-schema.json
@@ -55,7 +55,7 @@
         "section5": {
             "type": "section",
             "title": "Command settings",
-            "keys": ["signal-test", "keybinding-test", "demo-button", "long-text"]
+            "keys": ["signal-test", "keybinding-test", "demo-button", "long-text", "custom-widget"]
         },
         "section6": {
             "type": "section",
@@ -274,5 +274,12 @@
         "type" : "label",
         "description" : "The value of the spinner above is greater than or equal to 5",
         "dependency" : "dep-spin>=5"
+    },
+    "custom-widget": {
+        "type" : "custom",
+        "file" : "CustomWidget.py",
+        "widget" : "MyWidget",
+        "description" : "Try out this custom widget!",
+        "default" : "5"
     }
 }

--- a/files/usr/share/cinnamon/cinnamon-menu-editor/cinnamon-menu-editor.ui
+++ b/files/usr/share/cinnamon/cinnamon-menu-editor/cinnamon-menu-editor.ui
@@ -1,436 +1,355 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <!--*- mode: xml -*-->
 <interface>
-  <object class="GtkUIManager" id="uimanager1">
+  <requires lib="gtk+" version="3.20"/>
+  <object class="GtkMenu" id="edit_menu">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
     <child>
-      <object class="GtkActionGroup" id="actiongroup1">
-
-        <child>
-          <object class="GtkAction" id="edit_cut">
-            <property name="stock_id">gtk-cut</property>
-            <property name="name">edit_cut</property>
-            <signal handler="on_edit_cut_activate" name="activate"/>
-          </object>
-        </child>
-        <child>
-          <object class="GtkAction" id="edit_copy">
-            <property name="stock_id">gtk-copy</property>
-            <property name="name">edit_copy</property>
-            <signal handler="on_edit_copy_activate" name="activate"/>
-          </object>
-        </child>
-        <child>
-          <object class="GtkAction" id="edit_paste">
-            <property name="stock_id">gtk-paste</property>
-            <property name="name">edit_paste</property>
-            <signal handler="on_edit_paste_activate" name="activate"/>
-          </object>
-        </child>
-        <child>
-          <object class="GtkAction" id="edit_properties">
-            <property name="stock_id">gtk-properties</property>
-            <property name="name">edit_properties</property>
-            <signal handler="on_edit_properties_activate" name="activate"/>
-          </object>
-        </child>
-        <child>
-          <object class="GtkAction" id="edit_delete">
-            <property name="stock_id">gtk-delete</property>
-            <property name="name">edit_delete</property>
-            <signal handler="on_edit_delete_activate" name="activate"/>
-          </object>
-        </child>
-      </object>
-    </child>
-    <ui>
-      <popup name="edit_menu">
-        <menuitem action="edit_cut"/>
-        <menuitem action="edit_copy"/>
-        <menuitem action="edit_paste"/>
-        <separator/>
-        <menuitem action="edit_delete"/>
-        <separator/>
-        <menuitem action="edit_properties"/>
-      </popup>
-    </ui>
-  </object>
-  <object class="GtkMenu" constructor="uimanager1" id="edit_menu">
-
-
-</object>
-  <object class="GtkDialog" id="mainwindow">
-    <property name="border_width">5</property>
-    <property name="default_width">675</property>
-    <property name="default_height">530</property>
-    <property name="visible">True</property>
-    <property name="title" translatable="yes">Main Menu</property>
-    <property name="type">GTK_WINDOW_TOPLEVEL</property>
-    <property name="window_position">GTK_WIN_POS_CENTER</property>
-    <property name="modal">False</property>
-    <property name="resizable">True</property>
-    <property name="destroy_with_parent">False</property>
-    <property name="decorated">True</property>
-    <property name="skip_taskbar_hint">False</property>
-    <property name="skip_pager_hint">False</property>
-    <property name="type_hint">GDK_WINDOW_TYPE_HINT_NORMAL</property>
-    <property name="gravity">GDK_GRAVITY_NORTH_WEST</property>
-    <property name="focus_on_map">True</property>
-    <property name="urgency_hint">False</property>
-    <signal handler="on_close_button_clicked" name="close"/>
-    <signal handler="on_close_button_clicked" name="destroy"/>
-    <accelerator key="Escape" modifiers="0" signal="close"/>
-    <child internal-child="vbox">
-      <object class="GtkVBox" id="dialog-vbox5">
+      <object class="GtkMenuItem" id="cut_menuitem">
         <property name="visible">True</property>
-        <property name="homogeneous">False</property>
-        <property name="spacing">2</property>
-        <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="dialog-action_area5">
-            <property name="visible">True</property>
-            <property name="layout_style">GTK_BUTTONBOX_END</property>        
-            <child>
-              <object class="GtkButton" id="restore_button">
-                <property name="visible">True</property>
-                <property name="tooltip-text" translatable="yes">Restore the default menu layout</property>
-                <property name="can_default">True</property>
-                <property name="can_focus">True</property>
-                <property name="label" translatable="yes">Restore System Configuration</property>
-                <property name="use_stock">True</property>
-                <property name="relief">GTK_RELIEF_NORMAL</property>
-                <property name="focus_on_click">True</property>
-                <signal handler="on_restore_button_clicked" name="clicked"/>
-              </object>
-            </child>
-            <child>
-              <object class="GtkButton" id="close_button">
-                <property name="visible">True</property>
-                <property name="can_default">True</property>
-                <property name="has_default">True</property>
-                <property name="can_focus">True</property>
-                <property name="label">gtk-close</property>
-                <property name="use_stock">True</property>
-                <property name="relief">GTK_RELIEF_NORMAL</property>
-                <property name="focus_on_click">True</property>
-                <signal handler="on_close_button_clicked" name="clicked"/>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="padding">0</property>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="pack_type">GTK_PACK_END</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkAlignment" id="alignment9">
-            <property name="border_width">5</property>
-            <property name="visible">True</property>
-            <property name="xalign">0.5</property>
-            <property name="yalign">0.5</property>
-            <property name="xscale">1</property>
-            <property name="yscale">1</property>
-            <property name="top_padding">0</property>
-            <property name="bottom_padding">0</property>
-            <property name="left_padding">0</property>
-            <property name="right_padding">0</property>
-            <child>
-              <object class="GtkHBox" id="hbox2">
-                <property name="homogeneous">False</property>
-                <property name="spacing">6</property>
-                <child>
-                  <object class="GtkHPaned" id="hpaned1">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="position">200</property>
-                    <child>
-                      <object class="GtkVBox" id="vbox4">
-                        <property name="visible">True</property>
-                        <property name="homogeneous">False</property>
-                        <property name="spacing">6</property>
-                        <child>
-                          <object class="GtkScrolledWindow" id="scrolledwindow3">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-                            <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-                            <property name="shadow_type">GTK_SHADOW_IN</property>
-                            <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
-                            <child>
-                              <object class="GtkTreeView" id="menu_tree">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="has_focus">True</property>
-                                <property name="headers_visible">False</property>
-                                <property name="rules_hint">False</property>
-                                <property name="reorderable">False</property>
-                                <property name="enable_search">True</property>
-                                <property name="fixed_height_mode">False</property>
-                                <property name="hover_selection">False</property>
-                                <property name="hover_expand">False</property>
-                                <signal handler="on_item_tree_row_activated" name="row-activated"/>
-                                <signal handler="on_menu_tree_cursor_changed" name="cursor-changed"/>
-                                <signal handler="on_menu_tree_popup_menu" name="popup-menu"/>
-                                <signal handler="on_menu_tree_popup_menu" name="button_press_event"/>
-                              </object>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="padding">0</property>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="shrink">True</property>
-                        <property name="resize">False</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkVBox" id="vbox5">
-                        <property name="visible">True</property>
-                        <property name="homogeneous">False</property>
-                        <property name="spacing">6</property>
-                        <child>
-                          <object class="GtkHBox" id="hbox16">
-                            <property name="visible">True</property>
-                            <property name="homogeneous">False</property>
-                            <property name="spacing">6</property>
-                            <child>
-                              <object class="GtkScrolledWindow" id="scrolledwindow2">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-                                <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-                                <property name="shadow_type">GTK_SHADOW_IN</property>
-                                <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
-                                <child>
-                                  <object class="GtkTreeView" id="item_tree">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="headers_visible">True</property>
-                                    <property name="rules_hint">True</property>
-                                    <property name="reorderable">False</property>
-                                    <property name="enable_search">True</property>
-                                    <property name="fixed_height_mode">False</property>
-                                    <property name="hover_selection">False</property>
-                                    <property name="hover_expand">False</property>
-                                    <signal handler="on_item_tree_row_activated" name="row-activated"/>
-                                    <signal handler="on_item_tree_popup_menu" name="popup-menu"/>
-                                    <signal handler="on_item_tree_cursor_changed" name="cursor-changed"/>
-                                    <signal handler="on_item_tree_popup_menu" name="button_press_event"/>
-                                    <signal handler="on_item_tree_cursor_changed" name="cursor_changed"/>
-                                    <signal handler="on_item_tree_key_press_event" name="key_press_event"/>
-                                  </object>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="padding">0</property>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkVBox" id="vbox6">
-                                <property name="visible">True</property>
-                                <property name="homogeneous">False</property>
-                                <property name="spacing">6</property>
-                                <child>
-                                  <object class="GtkVButtonBox" id="vbuttonbox1">
-                                    <property name="visible">True</property>
-                                    <property name="layout_style">GTK_BUTTONBOX_START</property>
-                                    <property name="spacing">6</property>
-                                    <child>
-                                      <object class="GtkButton" id="new_menu_button">
-                                        <property name="label" translatable="yes">_New Menu</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="visible">True</property>
-                                        <property name="can_default">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="relief">GTK_RELIEF_NORMAL</property>
-                                        <property name="focus_on_click">True</property>
-                                        <property name="image">new_menu_image</property>
-                                        <signal handler="on_new_menu_button_clicked" name="clicked"/>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkButton" id="new_item_button">
-                                        <property name="label" translatable="yes">Ne_w Item</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="visible">True</property>
-                                        <property name="can_default">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="relief">GTK_RELIEF_NORMAL</property>
-                                        <property name="focus_on_click">True</property>
-                                        <property name="image">new_item_image</property>
-                                        <signal handler="on_new_item_button_clicked" name="clicked"/>
-                                      </object>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="padding">0</property>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkAlignment" id="alignment20">
-                                    <property name="visible">True</property>
-                                    <property name="xalign">0.5</property>
-                                    <property name="yalign">0.5</property>
-                                    <property name="xscale">1</property>
-                                    <property name="yscale">1</property>
-                                    <property name="top_padding">12</property>
-                                    <property name="bottom_padding">0</property>
-                                    <property name="left_padding">0</property>
-                                    <property name="right_padding">0</property>
-                                    <child>
-                                      <object class="GtkVButtonBox" id="vbuttonbox5">
-                                        <property name="visible">True</property>
-                                        <property name="layout_style">GTK_BUTTONBOX_START</property>
-                                        <property name="spacing">6</property>
-                                        <child>
-                                          <object class="GtkButton" id="cut_button">
-                                            <property name="label" translatable="no">gtk-cut</property>
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">True</property>
-                                            <property name="use_stock">True</property>
-                                            <signal handler="on_cut_button_clicked" name="clicked"/>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkButton" id="copy_button">
-                                            <property name="label" translatable="no">gtk-copy</property>
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">True</property>
-                                            <property name="use_stock">True</property>
-                                            <signal handler="on_copy_button_clicked" name="clicked"/>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkButton" id="paste_button">
-                                            <property name="label" translatable="no">gtk-paste</property>
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">True</property>
-                                            <property name="use_stock">True</property>
-                                            <signal handler="on_paste_button_clicked" name="clicked"/>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">2</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkButton" id="delete_button">
-                                            <property name="label" translatable="no">gtk-delete</property>
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">True</property>
-                                            <property name="use_stock">True</property>
-                                            <signal handler="on_delete_button_clicked" name="clicked"/>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">3</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkButton" id="properties_button">
-                                            <property name="label" translatable="no">gtk-properties</property>
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">True</property>
-                                            <property name="use_stock">True</property>
-                                            <signal handler="on_properties_button_clicked" name="clicked"/>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">4</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="padding">0</property>
-                                    <property name="expand">True</property>
-                                    <property name="fill">True</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="padding">0</property>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="padding">0</property>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="shrink">True</property>
-                        <property name="resize">True</property>
-                      </packing>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="padding">0</property>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                  </packing>
-                </child>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="padding">0</property>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-          </packing>
-        </child>
+        <property name="can_focus">False</property>
+        <property name="action_name">app.edit_cut</property>
+        <property name="label" translatable="yes">Cut</property>
+        <property name="use_underline">True</property>
       </object>
     </child>
-    <action-widgets>
-      <action-widget response="0">restore_button</action-widget>
-      <action-widget response="-7">close_button</action-widget>
-    </action-widgets>
-  </object>
-  <object class="GtkImage" id="new_menu_image">
-    <property name="visible">True</property>
-    <property name="stock">gtk-new</property>
-  </object>
-  <object class="GtkImage" id="new_item_image">
-    <property name="visible">True</property>
-    <property name="stock">gtk-add</property>
+    <child>
+      <object class="GtkMenuItem" id="copy_menuitem">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="action_name">app.edit_copy</property>
+        <property name="label" translatable="yes">Copy</property>
+        <property name="use_underline">True</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuItem" id="paste_menuitem">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="action_name">app.edit_paste</property>
+        <property name="label" translatable="yes">Paste</property>
+        <property name="use_underline">True</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuItem" id="delete_menuitem">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="action_name">app.edit_delete</property>
+        <property name="label" translatable="yes">Delete</property>
+        <property name="use_underline">True</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuItem" id="properties_menuitem">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="action_name">app.edit_properties</property>
+        <property name="label" translatable="yes">Properties</property>
+        <property name="use_underline">True</property>
+      </object>
+    </child>
   </object>
   <object class="GtkImage" id="move_down_image">
     <property name="visible">True</property>
+    <property name="can_focus">False</property>
     <property name="stock">gtk-go-down</property>
   </object>
   <object class="GtkImage" id="move_up_image">
     <property name="visible">True</property>
+    <property name="can_focus">False</property>
     <property name="stock">gtk-go-up</property>
+  </object>
+  <object class="GtkImage" id="new_item_image">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-add</property>
+  </object>
+  <object class="GtkImage" id="new_menu_image">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-new</property>
+  </object>
+  <object class="GtkBox" id="main_content">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="spacing">2</property>
+    <child>
+      <object class="GtkBox" id="hbox2">
+        <property name="can_focus">False</property>
+        <property name="spacing">6</property>
+        <child>
+          <object class="GtkPaned" id="hpaned1">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="position">200</property>
+            <child>
+              <object class="GtkBox" id="vbox4">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
+                <child>
+                  <object class="GtkScrolledWindow" id="scrolledwindow3">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="shadow_type">in</property>
+                    <child>
+                      <object class="GtkTreeView" id="menu_tree">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="has_focus">True</property>
+                        <property name="headers_visible">False</property>
+                        <signal name="button-press-event" handler="on_menu_tree_popup_menu" swapped="no"/>
+                        <signal name="cursor-changed" handler="on_menu_tree_cursor_changed" swapped="no"/>
+                        <signal name="popup-menu" handler="on_menu_tree_popup_menu" swapped="no"/>
+                        <signal name="row-activated" handler="on_item_tree_row_activated" swapped="no"/>
+                        <child internal-child="selection">
+                          <object class="GtkTreeSelection"/>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="resize">False</property>
+                <property name="shrink">True</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="vbox5">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
+                <child>
+                  <object class="GtkBox" id="hbox16">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkScrolledWindow" id="scrolledwindow2">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="shadow_type">in</property>
+                        <child>
+                          <object class="GtkTreeView" id="item_tree">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="rules_hint">True</property>
+                            <signal name="button-press-event" handler="on_item_tree_popup_menu" swapped="no"/>
+                            <signal name="cursor-changed" handler="on_item_tree_cursor_changed" swapped="no"/>
+                            <signal name="cursor-changed" handler="on_item_tree_cursor_changed" swapped="no"/>
+                            <signal name="key-press-event" handler="on_item_tree_key_press_event" swapped="no"/>
+                            <signal name="popup-menu" handler="on_item_tree_popup_menu" swapped="no"/>
+                            <signal name="row-activated" handler="on_item_tree_row_activated" swapped="no"/>
+                            <child internal-child="selection">
+                              <object class="GtkTreeSelection"/>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="vbox6">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">6</property>
+                        <child>
+                          <object class="GtkButtonBox" id="vbuttonbox1">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">6</property>
+                            <property name="layout_style">start</property>
+                            <child>
+                              <object class="GtkButton" id="new_menu_button">
+                                <property name="label" translatable="yes">_New Menu</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="can_default">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="image">new_menu_image</property>
+                                <property name="use_underline">True</property>
+                                <signal name="clicked" handler="on_new_menu_button_clicked" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkButton" id="new_item_button">
+                                <property name="label" translatable="yes">Ne_w Item</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="can_default">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="image">new_item_image</property>
+                                <property name="use_underline">True</property>
+                                <signal name="clicked" handler="on_new_item_button_clicked" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkButtonBox" id="vbuttonbox5">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">6</property>
+                            <property name="layout_style">start</property>
+                            <child>
+                              <object class="GtkButton" id="cut_button">
+                                <property name="label">Cut</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">True</property>
+                                <property name="action_name">app.edit_cut</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkButton" id="copy_button">
+                                <property name="label">Copy</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">True</property>
+                                <property name="action_name">app.edit_copy</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkButton" id="paste_button">
+                                <property name="label">Paste</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">True</property>
+                                <property name="action_name">app.edit_paste</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkButton" id="delete_button">
+                                <property name="label">Delete</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">True</property>
+                                <property name="action_name">app.edit_delete</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">3</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkButton" id="properties_button">
+                                <property name="label">Properties</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">True</property>
+                                <property name="action_name">app.edit_properties</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">4</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkButton" id="restore_button">
+                                <property name="label">Reset</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="can_default">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="tooltip_text" translatable="yes">Restore the default menu layout</property>
+                                <signal name="clicked" handler="on_restore_button_clicked" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">5</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="resize">True</property>
+                <property name="shrink">True</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">True</property>
+        <property name="fill">True</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
   </object>
 </interface>

--- a/js/ui/settings.js
+++ b/js/ui/settings.js
@@ -678,7 +678,7 @@ XletSettingsBase.prototype = {
         for (let key in this.settingsData) {
             let props = this.settingsData[key];
             if (!has_required_fields(props, key)) return false;
-            if (props.type in SETTINGS_TYPES)
+            if ('default' in props)
                 props.value = props.default;
         }
         this.settingsData.__md5__ = checksum;
@@ -693,8 +693,8 @@ XletSettingsBase.prototype = {
         for (let key in newSettings) {
             let props = newSettings[key];
 
-            if (!("type" in props) || !(props.type in SETTINGS_TYPES)) continue;
-            let type = SETTINGS_TYPES[props.type];
+            // ignore anything that doesn't appear to be a valid settings type
+            if (!("type" in props) || !("default" in props)) continue;
 
             // If the setting already exists, we want to use the old value. If not we use the default.
             let oldValue = null;


### PR DESCRIPTION
Adds the ability to embed custom widgets and pages in xlet settings. To use this feature, applet devs must include a .py file in which the new widget(s) and/or page(s) are defined, and then point to the file and class in the settings-schema.json file. Additionally, the settings example applet was updated to showcase the new feature, and the menu applet was also updated to embed the cinnamon menu editor into it's configuration dialog as a separate page. In order to do so, cme was also edited to remove deprecated widgets, and allow it to be embedded.

Still needs work:
* Custom widgets do not yet support subfolders in multi-version applets.
* The ui in cme still needs some work so that it looks good.
* There is currently no error handling to ensure that the class can be embedded into the settings app (ie, must be of type SettingsWidget or SettingsPage, depending).
* The documentation still needs to be updated to reflect these changes.