### PR TITLE
Menu applet: add support for theming opacity to greyed category icons

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -1134,6 +1134,9 @@ StScrollBar StButton#vhandle:hover {
     color: #9C9C9C;
     font-style: italic;
 }
+.menu-category-button-greyed StIcon {
+	opacity: 0.5;
+}
 .menu-category-button-selected {
     padding-top: 7px;
     padding-left: 7px;

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -3049,10 +3049,20 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
             let categoriesButtons = this.categoriesBox.get_children();
             for (var i in categoriesButtons) {
                 let button = categoriesButtons[i];
+                let icon = button._delegate.icon;
                 if (active){
                     button.set_style_class_name("menu-category-button");
+                    if (icon) {
+                        icon.set_opacity(255);
+                    }
                 } else {
                     button.set_style_class_name("menu-category-button-greyed");
+                    if (icon) {
+                        let icon_opacity = icon.get_theme_node().get_double('opacity');
+                        icon_opacity = Math.min(Math.max(0, icon_opacity), 1);
+                        if (icon_opacity) // Don't set opacity to 0 if not defined
+                            icon.set_opacity(icon_opacity * 255);
+                    }
                 }
             }
         } catch (e) {


### PR DESCRIPTION
Full-opacity icons don't match greyed out labels.