### PR TITLE
Applet: Replaced gvfs command by gio on trash applet

### DIFF
--- a/files/usr/share/cinnamon/applets/trash@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/trash@cinnamon.org/applet.js
@@ -78,7 +78,7 @@ class CinnamonTrashApplet extends Applet.IconApplet {
     }
 
     _doEmptyTrash() {
-        Util.spawn(['gvfs-trash', '--empty']);
+        Util.spawn(['gio', 'trash', '--empty']);
     }
 }
 


### PR DESCRIPTION
Replaced old gvfs command by th new gio command on trash applet since the command got removed in gvfs 1.37 and cause an `command not found` after pressing `Empty trash` button of trash applet.

```bash
# Old command (removed)
gvfs-trash --empty

# New command
gio trash --empty
```

https://gitlab.gnome.org/GNOME/gvfs/blob/1.38.0/NEWS#L36
https://gitlab.gnome.org/GNOME/gvfs/commit/6d711c07cbd00768c6b2b468f3100f02afc58f6f