### PR TITLE
DND, tweener: Fix invalid object access errors

### DIFF
--- a/js/ui/dnd.js
+++ b/js/ui/dnd.js
@@ -635,7 +635,7 @@ var _Draggable = new Lang.Class({
     },
 
     _dragComplete: function() {
-        if (!this._actorDestroyed)
+        if (!this._actorDestroyed && !this._dragActor.is_finalized())
             Cinnamon.util_set_hidden_from_pick(this._dragActor, false);
 
         this._ungrabEvents();
@@ -789,6 +789,7 @@ GenericDragItemContainer.prototype = {
     },
 
     set childScale(scale) {
+        if (this.child.is_finalized()) return;
         this._childScale = scale;
 
         if (this.child == null)
@@ -804,6 +805,7 @@ GenericDragItemContainer.prototype = {
     },
 
     set childOpacity(opacity) {
+        if (this.child.is_finalized()) return;
         this._childOpacity = opacity;
 
         if (this.child == null)

--- a/js/ui/tweener.js
+++ b/js/ui/tweener.js
@@ -235,7 +235,7 @@ function _getTweenState(target) {
 function _resetTweenState(target) {
     let state = target.__CinnamonTweenerState;
 
-    if (state && !target.is_finalized()) {
+    if (state && state.actor && !state.actor.is_finalized()) {
         if (state.destroyedId)
             state.actor.disconnect(state.destroyedId);
     }

--- a/js/ui/tweener.js
+++ b/js/ui/tweener.js
@@ -233,6 +233,7 @@ function _getTweenState(target) {
 }
 
 function _resetTweenState(target) {
+    if (target.is_finalized()) return;
     let state = target.__CinnamonTweenerState;
 
     if (state && state.actor && !state.actor.is_finalized()) {


### PR DESCRIPTION
This also corrects the invalid object access fix for tweener, we should be calling `is_finalized` on `state.actor` instead of `target`.