### PR TITLE
Issue template: Start requesting logs

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,6 +4,7 @@
  * Distribution - (Mint 17.2, Arch, Fedora 25, etc...)
  * Graphics hardware *and* driver used
  * 32 or 64 bit
+ * Attach /home/<username>/.xsession-errors, or /var/log/syslog
  ```
 
 **Issue**


### PR DESCRIPTION
This will help improve our ability to figure out issues we can't readily reproduce. If a user is experiencing a problem and a developer can't reproduce it, seeing debug output is the next best thing.

Not sure what the most distro-agnostic way is to get Cinnamon's stdout without asking everybody to use cinnamon --replace, feedback is welcome.