### PR TITLE
Spices.py: Don't try to load metadata for themes

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
@@ -402,6 +402,9 @@ class Spice_Harvester(GObject.Object):
     def _load_metadata(self):
         self.meta_map = {}
 
+        if self.themes: # Themes don't have metadata.json
+            return
+
         for directory in self.spices_directories:
             if os.path.exists(directory):
                 extensions = os.listdir(directory)


### PR DESCRIPTION
Themes don't have metadata.json and it was failing anyways, causing a lot of warnings in cs_themes.