### PR TITLE
Migrate to private Clutter and Cogl libraries

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -49,14 +49,14 @@ if $PKG_CONFIG --exists gstreamer-1.0 '>=' $GSTREAMER_MIN_VERSION ; then
    AC_MSG_RESULT(yes)
    build_recorder=true
    recorder_modules="gstreamer-1.0 gstreamer-base-1.0 x11"
-   PKG_CHECK_MODULES(TEST_CINNAMON_RECORDER, $recorder_modules clutter-1.0 xfixes)
+   PKG_CHECK_MODULES(TEST_CINNAMON_RECORDER, $recorder_modules muffin-clutter-0 xfixes)
 else
    AC_MSG_RESULT(no)
 fi
 
 AM_CONDITIONAL(BUILD_RECORDER, $build_recorder)
 
-CLUTTER_MIN_VERSION=1.10.0
+CLUTTER_MIN_VERSION=0
 GOBJECT_INTROSPECTION_MIN_VERSION=0.9.2
 GJS_MIN_VERSION=3.2.0
 MUFFIN_MIN_VERSION=3.5.0
@@ -73,7 +73,8 @@ PKG_CHECK_MODULES(CINNAMON, gio-2.0 >= $GIO_MIN_VERSION
                                cjs-1.0 >= $GJS_MIN_VERSION
 			       libcinnamon-menu-3.0 $recorder_modules
                                gdk-x11-3.0 libsoup-2.4 gl
-			       clutter-x11-1.0 >= $CLUTTER_MIN_VERSION
+			       muffin-clutter-0
+                   muffin-cogl-pango-0
                                libstartup-notification-1.0 >= $STARTUP_NOTIFICATION_MIN_VERSION
                                gobject-introspection-1.0 >= $GOBJECT_INTROSPECTION_MIN_VERSION
                                polkit-agent-1 >= $POLKIT_MIN_VERSION xfixes
@@ -98,9 +99,9 @@ AC_CHECK_FUNCS(XFixesCreatePointerBarrier)
 CFLAGS=$saved_CFLAGS
 LIBS=$saved_LIBS
 
-PKG_CHECK_MODULES(ST, clutter-1.0 gtk+-3.0 libcroco-0.6 >= 0.6.2 cinnamon-desktop >= 2.4.0 x11)
+PKG_CHECK_MODULES(ST, muffin-clutter-0 gtk+-3.0 libcroco-0.6 >= 0.6.2 cinnamon-desktop >= 2.4.0 x11)
 PKG_CHECK_MODULES(GDMUSER, dbus-glib-1 gtk+-3.0)
-PKG_CHECK_MODULES(TRAY, clutter-1.0 gtk+-3.0)
+PKG_CHECK_MODULES(TRAY, muffin-clutter-0 gtk+-3.0)
 PKG_CHECK_MODULES(DESKTOP_SCHEMAS, cinnamon-desktop >= 2.4.0)
 
 MUFFIN_GIR_DIR=`$PKG_CONFIG --variable=girdir libmuffin`

--- a/configure.ac
+++ b/configure.ac
@@ -74,10 +74,10 @@ PKG_CHECK_MODULES(CINNAMON, gio-2.0 >= $GIO_MIN_VERSION
                                cjs-1.0 >= $GJS_MIN_VERSION
                                libcinnamon-menu-3.0 $recorder_modules
                                gdk-x11-3.0 libsoup-2.4 gl
-                               muffin-clutter-0
-                               muffin-cogl-0
-                               muffin-cogl-path-0
                                muffin-cogl-pango-0
+                               muffin-cogl-path-0
+                               muffin-cogl-0
+                               muffin-clutter-0
                                libstartup-notification-1.0 >= $STARTUP_NOTIFICATION_MIN_VERSION
                                gobject-introspection-1.0 >= $GOBJECT_INTROSPECTION_MIN_VERSION
                                polkit-agent-1 >= $POLKIT_MIN_VERSION xfixes
@@ -102,9 +102,9 @@ AC_CHECK_FUNCS(XFixesCreatePointerBarrier)
 CFLAGS=$saved_CFLAGS
 LIBS=$saved_LIBS
 
-PKG_CHECK_MODULES(ST, muffin-clutter-0 muffin-cogl-0 muffin-cogl-path-0 muffin-cogl-pango-0 gtk+-3.0 libcroco-0.6 >= 0.6.2 cinnamon-desktop >= 2.4.0 x11)
+PKG_CHECK_MODULES(ST, muffin-cogl-path-0 muffin-clutter-0 gtk+-3.0 libcroco-0.6 >= 0.6.2 cinnamon-desktop >= 2.4.0 x11)
 PKG_CHECK_MODULES(GDMUSER, dbus-glib-1 gtk+-3.0)
-PKG_CHECK_MODULES(TRAY, muffin-clutter-0 muffin-cogl-0 muffin-cogl-path-0 muffin-cogl-pango-0 gtk+-3.0)
+PKG_CHECK_MODULES(TRAY, muffin-clutter-0 gtk+-3.0)
 PKG_CHECK_MODULES(DESKTOP_SCHEMAS, cinnamon-desktop >= 2.4.0)
 
 MUFFIN_GIR_DIR=`$PKG_CONFIG --variable=girdir libmuffin`

--- a/configure.ac
+++ b/configure.ac
@@ -72,10 +72,12 @@ PKG_CHECK_MODULES(CINNAMON, gio-2.0 >= $GIO_MIN_VERSION
                                gtk+-3.0 >= $GTK_MIN_VERSION
                                libmuffin >= $MUFFIN_MIN_VERSION
                                cjs-1.0 >= $GJS_MIN_VERSION
-			       libcinnamon-menu-3.0 $recorder_modules
+                               libcinnamon-menu-3.0 $recorder_modules
                                gdk-x11-3.0 libsoup-2.4 gl
-			       muffin-clutter-0
-                   muffin-cogl-pango-0
+                               muffin-clutter-0
+                               muffin-cogl-0
+                               muffin-cogl-path-0
+                               muffin-cogl-pango-0
                                libstartup-notification-1.0 >= $STARTUP_NOTIFICATION_MIN_VERSION
                                gobject-introspection-1.0 >= $GOBJECT_INTROSPECTION_MIN_VERSION
                                polkit-agent-1 >= $POLKIT_MIN_VERSION xfixes
@@ -100,9 +102,9 @@ AC_CHECK_FUNCS(XFixesCreatePointerBarrier)
 CFLAGS=$saved_CFLAGS
 LIBS=$saved_LIBS
 
-PKG_CHECK_MODULES(ST, muffin-clutter-0 gtk+-3.0 libcroco-0.6 >= 0.6.2 cinnamon-desktop >= 2.4.0 x11)
+PKG_CHECK_MODULES(ST, muffin-clutter-0 muffin-cogl-0 muffin-cogl-path-0 muffin-cogl-pango-0 gtk+-3.0 libcroco-0.6 >= 0.6.2 cinnamon-desktop >= 2.4.0 x11)
 PKG_CHECK_MODULES(GDMUSER, dbus-glib-1 gtk+-3.0)
-PKG_CHECK_MODULES(TRAY, muffin-clutter-0 gtk+-3.0)
+PKG_CHECK_MODULES(TRAY, muffin-clutter-0 muffin-cogl-0 muffin-cogl-path-0 muffin-cogl-pango-0 gtk+-3.0)
 PKG_CHECK_MODULES(DESKTOP_SCHEMAS, cinnamon-desktop >= 2.4.0)
 
 MUFFIN_GIR_DIR=`$PKG_CONFIG --variable=girdir libmuffin`

--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,7 @@ AM_INIT_AUTOMAKE([1.11 no-dist-gzip dist-xz tar-ustar foreign subdir-objects])
 AM_MAINTAINER_MODE([enable])
 
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])
+m4_divert_text([DEFAULTS], [: "${ARFLAGS=cr} ${AR_FLAGS=cr}"])
 
 # Checks for programs.
 AC_PROG_CC

--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,6 @@ Build-Depends:
  libcinnamon-desktop-dev (>= 3.8),
  libcinnamon-menu-3-dev,
  libcjs-dev (>= 3.8),
- libclutter-1.0-dev (>= 1.10.0),
  libcroco3-dev (>= 0.6.2),
  libdbus-glib-1-dev,
  libgirepository1.0-dev (>= 1.29.15),

--- a/debian/control
+++ b/debian/control
@@ -26,7 +26,7 @@ Build-Depends:
  libgtk-3-dev (>= 3.9.12),
  libgudev-1.0-dev,
  libjson-glib-dev (>= 0.13.2),
- libmuffin-dev (>= 3.8),
+ libmuffin0 (>= 3.8),
  libnm-glib-dev (>= 0.8.999),
  libpolkit-agent-1-dev (>= 0.100),
  libpulse-dev,

--- a/debian/rules
+++ b/debian/rules
@@ -28,9 +28,9 @@ override_dh_autoreconf:
 	dh_autoreconf --as-needed ./autogen.sh
 
 override_dh_auto_configure:
-	dh_auto_configure -- --enable-compile-warnings=yes \
-	                     --disable-schemas-install\
-			     --enable-gtk-doc
+	dh_auto_configure -- \
+		--enable-compile-warnings=yes \
+		--enable-gtk-doc \
 
 override_dh_auto_test:
 	# Disable checks since they are not functional for the moment

--- a/docs/reference/cinnamon/Makefile.am
+++ b/docs/reference/cinnamon/Makefile.am
@@ -88,7 +88,7 @@ expand_content_files=
 # e.g. GTKDOC_CFLAGS=-I$(top_srcdir) -I$(top_builddir) $(GTK_DEBUG_FLAGS)
 # e.g. GTKDOC_LIBS=$(top_builddir)/gtk/$(gtktargetlib)
 GTKDOC_CFLAGS=$(GNOME_SHELL_CFLAGS)
-GTKDOC_LIBS=$(GNOME_SHELL_LIBS) $(top_builddir)/src/libcinnamon.la
+GTKDOC_LIBS=$(GNOME_SHELL_LIBS) $(top_builddir)/src/libcinnamon.la -rpath $(MUFFIN_TYPELIB_DIR)
 
 # This includes the standard gtk-doc make rules, copied by gtkdocize.
 include $(top_srcdir)/gtk-doc.make

--- a/docs/reference/cinnamon/Makefile.am
+++ b/docs/reference/cinnamon/Makefile.am
@@ -88,7 +88,7 @@ expand_content_files=
 # e.g. GTKDOC_CFLAGS=-I$(top_srcdir) -I$(top_builddir) $(GTK_DEBUG_FLAGS)
 # e.g. GTKDOC_LIBS=$(top_builddir)/gtk/$(gtktargetlib)
 GTKDOC_CFLAGS=$(GNOME_SHELL_CFLAGS)
-GTKDOC_LIBS=$(GNOME_SHELL_LIBS) $(top_builddir)/src/libcinnamon.la -rpath $(MUFFIN_TYPELIB_DIR)
+GTKDOC_LIBS=$(GNOME_SHELL_LIBS) $(abs_top_builddir)/src/libcinnamon.la -rpath $(libdir)/muffin
 
 # This includes the standard gtk-doc make rules, copied by gtkdocize.
 include $(top_srcdir)/gtk-doc.make

--- a/docs/reference/st/Makefile.am
+++ b/docs/reference/st/Makefile.am
@@ -78,7 +78,7 @@ expand_content_files=
 # e.g. GTKDOC_CFLAGS=-I$(top_srcdir) -I$(top_builddir) $(GTK_DEBUG_FLAGS)
 # e.g. GTKDOC_LIBS=$(top_builddir)/gtk/$(gtktargetlib)
 GTKDOC_CFLAGS=
-GTKDOC_LIBS=$(top_builddir)/src/libst-1.0.la
+GTKDOC_LIBS=$(top_builddir)/src/libst-1.0.la -rpath $(MUFFIN_TYPELIB_DIR)
 
 # This includes the standard gtk-doc make rules, copied by gtkdocize.
 include $(top_srcdir)/gtk-doc.make

--- a/docs/reference/st/Makefile.am
+++ b/docs/reference/st/Makefile.am
@@ -77,8 +77,8 @@ expand_content_files=
 # signals and properties.
 # e.g. GTKDOC_CFLAGS=-I$(top_srcdir) -I$(top_builddir) $(GTK_DEBUG_FLAGS)
 # e.g. GTKDOC_LIBS=$(top_builddir)/gtk/$(gtktargetlib)
-GTKDOC_CFLAGS=
-GTKDOC_LIBS=$(top_builddir)/src/libst-1.0.la -rpath $(MUFFIN_TYPELIB_DIR)
+GTKDOC_CFLAGS=-Wno-undef
+GTKDOC_LIBS=$(top_builddir)/src/libst-1.0.la -rpath $(libdir)/muffin
 
 # This includes the standard gtk-doc make rules, copied by gtkdocize.
 include $(top_srcdir)/gtk-doc.make

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_general.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_general.py
@@ -42,6 +42,11 @@ class Module:
 
             settings = page.add_section(_("Miscellaneous Options"))
 
+            switch = GSettingsSwitch(_("Enable VBLANK"), "org.cinnamon.muffin", "sync-to-vblank")
+            switch.set_tooltip_text(_("""Select this option to allow Cinnamon to match the timing of frames rendered with the monitor's refresh rate. """
+                """Select this option if you are experiencing screen-tearing. The option to disable compositing for full-screen windows overrides this setting."""))
+            settings.add_row(switch)
+
             switch = GSettingsSwitch(_("Disable compositing for full-screen windows"), "org.cinnamon.muffin", "unredirect-fullscreen-windows")
             switch.set_tooltip_text(_("Select this option to let full-screen applications skip the compositing manager and run at maximum speed. Unselect it if you're experiencing screen-tearing in full screen mode."))
             settings.add_row(switch)

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_general.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_general.py
@@ -40,16 +40,18 @@ class Module:
 
                 combo.content_widget.connect('changed', on_changed)
 
-            settings = page.add_section(_("Miscellaneous Options"))
+            settings = page.add_section(_("Compositor Options"))
 
-            switch = GSettingsSwitch(_("Enable VBLANK"), "org.cinnamon.muffin", "sync-to-vblank")
+            switch = GSettingsSwitch(_("Enable VBlank (Requires Cinnamon restart)"), "org.cinnamon.muffin", "sync-to-vblank")
             switch.set_tooltip_text(_("""Select this option to allow Cinnamon to match the timing of frames rendered with the monitor's refresh rate. """
-                """Select this option if you are experiencing screen-tearing. The option to disable compositing for full-screen windows overrides this setting."""))
+                """Choose this option if you are experiencing screen-tearing. The option to disable compositing for full-screen windows overrides this setting."""))
             settings.add_row(switch)
 
             switch = GSettingsSwitch(_("Disable compositing for full-screen windows"), "org.cinnamon.muffin", "unredirect-fullscreen-windows")
             switch.set_tooltip_text(_("Select this option to let full-screen applications skip the compositing manager and run at maximum speed. Unselect it if you're experiencing screen-tearing in full screen mode."))
             settings.add_row(switch)
+
+            settings = page.add_section(_("Miscellaneous Options"))
 
             switch = GSettingsSwitch(_("Disable automatic screen rotation"), "org.cinnamon.settings-daemon.peripherals.touchscreen", "orientation-lock")
             switch.set_tooltip_text(_("Select this option to disable automatic screen rotation on hardware equipped with supported accelerometers."))

--- a/js/ui/environment.js
+++ b/js/ui/environment.js
@@ -1,6 +1,6 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
-imports.gi.versions.Clutter = '1.0';
+imports.gi.versions.Clutter = '0';
 imports.gi.versions.Gio = '2.0';
 imports.gi.versions.Gdk = '3.0';
 imports.gi.versions.GdkPixbuf = '2.0';

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -146,7 +146,7 @@ cinnamon_real_CPPFLAGS = \
 	$(MUFFIN_CFLAGS) \
 	$(cinnamon_cflags)
 
-cinnamon_real_LDADD = libcinnamon.la $(CINNAMON_LIBS) $(MUFFIN_LIBS) -lm
+cinnamon_real_LDADD = libcinnamon.la $(CINNAMON_LIBS) $(MUFFIN_LIBS) -lm -lpthread
 cinnamon_real_LDFLAGS = -rpath $(MUFFIN_TYPELIB_DIR)
 cinnamon_real_DEPENDENCIES = libcinnamon.la
 
@@ -222,6 +222,7 @@ cinnamon-enum-types.c: $(srcdir)/cinnamon-enum-types.c.in stamp-cinnamon-enum-ty
 EXTRA_DIST += cinnamon-enum-types.c.in
 
 libcinnamon_libadd =		\
+	-lpthread \
 	-lm			\
 	$(CINNAMON_LIBS)	\
 	libst-1.0.la       	\

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -10,7 +10,7 @@ service_in_files =
 
 -include $(INTROSPECTION_MAKEFILE)
 INTROSPECTION_GIRS =
-INTROSPECTION_SCANNER_ARGS = --warn-all --add-include-path=$(srcdir)
+INTROSPECTION_SCANNER_ARGS = --warn-all --add-include-path=$(srcdir) --add-include-path=$(MUFFIN_GIR_DIR) -L$(MUFFIN_TYPELIB_DIR)
 INTROSPECTION_COMPILER_ARGS = --includedir=$(srcdir) --includedir=$(MUFFIN_TYPELIB_DIR)
 
 typelibdir = $(pkglibdir)
@@ -49,6 +49,7 @@ generated_script_substitutions = \
 	    -e "s|@pkglibexecdir[@]|$(pkglibexecdir)|" \
 	    -e "s|@VERSION[@]|$(VERSION)|" \
 	    -e "s|@sysconfdir[@]|$(sysconfdir)|" \
+			-e "s|@MUFFIN_PLUGIN_API_VERSION[@]|$(MUFFIN_PLUGIN_API_VERSION)|" \
         -e "s|@GJS_CONSOLE[@]|$(GJS_CONSOLE)|"
 
 CLEANFILES += cinnamon $(bin_SCRIPTS)
@@ -61,13 +62,17 @@ cinnamon_cflags =				\
 	$(WARN_CFLAGS)				\
 	$(CINNAMON_CFLAGS)			\
 	-I$(srcdir)/tray			\
-    -DCLUTTER_ENABLE_EXPERIMENTAL_API   \
-    -DCOGL_ENABLE_EXPERIMENTAL_API  \
+	-DCLUTTER_ENABLE_EXPERIMENTAL_API				\
+	-DCOGL_ENABLE_EXPERIMENTAL_API \
+	-DCOGL_ENABLE_EXPERIMENTAL_2_0_API   \
+	-DCLUTTER_DISABLE_DEPRECATION_WARNINGS				\
+	-DCOGL_DISABLE_DEPRECATION_WARNINGS				\
 	-DVERSION=\"$(VERSION)\"		\
 	-DLOCALEDIR=\"$(datadir)/locale\" 	\
 	-DDATADIR=\"$(datadir)\"		\
 	-DCINNAMON_LIBEXECDIR=\"$(libexecdir)\"	\
 	-DCINNAMON_DATADIR=\"$(pkgdatadir)\"	\
+	-DMUFFIN_TYPELIB_DIR=\"$(MUFFIN_TYPELIB_DIR)\" \
 	-DCINNAMON_PKGLIBDIR=\"$(pkglibdir)\" \
 	-DCINNAMON_PKGLIBEXECDIR=\"$(pkglibexecdir)\"	\
 	-DJSDIR=\"$(pkgdatadir)/js\"
@@ -136,7 +141,8 @@ libcinnamon_la_gir_sources = \
 cinnamon_real_SOURCES =		\
 	main.c
 cinnamon_real_CPPFLAGS = $(cinnamon_cflags)
-cinnamon_real_LDADD = libcinnamon.la $(libcinnamon_la_LIBADD)
+cinnamon_real_LDADD = libcinnamon.la $(libcinnamon_la_LIBADD) $(MUFFIN_LIBS)
+cinnamon_real_LDFLAGS = -rpath $(MUFFIN_TYPELIB_DIR)
 cinnamon_real_DEPENDENCIES = libcinnamon.la
 
 ########################################
@@ -180,9 +186,9 @@ cinnamon_perf_helper_LDADD = $(CINNAMON_PERF_HELPER_LIBS)
 
 noinst_PROGRAMS += run-js-test
 
-run_js_test_CPPFLAGS = $(cinnamon_cflags)
+run_js_test_CPPFLAGS = $(MUFFIN_CFLAGS) $(cinnamon_cflags)
 run_js_test_LDADD = libcinnamon.la $(libcinnamon_la_LIBADD)
-run_js_test_LDFLAGS = $(WARN_LDFLAGS) -export-dynamic
+run_js_test_LDFLAGS = $(WARN_LDFLAGS) -export-dynamic -rpath $(MUFFIN_TYPELIB_DIR)
 
 run_js_test_SOURCES =			\
 	run-js-test.c
@@ -222,7 +228,7 @@ libcinnamon_la_LIBADD =		\
 libcinnamon_la_CPPFLAGS = $(cinnamon_cflags)
 
 Cinnamon-0.1.gir: libcinnamon.la St-1.0.gir
-Cinnamon_0_1_gir_INCLUDES = Clutter-1.0 ClutterX11-1.0 Meta-Muffin.0 Soup-2.4 CMenu-3.0 NetworkManager-1.0 NMClient-1.0
+Cinnamon_0_1_gir_INCLUDES = Clutter-0 ClutterX11-0 CoglPango-0 Cogl-0 Meta-Muffin.0 Soup-2.4 CMenu-3.0 NetworkManager-1.0 NMClient-1.0
 Cinnamon_0_1_gir_CFLAGS = $(libcinnamon_la_CPPFLAGS) -I $(srcdir)
 Cinnamon_0_1_gir_LIBS = libcinnamon.la
 Cinnamon_0_1_gir_FILES = $(libcinnamon_la_gir_sources)
@@ -232,7 +238,7 @@ INTROSPECTION_GIRS += Cinnamon-0.1.gir
 CLEANFILES += Cinnamon-0.1.gir
 
 St-1.0.gir: libst-1.0.la
-St_1_0_gir_INCLUDES = Clutter-1.0 Gtk-3.0
+St_1_0_gir_INCLUDES = Clutter-0 ClutterX11-0 CoglPango-0 Cogl-0 Meta-Muffin.0 Gtk-3.0
 St_1_0_gir_CFLAGS = $(st_cflags) -DST_COMPILATION
 St_1_0_gir_LIBS = libst-1.0.la
 St_1_0_gir_FILES = $(filter-out %-private.h $(st_non_gir_sources), $(addprefix $(srcdir)/,$(st_source_h))) \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -50,7 +50,8 @@ generated_script_substitutions = \
 	    -e "s|@VERSION[@]|$(VERSION)|" \
 	    -e "s|@sysconfdir[@]|$(sysconfdir)|" \
 			-e "s|@MUFFIN_PLUGIN_API_VERSION[@]|$(MUFFIN_PLUGIN_API_VERSION)|" \
-        -e "s|@GJS_CONSOLE[@]|$(GJS_CONSOLE)|"
+      -e "s|@MUFFIN_TYPELIB_DIR[@]|$(MUFFIN_TYPELIB_DIR)|" \
+      -e "s|@GJS_CONSOLE[@]|$(GJS_CONSOLE)|"
 
 CLEANFILES += cinnamon $(bin_SCRIPTS)
 
@@ -78,7 +79,7 @@ cinnamon_cflags =				\
 	-DJSDIR=\"$(pkgdatadir)/js\"
 
 privlibdir = $(pkglibdir)
-privlib_LTLIBRARIES = libcinnamon.la
+privlib_LTLIBRARIES = libcinnamon.la $(MUFFIN_LIBS)
 
 cinnamon_built_sources = \
 	cinnamon-enum-types.h \
@@ -140,8 +141,12 @@ libcinnamon_la_gir_sources = \
 
 cinnamon_real_SOURCES =		\
 	main.c
-cinnamon_real_CPPFLAGS = $(cinnamon_cflags)
-cinnamon_real_LDADD = libcinnamon.la $(libcinnamon_la_LIBADD) $(MUFFIN_LIBS)
+cinnamon_real_CPPFLAGS = \
+	-DMUFFIN_TYPELIB_DIR=\"$(MUFFIN_TYPELIB_DIR)\" \
+	$(MUFFIN_CFLAGS) \
+	$(cinnamon_cflags)
+
+cinnamon_real_LDADD = libcinnamon.la $(CINNAMON_LIBS) $(MUFFIN_LIBS) -lm
 cinnamon_real_LDFLAGS = -rpath $(MUFFIN_TYPELIB_DIR)
 cinnamon_real_DEPENDENCIES = libcinnamon.la
 
@@ -168,7 +173,6 @@ test_recorder_CPPFLAGS = $(WARN_CFLAGS)		\
 test_recorder_LDADD = $(TEST_CINNAMON_RECORDER_LIBS) \
                        libst-1.0.la
 
-
 test_recorder_SOURCES =     \
 	$(cinnamon_recorder_sources) $(cinnamon_recorder_non_gir_sources) \
 	test-recorder.c
@@ -180,15 +184,15 @@ pkglibexec_PROGRAMS += cinnamon-perf-helper
 
 cinnamon_perf_helper_SOURCES = cinnamon-perf-helper.c
 cinnamon_perf_helper_CPPFLAGS = $(WARN_CFLAGS) $(CINNAMON_PERF_HELPER_CFLAGS)
-cinnamon_perf_helper_LDADD = $(CINNAMON_PERF_HELPER_LIBS)
+cinnamon_perf_helper_LDADD = $(CINNAMON_PERF_HELPER_LIBS) -lm
 
 ########################################
 
 noinst_PROGRAMS += run-js-test
 
 run_js_test_CPPFLAGS = $(MUFFIN_CFLAGS) $(cinnamon_cflags)
-run_js_test_LDADD = libcinnamon.la $(libcinnamon_la_LIBADD)
-run_js_test_LDFLAGS = $(WARN_LDFLAGS) -export-dynamic -rpath $(MUFFIN_TYPELIB_DIR)
+run_js_test_LDADD = libcinnamon.la $(CINNAMON_LIBS) $(MUFFIN_LIBS)
+run_js_test_LDFLAGS = -export-dynamic -rpath $(MUFFIN_TYPELIB_DIR)
 
 run_js_test_SOURCES =			\
 	run-js-test.c
@@ -217,15 +221,21 @@ cinnamon-enum-types.c: $(srcdir)/cinnamon-enum-types.c.in stamp-cinnamon-enum-ty
 	rm -f $(@F).tmp
 EXTRA_DIST += cinnamon-enum-types.c.in
 
-libcinnamon_la_LDFLAGS = $(WARN_LDFLAGS) -avoid-version
-libcinnamon_la_LIBADD =		\
+libcinnamon_libadd =		\
 	-lm			\
 	$(CINNAMON_LIBS)	\
 	libst-1.0.la       	\
-	libtray.la		\
+	libtray.la \
+	$(libdir)/muffin/libmuffin-clutter-0.so \
+	$(libdir)/muffin/libmuffin-cogl-0.so \
+	$(libdir)/muffin/libmuffin-cogl-pango-0.so \
+	$(libdir)/muffin/libmuffin-cogl-path-0.so \
+	$(MUFFIN_LIBS)
 	$(NULL)
 
-libcinnamon_la_CPPFLAGS = $(cinnamon_cflags)
+libcinnamon_la_LDFLAGS = $(WARN_LDFLAGS) -avoid-version -L$(libdir)/muffin
+libcinnamon_la_LIBADD = $(CINNAMON_LIBS) $(MUFFIN_LIBS) $(libcinnamon_libadd)
+libcinnamon_la_CPPFLAGS = $(MUFFIN_CFLAGS) $(cinnamon_cflags)
 
 Cinnamon-0.1.gir: libcinnamon.la St-1.0.gir
 Cinnamon_0_1_gir_INCLUDES = Clutter-0 ClutterX11-0 CoglPango-0 Cogl-0 Meta-Muffin.0 Soup-2.4 CMenu-3.0 NetworkManager-1.0 NMClient-1.0
@@ -238,7 +248,7 @@ INTROSPECTION_GIRS += Cinnamon-0.1.gir
 CLEANFILES += Cinnamon-0.1.gir
 
 St-1.0.gir: libst-1.0.la
-St_1_0_gir_INCLUDES = Clutter-0 ClutterX11-0 CoglPango-0 Cogl-0 Meta-Muffin.0 Gtk-3.0
+St_1_0_gir_INCLUDES = Clutter-0 ClutterX11-0 Meta-Muffin.0 Gtk-3.0
 St_1_0_gir_CFLAGS = $(st_cflags) -DST_COMPILATION
 St_1_0_gir_LIBS = libst-1.0.la
 St_1_0_gir_FILES = $(filter-out %-private.h $(st_non_gir_sources), $(addprefix $(srcdir)/,$(st_source_h))) \

--- a/src/cinnamon-global.c
+++ b/src/cinnamon-global.c
@@ -1023,13 +1023,7 @@ update_scale_factor (GtkSettings *settings,
   g_object_get (gtk_settings, "gtk-xft-dpi", &xft_dpi, NULL);
   g_object_set (clutter_settings_get_default (), "font-dpi", xft_dpi, NULL);
 
-   /* Make sure clutter and gdk scaling stays disabled
-    * window-scaling-factor doesn't exist yet in clutter < 1.18 */
-  if (g_object_class_find_property (G_OBJECT_GET_CLASS (clutter_settings_get_default ()),
-                                    "window-scaling-factor"))
-    {
-      g_object_set (clutter_settings_get_default (), "window-scaling-factor", 1, NULL);
-    }
+   /* Make sure gdk scaling stays disabled */
   gdk_x11_display_set_window_scale (gdk_display_get_default (), 1);
 }
 

--- a/src/cinnamon-global.c
+++ b/src/cinnamon-global.c
@@ -16,7 +16,6 @@
 
 #include <X11/extensions/Xfixes.h>
 #include <cogl-pango/cogl-pango.h>
-#include <clutter/glx/clutter-glx.h>
 #include <clutter/x11/clutter-x11.h>
 #include <gdk/gdkx.h>
 #include <gio/gio.h>
@@ -51,7 +50,7 @@ struct _CinnamonGlobal {
   /* We use this window to get a notification from GTK+ when
    * a widget in our process does a GTK+ grab.  See
    * http://bugzilla.gnome.org/show_bug.cgi?id=570641
-   * 
+   *
    * This window is never mapped or shown.
    */
   GtkWindow *grab_notifier;
@@ -1284,10 +1283,10 @@ pre_exec_close_fds(void)
 /**
  * cinnamon_global_reexec_self:
  * @global: A #CinnamonGlobal
- * 
- * Restart the current process.  Only intended for development purposes. 
+ *
+ * Restart the current process.  Only intended for development purposes.
  */
-void 
+void
 cinnamon_global_reexec_self (CinnamonGlobal *global)
 {
   GPtrArray *arr;
@@ -1296,20 +1295,20 @@ cinnamon_global_reexec_self (CinnamonGlobal *global)
   char *buf_p;
   char *buf_end;
   GError *error = NULL;
-  
+
   /* Linux specific (I think, anyways). */
   if (!g_file_get_contents ("/proc/self/cmdline", &buf, &len, &error))
     {
       g_warning ("failed to get /proc/self/cmdline: %s", error->message);
       return;
     }
-      
+
   buf_end = buf+len;
   arr = g_ptr_array_new ();
   /* The cmdline file is NUL-separated */
   for (buf_p = buf; buf_p < buf_end; buf_p = buf_p + strlen (buf_p) + 1)
     g_ptr_array_add (arr, buf_p);
-  
+
   g_ptr_array_add (arr, NULL);
 
   /* Close all file descriptors other than stdin/stdout/stderr, otherwise
@@ -1363,7 +1362,7 @@ static void
 grab_notify (GtkWidget *widget, gboolean was_grabbed, gpointer user_data)
 {
   CinnamonGlobal *global = CINNAMON_GLOBAL (user_data);
-  
+
   global->gtk_grab_active = !was_grabbed;
 
   /* Update for the new setting of gtk_grab_active */
@@ -1420,7 +1419,7 @@ cinnamon_global_get_pointer (CinnamonGlobal         *global,
   GdkDevice *gdevice;
   GdkScreen *gscreen;
   GdkModifierType raw_mods;
-  
+
   gmanager = gdk_display_get_device_manager (global->gdk_display);
   gdevice = gdk_device_manager_get_client_pointer (gmanager);
   gdk_device_get_position (gdevice, &gscreen, x, y);
@@ -1449,7 +1448,7 @@ cinnamon_global_set_pointer (CinnamonGlobal         *global,
   GdkDevice *gdevice;
   GdkScreen *gscreen;
   int x2, y2;
-  
+
   gmanager = gdk_display_get_device_manager (global->gdk_display);
   gdevice = gdk_device_manager_get_client_pointer (gmanager);
   gdk_device_get_position (gdevice, &gscreen, &x2, &y2);
@@ -1597,7 +1596,7 @@ cinnamon_global_create_app_launch_context (CinnamonGlobal *global)
   GdkAppLaunchContext *context;
 
   context = gdk_display_get_app_launch_context (global->gdk_display);
-  
+
   gdk_app_launch_context_set_timestamp (context, cinnamon_global_get_current_time (global));
 
   // Make sure that the app is opened on the current workspace even if

--- a/src/cinnamon-global.c
+++ b/src/cinnamon-global.c
@@ -1017,6 +1017,12 @@ update_scale_factor (GtkSettings *settings,
     g_settings_set_int (global->settings, "active-display-scale", (int)scale);
   }
 
+  GtkSettings *gtk_settings = gtk_settings_get_default ();
+  int xft_dpi;
+
+  g_object_get (gtk_settings, "gtk-xft-dpi", &xft_dpi, NULL);
+  g_object_set (clutter_settings_get_default (), "font-dpi", xft_dpi, NULL);
+
    /* Make sure clutter and gdk scaling stays disabled
     * window-scaling-factor doesn't exist yet in clutter < 1.18 */
   if (g_object_class_find_property (G_OBJECT_GET_CLASS (clutter_settings_get_default ()),

--- a/src/main.c
+++ b/src/main.c
@@ -309,7 +309,6 @@ main (int argc, char **argv)
   cinnamon_a11y_init ();
   cinnamon_perf_log_init ();
 
-  g_irepository_prepend_search_path (MUFFIN_TYPELIB_DIR);
   g_irepository_prepend_search_path (CINNAMON_PKGLIBDIR);
 
   /* Disable debug spew from various libraries */

--- a/src/main.c
+++ b/src/main.c
@@ -309,6 +309,7 @@ main (int argc, char **argv)
   cinnamon_a11y_init ();
   cinnamon_perf_log_init ();
 
+  g_irepository_prepend_search_path (MUFFIN_TYPELIB_DIR);
   g_irepository_prepend_search_path (CINNAMON_PKGLIBDIR);
 
   /* Disable debug spew from various libraries */

--- a/src/st/st-cogl-wrapper.h
+++ b/src/st/st-cogl-wrapper.h
@@ -8,6 +8,7 @@
 #define __ST_COGL_WRAPPER_H__
 
 #include <clutter/clutter.h>
+#include <cogl/cogl.h>
 
 G_BEGIN_DECLS
 

--- a/src/st/st-polygon.c
+++ b/src/st/st-polygon.c
@@ -201,8 +201,9 @@ st_polygon_paint (ClutterActor *self)
         coords[6] = priv->urc_x;
         coords[7] = priv->urc_y;
 
-        cogl_path_polygon ((float *)coords, 4);
-        cogl_path_fill ();
+        // CoglPath *selection_path = cogl_path_new();
+        // cogl_path_polygon (selection_path, (float *)coords, 4);
+        // cogl_path_fill (selection_path);
     }
 }
 
@@ -232,8 +233,9 @@ st_polygon_pick (ClutterActor       *self,
                               pick_color->blue,
                               pick_color->alpha);
 
-    cogl_path_polygon ((float *)coords, 4);
-    cogl_path_fill ();
+    // CoglPath *selection_path = cogl_path_new();
+    // cogl_path_polygon (selection_path, (float *)coords, 4);
+    // cogl_path_fill (selection_path);
 }
 
 static void

--- a/src/st/st-polygon.c
+++ b/src/st/st-polygon.c
@@ -201,9 +201,9 @@ st_polygon_paint (ClutterActor *self)
         coords[6] = priv->urc_x;
         coords[7] = priv->urc_y;
 
-        // CoglPath *selection_path = cogl_path_new();
-        // cogl_path_polygon (selection_path, (float *)coords, 4);
-        // cogl_path_fill (selection_path);
+        CoglPath *selection_path = cogl2_path_new();
+        cogl_path_polygon (selection_path, (float *)coords, 4);
+        cogl_path_fill (selection_path);
     }
 }
 
@@ -233,9 +233,9 @@ st_polygon_pick (ClutterActor       *self,
                               pick_color->blue,
                               pick_color->alpha);
 
-    // CoglPath *selection_path = cogl_path_new();
-    // cogl_path_polygon (selection_path, (float *)coords, 4);
-    // cogl_path_fill (selection_path);
+    CoglPath *selection_path = cogl2_path_new();
+    cogl_path_polygon (selection_path, (float *)coords, 4);
+    cogl_path_fill (selection_path);
 }
 
 static void


### PR DESCRIPTION
Based on:
https://github.com/GNOME/gnome-shell/commit/af28a219be30490c1c50a9ed99c1e22e70a36826

This links the private Muffin versions of Clutter and Cogl into Cinnamon. Depends on https://github.com/linuxmint/muffin/pull/335. 
