### PR TITLE
[WIP] Network Applet: Added Airplane Mode.

### DIFF
--- a/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
@@ -1762,6 +1762,9 @@ CinnamonNetworkApplet.prototype = {
             this.menu.addAction(_("Network Connections"), Lang.bind(this, function() {
 				Util.spawnCommandLine("nm-connection-editor");
             }));
+            this.menu.addAction(_("Airplane Mode"), Lang.bind(this, function() {
+                Util.spawnCommandLine("rfkill block all");
+            }));
 
             this.menu.connect("open-state-changed", Lang.bind(this, this._updateForMenuToggle));
 


### PR DESCRIPTION
As part of the Cinnamon Roadmap, added Airplane Mode to the Network Applet. This can be accessed from Network Applet in the tray icon.