### PR TITLE
menu: Fix application items not rendering

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -2903,10 +2903,10 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
             this._displayButtons(null, null, -1);
         } else
         if (name == null) {
-            this._displayButtons(this._listApplications(null));
+            this._displayButtons(this._listApplications(null)[0]);
         } else
         {
-            this._displayButtons(this._listApplications(name));
+            this._displayButtons(this._listApplications(name)[0]);
         }
 
         this.closeContextMenus(null, false);


### PR DESCRIPTION
`_listApplications` was changed to return an array in #7395, but this was only handled in `_doSearch`.