### PR TITLE
Make critical notification respect timeouts

### DIFF
--- a/js/ui/notificationDaemon.js
+++ b/js/ui/notificationDaemon.js
@@ -323,7 +323,7 @@ NotificationDaemon.prototype = {
 
         // Find expiration timestamp.
         let expires;
-        if (!timeout || hints.resident || hints.urgency == 2) { // Never expires.
+        if (!timeout || hints.resident) { // Never expires.
             expires = ndata.expires = 0;
         } else if (timeout == -1) { // Default expiration.
             expires = ndata.expires = Date.now()+this.timeout*1000;


### PR DESCRIPTION
When sending a critical notification, the timeout is currently ignored.
e.g.: `notify-send -t 1000 -u critical 'test'`
This will fix it so timeouts are respected

For critical notification without an explicit timeout, the current behavior is kept, and they will not dismiss automatically
e.g.: `notify-send -u critical 'test'`

Currently there's no way to have notifications that both work in full screen apps (e.g. calibre viewer in full screen mode) and respect the timeout.
This makes it possible.

Related issues: #3896 and #7179