### PR TITLE
string formatting - line 112

### DIFF
--- a/utils/cinnamon-stap-monitor/cinnamon-stap-monitor.py
+++ b/utils/cinnamon-stap-monitor/cinnamon-stap-monitor.py
@@ -107,9 +107,9 @@ class Main:
 
         elapsed = now - self.start_time
 
-        string = str(timedelta(seconds=int(elapsed + .5)))
+        time_passed = timedelta(seconds=int(elapsed + .5))
 
-        self.timer_label.set_text("Elapsed time: %s" % string)
+        self.timer_label.set_text("Elapsed time: {}".format(time_passed))
 
         return True
 


### PR DESCRIPTION
% is used to cast objects, %s to string etc. now, if int or float, the corresponding formatting (like %d) should be used instead of converting via str() then passing via  %s (double job as the purpose of formatting is precisely to allow even numbers)

now .format() is supported since py2.7 . it is more flexible and less dense