### PR TITLE
Improve workspace switching performance

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -1005,7 +1005,7 @@ class CinnamonWindowListApplet extends Applet.Applet {
         this.signals.connect(global.screen, 'window-workspace-changed', this._onWindowWorkspaceChanged, this);
         this.signals.connect(global.screen, 'window-skip-taskbar-changed', this._onWindowSkipTaskbarChanged, this);
         this.signals.connect(global.screen, 'monitors-changed', this._updateWatchedMonitors, this);
-        this.signals.connect(global.window_manager, 'switch-workspace', this._refreshAllItems, this);
+        this.signals.connect(Main.wm, 'switch-workspace', this._refreshAllItems, this);
 
         this.actor.connect('style-changed', Lang.bind(this, this._updateSpacing));
 

--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
@@ -280,6 +280,7 @@ class CinnamonWorkspaceSwitcher extends Applet.Applet {
     }
 
     _onWorkspaceChanged(windowManager, wm, from, to) {
+        if (!this.buttons[from] || !this.buttons[to]) return;
         this.buttons[from].activate(false);
         this.buttons[to].activate(true);
     }

--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
@@ -280,8 +280,12 @@ class CinnamonWorkspaceSwitcher extends Applet.Applet {
     }
 
     _onWorkspaceChanged(windowManager, wm, from, to) {
-        if (!this.buttons[from] || !this.buttons[to]) return;
-        this.buttons[from].activate(false);
+        // Make sure we always reset everything to inactive before setting
+        // a new active item. This prevents multiple buttons from being highlighted.
+        for (let i = 0; i < this.buttons.length; i++) {
+            this.buttons[i].activate(false);
+        }
+
         this.buttons[to].activate(true);
     }
 

--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
@@ -231,7 +231,7 @@ class CinnamonWorkspaceSwitcher extends Applet.Applet {
 
         this._createButtons();
         global.screen.connect('notify::n-workspaces', Lang.bind(this, this.onNumberOfWorkspacesChanged));
-        global.window_manager.connect('switch-workspace', this._onWorkspaceChanged.bind(this));
+        Main.wm.connect('switch-workspace', this._onWorkspaceChanged.bind(this));
         global.settings.connect('changed::panel-edit-mode', Lang.bind(this, this.on_panel_edit_mode_changed));
 
         let expoMenuItem = new PopupMenu.PopupIconMenuItem(_("Manage workspaces (Expo)"), "view-grid-symbolic", St.IconType.SYMBOLIC);
@@ -279,7 +279,7 @@ class CinnamonWorkspaceSwitcher extends Applet.Applet {
         }
     }
 
-    _onWorkspaceChanged(wm, from, to) {
+    _onWorkspaceChanged(windowManager, wm, from, to) {
         this.buttons[from].activate(false);
         this.buttons[to].activate(true);
     }

--- a/js/ui/expoThumbnail.js
+++ b/js/ui/expoThumbnail.js
@@ -1098,7 +1098,7 @@ ExpoThumbnailsBox.prototype = {
 
     show: function() {
         this.switchWorkspaceNotifyId =
-            global.window_manager.connect('switch-workspace',
+            Main.wm.connect('switch-workspace',
                                           Lang.bind(this, this.activeWorkspaceChanged));
 
         this.workspaceAddedId = global.screen.connect('workspace-added', Lang.bind(this, function(screen, index) {
@@ -1206,7 +1206,7 @@ ExpoThumbnailsBox.prototype = {
     },
 
     hide: function() {
-        global.window_manager.disconnect(this.switchWorkspaceNotifyId);
+        Main.wm.disconnect(this.switchWorkspaceNotifyId);
         global.screen.disconnect(this.workspaceAddedId);
         global.screen.disconnect(this.workspaceRemovedId);
 
@@ -1683,7 +1683,8 @@ ExpoThumbnailsBox.prototype = {
         this.emit('allocated');
     },
 
-    activeWorkspaceChanged: function(wm, from, to, direction) {
+    activeWorkspaceChanged: function(windowManager, wm, from, to, direction) {
+        if (!this.thumbnails[this.kbThumbnailIndex]) return;
         this.thumbnails[this.kbThumbnailIndex].showKeyboardSelectedState(false);
         this.kbThumbnailIndex = global.screen.get_active_workspace_index();
         this.thumbnails[this.kbThumbnailIndex].showKeyboardSelectedState(true);

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -442,7 +442,6 @@ Chrome.prototype = {
         global.screen.connect('restacked',
                               Lang.bind(this, this._windowsRestacked));
         global.screen.connect('in-fullscreen-changed', Lang.bind(this, this._updateVisibility));
-        global.window_manager.connect('switch-workspace', Lang.bind(this, this._queueUpdateRegions));
 
         // Need to update struts on new workspaces when they are added
         global.screen.connect('notify::n-workspaces',

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -19,6 +19,7 @@ const ModalDialog = imports.ui.modalDialog;
 const Tweener = imports.ui.tweener;
 
 const WINDOW_ANIMATION_TIME = 0.25;
+const WORKSPACE_SWITCH_ANIMATION_TIME = 0.075;
 const TILE_HUD_ANIMATION_TIME = 0.15;
 const DIM_TIME = 0.500;
 const DIM_DESATURATION = 0.6;
@@ -850,7 +851,7 @@ WindowManager.prototype = {
                 Tweener.addTween(window,
                         { x: window.origX + xDest,
                           y: window.origY + yDest,
-                          time: WINDOW_ANIMATION_TIME,
+                          time: WORKSPACE_SWITCH_ANIMATION_TIME,
                           transition: 'easeOutQuad',
                           onComplete: function() {
                               window.hide();
@@ -868,7 +869,7 @@ WindowManager.prototype = {
                 Tweener.addTween(window,
                         { x: window.origX,
                           y: window.origY,
-                          time: WINDOW_ANIMATION_TIME,
+                          time: WORKSPACE_SWITCH_ANIMATION_TIME,
                           transition: 'easeOutQuad',
                           onComplete: Lang.bind(window, function() {
                               window.origX = undefined;
@@ -880,7 +881,7 @@ WindowManager.prototype = {
         }
 
         Tweener.addTween(this, {
-            time: WINDOW_ANIMATION_TIME,
+            time: WORKSPACE_SWITCH_ANIMATION_TIME,
             onComplete: () => {
                 cinnamonwm.completed_switch_workspace();
                 this.emitSwitchWorkspace(...arguments);

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -827,10 +827,14 @@ WindowManager.prototype = {
             }
         }
 
-        Tweener.addTween(this, {time: WINDOW_ANIMATION_TIME, onComplete: function() {
-            cinnamonwm.completed_switch_workspace();
-            this.emitSwitchWorkspace(...arguments);
-        }});
+        Tweener.addTween(this, {
+            time: WINDOW_ANIMATION_TIME,
+            onComplete: function() {
+                cinnamonwm.completed_switch_workspace();
+                this.emitSwitchWorkspace(...arguments);
+            },
+            onCompleteParams: Array.from(arguments)
+        });
     },
 
     _showTilePreview: function(cinnamonwm, window, tileRect, monitorIndex, snapQueued) {

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -436,8 +436,8 @@ WindowManager.prototype = {
         this._cinnamonwm.connect('kill-window-effects', Lang.bind(this, this._killWindowEffects));
         this._cinnamonwm.connect(
             'switch-workspace',
-            (...args) => Mainloop.idle_add_full(
-                Mainloop.PRIORITY_DEFAULT,
+            (...args) => Meta.later_add(
+                Meta.LaterType.BEFORE_REDRAW,
                 () => this._switchWorkspace(...args)
             )
         );

--- a/js/ui/workspacesView.js
+++ b/js/ui/workspacesView.js
@@ -91,13 +91,13 @@ WorkspacesView.prototype = {
         this._swipeScrollEndId = 0;
 
         let restackedNotifyId = global.screen.connect('restacked', Lang.bind(this, this._onRestacked));
-        let switchWorkspaceNotifyId = global.window_manager.connect('switch-workspace',
+        let switchWorkspaceNotifyId = Main.wm.connect('switch-workspace',
                                           Lang.bind(this, this._activeWorkspaceChanged));
 
         let nWorkspacesChangedId = global.screen.connect('notify::n-workspaces', Lang.bind(this, this._workspacesChanged));
 
         this._disconnectHandlers = function() {
-            global.window_manager.disconnect(switchWorkspaceNotifyId);
+            Main.wm.disconnect(switchWorkspaceNotifyId);
             global.screen.disconnect(nWorkspacesChangedId);
             global.screen.disconnect(restackedNotifyId);
         };
@@ -272,7 +272,7 @@ WorkspacesView.prototype = {
         this._updateVisibility();
     },
 
-    _activeWorkspaceChanged: function(wm, from, to, direction) {
+    _activeWorkspaceChanged: function(windowManager, wm, from, to, direction) {
         if (this._scrolling)
             return;
 


### PR DESCRIPTION
This moves all callbacks that are called on the `switch-workspace` signal to a new signal emitted from `Main.wm` (`WindowManager`) after it is done switching workspaces. Before, everything connected to `global.window_manager`'s switch-workspace signal which is emitted in C. What this PR does is add signal methods to `WindowManager.prototype`, and makes it so only it receives the C signal. It then emits its own switch-workspace signal that everything else now connects to. This allows the workspace switching to happen first, then everything else can react after Clutter paints the workspace.

- This adds a new API, `afterStageRelayout` to `Main.wm`. It is a self-contained signal handler that connects to the stage's `queue-relayout` signal with connect_after. This is used to emit `Main.wm`'s `switch-workspace` signal that other parts of Cinnamon will receive, but does so after the next stage relayout so its not blocking workspace switching.
- Removes invocation of `_queueUpdateRegions` on `switch-workspace` in layout.js/Chrome. This function is heavy and seems to be getting called very frequently via `Chrome.prototype._windowsRestacked` emission. After looking back at why it was added, and testing panel auto hide, hot corners, window, and workspace overviews, I'm not seeing any regressions from its removal.
- This is backwards compatible, as it is not changing the signal on `global.window_manager`, which is emitted from C code. Maintainers of multi-version xlets might want to consider connecting their `switch-workspace` signal to `Main.wm` instead though.

Tested with and without #7541.

Refs #5140 #6376 #2081 #1413 #1037