### PR TITLE
popupMenu: Fix undefined _delegate property warning

### DIFF
--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -2045,7 +2045,8 @@ PopupMenuBase.prototype = {
 
     _getMenuItems: function() {
         return this.box.get_children().reduce((children, actor) => {
-            if (actor._delegate instanceof PopupBaseMenuItem || actor._delegate instanceof PopupMenuSection)
+            if (actor._delegate &&
+                (actor._delegate instanceof PopupBaseMenuItem || actor._delegate instanceof PopupMenuSection))
                 children.push(actor._delegate);
             return children;
         }, []);


### PR DESCRIPTION
`Cjs-Message: 03:25:55.954: JS WARNING: [/usr/share/cinnamon/js/ui/popupMenu.js 2048]: reference to undefined property "_delegate"`