### PR TITLE
Overview: Remove META_KEYBINDING_ACTION_PANEL_MAIN_MENU

### DIFF
--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -1266,7 +1266,6 @@ function _stageEventHandler(actor, event) {
     switch (action) {
         // left/right would effectively act as synonyms for up/down if we enabled them;
         // but that could be considered confusing; we also disable them in the main view.
-        //
          case Meta.KeyBindingAction.WORKSPACE_LEFT:
              wm.actionMoveWorkspaceLeft();
              return true;
@@ -1283,10 +1282,6 @@ function _stageEventHandler(actor, event) {
             return true;
         case Meta.KeyBindingAction.PANEL_RUN_DIALOG:
             getRunDialog().open();
-            return true;
-        case Meta.KeyBindingAction.PANEL_MAIN_MENU:
-            overview.hide();
-            expo.hide();
             return true;
     }
 


### PR DESCRIPTION
This keybinding doesn't exist and outputs a warning when using the arrow keys to navigate the window overview.