### PR TITLE
environment: Override Clutter.Actor.prototype.destroy and add is_finalized check

### DIFF
--- a/js/ui/environment.js
+++ b/js/ui/environment.js
@@ -104,8 +104,15 @@ function init() {
     GObject.Object.prototype._toString = GObject.Object.prototype.toString;
     // Add method to determine if a GObject is finalized - needed to prevent accessing
     // objects that have been disposed in C code.
-    GObject.Object.prototype.is_finalized = function() {
+    GObject.Object.prototype.is_finalized = function is_finalized() {
         return this._toString().includes('FINALIZED');
+    };
+    // Override destroy so it checks if its finalized before calling the real destroy method.
+    Clutter.Actor.prototype._destroy = Clutter.Actor.prototype.destroy;
+    Clutter.Actor.prototype.destroy = function destroy() {
+        if (!this.is_finalized()) {
+            this._destroy();
+        }
     };
     Clutter.Actor.prototype.toString = function() {
         return St.describe_actor(this);

--- a/js/ui/expoThumbnail.js
+++ b/js/ui/expoThumbnail.js
@@ -218,12 +218,8 @@ ExpoWindowClone.prototype = {
     destroy: function () {
         this.killUrgencyTimeout();
         this.disconnectAttentionSignals();
-        if (!this.actor.is_finalized()) {
-            this.actor.destroy();
-        }
-        if (!this.icon.is_finalized()) {
-            this.icon.destroy();
-        }
+        this.actor.destroy();
+        this.icon.destroy();
     },
 
     onPositionChanged: function() {

--- a/js/ui/expoThumbnail.js
+++ b/js/ui/expoThumbnail.js
@@ -218,8 +218,12 @@ ExpoWindowClone.prototype = {
     destroy: function () {
         this.killUrgencyTimeout();
         this.disconnectAttentionSignals();
-        this.actor.destroy();
-        this.icon.destroy();
+        if (!this.actor.is_finalized()) {
+            this.actor.destroy();
+        }
+        if (!this.icon.is_finalized()) {
+            this.icon.destroy();
+        }
     },
 
     onPositionChanged: function() {

--- a/js/ui/messageTray.js
+++ b/js/ui/messageTray.js
@@ -1027,7 +1027,6 @@ Notification.prototype = {
     },
 
     destroy: function(reason) {
-        if (this.actor.is_finalized()) return;
         this._destroyedReason = reason;
         this.actor.destroy();
     }

--- a/js/ui/tooltips.js
+++ b/js/ui/tooltips.js
@@ -245,7 +245,6 @@ Tooltip.prototype = {
     },
 
     _destroy: function() {
-        if (this._tooltip.is_finalized()) return;
         this._tooltip.destroy();
     }
 };


### PR DESCRIPTION
This should prevent us from having to guard `destroy` on every possible code path that redundantly destroys objects, or where objects are destroyed in JS when they have already been destroyed in C code.