### PR TITLE
signalManager: Migrate to ES2015 class, improve code readability

### DIFF
--- a/js/misc/signalManager.js
+++ b/js/misc/signalManager.js
@@ -9,6 +9,9 @@ const _signalIsConnected = function(signal) {
     if (obj instanceof GObject.Object) { // GObject
         // MetaWindowActor is always destroyed in muffin, so accessing the
         // object here will trigger finalized object warnings from CJS.
+        if (obj.is_finalized()) {
+            return false;
+        }
         return GObject.signal_handler_is_connected(obj, id);
     }
     if ('signalHandlerIsConnected' in obj) { // JS Object

--- a/js/misc/signalManager.js
+++ b/js/misc/signalManager.js
@@ -1,6 +1,30 @@
 const GObject = imports.gi.GObject;
 const Lang = imports.lang;
 
+const _signalIsConnected = function(signal) {
+    let [sigName, obj, callback, id] = signal;
+    if (!obj) {
+        return false;
+    }
+    if (obj instanceof GObject.Object) { // GObject
+        // MetaWindowActor is always destroyed in muffin, so accessing the
+        // object here will trigger finalized object warnings from CJS.
+        return GObject.signal_handler_is_connected(obj, id);
+    }
+    if ('signalHandlerIsConnected' in obj) { // JS Object
+        return obj.signalHandlerIsConnected(id);
+    }
+
+    return false;
+};
+
+const _disconnect = function(results) {
+    for (let i = 0; i < results.length; i++) {
+        let [sigName, obj, callback, id] = results[i];
+        obj.disconnect(id);
+    }
+};
+
 /**
  * #SignalManager:
  * @short_description: A convenience object for managing signals
@@ -31,39 +55,39 @@ const Lang = imports.lang;
  *
  * An example usage is as follows:
  * ```
- * MyApplet.prototype = {
- *     __proto__: Applet.Applet.prototype,
+ * class MyApplet extends Applet.Applet {
+ *     constructor(orientation, panelHeight, instanceId) {
+ *         super(orientation, panelHeight, instanceId);
  *
- *     _init: function(orientation, panelHeight, instanceId) {
- *         Applet.Applet.prototype._init.call(this, orientation, panelHeight, instanceId);
+ *         this._signalManager = new SignalManager.SignalManager(null);
+ *         this._signalManager.connect(global.settings, "changed::foo", (...args) => this._onChanged(...args));
+ *     }
  *
- *         this._signalManager = new SignalManager.SignalManager(this);
- *         this._signalManager.connect(global.settings, "changed::foo", this._onChanged);
- *     },
- *
- *     _onChanged: function() {
+ *     _onChanged() {
  *         // Do something
- *     },
+ *     }
  *
- *     on_applet_removed_from_panel: function() {
+ *     on_applet_removed_from_panel() {
  *         this._signalManager.disconnectAllSignals();
  *     }
  * }
  * ```
  */
-function SignalManager(object) {
-    this._init(object);
-}
 
-SignalManager.prototype = {
+var SignalManager = class SignalManager {
     /**
      * _init:
-     * @object (Object): the object owning the #SignalManager (usually @this)
+     * @object (Object): the object owning the #SignalManager (usually @this) (Deprecated)
      */
-    _init: function(object) {
-        this._object = object;
+    constructor(object) {
+        if (object) {
+            global.dump_gjs_stack(
+                'Initializing SignalManager with an object is deprecated.' +
+                ' Please bind the callback before passing it to SignalManager.'
+            );
+        }
         this._storage = [];
-    },
+    }
 
     /**
      * connect:
@@ -76,9 +100,7 @@ SignalManager.prototype = {
      * @force (boolean): whether to connect again even if it is connected
      *
      * This listens to the signal @sigName from @obj and calls @callback when
-     * the signal is emitted. @callback is automatically binded to
-     * %this._object, unless the @bind argument is set to something else, in
-     * which case the function will be binded to @bind.
+     * the signal is emitted. @callback is bound to the @bind argument if passed.
      *
      * This checks whether the signal is already connected and will not connect
      * again if it is already connected. This behaviour can be overridden by
@@ -98,44 +120,23 @@ SignalManager.prototype = {
      * signal name, then the object (since the object is rarely passed in other
      * functions).
      */
-    connect: function(obj, sigName, callback, bind, force) {
-        if (!force && this.isConnected(sigName, obj, callback))
-            return
+    _connect(method, obj, sigName, callback, bind, force) {
+        if (!obj || (!force && this.isConnected(sigName, obj, callback)))
+            return;
 
-        let id;
-
-        if (bind)
-            id = obj.connect(sigName, Lang.bind(bind, callback));
-        else
-            id = obj.connect(sigName, Lang.bind(this._object, callback));
+        let id = bind ? obj[method](sigName, Lang.bind(bind, callback))
+            : obj[method](sigName, callback);
 
         this._storage.push([sigName, obj, callback, id]);
-    },
+    }
 
-    connect_after: function(obj, sigName, callback, bind, force) {
-        if (!force && this.isConnected(sigName, obj, callback))
-            return
+    connect() {
+        this._connect('connect', ...arguments);
+    }
 
-        let id;
-
-        if (bind)
-            id = obj.connect_after(sigName, Lang.bind(bind, callback));
-        else
-            id = obj.connect_after(sigName, Lang.bind(this._object, callback));
-
-        this._storage.push([sigName, obj, callback, id]);
-    },
-
-    _signalIsConnected: function (signal) {
-        if (!signal[1])
-            return false;
-        else if (signal[1] instanceof GObject.Object)// GObject
-            return GObject.signal_handler_is_connected(signal[1], signal[3]);
-        else if ('signalHandlerIsConnected' in signal[1]) // JS Object
-            return signal[1].signalHandlerIsConnected(signal[3]);
-        else
-            return false;
-    },
+    connect_after() {
+        this._connect('connect_after', ...arguments);
+    }
 
     /**
      * isConnected:
@@ -158,9 +159,9 @@ SignalManager.prototype = {
      *
      * Returns: Whether the signal is connected
      */
-    isConnected: function() {
-        return (this.getSignals.apply(this, arguments).length > 0);
-    },
+    isConnected() {
+        return this.getSignals.apply(this, arguments).length > 0;
+    }
 
     /**
      * getSignals:
@@ -176,7 +177,7 @@ SignalManager.prototype = {
      *
      * Returns (Array): The list of signals
      */
-    getSignals: function(sigName, obj, callback) {
+    getSignals(sigName, obj, callback) {
         let results = this._storage;
 
         if (sigName)
@@ -187,7 +188,7 @@ SignalManager.prototype = {
             results = results.filter(x => x[2] == callback);
 
         return results;
-    },
+    }
 
     /**
      * disconnect:
@@ -205,12 +206,16 @@ SignalManager.prototype = {
      * no longer exists, or the signal is somehow already disconnected. So
      * checks need not be performed before calling this function.
      */
-    disconnect: function() {
-        let results = this.getSignals.apply(this, arguments);
-        results.filter(this._signalIsConnected).forEach(x => x[1].disconnect(x[3]));
 
-        this._storage = this._storage.filter(x => results.indexOf(x) == -1);
-    },
+    disconnect() {
+        let results = this.getSignals.apply(this, arguments).filter(_signalIsConnected);
+        _disconnect(results);
+        this._storage = this._storage.filter((x) => {
+            return results.findIndex(function(signalObj) {
+                return signalObj[0] === x[0] && signalObj[1] === x[1];
+            }) === -1;
+        });
+    }
 
     /**
      * disconnectAllSignals:
@@ -218,9 +223,10 @@ SignalManager.prototype = {
      * Disconnects *all signals* managed by the #SignalManager. This is useful
      * in the @destroy function of objects.
      */
-    disconnectAllSignals: function() {
-        this._storage.filter(this._signalIsConnected).forEach(x => x[1].disconnect(x[3]));
-
+    disconnectAllSignals() {
+        _disconnect(
+            this._storage.filter(_signalIsConnected)
+        );
         this._storage = [];
     }
 }

--- a/js/ui/environment.js
+++ b/js/ui/environment.js
@@ -6,6 +6,7 @@ imports.gi.versions.Gdk = '3.0';
 imports.gi.versions.GdkPixbuf = '2.0';
 imports.gi.versions.Gtk = '3.0';
 
+const GObject = imports.gi.GObject;
 const Clutter = imports.gi.Clutter;
 const Gettext = imports.gettext;
 const GLib = imports.gi.GLib;
@@ -99,6 +100,13 @@ function init() {
     _patchContainerClass(St.BoxLayout);
     _patchContainerClass(St.Table);
 
+    // Cache the original toString since it will be overriden for Clutter.Actor
+    GObject.Object.prototype._toString = GObject.Object.prototype.toString;
+    // Add method to determine if a GObject is finalized - needed to prevent accessing
+    // objects that have been disposed in C code.
+    GObject.Object.prototype.is_finalized = function() {
+        return this._toString().includes('FINALIZED');
+    };
     Clutter.Actor.prototype.toString = function() {
         return St.describe_actor(this);
     };


### PR DESCRIPTION
- Moves duplicate code to _disconnect and _connect.
- Pulls _signalIsConnected and _disconnect out of the class because they
don't need class context, and the functions would be re-created for
every instance otherwise.
- Fully deprecates passing context to the constructor with a warning
since it creates circular references.
- Adds method `GObject.Object.prototype.is_finalized`.