### PR TITLE
systray: Fix invalid access errors, implement a reloading API for xlets

### DIFF
--- a/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
@@ -354,7 +354,10 @@ class CinnamonSystrayApplet extends Applet.Applet {
         let iconIndex = findIndex(this._statusItems, function(statusItem) {
             return statusItem.state.role === role;
         });
-        if (this.reloading || iconIndex === -1 || iconIndex > -1 && (this._statusItems[iconIndex].state.obsolete || !this._statusItems[iconIndex].icon)) {
+        if (this.reloading
+            || iconIndex === -1
+            || this._statusItems[iconIndex].state.obsolete
+            || !this._statusItems[iconIndex].icon) {
             return;
         }
         this.manager_container.insert_child_at_index(icon, 0);
@@ -378,7 +381,7 @@ class CinnamonSystrayApplet extends Applet.Applet {
         let iconIndex = findIndex(this._statusItems, function(statusItem) {
             return statusItem.state.role === role;
         });
-        if (iconIndex === -1 || iconIndex > -1 && this._statusItems[iconIndex].state.obsolete) {
+        if (iconIndex === -1 || this._statusItems[iconIndex].state.obsolete) {
             return;
         }
         icon = this._statusItems[iconIndex].icon;

--- a/files/usr/share/cinnamon/applets/systray@cinnamon.org/metadata.json
+++ b/files/usr/share/cinnamon/applets/systray@cinnamon.org/metadata.json
@@ -2,5 +2,6 @@
  "uuid": "systray@cinnamon.org",
  "name": "System Tray",
  "icon": "applications-system",
+ "role": "tray",
  "description": "An applet which hosts all the system tray icons"
 }

--- a/js/misc/util.js
+++ b/js/misc/util.js
@@ -397,7 +397,7 @@ function queryCollection(collection, query, indexOnly = false) {
 function findIndex(array, callback) {
     for (let i = 0, len = array.length; i < len; i++) {
         if (callback(array[i], i, array)) {
-        return i;
+            return i;
         }
     }
     return -1;

--- a/js/misc/util.js
+++ b/js/misc/util.js
@@ -386,6 +386,23 @@ function queryCollection(collection, query, indexOnly = false) {
     return indexOnly ? -1 : null;
 }
 
+/**
+ * findIndex:
+ * @array (array): Array to be iterated.
+ * @callback (function): The function to call on every iteration,
+ * should return a boolean value.
+ *
+ * Returns (number): the index of @array.
+ */
+function findIndex(array, callback) {
+    for (let i = 0, len = array.length; i < len; i++) {
+        if (callback(array[i], i, array)) {
+        return i;
+        }
+    }
+    return -1;
+}
+
 const READWRITE = GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE;
 
 // Based on https://gist.github.com/ptomato/c4245c77d375022a43c5

--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -406,6 +406,16 @@ Applet.prototype = {
     on_applet_removed_from_panel: function(deleteConfig) {
     },
 
+    /**
+     * on_applet_reloaded:
+     *
+     * This function is called by appletManager when the applet is reloaded.
+     *
+     * This is meant to be overridden in individual applets.
+     */
+    on_applet_reloaded: function(deleteConfig) {
+    },
+
     // should only be called by appletManager
     _onAppletRemovedFromPanel: function(deleteConfig) {
         global.settings.disconnect(this._panelEditModeChangedId);

--- a/js/ui/desklet.js
+++ b/js/ui/desklet.js
@@ -111,6 +111,14 @@ Desklet.prototype = {
     },
 
     /**
+     * on_desklet_reloaded:
+     *
+     * Callback when desklet is reloaded. To be overridden by individual desklets
+     */
+    on_desklet_reloaded: function() {
+    },
+
+    /**
      * destroy:
      *
      * Destroys the actor with an fading animation

--- a/js/ui/deskletManager.js
+++ b/js/ui/deskletManager.js
@@ -192,6 +192,19 @@ function prepareExtensionUnload(extension, deleteConfig) {
     }
 }
 
+// Callback for extension.js
+function prepareExtensionReload(extension) {
+    for (var i = 0; i < definitions.length; i++) {
+        if (extension.uuid === definitions[i].uuid) {
+            let {desklet, desklet_id} = definitions[i];
+            if (!desklet) continue;
+            global.log(`Reloading desklet: ${extension.uuid}/${desklet_id}`);
+            desklet.on_desklet_reloaded();
+            return;
+        }
+    }
+}
+
 function _onEnabledDeskletsChanged() {
     let oldDefinitions = definitions.slice();
     definitions = getDefinitions();

--- a/js/ui/extensionSystem.js
+++ b/js/ui/extensionSystem.js
@@ -45,6 +45,17 @@ function prepareExtensionUnload(extension) {
         delete extensionObj[extension.uuid];
 }
 
+
+// Callback for extension.js
+function prepareExtensionReload(extension) {
+    try {
+        let on_extension_reloaded = getModuleByIndex(extension.moduleIndex).on_extension_reloaded;
+        if (on_extension_reloaded) on_extension_reloaded();
+    } catch (e) {
+        Extension.logError('Failed to evaluate \'on_extension_reloaded\' function on extension: ' + extension.uuid, e);
+    }
+}
+
 // Callback for extension.js
 function finishExtensionLoad(extensionIndex) {
     let extension = Extension.extensions[extensionIndex];


### PR DESCRIPTION
Depends on #7868

- Adds an API that lets xlets know when they are being reloaded vs. just seeing that they are being unloaded and loaded. There were workarounds to figure out if the xlet was being reloaded from the xlet, but this is more precise.
- Used this API in the systray applet to move `Main.statusIconDispatcher.redisplay` from `onEnabledAppletsChanged` in appletManager to `on_applet_added_to_panel`. Since 3.8, extensions load asynchronously, but there was a side effect from that change causing the `redisplay` call to occur before the xlet was reloaded.
- Adds a small function to utils, `findIndex`, because it is a little [faster than native findIndex](http://jsben.ch/ABI1C) with Spidermonkey.
- Uses `is_finalized` from #7868 to prevent invalid object access.
- Cleans up various things that looked redundant or inefficient.
- Adds a tray role for applets because having more than one tray applet loaded crashes Cinnamon.