### PR TITLE
[WIP] Add a window list with app grouping

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,7 +31,7 @@
     "rules": {
         "comma-dangle": 0,
         "no-cond-assign": 0,
-        "no-console": 2,
+        "no-console": 0,
         "no-constant-condition": 0,
         "no-control-regex": 0,
         "no-debugger": 0,

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -1,0 +1,1121 @@
+const Cinnamon = imports.gi.Cinnamon;
+const Meta = imports.gi.Meta;
+const Clutter = imports.gi.Clutter;
+const St = imports.gi.St;
+const Main = imports.ui.main;
+const Tweener = imports.ui.tweener;
+const DND = imports.ui.dnd;
+const Tooltips = imports.ui.tooltips;
+const PopupMenu = imports.ui.popupMenu;
+const {SignalManager} = imports.misc.signalManager;
+const {each, find, findIndex, unref} = imports.misc.util;
+const {createStore} = imports.misc.state;
+
+const {AppMenuButtonRightClickMenu, HoverMenuController, AppThumbnailHoverMenu} = require('./menus');
+const {
+    FLASH_INTERVAL,
+    MAX_BUTTON_WIDTH,
+    BUTTON_BOX_ANIMATION_TIME,
+    ICON_HEIGHT_FACTOR,
+    VERTICAL_ICON_HEIGHT_FACTOR,
+    RESERVE_KEYS,
+    TitleDisplay,
+    NumberDisplay,
+    pseudoOptions
+} = require('./constants');
+
+// returns [x1,x2] so that the area between x1 and x2 is
+// centered in length
+
+const center = function(length, naturalLength) {
+    let maxLength = Math.min(length, naturalLength);
+    let x1 = Math.max(0, Math.floor((length - maxLength) / 2));
+    let x2 = Math.min(length, x1 + maxLength);
+    return [x1, x2];
+};
+
+const getPseudoClass = function(pseudoClass) {
+    let item = find(pseudoOptions, (item) => item.id === pseudoClass);
+    if (item) {
+        return item.label;
+    }
+    return 'outlined';
+};
+
+const getFocusState = function(metaWindow) {
+    if (!metaWindow || metaWindow.minimized) {
+        return false;
+    }
+
+    if (metaWindow.appears_focused) {
+        return true;
+    }
+
+    let transientHasFocus = false;
+    metaWindow.foreach_transient(function(transient) {
+        if (transient && transient.appears_focused) {
+            transientHasFocus = true;
+            return false;
+        }
+        return true;
+    });
+    return transientHasFocus;
+};
+
+class _Draggable extends DND._Draggable {
+    constructor(actor, params) {
+        super(actor, params);
+    }
+    _grabActor() {
+        this._onEventId = this.actor.connect('event', (...args) => this._onEvent(...args));
+    }
+    _onButtonPress(actor, event) {
+        if (this.inhibit) {
+            return false;
+        }
+
+        if (event.get_button() !== 1) {
+            return false;
+        }
+
+        if (Tweener.getTweenCount(actor)) {
+            return false;
+        }
+
+        this._buttonDown = true;
+        this._grabActor();
+
+        let [stageX, stageY] = event.get_coords();
+        this._dragStartX = stageX;
+        this._dragStartY = stageY;
+
+        return false;
+    }
+}
+
+class AppGroup {
+    constructor(params) {
+        if (DND.LauncherDraggable) {
+            DND.LauncherDraggable.prototype._init.call(this);
+        }
+
+        this.state = params.state;
+        this.listState = params.listState;
+        this.groupState = createStore({
+            app: params.app,
+            appId: params.appId,
+            appName: params.app.get_name(),
+            appInfo: params.app.get_app_info(),
+            metaWindows: params.metaWindows || [],
+            lastFocused: params.metaWindow || null,
+            isFavoriteApp: !params.metaWindow ? true : params.isFavoriteApp === true,
+            autoStartIndex: findIndex(this.state.autoStartApps, (app) => app.id === params.appId),
+            willUnmount: false,
+            tooltip: null,
+            groupReady: false
+        });
+
+        this.groupState.connect({
+            isFavoriteApp: () => this.handleFavorite(true),
+            getActor: () => this.actor,
+            launchNewInstance: () => this.launchNewInstance()
+        });
+
+        this.signals = new SignalManager(null);
+
+        // TODO: This needs to be in state so it can be updated more reliably.
+        this.labelVisible = this.state.settings.titleDisplay !== TitleDisplay.None && this.state.isHorizontal;
+        this._progress = 0;
+        this.padding = 0;
+        this.wasFavapp = false;
+        this.time = params.time;
+        this.focusedWindow = false;
+        this.title = '';
+        this.pseudoClassStash = [];
+
+        this.actor = new St.Bin({
+            style_class: 'window-list-item-box',
+            reactive: true,
+            can_focus: true,
+            x_fill: true,
+            y_fill: true,
+            track_hover: false
+        });
+        this.actor._delegate = this;
+        this.container = new Cinnamon.GenericContainer({
+            name: 'iconLabelButton'
+        });
+        this.actor.set_child(this.container);
+        this.progressOverlay = new St.Widget({
+            name: 'progressOverlay',
+            style_class: 'progress',
+            reactive: false,
+            important: true,
+            show_on_set_parent: false
+        });
+        this.container.add_actor(this.progressOverlay);
+
+        // Create the app button icon, number label, and text label for titleDisplay
+        this.iconBox = new St.Bin({name: 'appMenuIcon'});
+        this.iconBox.connect('style-changed', (...args) => this.onIconBoxStyleChanged(...args));
+        this.iconBottomClip = 0;
+        this.container.add_actor(this.iconBox);
+        this.updateIconBoxClip();
+        this.setActorAttributes();
+        this.label = new St.Label({
+            style_class: 'app-button-label',
+            text: '',
+            show_on_set_parent: this.state.settings.titleDisplay !== 1 && this.state.settings.titleDisplay !== 4
+        });
+        this.numberLabel = new St.Label({
+            style_class: 'window-list-item-label window-icon-list-numlabel',
+            text: ''
+        });
+        this.numberLabel.clutter_text.ellipsize = false;
+
+        this.container.add_actor(this.numberLabel);
+        this.label.x_align = St.Align.START;
+        this.container.add_actor(this.label);
+
+        this.groupState.set({tooltip: new Tooltips.PanelItemTooltip({actor: this.actor}, '', this.state.orientation)});
+
+        this.rightClickMenu = new AppMenuButtonRightClickMenu({
+                state: this.state,
+                groupState: this.groupState,
+                actor: this.actor
+        }, this.state.orientation);
+
+        // Set up the hover menu
+        this.hoverMenuManager = new HoverMenuController({actor: this.actor});
+        this.rightClickMenuManager = new PopupMenu.PopupMenuManager({actor: this.actor});
+        this.hoverMenu = new AppThumbnailHoverMenu(this.state, this.groupState);
+        this.hoverMenu.actor.hide();
+
+        Main.layoutManager.addChrome(this.hoverMenu.actor, {});
+
+        this.hoverMenu.setVerticalSetting();
+        this.hoverMenu.actor.set_style_class_name('');
+        this.hoverMenu.box.set_style_class_name('switcher-list');
+
+        this.hoverMenuManager.addMenu(this.hoverMenu);
+        this.rightClickMenuManager.addMenu(this.rightClickMenu);
+
+        this._draggable = new _Draggable(this.actor);
+        this.signals.connect(this.hoverMenu.actor, 'enter-event',
+            (...args) => this.hoverMenu.onMenuEnter.call(this.hoverMenu, ...args));
+        this.signals.connect(this.hoverMenu.actor, 'leave-event',
+            (...args) => this.hoverMenu.onMenuLeave.call(this.hoverMenu, ...args));
+        this.signals.connect(this.hoverMenu.actor, 'key-release-event',
+            (...args) => this.hoverMenu.onKeyRelease.call(this.hoverMenu, ...args));
+        this.signals.connect(this.hoverMenu.actor, 'scroll-event',
+            (c, e) => this.state.trigger('cycleWindows', e, this.actor._delegate));
+        this.signals.connect(this.hoverMenu.box, 'key-press-event',
+            (...args) => this.hoverMenu._onKeyPress.call(this.hoverMenu, ...args));
+        this.signals.connect(this.container, 'get-preferred-width', (...args) => this.getPreferredWidth(...args));
+        this.signals.connect(this.container, 'get-preferred-height', (...args) => this.getPreferredHeight(...args));
+        this.signals.connect(this.container, 'allocate', (...args) => this.allocate(...args));
+        this.signals.connect(this.actor, 'enter-event', (...args) => this.onEnter(...args));
+        this.signals.connect(this.actor, 'leave-event', (...args) => this.onLeave(...args));
+        this.signals.connect(this.actor, 'button-release-event', (...args) => this.onAppButtonRelease(...args));
+        this.signals.connect(this.actor, 'button-press-event', (...args) => this.onAppButtonPress(...args));
+        this.signals.connect(this._draggable, 'drag-begin', (...args) => this.onDragBegin(...args));
+        this.signals.connect(this._draggable, 'drag-cancelled', (...args) => this.onDragCancelled(...args));
+        this.signals.connect(this._draggable, 'drag-end', (...args) => this.onDragEnd(...args));
+        this.calcWindowNumber(this.groupState.metaWindows);
+
+        this.on_orientation_changed(true);
+        setTimeout(() => {
+            if (!this.groupState.set) return;
+
+            this.groupState.set({groupReady: true});
+            this.handleFavorite();
+        }, 0);
+    }
+
+    on_orientation_changed(fromInit) {
+        this.actor.set_style_class_name('window-list-item-box');
+        if (this.state.orientation === St.Side.TOP) {
+            this.actor.add_style_class_name('top');
+        } else if (this.state.orientation === St.Side.BOTTOM) {
+            this.actor.add_style_class_name('bottom');
+        } else if (this.state.orientation === St.Side.LEFT) {
+            this.actor.add_style_class_name('left');
+        } else if (this.state.orientation === St.Side.RIGHT) {
+            this.actor.add_style_class_name('right');
+        }
+
+        if (this.state.appletReady && !fromInit) {
+            this.setActorAttributes();
+        }
+    }
+
+    setActorAttributes() {
+        this.actor.style = null;
+
+        // TODO: Button width should be applied to buttons if they don't have a label set, not based on
+        // mode, but not currently sure how to unset the fixed width on the actor so it revert to a
+        // resizable state without destroying it. Otherwise, buttons with labels don't have enough padding set.
+        if (!this.state.isHorizontal
+            || this.state.settings.titleDisplay === 1
+            || this.state.settings.titleDisplay === 3 && !this.labelVisible) {
+            if (this.state.settings.enableAppButtonWidth) {
+                this.actor.width = this.state.settings.appButtonWidth;
+            } else {
+                this.actor.width = this.state.trigger('getPanelHeight');
+            }
+        }
+
+        if (this.state.isHorizontal) {
+            this.actor.height = this.state.trigger('getPanelHeight');
+        }
+        this.setIcon();
+        this.updateIconBoxClip();
+        this.setIconPadding();
+        this.setMargin();
+        this.setTransitionDuration();
+    }
+
+    setIconPadding() {
+        this.themeNode = this.actor.peek_theme_node();
+        this.padding = this.labelVisible ? 0 : Math.floor(this.actor.width - this.iconSize) / 2;
+        if (global.ui_scale > 1) {
+            this.padding = this.padding / global.ui_scale - Math.ceil(this.padding / 4);
+        }
+        const rightPadding = 0;
+        this.actor.style = 'padding-left: ' + this.padding + 'px;padding-right: ' + rightPadding + 'px;';
+    }
+
+    setMargin() {
+        let direction = this.state.isHorizontal ? 'right' : 'bottom';
+        let existingStyle = this.actor.style ? this.actor.style : '';
+        this.actor.style = existingStyle + 'margin-' + direction + ': ' + this.state.settings.iconSpacing + 'px;';
+    }
+
+    setTransitionDuration() {
+        if (!this.state.settings.appButtonTransitionDuration) {
+            return;
+        }
+        let existingStyle = this.actor.style ? this.actor.style : '';
+        this.actor.style = existingStyle
+            + 'transition-duration: '
+            + this.state.settings.appButtonTransitionDuration
+            + ';';
+    }
+
+    onIconBoxStyleChanged() {
+        if (this.state.panelEditMode || this.groupState.metaWindows.length === 0) {
+            return;
+        }
+        let node = this.iconBox.get_theme_node();
+        this.iconBottomClip = node.get_length('app-icon-bottom-clip');
+        this.updateIconBoxClip();
+    }
+
+    updateIconBoxClip() {
+        let allocation = this.iconBox.allocation;
+        if (this.iconBottomClip > 0) {
+            this.iconBox.set_clip(
+                0,
+                0,
+                allocation.x2 - allocation.x1,
+                allocation.y2 - allocation.y1 - this.iconBottomClip
+            );
+        } else {
+            this.iconBox.remove_clip();
+        }
+    }
+
+    setIcon() {
+        let panelHeight = this.state.trigger('getPanelHeight');
+        panelHeight = panelHeight % 2 > 0 ? panelHeight + 1 : panelHeight;
+        let height = this.state.settings.enableIconSize ? this.state.settings.iconSize : panelHeight;
+        if (this.state.trigger('getScaleMode') && this.labelVisible) {
+            this.iconSize = Math.round((height * ICON_HEIGHT_FACTOR) / global.ui_scale);
+        } else {
+            this.iconSize = Math.round((height * VERTICAL_ICON_HEIGHT_FACTOR) / global.ui_scale);
+        }
+        let icon;
+        if (this.groupState.app) {
+            icon = this.groupState.app.create_icon_texture(this.iconSize);
+        } else {
+            icon = new St.Icon({
+                icon_name: 'application-default-icon',
+                icon_type: St.IconType.FULLCOLOR,
+                icon_size: this.iconSize
+            });
+        }
+
+        let oldChild = this.iconBox.get_child();
+        this.iconBox.set_child(icon);
+
+        if (oldChild) oldChild.destroy();
+    }
+
+    setText(text) {
+        if (text
+            && (typeof text === 'string' || text instanceof String)
+            && text.length > 0 && this.label) {
+            this.label.set_text(text);
+        }
+    }
+
+    getAttention() {
+        if (this._needsAttention) return;
+
+        this._needsAttention = true;
+        let counter = 0;
+        this.flashButton(counter);
+    }
+
+    flashButton(counter) {
+        if (!this._needsAttention || !this.actor) return;
+
+        const activePseudoClass = getPseudoClass(this.state.settings.activePseudoClass);
+        if (this.state.settings.showActive) {
+            this.actor.remove_style_pseudo_class(activePseudoClass);
+        }
+        this.actor.add_style_class_name('window-list-item-demands-attention');
+        if (counter < 4) {
+            setTimeout(() => {
+                if (this.actor && this.actor.has_style_class_name('window-list-item-demands-attention')) {
+                    this.actor.remove_style_class_name('window-list-item-demands-attention');
+                    if (this.state.settings.showActive) {
+                        this.actor.add_style_pseudo_class(activePseudoClass);
+                    }
+                }
+                setTimeout(() => {
+                    this.flashButton(++counter);
+                }, FLASH_INTERVAL);
+            }, FLASH_INTERVAL);
+        }
+    }
+
+    getPreferredWidth(actor, forHeight, alloc) {
+        let [iconMinSize, iconNaturalSize] = this.iconBox.get_preferred_width(forHeight);
+        let labelNaturalSize = this.label.get_preferred_width(forHeight)[1];
+        // The label text starts in the center of the icon, so we should allocate the space
+        // needed for the icon plus the space needed for(label - icon/2)
+        alloc.min_size = iconMinSize;
+        if (this.state.orientation === St.Side.TOP || this.state.orientation === St.Side.BOTTOM) {
+            alloc.natural_size = Math.min(iconNaturalSize + Math.max(0, labelNaturalSize), MAX_BUTTON_WIDTH);
+        } else {
+            alloc.natural_size = this.state.trigger('getPanelHeight');
+        }
+    }
+
+    getPreferredHeight(actor, forWidth, alloc) {
+        let [iconMinSize, iconNaturalSize] = this.iconBox.get_preferred_height(forWidth);
+        let [labelMinSize, labelNaturalSize] = this.label.get_preferred_height(forWidth);
+        alloc.min_size = Math.min(iconMinSize, labelMinSize);
+        alloc.natural_size = Math.max(iconNaturalSize, labelNaturalSize);
+    }
+
+    allocate(actor, box, flags) {
+        let allocWidth = box.x2 - box.x1;
+        let allocHeight = box.y2 - box.y1;
+        let childBox = new Clutter.ActorBox();
+        let direction = this.actor.get_text_direction();
+
+        // Set the icon to be left-justified (or right-justified) and centered vertically
+        let [iconNaturalWidth, iconNaturalHeight] = this.iconBox.get_preferred_size();
+        [childBox.y1, childBox.y2] = center(allocHeight, iconNaturalHeight);
+        if (direction === Clutter.TextDirection.LTR) {
+            [childBox.x1, childBox.x2] = [0, Math.min(iconNaturalWidth, allocWidth)];
+        } else {
+            [childBox.x1, childBox.x2] = [Math.max(0, allocWidth - iconNaturalWidth), allocWidth];
+        }
+        this.iconBox.allocate(childBox, flags);
+
+        // Set the label to start its text in the left of the icon
+        let iconWidth = childBox.x2 - childBox.x1;
+        let [naturalWidth, naturalHeight] = this.label.get_preferred_size();
+        [childBox.y1, childBox.y2] = center(allocHeight, naturalHeight);
+        if (direction === Clutter.TextDirection.LTR) {
+            childBox.x1 = iconWidth;
+            childBox.x2 = Math.min(allocWidth, MAX_BUTTON_WIDTH);
+        } else {
+            childBox.x2 = Math.min(allocWidth - iconWidth, MAX_BUTTON_WIDTH);
+            childBox.x1 = Math.max(0, childBox.x2 - naturalWidth);
+        }
+        this.label.allocate(childBox, flags);
+        if (direction === Clutter.TextDirection.LTR) {
+            childBox.x1 = -3 * global.ui_scale;
+            childBox.x2 = childBox.x1 + this.numberLabel.width;
+            childBox.y1 = box.y1 - 2;
+            childBox.y2 = box.y2 - 1;
+        } else {
+            childBox.x1 = -this.numberLabel.width;
+            childBox.x2 = childBox.x1 + this.numberLabel.width;
+            childBox.y1 = box.y1;
+            childBox.y2 = box.y2 - 1;
+        }
+        this.numberLabel.allocate(childBox, flags);
+
+        // Call set_icon_geometry for support of Cinnamon's minimize animation
+        if (this.groupState.metaWindows.length > 0 && this.container.realized) {
+            let rect = new Meta.Rectangle();
+            [rect.x, rect.y] = this.container.get_transformed_position();
+            [rect.width, rect.height] = this.container.get_transformed_size();
+
+            each(this.groupState.metaWindows, (metaWindow) => {
+                if (metaWindow) {
+                    metaWindow.set_icon_geometry(rect);
+                }
+            });
+        }
+
+        if (this.progressOverlay.visible) {
+            childBox.x1 = -this.padding;
+            childBox.y1 = 0;
+            childBox.y2 = this.container.height;
+            childBox.x2 = Math.max(this.container.width * (this._progress / 100.0), 1.0);
+            this.progressOverlay.allocate(childBox, flags);
+        }
+    }
+
+    _showLabel() {
+        this.labelVisible = true;
+        if (this.label.text == null) {
+            this.label.set_text('');
+        }
+        // TODO: This should be set by the theme.
+        this.label.set_style('padding-right: 4px;');
+
+        Tweener.addTween(this.label, {
+            width: MAX_BUTTON_WIDTH, // Should probably check preferred width
+            time: BUTTON_BOX_ANIMATION_TIME,
+            transition: 'easeOutQuad',
+            onComplete: () => {
+                this.label.show();
+            }
+        });
+        return false;
+    }
+
+    showLabel() {
+        if (!this.label || !this.state.isHorizontal) {
+            return false;
+        }
+
+        // Fixes 'st_widget_get_theme_node called on the widget which is not in the stage' warnings
+        if (!this.label.realized) {
+            setTimeout(() => this._showLabel(), 0);
+        } else {
+            this._showLabel();
+        }
+    }
+
+    hideLabel(animate) {
+        if (!this.label) {
+            return false;
+        }
+
+        if (this.label.text == null) {
+            this.label.set_text('');
+        }
+        this.labelVisible = false;
+        if (!animate) {
+            this.label.width = 1;
+            this.label.hide();
+            return false;
+        }
+
+        Tweener.addTween(this.label, {
+            width: 1,
+            time: BUTTON_BOX_ANIMATION_TIME,
+            transition: 'easeOutQuad',
+            onCompleteScope: this,
+            onComplete() {
+                this.label.hide();
+                this.label.set_style('padding-right: 0px;');
+            }
+        });
+        return false;
+    }
+
+    onEnter() {
+        if (this.state.panelEditMode) {
+            return false;
+        }
+        let hoverPseudoClass = getPseudoClass(this.state.settings.hoverPseudoClass);
+
+        if (this.actor.has_style_pseudo_class('closed')) {
+            this.hadClosedPseudoClass = true;
+            this.actor.remove_style_pseudo_class('closed');
+        }
+
+        if (!this.actor.has_style_pseudo_class(hoverPseudoClass)) {
+            this.actor.add_style_pseudo_class(hoverPseudoClass);
+        }
+
+        this.hoverMenu.onMenuEnter();
+    }
+
+    onLeave() {
+        if (this.state.panelEditMode) {
+            return false;
+        }
+
+        this.resetHoverStatus();
+
+        if (this.hadClosedPseudoClass && this.groupState.metaWindows.length === 0) {
+            this.hadClosedPseudoClass = false;
+            this.actor.add_style_pseudo_class('closed');
+        }
+
+        this.setFavoriteAttributes();
+        this.hoverMenu.onMenuLeave();
+    }
+
+    resetHoverStatus() {
+        if (this.actor.is_finalized()) return;
+
+        let hoverPseudoClass = getPseudoClass(this.state.settings.hoverPseudoClass);
+        let focusPseudoClass = getPseudoClass(this.state.settings.focusPseudoClass);
+        let activePseudoClass = getPseudoClass(this.state.settings.activePseudoClass);
+        let focused = false;
+
+        each(this.groupState.metaWindows, function(metaWindow) {
+            if (getFocusState(metaWindow)) {
+                focused = true;
+                return false;
+            }
+        });
+
+        if (!focused && (hoverPseudoClass !== focusPseudoClass || hoverPseudoClass !== activePseudoClass)) {
+            this.actor.remove_style_pseudo_class(hoverPseudoClass);
+        }
+    }
+
+    setActiveStatus(windows) {
+        let pseudoClass = getPseudoClass(this.state.settings.activePseudoClass);
+        if (windows.length > 0 && !this.actor.has_style_pseudo_class(pseudoClass)) {
+            this.actor.add_style_pseudo_class(pseudoClass);
+        } else {
+            this.actor.remove_style_pseudo_class(pseudoClass);
+        }
+    }
+
+    onProgressChange(metaWindow) {
+        if (metaWindow.progress !== this._progress) {
+            this._progress = metaWindow.progress;
+            if (this._progress > 0) {
+                this.progressOverlay.show();
+            } else {
+                this.progressOverlay.hide();
+            }
+            this.container.queue_relayout();
+        }
+    }
+
+    onFocusChange(hasFocus) {
+        // If any of the windows associated with our app have focus,
+        // we should set ourselves to active
+        let focusPseudoClass = getPseudoClass(this.state.settings.focusPseudoClass);
+        if (hasFocus) {
+            this.listState.trigger('updateFocusState', this.groupState.appId);
+            this.actor.add_style_pseudo_class(focusPseudoClass);
+            if (this.actor.has_style_class_name('window-list-item-demands-attention')) {
+                this.actor.remove_style_class_name('window-list-item-demands-attention');
+            }
+            if (this.actor.has_style_class_name('window-list-item-demands-attention-top')) {
+                this.actor.remove_style_class_name('window-list-item-demands-attention-top');
+            }
+            this._needsAttention = false;
+        } else {
+            this.actor.remove_style_pseudo_class(focusPseudoClass);
+            // If hover pseudo class is substituted with the active pseudo class, make sure it gets removed.
+            if (this.state.settings.hoverPseudoClass === 3) {
+                this.actor.remove_style_pseudo_class(getPseudoClass(this.state.settings.hoverPseudoClass));
+            }
+        }
+        if (this.state.settings.showActive && this.groupState.metaWindows.length > 0) {
+            this.actor.add_style_pseudo_class(getPseudoClass(this.state.settings.activePseudoClass));
+        }
+        this.resetHoverStatus();
+    }
+
+    onWindowDemandsAttention(metaWindow) {
+        // Prevent apps from indicating attention when they are starting up.
+        if (!this.groupState || !this.groupState.groupReady || this.groupState.willUnmount) {
+            return;
+        }
+        let windows = this.groupState.metaWindows;
+        for (let i = 0, len = windows.length; i < len; i++) {
+            if (windows[i] === metaWindow) {
+                // Even though this may not be the last focused window, we want it to be
+                // the window that gets focused when a user responds to an alert.
+                this.groupState.set({lastFocused: metaWindow});
+                this.setText(metaWindow.get_title());
+                this.getAttention();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    onDragBegin() {
+        this.groupState.trigger('hoverMenuClose');
+    }
+
+    onDragEnd() {
+        this.rightClickMenu.close(false);
+        this.hoverMenu.close(false);
+        this.listState.trigger('updateAppGroupIndexes', this.groupState.appId);
+        this.state.trigger('clearDragPlaceholder');
+    }
+
+    onDragCancelled() {
+        this.rightClickMenu.close(false);
+        this.hoverMenu.close(false);
+        this.state.trigger('clearDragPlaceholder');
+    }
+
+    handleDragOver(source, actor, x, y, time) {
+        if (!this.state.settings.enableDragging
+            || source instanceof AppGroup
+            || (DND.LauncherDraggable && source instanceof DND.LauncherDraggable)
+            || this.state.panelEditMode) {
+            return DND.DragMotionResult.CONTINUE;
+        }
+        if (this.groupState.metaWindows.length > 0 && this.groupState.lastFocused) {
+            Main.activateWindow(this.groupState.lastFocused, global.get_current_time());
+        }
+        return true;
+    }
+
+    getDragActor() {
+        return this.groupState.app.create_icon_texture(this.state.trigger('getPanelHeight'));
+    }
+
+    // Returns the original actor that should align with the actor
+    // we show as the item is being dragged.
+    getDragActorSource() {
+        return this.actor;
+    }
+
+    showOrderLabel(number) {
+        this.numberLabel.text = (number + 1).toString();
+        this.numberLabel.show();
+    }
+
+    launchNewInstance() {
+        this.groupState.app.open_new_window(-1);
+        this.animate();
+    }
+
+    onAppButtonRelease(actor, event) {
+        this.state.trigger('clearDragPlaceholder');
+        let button = event.get_button();
+
+        let shouldStartInstance = (
+            (button === 1
+                && this.groupState.isFavoriteApp
+                && this.groupState.metaWindows.length === 0
+                && this.state.settings.leftClickAction === 2)
+            || (button === 2
+                && this.state.settings.middleClickAction === 2)
+        );
+
+        let shouldEndInstance = button === 2
+            && this.state.settings.middleClickAction === 3
+            && this.groupState.lastFocused;
+
+        if (shouldStartInstance) {
+            this.launchNewInstance();
+            return;
+        }
+
+        if (shouldEndInstance) {
+            this.groupState.lastFocused.delete(global.get_current_time());
+            return;
+        }
+
+        let handleMinimizeToggle = (win) => {
+            if (this.state.settings.onClickThumbs && this.groupState.metaWindows.length > 1) {
+                if (this.hoverMenu.isOpen) {
+                    this.hoverMenu.close();
+                } else {
+                    this.hoverMenu.open();
+                }
+                if (this.state.overlayPreview) {
+                    this.hoverMenu.appThumbnails[0].destroyOverlayPreview();
+                    this.hoverMenu.close(true);
+                }
+                return;
+            }
+            if (win.appears_focused) {
+                win.minimize();
+            } else {
+                Main.activateWindow(win, global.get_current_time());
+            }
+        };
+
+        if (button === 1) {
+            global.log(this.state.settings.leftClickAction)
+            if (this.state.settings.leftClickAction === 1) {
+                return;
+            }
+            if (this.state.settings.leftClickAction === 3) {
+                this.state.trigger('cycleWindows', null, this.actor._delegate);
+                return;
+            }
+            this.hoverMenu.shouldOpen = false;
+            if (this.rightClickMenu.isOpen) {
+                this.rightClickMenu.toggle();
+            }
+            if (this.groupState.metaWindows.length === 1) {
+                handleMinimizeToggle(this.groupState.metaWindows[0]);
+            } else {
+                let actionTaken = false;
+                for (let i = 0, len = this.groupState.metaWindows.length; i < len; i++) {
+                    if (this.groupState.lastFocused && this.groupState.metaWindows[i] === this.groupState.lastFocused) {
+                        handleMinimizeToggle(this.groupState.metaWindows[i]);
+                        actionTaken = true;
+                        break;
+                    }
+                }
+                if (!actionTaken) {
+                    handleMinimizeToggle(this.groupState.metaWindows[0]);
+                }
+            }
+        } else if (button === 3) {
+            if (!this.rightClickMenu.isOpen) {
+                this.listState.trigger('closeAllRightClickMenus', () => {
+                    this.listState.trigger('closeAllHoverMenus', () => {
+                        this.rightClickMenu.open();
+                    });
+                });
+            } else {
+                this.listState.trigger('closeAllRightClickMenus', this.listState.trigger('closeAllHoverMenus'));
+            }
+        }
+        this.hoverMenu.onButtonPress();
+    }
+
+    onAppButtonPress(actor, event) {
+        let button = event.get_button();
+
+        if (button === 3) return true;
+        return false;
+    }
+
+    onAppKeyPress() {
+        if (this.groupState.isFavoriteApp && this.groupState.metaWindows.length === 0) {
+            this.launchNewInstance();
+        } else {
+            if (this.groupState.metaWindows.length > 1) {
+                this.hoverMenu.open(true);
+            } else {
+                this.listState.trigger('closeAllHoverMenus');
+            }
+            this.windowHandle(false);
+        }
+    }
+
+    windowHandle() {
+        if (this.groupState.lastFocused.appears_focused) {
+            if (this.groupState.metaWindows.length > 1) {
+                let nextWindow = null;
+                for (let i = 0, max = this.groupState.metaWindows.length - 1; i < max; i++) {
+                    if (this.groupState.metaWindows[i] === this.groupState.lastFocused) {
+                        nextWindow = this.groupState.metaWindows[i + 1];
+                        break;
+                    }
+                }
+                if (nextWindow === null) {
+                    nextWindow = this.groupState.metaWindows[0];
+                }
+                Main.activateWindow(nextWindow, global.get_current_time());
+            } else {
+                this.groupState.lastFocused.minimize();
+                this.actor.remove_style_pseudo_class('focus');
+            }
+        } else {
+            if (this.groupState.lastFocused.minimized) {
+                this.groupState.lastFocused.unminimize();
+            }
+            let ws = this.groupState.lastFocused.get_workspace().index();
+            if (ws !== global.screen.get_active_workspace_index()) {
+                global.screen.get_workspace_by_index(ws).activate(global.get_current_time());
+            }
+            Main.activateWindow(this.groupState.lastFocused, global.get_current_time());
+            this.actor.add_style_pseudo_class('focus');
+        }
+    }
+
+    windowAdded(metaWindow, metaWindows) {
+        if (metaWindows) {
+            this.groupState.metaWindows = [];
+            for (var i = 0; i < metaWindows.length; i++) {
+                this.groupState.metaWindows.push(metaWindows[i]);
+            }
+        }
+        let refWindow = findIndex(this.groupState.metaWindows, (win) => {
+            return win === metaWindow;
+        });
+        if (metaWindow) {
+            this.signals.connect(metaWindow, 'notify::title', (...args) => this.onWindowTitleChanged(...args));
+            this.signals.connect(metaWindow, 'notify::appears-focused', (...args) => this.onFocusWindowChange(...args));
+            this.signals.connect(metaWindow, 'notify::gtk-application-id', (w) => this.onAppChange(w));
+            this.signals.connect(metaWindow, 'notify::wm-class', (w) => this.onAppChange(w));
+            if (metaWindow.progress !== undefined) {
+                this._progress = metaWindow.progress;
+                this.signals.connect(metaWindow, 'notify::progress', () => this.onProgressChange(metaWindow));
+            }
+
+            // Set the initial button label as not all windows will get updated via signals initially.
+            this.onWindowTitleChanged(metaWindow);
+            if (refWindow === -1) {
+                this.groupState.metaWindows.push(metaWindow);
+                this.groupState.trigger('addThumbnailToMenu', metaWindow);
+            }
+            this.calcWindowNumber(this.groupState.metaWindows);
+            this.onFocusChange();
+        }
+        this.groupState.set({
+            metaWindows: this.groupState.metaWindows,
+            lastFocused: metaWindow
+        });
+        this.handleFavorite();
+    }
+
+    windowRemoved(metaWorkspace, metaWindow, refWindow, cb) {
+        if (refWindow === -1) return;
+
+        this.signals.disconnect('notify::title', metaWindow);
+        this.signals.disconnect('notify::appears-focused', metaWindow);
+        this.signals.disconnect('notify::gtk-application-id', metaWindow);
+        this.signals.disconnect('notify::wm-class', metaWindow);
+
+        this.groupState.metaWindows.splice(refWindow, 1);
+        this.calcWindowNumber(this.groupState.metaWindows);
+
+        if (this.groupState.metaWindows.length > 0 && !this.groupState.willUnmount) {
+            if (this.progressOverlay.visible && metaWindow.progress > 0) {
+                this._progress = 0;
+                this.progressOverlay.visible = false;
+            }
+            this.onWindowTitleChanged(this.groupState.lastFocused);
+            this.groupState.set({
+                    metaWindows: this.groupState.metaWindows,
+                    lastFocused: this.groupState.metaWindows[this.groupState.metaWindows.length - 1]
+            },
+                true);
+            this.groupState.trigger('removeThumbnailFromMenu', metaWindow);
+            this.groupState.trigger('refreshThumbnails');
+        } else {
+            // This is the last window, so this group needs to be destroyed. We'll call back windowRemoved
+            // in appList to put the final nail in the coffin.
+            if (typeof cb === 'function') {
+                cb(this.groupState.appId, this.groupState.isFavoriteApp);
+            }
+        }
+    }
+
+    onAppChange(metaWindow) {
+        if (!this.listState) return;
+
+        this.listState.trigger('windowRemoved', metaWindow);
+        this.listState.trigger('windowAdded', metaWindow);
+    }
+
+    onWindowTitleChanged(metaWindow, refresh) {
+        if (this.groupState.willUnmount || !this.state.settings) {
+            return;
+        }
+
+        let shouldHideLabel = this.state.settings.titleDisplay === TitleDisplay.None
+            || !this.state.isHorizontal;
+
+        if (shouldHideLabel) {
+            this.setText('');
+        }
+
+        if (!refresh && (!metaWindow ||
+                !metaWindow.title ||
+                (this.groupState.metaWindows.length === 0 && this.groupState.isFavoriteApp) ||
+                !this.state.isHorizontal)) {
+            this.hideLabel();
+            return;
+        }
+
+        if ((metaWindow.lastTitle && metaWindow.lastTitle === metaWindow.title) &&
+            !refresh && shouldHideLabel) {
+            return;
+        }
+        metaWindow.lastTitle = metaWindow.title;
+
+        each(this.hoverMenu.appThumbnails, (thumbnail) => {
+            if (thumbnail.metaWindow === metaWindow) {
+                thumbnail.label.set_text(metaWindow.title);
+                return false;
+            }
+        });
+
+        this.groupState.set({
+            appName: this.groupState.app.get_name()
+        });
+        if (this.state.settings.titleDisplay === TitleDisplay.Title) {
+            this.setText(metaWindow.title);
+            this.showLabel(true);
+        } else if (this.state.settings.titleDisplay === TitleDisplay.App) {
+            if (this.groupState.appName) {
+                this.setText(this.groupState.appName);
+                this.showLabel(true);
+            }
+        }
+    }
+
+    onFocusWindowChange(metaWindow) {
+        if (this.groupState.metaWindows.length === 0) return;
+
+        let hasFocus = getFocusState(metaWindow);
+        if (hasFocus && this.groupState.hasOwnProperty('lastFocused')) {
+            this.listState.set({lastFocusedApp: this.groupState.appId});
+            this.groupState.set({lastFocused: metaWindow});
+        }
+        this.onFocusChange(hasFocus);
+        if (this.state.settings.titleDisplay > 1) {
+            if (hasFocus) {
+                this.setText(metaWindow.title);
+                this.showLabel(true);
+            } else if (this.state.settings.titleDisplay === TitleDisplay.Focused) {
+                this.hideLabel(true);
+            }
+        }
+        if (this.state.settings.sortThumbs) {
+            this.hoverMenu.addThumbnail(metaWindow);
+        }
+    }
+
+    handleFavorite(changed) {
+        if (this.actor.is_finalized()) return;
+
+        if (changed) {
+            setTimeout(() => this.listState.trigger('updateAppGroupIndexes', this.groupState.appId), 0);
+        }
+        this.setFavoriteAttributes();
+        if (this.groupState.metaWindows.length === 0 && this.state.appletReady) {
+            this.hoverMenu.close();
+            this.onLeave();
+            this.actor.add_style_pseudo_class('closed');
+            return;
+        } else if (this.actor.has_style_pseudo_class('closed')) {
+            this.actor.remove_style_pseudo_class('closed');
+        }
+        this.onWindowTitleChanged(this.groupState.lastFocused);
+        this.onFocusChange();
+    }
+
+    setFavoriteAttributes() {
+        let pseudoClasses = ['active', 'focus', 'hover'];
+        if ((!this.groupState.app || this.groupState.app.state === 0) && this.groupState.isFavoriteApp) {
+            for (let i = 0; i < pseudoClasses.length; i++) {
+                let pseudoClass = getPseudoClass(this.state.settings[pseudoClasses[i] + 'PseudoClass']);
+                if (this.actor.has_style_pseudo_class(pseudoClass)) {
+                    this.actor.remove_style_pseudo_class(pseudoClass);
+                }
+            }
+        }
+    }
+
+    calcWindowNumber() {
+        if (this.groupState.willUnmount) return;
+
+        let windowNum = this.groupState.metaWindows ? this.groupState.metaWindows.length : 0;
+        this.numberLabel.text = windowNum.toString();
+        if (this.state.settings.numDisplay === NumberDisplay.Smart) {
+            if (windowNum <= 1) {
+                this.numberLabel.hide();
+            } else {
+                this.numberLabel.show();
+            }
+        } else if (this.state.settings.numDisplay === NumberDisplay.Normal) {
+            if (windowNum <= 0) {
+                this.numberLabel.hide();
+            } else {
+                this.numberLabel.show();
+            }
+        } else if (this.state.settings.numDisplay === NumberDisplay.All) {
+            this.numberLabel.show();
+        } else {
+            this.numberLabel.hide();
+        }
+    }
+
+    handleTitleDisplayChange() {
+        each(this.groupState.metaWindows, (win) => {
+            this.onWindowTitleChanged(win, true);
+            if (this.state.settings.titleDisplay !== TitleDisplay.Focused || getFocusState(win)) {
+                this.showLabel();
+            }
+        });
+    }
+
+    animate(step = 0) {
+        let effect = this.state.settings.launcherAnimationEffect;
+        if (effect === 1) {
+            return;
+        } else if (effect === 2) {
+            this.iconBox.set_z_rotation_from_gravity(0.0, Clutter.Gravity.CENTER);
+            Tweener.addTween(this.iconBox, {
+                opacity: 70,
+                time: 1.0,
+                transition: 'linear',
+                onCompleteScope: this,
+                onComplete() {
+                    Tweener.addTween(this.iconBox, {
+                        opacity: 255,
+                        time: 0.5,
+                        transition: 'linear'
+                    });
+                }
+            });
+        } else if (effect === 3) {
+            if (step >= 3) return;
+
+            this.iconBox.set_pivot_point(0.5, 0.5);
+            Tweener.addTween(this.iconBox, {
+                scale_x: 0.7,
+                scale_y: 0.7,
+                time: 0.2,
+                transition: 'easeOutQuad',
+                onComplete: () => {
+                    Tweener.addTween(this.iconBox, {
+                        scale_x: 1.0,
+                        scale_y: 1.0,
+                        time: 0.2,
+                        transition: 'easeOutQuad',
+                        onComplete: () => {
+                            this.animate(step + 1);
+                        }
+                    });
+                }
+            });
+        }
+    }
+
+    destroy(skipRefCleanup) {
+        this.signals.disconnectAllSignals();
+        this.groupState.set({willUnmount: true});
+
+        if (this.rightClickMenu) {
+            if (this.rightClickMenu.isOpen) {
+                this.rightClickMenu.close();
+            }
+            this.rightClickMenu.destroy();
+        }
+        this.hoverMenu.destroy();
+        this.listState.trigger('removeChild', this.actor);
+        this.container.destroy();
+        this.actor.destroy();
+
+        if (!skipRefCleanup) {
+            this.groupState.destroy();
+            unref(this, RESERVE_KEYS);
+        }
+    }
+}
+
+module.exports = AppGroup;

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appList.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appList.js
@@ -1,0 +1,426 @@
+const Clutter = imports.gi.Clutter;
+const Gio = imports.gi.Gio;
+const {SignalManager} = imports.misc.signalManager;
+const {each, findIndex, find, unref} = imports.misc.util;
+const {createStore} = imports.misc.state;
+
+const AppGroup = require('./appGroup');
+const {RESERVE_KEYS} = require('./constants');
+
+class AppList {
+    constructor(params) {
+        this.state = params.state;
+        this.state.connect({
+            orientation: () => this.on_orientation_changed(false)
+        });
+        this.listState = createStore({
+            workspaceIndex: params.index,
+            lastFocusedApp: null
+        });
+        this.listState.connect({
+            getWorkspace: () => this.metaWorkspace,
+            updateAppGroupIndexes: () => this.updateAppGroupIndexes(),
+            closeAllRightClickMenus: (cb) => this.closeAllRightClickMenus(cb),
+            closeAllHoverMenus: (cb) => this.closeAllHoverMenus(cb),
+            windowAdded: (win) => this.windowAdded(this.metaWorkspace, win),
+            windowRemoved: (win) => this.windowRemoved(this.metaWorkspace, win),
+            removeChild: (actor) => {
+                if (this.state.willUnmount) {
+                    return;
+                }
+                this.actor.remove_child(actor);
+            },
+            updateFocusState: (focusedAppId) => {
+                each(this.appList, (appGroup) => {
+                    if (focusedAppId === appGroup.groupState.appId) {
+                        return;
+                    }
+                    appGroup.onFocusChange(false);
+                });
+            }
+        });
+
+        this.signals = new SignalManager(null);
+        this.metaWorkspace = params.metaWorkspace;
+
+        const managerOrientation = this.state.isHorizontal ? 'HORIZONTAL' : 'VERTICAL';
+        this.manager = new Clutter.BoxLayout({orientation: Clutter.Orientation[managerOrientation]});
+        this.actor = new Clutter.Actor({layout_manager: this.manager});
+
+        this.appList = [];
+        this.lastFocusedApp = null;
+
+        // Connect all the signals
+        this.signals.connect(
+            this.metaWorkspace,
+            'window-added',
+            (...args) => this.windowAdded(...args)
+        );
+        this.signals.connect(
+            this.metaWorkspace,
+            'window-removed',
+            (...args) => this.windowRemoved(...args)
+        );
+        this.on_orientation_changed(null, true);
+    }
+
+    on_orientation_changed() {
+        if (this.manager === undefined) {
+            return;
+        }
+        if (!this.state.isHorizontal) {
+            this.manager.set_orientation(Clutter.Orientation.VERTICAL);
+            this.actor.set_x_align(Clutter.ActorAlign.CENTER);
+        } else {
+            this.manager.set_orientation(Clutter.Orientation.HORIZONTAL);
+        }
+        this.refreshList();
+    }
+
+    closeAllHoverMenus(cb) {
+        for (let i = 0, len = this.appList.length; i < len; i++) {
+            if (this.appList[i].hoverMenu.isOpen) {
+                this.appList[i].hoverMenu.close();
+            }
+        }
+        if (typeof cb === 'function') {
+            cb();
+        }
+    }
+
+    closeAllRightClickMenus(cb) {
+        for (let i = 0, len = this.appList.length; i < len; i++) {
+            if (typeof this.appList[i].rightClickMenu !== 'undefined' && this.appList[i].rightClickMenu.isOpen) {
+                this.appList[i].rightClickMenu.close();
+            }
+        }
+        if (typeof cb === 'function') {
+            cb();
+        }
+    }
+
+    onAppKeyPress(number) {
+        if (!this.appList[number - 1]) {
+            return;
+        }
+        this.appList[number - 1].onAppKeyPress(number);
+    }
+
+    onNewAppKeyPress(number) {
+        if (number > this.appList.length) {
+            return;
+        }
+        this.appList[number - 1].launchNewInstance();
+    }
+
+    showAppsOrder() {
+        for (let i = 0, len = this.appList.length; i < len; i++) {
+            this.appList[i].showOrderLabel(i);
+        }
+        setTimeout(() => this.calcAllWindowNumbers(), this.state.settings.showAppsOrderTimeout);
+    }
+
+    cycleMenus() {
+        let refApp = 0;
+        if (!this.state.lastCycled && this.listState.lastFocusedApp) {
+            refApp = findIndex(this.appList, (app) => app.groupState.appId === this.listState.lastFocusedApp);
+        }
+        if (this.state.lastCycled && this.appList[this.state.lastCycled]) {
+            this.appList[this.state.lastCycled].hoverMenu.close();
+            refApp = this.state.lastCycled + 1;
+        }
+        if (refApp === this.state.lastCycled) {
+            refApp = this.state.lastCycled + 1;
+        }
+        this.state.lastCycled = refApp;
+        if (refApp > this.appList.length - 1) {
+            refApp = 0;
+            this.state.lastCycled = 0;
+        }
+        this.state.set({lastCycled: this.state.lastCycled});
+        if (refApp > -1 && this.appList[refApp].groupState.metaWindows.length > 0) {
+            this.appList[refApp].hoverMenu.open();
+        } else {
+            this.cycleMenus();
+        }
+    }
+
+    updateSpacing() {
+        each(this.appList, function(appGroup) {
+            appGroup.setMargin();
+        });
+    }
+
+    // Gets a list of every app on the current workspace
+    getSpecialApps() {
+        this.specialApps = [];
+        let apps = Gio.app_info_get_all();
+
+        for (let i = 0, len = apps.length; i < len; i++) {
+            let wmClass = apps[i].get_startup_wm_class();
+            if (wmClass) {
+                let id = apps[i].get_id();
+                this.specialApps.push({id: id, wmClass: wmClass});
+            }
+        }
+    }
+
+    refreshList() {
+        for (let i = 0, len = this.appList.length; i < len; i++) {
+            this.appList[i].destroy();
+            this.appList[i] = null;
+        }
+        this.appList = [];
+        this.getSpecialApps();
+        this.loadFavorites();
+        this.refreshApps();
+    }
+
+    loadFavorites() {
+        if (!this.state.settings.showPinned) {
+            return;
+        }
+        const favorites = this.state.trigger('getFavorites');
+        const appSystem = this.state.trigger('getAppSystem');
+        for (let i = 0; i < favorites.length; i++) {
+            let app = appSystem.lookup_app(favorites[i].id);
+            if (!app) {
+                app = appSystem.lookup_settings_app(favorites[i].id);
+            }
+            if (!app) {
+                continue;
+            }
+            this.windowAdded(this.metaWorkspace, null, app, true);
+        }
+    }
+
+    refreshApps() {
+        let windows;
+        if (this.state.settings.showAllWorkspaces) {
+            windows = global.display.list_windows(0);
+        } else {
+            windows = this.metaWorkspace.list_windows();
+        }
+
+        for (let i = 0, len = windows.length; i < len; i++) {
+            this.windowAdded(this.metaWorkspace, windows[i]);
+        }
+    }
+
+    updateAttentionState(display, window) {
+        each(this.appList, (appGroup) => {
+            if (appGroup.groupState.metaWindows) {
+                appGroup.onWindowDemandsAttention(window);
+            }
+            if (appGroup.hoverMenu.isOpen) {
+                each(appGroup.hoverMenu.appThumbnails, (thumbnail) => {
+                    thumbnail.onWindowDemandsAttention(window);
+                    return false;
+                });
+            }
+        });
+    }
+
+    windowAdded(metaWorkspace, metaWindow, app, isFavoriteApp) {
+        if (!this.state) return;
+
+        if (this.state.appletReady && this.state.settings.showAllWorkspaces && metaWindow && !metaWindow.__gwlInit__) {
+            metaWindow.__gwlInit__ = true;
+            this.state.trigger('addWindowToAllWorkspaces', metaWindow, app, isFavoriteApp);
+        }
+        // Check to see if the window that was added already has an app group.
+        // If it does, then we don't need to do anything.  If not, we need to
+        // create an app group.
+        if (!app) {
+            app = this.state.trigger('getAppFromWMClass', this.specialApps, metaWindow);
+        }
+        if (!app) {
+            let tracker = this.state.trigger('getTracker');
+            if (tracker) {
+                app = tracker.get_window_app(metaWindow);
+            }
+        }
+        if (!app
+            || (!isFavoriteApp
+                && metaWindow
+                && (this.state.settings.listMonitorWindows
+                    && this.state.monitorWatchList.indexOf(metaWindow.get_monitor()) === -1))) {
+            return;
+        }
+
+        let appId = app.get_id(),
+            refApp = -1,
+            refWindow = -1,
+            transientFavorite = false;
+
+        each(this.appList, (appGroup, i) => {
+            let shouldReturn = false;
+            if (app === appGroup.groupState.app) {
+                refApp = i;
+            }
+            each(appGroup.groupState.metaWindows, (win, z) => {
+                if (win === metaWindow) {
+                    if (refApp === -1 || !this.state.settings.groupApps) {
+                        refApp = i;
+                    }
+                    refWindow = z;
+                    shouldReturn = true;
+                    return false;
+                }
+            });
+            if (shouldReturn) {
+                return false;
+            }
+        });
+
+        if (!this.state.settings.groupApps && !isFavoriteApp) {
+            let refFav = findIndex(this.state.trigger('getFavorites'), (favorite) => {
+                return favorite.app === app;
+            });
+            if (refFav > -1) {
+                transientFavorite = true;
+            }
+        }
+
+        let initApp = (metaWindows, window) => {
+            let appGroup = new AppGroup({
+                state: this.state,
+                listState: this.listState,
+                app,
+                isFavoriteApp,
+                metaWorkspace,
+                metaWindows,
+                metaWindow,
+                appId
+            });
+            this.actor.add_child(appGroup.actor);
+            this.appList.push(appGroup);
+
+            if (this.state.settings.groupApps && metaWindows.length > 0) {
+                each(metaWindows, (win) => {
+                    appGroup.windowAdded(win, metaWindows);
+                });
+            } else {
+                appGroup.windowAdded(window);
+            }
+        };
+
+        if (refApp === -1) {
+            let _appWindows = app.get_windows();
+            let appWindows = [];
+
+            for (var i = 0; i < _appWindows.length; i++) {
+                if ((this.state.settings.showAllWorkspaces
+                        || _appWindows[i].is_on_all_workspaces()
+                        || _appWindows[i].get_workspace() === this.metaWorkspace)
+                    && (this.state.settings.includeAllWindows
+                        || this.state.trigger('isWindowInteresting', _appWindows[i]))
+                    && (!this.state.settings.listMonitorWindows
+                        || this.state.monitorWatchList.indexOf(_appWindows[i].get_monitor()) > -1)) {
+                    appWindows.push(_appWindows[i]);
+                }
+            }
+
+            if (this.state.settings.groupApps) {
+                initApp(appWindows);
+            } else {
+                if (appWindows.length > 0) {
+                    each(appWindows, (win) => {
+                        initApp([win], win);
+                    });
+                } else {
+                    initApp([], null);
+                }
+            }
+        } else if (metaWindow) {
+            if (this.state.settings.groupApps) {
+                this.appList[refApp].windowAdded(metaWindow, null);
+            } else if (transientFavorite && this.appList[refApp].groupState.metaWindows.length === 0) {
+                this.appList[refApp].windowAdded(metaWindow, [metaWindow]);
+            } else if (refWindow === -1) {
+                initApp([metaWindow], metaWindow);
+            }
+        }
+    }
+
+    calcAllWindowNumbers() {
+        for (let i = 0, len = this.appList.length; i < len; i++) {
+            this.appList[i].calcWindowNumber(this.appList[i].groupState.metaWindows);
+        }
+    }
+
+    updateAppGroupIndexes() {
+        const newAppList = [];
+        let children = this.actor.get_children();
+        for (let i = 0; i < children.length; i++) {
+            let appGroup = find(this.appList, (appGroup) => appGroup.actor === children[i]);
+            if (appGroup) {
+                newAppList.push(appGroup);
+            }
+        }
+        this.appList = newAppList;
+    }
+
+    windowRemoved(metaWorkspace, metaWindow) {
+        if (!this.state) return;
+
+        if ((metaWindow.is_on_all_workspaces() || this.state.settings.showAllWorkspaces)
+            && !metaWindow.__gwlFinalize__) {
+            metaWindow.__gwlFinalize__ = true;
+            this.state.trigger('removeWindowFromAllWorkspaces', metaWindow);
+            return;
+        }
+
+        let wmClass = metaWindow.get_wm_class(),
+            refApp = -1,
+            refWindow = -1,
+            windowCount = 0;
+
+        each(this.appList, (appGroup, i) => {
+            let shouldReturn = false;
+            each(appGroup.groupState.metaWindows, (win, z) => {
+                if (win.get_wm_class() === wmClass) {
+                    ++windowCount;
+                }
+                if (win === metaWindow) {
+                    ++windowCount;
+                    refApp = i;
+                    refWindow = z;
+                    shouldReturn = this.state.settings.groupApps;
+                    return false;
+                }
+            });
+            if (shouldReturn) {
+                return false;
+            }
+        });
+        if (refApp > -1) {
+            this.appList[refApp].windowRemoved(metaWorkspace, metaWindow, refWindow, (appId, isFavoriteApp) => {
+                if (isFavoriteApp || (isFavoriteApp && !this.state.settings.groupApps && windowCount === 0)) {
+                    this.appList[refApp].groupState.trigger('isFavoriteApp');
+                    if (this.state.settings.titleDisplay > 1) {
+                        this.appList[refApp].hideLabel(true);
+                        this.appList[refApp].groupState.set({groupReady: false});
+                    }
+                    return;
+                }
+                this.appList[refApp].destroy(true);
+                this.appList[refApp] = undefined;
+                this.appList.splice(refApp, 1);
+            });
+        }
+    }
+
+    destroy() {
+        this.signals.disconnectAllSignals();
+        for (let i = 0, len = this.appList.length; i < len; i++) {
+            this.appList[i].destroy();
+        }
+        this.listState.destroy();
+        this.manager = null;
+        this.actor.destroy();
+        unref(this, RESERVE_KEYS);
+    }
+}
+
+module.exports = AppList;

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -1,0 +1,1020 @@
+const Gio = imports.gi.Gio;
+const Gtk = imports.gi.Gtk;
+const GLib = imports.gi.GLib;
+const Gdk = imports.gi.Gdk;
+const Meta = imports.gi.Meta;
+const St = imports.gi.St;
+const Gettext = imports.gettext;
+const Applet = imports.ui.applet;
+const Cinnamon = imports.gi.Cinnamon;
+const Main = imports.ui.main;
+const DND = imports.ui.dnd;
+const {AppletSettings} = imports.ui.settings;
+const {SignalManager} = imports.misc.signalManager;
+const {each, findIndex, filter, throttle, unref, trySpawnCommandLine} = imports.misc.util;
+const {createStore} = imports.misc.state;
+
+const AppList = require('./appList');
+const {
+  RESERVE_KEYS,
+  TitleDisplay,
+  autoStartStrDir
+}  = require('./constants');
+
+class PinnedFavs {
+    constructor(params) {
+        this.params = params;
+        this.favoriteSettingKey = 'favorite-apps';
+        this.reload();
+    }
+
+    reload() {
+        const {state, signals, settings} = this.params;
+        const appSystem = state.trigger('getAppSystem');
+        if (signals.isConnected('changed::favorite-apps', global.settings)) {
+            signals.disconnect('changed::favorite-apps', global.settings);
+        }
+        if (signals.isConnected('changed::pinned-apps', settings)) {
+            signals.disconnect('changed::pinned-apps', settings);
+        }
+        let cb = () => this.onFavoritesChange();
+        if (state.settings.systemFavorites) {
+            signals.connect(
+                global.settings,
+                'changed::favorite-apps',
+                cb
+            );
+        } else {
+            signals.connect(
+                settings,
+                'changed::pinned-apps',
+                cb
+            );
+        }
+        this._favorites = [];
+        let ids = [];
+        if (state.settings.systemFavorites) {
+            ids = global.settings.get_strv(this.favoriteSettingKey);
+        } else {
+            ids = settings.getValue('pinned-apps');
+        }
+        for (let i = 0, len = ids.length; i < len; i++) {
+            let refFav = findIndex(this._favorites, (item) => item.id === ids[i]);
+            if (refFav === -1) {
+                let app = appSystem.lookup_app(ids[i]);
+                this._favorites.push({
+                    id: ids[i],
+                    app: app
+                });
+            }
+        }
+    }
+
+    triggerUpdate(appId, pos, isFavoriteApp) {
+        let currentAppList = this.params.state.trigger('getCurrentAppList');
+        let refApp = findIndex(currentAppList.appList, (appGroup) => appGroup.groupState.appId === appId);
+        if (refApp > -1) {
+            // Destroy pinned app
+            if (
+                !isFavoriteApp &&
+                currentAppList.appList[refApp] &&
+                currentAppList.appList[refApp].groupState.metaWindows.length === 0
+            ) {
+                currentAppList.appList[refApp].destroy(true);
+                currentAppList.appList[refApp] = undefined;
+                currentAppList.appList.splice(refApp, 1);
+            } else {
+                // Move actor to index, trigger favorite state change
+                currentAppList.appList[refApp].groupState.set({isFavoriteApp: isFavoriteApp});
+                // Some favorite apps may be present from a previous installation,
+                // but not rendered and added to the app list because they're uninstalled.
+                currentAppList.actor.set_child_at_index(currentAppList.appList[refApp].actor, pos);
+            }
+        }
+    }
+
+    saveFavorites() {
+        let uniqueSet = new Set();
+        let ids = [];
+        for (let i = 0; i < this._favorites.length; i++) {
+            if (uniqueSet.has(this._favorites[i].id) === false) {
+                ids.push(this._favorites[i].id);
+                uniqueSet.add(this._favorites[i].id);
+            }
+        }
+        if (this.params.state.settings.systemFavorites) {
+            global.settings.set_strv(this.favoriteSettingKey, ids);
+        } else {
+            this.params.settings.setValue('pinned-apps', ids);
+        }
+    }
+
+    onFavoritesChange() {
+        if (!this.params.state.settings.groupApps) {
+            let currentAppList = this.params.state.trigger('getCurrentAppList');
+            setTimeout(() => currentAppList.refreshList(), 0);
+            return;
+        }
+        let oldFavoritesIds = [];
+        let newFavoritesIds = [];
+        for (let i = 0; i < this._favorites.length; i++) {
+            oldFavoritesIds.push(this._favorites[i].id);
+        }
+        this.reload();
+        for (let i = 0; i < this._favorites.length; i++) {
+            newFavoritesIds.push(this._favorites[i].id);
+        }
+        for (let i = 0; i < oldFavoritesIds.length; i++) {
+            if (newFavoritesIds.indexOf(oldFavoritesIds[i]) < 0) {
+                this.triggerUpdate(oldFavoritesIds[i], -1, false);
+            }
+        }
+        for (let i = 0; i < this._favorites.length; i++) {
+            this.triggerUpdate(newFavoritesIds[i], i, true);
+        }
+    }
+
+    addFavorite(opts = {appId: null, app: null, pos: -1}) {
+        const appSystem = this.params.state.trigger('getAppSystem');
+        let oldIndex = -1;
+        if (!opts.app) {
+            opts.app = appSystem.lookup_app(opts.appId);
+        }
+        if (!opts.app) {
+            opts.app = appSystem.lookup_settings_app(opts.appId);
+        }
+        if (!opts.app) {
+            opts.app = appSystem.lookup_desktop_wmclass(opts.appId);
+        }
+        if (!opts.app) {
+            return false;
+        }
+        if (!opts.pos) {
+            opts.pos = -1;
+        }
+        let newFav = {
+            id: opts.appId,
+            app: opts.app
+        };
+        let refFavorite = findIndex(this._favorites, function(favorite) {
+            return favorite.id === opts.appId;
+        });
+        if (refFavorite === -1) {
+            this._favorites.push(newFav);
+        } else {
+            oldIndex = refFavorite;
+        }
+        if (opts.pos > -1) {
+            this.moveFavoriteToPos(opts, oldIndex);
+            return true;
+        }
+
+        this.saveFavorites();
+        return true;
+    }
+
+    moveFavoriteToPos(opts, oldIndex) {
+        if (!oldIndex || !this.params.state.settings.groupApps) {
+            oldIndex = findIndex(this._favorites, function(favorite) {
+                return favorite.id === opts.appId;
+            });
+        }
+        let newIndex = opts.pos;
+        if (oldIndex > -1 && newIndex > oldIndex) {
+            newIndex = newIndex - 1;
+        }
+        this._favorites.splice(newIndex, 0, this._favorites.splice(oldIndex, 1)[0]);
+        this._favorites = filter(this._favorites, function(favorite) {
+            return favorite.app != null;
+        });
+        this.saveFavorites();
+    }
+
+    removeFavorite(appId) {
+        let refFav = findIndex(this._favorites, (favorite) => favorite.id === appId);
+        this.triggerUpdate(appId, -1, false);
+        this._favorites.splice(refFav, 1);
+        this.saveFavorites();
+        return true;
+    }
+}
+
+class GroupedWindowListApplet extends Applet.Applet {
+    constructor(metadata, orientation, panel_height, instance_id) {
+        super(orientation, panel_height, instance_id);
+
+        this.tracker = Cinnamon.WindowTracker.get_default();
+        this.recentManager = Gtk.RecentManager.get_default();
+        this.appLists = [];
+        // Initialize the default state. Any values passed through store.set must be declared here
+        // first, or an error will be thrown.
+        this.state = createStore({
+            uuid: metadata.uuid,
+            orientation,
+            isHorizontal: orientation === St.Side.TOP || orientation === St.Side.BOTTOM,
+            panel_height,
+            instance_id,
+            monitorWatchList: [],
+            autoStartApps: [],
+            currentWs: global.screen.get_active_workspace_index(),
+            panelEditMode: global.settings.get_boolean('panel-edit-mode'),
+            menuOpen: false,
+            dragPlaceholder: null,
+            dragPlaceholderPos: -1,
+            animatingPlaceholdersCount: 0,
+            appletReady: false,
+            willUnmount: false,
+            settings: {},
+            homeDir: GLib.get_home_dir(),
+            overlayPreview: null,
+            lastCycled: null,
+            lastTitleDisplay: null,
+            scrollActive: false
+        });
+
+        // key-function pairs of actions that can be triggered from the store's callback queue. This allows the
+        // applet to avoid passing down the parent class down the constructor chain and creating circular references.
+        // In addition to manual event emitting, store.js can emit updates on property changes when set through
+        // store.set. Any keys emitted through store.trigger that are not declared here first will throw an error.
+        this.state.connect({
+            setSettingsValue: (k, v) => this.settings.setValue(k, v),
+            getPanel: () => (this.panel ? this.panel : null),
+            getPanelHeight: () => this._panelHeight,
+            getScaleMode: () => this._scaleMode,
+            getAppSystem: () => Cinnamon.AppSystem.get_default(),
+            getAppFromWMClass: (specialApps, metaWindow) => this.getAppFromWMClass(specialApps, metaWindow),
+            getTracker: () => this.tracker,
+            isWindowInteresting: (metaWindow) => Main.isInteresting(metaWindow),
+            addWindowToAllWorkspaces: (win, app, isFavoriteApp) => {
+                each(this.appLists, function(appList) {
+                    appList.windowAdded(appList.metaWorkspace, win, app, isFavoriteApp);
+                });
+            },
+            removeWindowFromAllWorkspaces: (win) => {
+                each(this.appLists, function(appList) {
+                    appList.windowRemoved(appList.metaWorkspace, win);
+                });
+            },
+            removeWindowFromOtherWorkspaces: (win) => {
+                each(this.appLists, (appList) => {
+                    if (appList.listState.workspaceIndex === this.state.currentWs) {
+                        return;
+                    }
+                    appList.windowRemoved(appList.metaWorkspace, win);
+                });
+            },
+            refreshCurrentAppList: () => this.refreshCurrentAppList(),
+            getCurrentAppList: () => this.getCurrentAppList(),
+            clearDragPlaceholder: () => this.clearDragPlaceholder(),
+            getAutoStartApps: () => this.getAutoStartApps(),
+            getRecentItems: () =>
+                Gtk.RecentManager.get_default()
+                .get_items()
+                .sort(function(a, b) {
+                    return a.get_modified() - b.get_modified();
+                })
+                .reverse(),
+            addFavorite: (obj) => this.pinnedFavorites.addFavorite(obj),
+            removeFavorite: (id) => this.pinnedFavorites.removeFavorite(id),
+            getFavorites: () => this.pinnedFavorites._favorites,
+            setThumbnailActorStyle: (actor) => {
+                actor.set_style('border-width:2px;padding:' + this.state.settings.thumbnailPadding + 'px;')
+            },
+            setThumbnailCloseButtonStyle: (button) => {
+                let size = this.state.settings.thumbnailCloseButtonSize;
+                button.width = size;
+                button.height = size;
+                let left = global.ui_scale > 1 ? -10 : 0;
+                button.style = 'padding: 0px; width: ' + size + 'px; height: ' + size + 'px; max-width: ' + size
+                    + 'px; max-height: ' + size + 'px; ' + '-cinnamon-close-overlap: 0px; postion: ' + left
+                    + 'px -2px;background-size: ' + size + 'px ' + size + 'px;';
+                button.style_class = 'window-close';
+            },
+            cycleWindows: (e, source) => this.handleScroll(e, source),
+            openAbout: () => this.openAbout(),
+            configureApplet: () => this.configureApplet()
+        });
+
+        this.settings = new AppletSettings(this.state.settings, metadata.uuid, instance_id);
+        this.bindSettings();
+        // Passing an empty object instead of `this` because its only used by SignalManager to bind the callback, which
+        // we already do here. Otherwise, it creates more circular references.
+        this.signals = new SignalManager(null);
+        this.appSystem = this.state.trigger('getAppSystem');
+        this.pinnedFavorites = new PinnedFavs({
+            signals: this.signals,
+            settings: this.settings,
+            state: this.state
+        });
+        this.actor.set_track_hover(false);
+        // Declare vertical panel compatibility
+        this.setAllowedLayout(Applet.AllowedLayout.BOTH);
+        Gettext.bindtextdomain(metadata.uuid, GLib.get_home_dir() + '/.local/share/locale');
+
+        this.getAutoStartApps();
+        this.onSwitchWorkspace = throttle(this.onSwitchWorkspace, 100, true);
+        this.signals.connect(this.actor, 'scroll-event', (c, e) => this.handleScroll(e));
+        this.signals.connect(global.window_manager, 'switch-workspace', (...args) => this.onSwitchWorkspace(...args));
+        this.signals.connect(global.screen, 'workspace-removed', (...args) => this.onWorkspaceRemoved(...args));
+        this.signals.connect(global.screen, 'window-monitor-changed', (...args) => this.onWindowMonitorChanged(...args));
+        this.signals.connect(global.screen, 'monitors-changed', (...args) => this.on_applet_instances_changed(...args));
+        this.signals.connect(global.display, 'window-marked-urgent', (...args) => this.updateAttentionState(...args));
+        this.signals.connect(global.display, 'window-demands-attention', (...args) => this.updateAttentionState(...args));
+        this.signals.connect(global.settings, 'changed::panel-edit-mode', (...args) => this.on_panel_edit_mode_changed(...args));
+        this.signals.connect(Main.overview, 'showing', (...args) => this.onOverviewShow(...args));
+        this.signals.connect(Main.overview, 'hiding', (...args) => this.onOverviewHide(...args));
+        this.signals.connect(Main.expo, 'showing', (...args) => this.onOverviewShow(...args));
+        this.signals.connect(Main.expo, 'hiding', (...args) => this.onOverviewHide(...args));
+        this.signals.connect(Main.themeManager, 'theme-set', (...args) => this.refreshCurrentAppList(...args));
+    }
+
+    bindSettings() {
+        let settingsProps = [
+            {key: 'show-pinned', value: 'showPinned', cb: this.refreshCurrentAppList},
+            {key: 'show-active', value: 'showActive', cb: this.refreshCurrentAppList},
+            {key: 'show-alerts', value: 'showAlerts', cb: this.updateAttentionState},
+            {key: 'group-apps', value: 'groupApps', cb: this.refreshCurrentAppList},
+            {key: 'enable-app-button-dragging', value: 'enableDragging', cb: null},
+            {key: 'pinOnDrag', value: 'pinOnDrag', cb: null},
+            {key: 'launcher-animation-effect', value: 'launcherAnimationEffect', cb: null},
+            {key: 'pinned-apps', value: 'pinnedApps', cb: null},
+            {key: 'middle-click-action', value: 'middleClickAction', cb: null},
+            {key: 'left-click-action', value: 'leftClickAction', cb: null},
+            {key: 'show-apps-order-hotkey', value: 'showAppsOrderHotkey', cb: this.bindAppKeys},
+            {key: 'show-apps-order-timeout', value: 'showAppsOrderTimeout', cb: null},
+            {key: 'cycleMenusHotkey', value: 'cycleMenusHotkey', cb: this.bindAppKeys},
+            {key: 'hoverPseudoClass', value: 'hoverPseudoClass', cb: this.refreshCurrentAppList},
+            {key: 'focusPseudoClass', value: 'focusPseudoClass', cb: this.refreshCurrentAppList},
+            {key: 'activePseudoClass', value: 'activePseudoClass', cb: this.refreshCurrentAppList},
+            {
+                key: 'app-button-transition-duration',
+                value: 'appButtonTransitionDuration',
+                cb: this.refreshCurrentAppList
+            },
+            {key: 'enable-hover-peek', value: 'enablePeek', cb: null},
+            {key: 'onclick-thumbnails', value: 'onClickThumbs', cb: null},
+            {key: 'hover-peek-opacity', value: 'peekOpacity', cb: null},
+            {key: 'hover-peek-time', value: 'peekTime', cb: null},
+            {key: 'thumbnail-timeout', value: 'thumbTimeout', cb: null},
+            {key: 'thumbnail-size', value: 'thumbSize', cb: null},
+            {
+                key: 'thumbnail-close-button-size',
+                value: 'thumbnailCloseButtonSize',
+                cb: this.updateThumbnailCloseButtonSize
+            },
+            {key: 'thumbnail-padding', value: 'thumbnailPadding', cb: this.updateThumbnailPadding},
+            {key: 'thumbnail-scroll-behavior', value: 'thumbnailScrollBehavior', cb: null},
+            {key: 'sort-thumbnails', value: 'sortThumbs', cb: this.updateVerticalThumbnailState},
+            {
+                key: 'highlight-last-focused-thumbnail',
+                value: 'highlightLastFocusedThumbnail',
+                cb: this.updateVerticalThumbnailState
+            },
+            {key: 'vertical-thumbnails', value: 'verticalThumbs', cb: this.updateVerticalThumbnailState},
+            {key: 'show-thumbnails', value: 'showThumbs', cb: this.updateVerticalThumbnailState},
+            {key: 'show-icons', value: 'showIcons', cb: this.updateVerticalThumbnailState},
+            {key: 'animate-thumbnails', value: 'animateThumbs', cb: null},
+            {key: 'include-all-windows', value: 'includeAllWindows', cb: this.refreshCurrentAppList},
+            {key: 'number-display', value: 'numDisplay', cb: this.updateWindowNumberState},
+            {key: 'title-display', value: 'titleDisplay', cb: this.updateTitleDisplay},
+            {key: 'scroll-behavior', value: 'scrollBehavior', cb: null},
+            {key: 'icon-spacing', value: 'iconSpacing', cb: this.updateSpacing},
+            {key: 'enable-iconSize', value: 'enableIconSize', cb: this.updateActorAttributes},
+            {key: 'icon-size', value: 'iconSize', cb: this.updateActorAttributes},
+            {key: 'show-recent', value: 'showRecent', cb: null},
+            {key: 'menuItemType', value: 'menuItemType', cb: null},
+            {key: 'firefox-menu', value: 'firefoxMenu', cb: null},
+            {key: 'autostart-menu-item', value: 'autoStart', cb: null},
+            {key: 'launch-new-instance-menu-item', value: 'launchNewInstance', cb: null},
+            {key: 'monitor-move-all-windows', value: 'monitorMoveAllWindows', cb: null},
+            {key: 'enable-app-button-width', value: 'enableAppButtonWidth', cb: this.updateActorAttributes},
+            {key: 'app-button-width', value: 'appButtonWidth', cb: this.updateActorAttributes},
+            {key: 'system-favorites', value: 'systemFavorites', cb: this.updateFavorites},
+            {key: 'show-all-workspaces', value: 'showAllWorkspaces', cb: this.refreshAllAppLists},
+            {key: 'list-monitor-windows', value: 'listMonitorWindows', cb: this.handleMonitorWindowsPrefsChange}
+        ];
+
+        for (let i = 0, len = settingsProps.length; i < len; i++) {
+            this.settings.bind(
+                settingsProps[i].key,
+                settingsProps[i].value,
+                settingsProps[i].cb ? (...args) => settingsProps[i].cb.call(this, ...args) : null
+            );
+        }
+
+        this.state.set({lastTitleDisplay: this.state.settings.titleDisplay});
+    }
+
+    on_applet_added_to_panel() {
+        if (this.state.appletReady && this.state.panelEditMode) {
+            return;
+        }
+        // Query apps for the current workspace
+        this.onSwitchWorkspace();
+        this.bindAppKeys();
+        this.updateSpacing();
+        this.state.set({appletReady: true});
+        setTimeout(() => this.updateMonitorWatchlist(), 0);
+    }
+
+    on_applet_instances_changed(loaded) {
+        if (this.state.appletReady) {
+            this.updateMonitorWatchlist();
+        }
+    }
+
+    on_panel_edit_mode_changed() {
+        this.state.set({panelEditMode: !this.state.panelEditMode});
+        each(this.appLists, (workspace) => {
+            each(workspace.appList, (appGroup) => {
+                appGroup.hoverMenu.actor.reactive = !this.state.panelEditMode;
+                appGroup.rightClickMenu.actor.reactive = !this.state.panelEditMode;
+                appGroup.actor.reactive = !this.state.panelEditMode;
+            });
+        });
+    }
+
+    on_panel_height_changed() {
+        this.updateActorAttributes();
+    }
+
+    on_orientation_changed(orientation) {
+        this.state.set({
+            orientation: orientation,
+            isHorizontal: orientation === St.Side.TOP || orientation === St.Side.BOTTOM
+        });
+        if (this.state.isHorizontal) {
+            this.actor.remove_style_class_name('vertical');
+        } else {
+            this.actor.add_style_class_name('vertical');
+            this.actor.set_important(true);
+        }
+    }
+
+    on_applet_removed_from_panel() {
+        this.state.set({willUnmount: true});
+        this.unbindAppKeys();
+        this.signals.disconnectAllSignals();
+        for (let i = 0, len = this.appLists.length; i < len; i++) {
+            if (this.appLists[i]) {
+                this.appLists[i].destroy();
+            }
+        }
+        this.settings.finalize();
+        unref(this, RESERVE_KEYS);
+    }
+
+    // Override Applet._onButtonPressEvent due to the applet menu being replicated in AppMenuButtonRightClickMenu.
+    _onButtonPressEvent(actor, event) {
+        if (this.state.panelEditMode) {
+            super._onButtonPressEvent(actor, event);
+        }
+        return false;
+    }
+
+    onWindowMonitorChanged(screen, metaWindow, metaWorkspace) {
+        if (this.state.settings.listMonitorWindows) {
+            this.getCurrentAppList().windowRemoved(metaWorkspace, metaWindow);
+            this.getCurrentAppList().windowAdded(metaWorkspace, metaWindow);
+        }
+    }
+
+    bindAppKeys() {
+        this.unbindAppKeys();
+
+        for (let i = 1; i < 10; i++) {
+            this.bindAppKey(i);
+        }
+        Main.keybindingManager.addHotKey('launch-show-apps-order', this.state.settings.showAppsOrderHotkey, () =>
+            this.showAppsOrder()
+        );
+        Main.keybindingManager.addHotKey('launch-cycle-menus', this.state.settings.cycleMenusHotkey, () =>
+            this.cycleMenus()
+        );
+    }
+
+    unbindAppKeys() {
+        for (let i = 1; i < 10; i++) {
+            Main.keybindingManager.removeHotKey('launch-app-key-' + i);
+            Main.keybindingManager.removeHotKey('launch-new-app-key-' + i);
+        }
+        Main.keybindingManager.removeHotKey('launch-show-apps-order');
+        Main.keybindingManager.removeHotKey('launch-cycle-menus');
+    }
+
+    bindAppKey(i) {
+        Main.keybindingManager.addHotKey('launch-app-key-' + i, '<Super>' + i, () => this.onAppKeyPress(i));
+        Main.keybindingManager.addHotKey('launch-new-app-key-' + i, '<Super><Shift>' + i, () =>
+            this.onNewAppKeyPress(i)
+        );
+    }
+
+    onAppKeyPress(number) {
+        this.getCurrentAppList().onAppKeyPress(number);
+    }
+
+    onNewAppKeyPress(number) {
+        this.getCurrentAppList().onNewAppKeyPress(number);
+    }
+
+    showAppsOrder() {
+        this.getCurrentAppList().showAppsOrder();
+    }
+
+    cycleMenus() {
+        this.getCurrentAppList().cycleMenus();
+    }
+
+    handleMonitorWindowsPrefsChange(value) {
+        let instances = Main.AppletManager.getRunningInstancesForUuid(this.state.uuid);
+        for (let i = 0; i < instances.length; i++) {
+            if (!instances[i]) {
+                continue;
+            }
+            instances[i].updateMonitorWatchlist();
+            if (instances[i].panel.monitorIndex !== this.panel.monitorIndex) {
+                instances[i].state.settings.listMonitorWindows = this.state.settings.listMonitorWindows;
+            }
+            instances[i].refreshCurrentAppList();
+        }
+    }
+
+    updateMonitorWatchlist() {
+        let numberOfMonitors = Gdk.Screen.get_default().get_n_monitors();
+        let onPrimary = this.panel.monitorIndex === Main.layoutManager.primaryIndex;
+        let instances = Main.AppletManager.getRunningInstancesForUuid(this.state.uuid);
+        /* Simple cases */
+        if (numberOfMonitors === 1) {
+            this.state.monitorWatchList = [Main.layoutManager.primaryIndex];
+        } else if (instances.length > 1 && !onPrimary) {
+            this.state.monitorWatchList = [this.panel.monitorIndex];
+        } else {
+           /* This is an instance on the primary monitor - it will be
+            * responsible for any monitors not covered individually.  First
+            * convert the instances list into a list of the monitor indices,
+            * and then add the monitors not present to the monitor watch list
+            * */
+            this.state.monitorWatchList = [this.panel.monitorIndex];
+            for (let i = 0; i < instances.length; i++) {
+                if (!instances[i]) {
+                    continue;
+                }
+                instances[i] = instances[i].panel.monitorIndex;
+            }
+
+            for (let i = 0; i < numberOfMonitors; i++) {
+                if (instances.indexOf(i) === -1) {
+                    this.state.monitorWatchList.push(i);
+                }
+            }
+        }
+
+        this.state.set({monitorWatchList: this.state.monitorWatchList});
+    }
+
+    refreshCurrentAppList() {
+        this.appLists[this.state.currentWs].refreshList();
+    }
+
+    refreshAllAppLists() {
+        each(this.appLists, function(appList) {
+            appList.refreshList();
+        });
+    }
+
+    handleMintYThemePreset() {
+        this.settings.setValue('hoverPseudoClass', 1);
+        this.settings.setValue('focusPseudoClass', 1);
+        this.settings.setValue('activePseudoClass', 3);
+        this.settings.setValue('number-display', 1);
+        this.settings.setValue('show-active', true);
+        this.refreshCurrentAppList();
+    }
+
+    handleMintXThemePreset() {
+        this.settings.setValue('hoverPseudoClass', 3);
+        this.settings.setValue('focusPseudoClass', 2);
+        this.settings.setValue('activePseudoClass', 4);
+        this.settings.setValue('number-display', 1);
+        this.settings.setValue('show-active', false);
+        this.refreshCurrentAppList();
+    }
+
+    updateFavorites() {
+        this.pinnedFavorites.reload();
+        this.refreshCurrentAppList();
+    }
+
+    updateThumbnailPadding() {
+        each(this.appLists, (workspace) => {
+            each(workspace.appList, (appGroup) => {
+                appGroup.hoverMenu.updateThumbnailPadding();
+            });
+        });
+    }
+
+    updateThumbnailCloseButtonSize() {
+        each(this.appLists, (workspace) => {
+            each(workspace.appList, (appGroup) => {
+                appGroup.hoverMenu.updateThumbnailCloseButtonSize();
+            });
+        });
+    }
+
+    updateActorAttributes() {
+        each(this.appLists, (workspace) => {
+            if (!workspace) return;
+
+            each(workspace.appList, (appGroup) => {
+                appGroup.setActorAttributes();
+            });
+        });
+    }
+
+    updateSpacing() {
+        each(this.appLists, (workspace) => {
+            workspace.updateSpacing();
+        });
+    }
+
+    updateWindowNumberState() {
+        each(this.appLists, (workspace) => {
+            workspace.calcAllWindowNumbers();
+        });
+    }
+
+    updateAttentionState(display, window) {
+        if (!this.state.settings.showAlerts) {
+            return false;
+        }
+        each(this.appLists, (workspace) => {
+            workspace.updateAttentionState(display, window);
+        });
+    }
+
+    updateVerticalThumbnailState() {
+        each(this.appLists, (workspace) => {
+            each(workspace.appList, (appGroup) => {
+                if (appGroup && appGroup.hoverMenu) {
+                    appGroup.hoverMenu.setVerticalSetting();
+                }
+            });
+        });
+    }
+
+    updateTitleDisplay(titleDisplay) {
+        if (titleDisplay === TitleDisplay.None
+            || this.state.lastTitleDisplay === TitleDisplay.None) {
+            this.refreshCurrentAppList();
+        }
+        let appList = this.getCurrentAppList().appList;
+        each(appList, (appGroup) => {
+            if (titleDisplay === TitleDisplay.Focused) {
+                appGroup.hideLabel(false);
+            }
+            appGroup.handleTitleDisplayChange();
+        });
+        this.state.set({lastTitleDisplay: titleDisplay});
+    }
+
+    getAppFromWMClass(specialApps, metaWindow) {
+        let startupClass = (wmClass) => {
+            let app = null;
+            for (let i = 0, len = specialApps.length; i < len; i++) {
+                if (specialApps[i].wmClass === wmClass) {
+                    app = this.appSystem.lookup_app(specialApps[i].id);
+                    if (!app) {
+                        app = this.appSystem.lookup_settings_app(specialApps[i].id);
+                    }
+                    if (app) {
+                        app.wmClass = wmClass;
+                    }
+                }
+            }
+            return app;
+        };
+        return startupClass(metaWindow.get_wm_class_instance());
+    }
+
+    getCurrentAppList() {
+        if (typeof this.appLists[this.state.currentWs] !== 'undefined') {
+            return this.appLists[this.state.currentWs];
+        } else if (typeof this.appLists[0] !== 'undefined') {
+            return this.appLists[0];
+        } else {
+            return null;
+        }
+    }
+
+    getAutoStartApps() {
+        let info, autoStartDir;
+
+        let getChildren = () => {
+            let children = autoStartDir.enumerate_children(
+                'standard::name,standard::type,time::modified',
+                Gio.FileQueryInfoFlags.NONE,
+                null
+            );
+            while ((info = children.next_file(null)) !== null) {
+                if (info.get_file_type() === Gio.FileType.REGULAR) {
+                    let name = info.get_name();
+                    let file = Gio.file_new_for_path(autoStartStrDir + '/' + name);
+                    this.state.autoStartApps.push({id: name, file: file});
+                }
+            }
+            this.state.set({autoStartApps: this.state.autoStartApps});
+        };
+
+        autoStartDir = Gio.file_new_for_path(autoStartStrDir);
+
+        if (autoStartDir.query_exists(null)) {
+            getChildren();
+        } else {
+            trySpawnCommandLine(`bash -c "mkdir ${autoStartStrDir}"`);
+            setTimeout(() => getChildren(), 2000);
+        }
+    }
+
+    handleScroll(e, sourceFromAppGroup) {
+        if ((this.state.settings.scrollBehavior === 1 && this.state.settings.leftClickAction !== 3)
+            || (e && sourceFromAppGroup && !this.state.settings.thumbnailScrollBehavior)) {
+            return;
+        }
+
+        this.state.set({scrollActive: true});
+
+        let isAppScroll = this.state.settings.scrollBehavior === 2;
+        let direction, source;
+
+        if (sourceFromAppGroup) {
+            isAppScroll = false;
+            direction = e ? e.get_scroll_direction() : 1;
+            source = sourceFromAppGroup;
+        } else {
+            direction = e.get_scroll_direction();
+            source = e.get_source()._delegate;
+        }
+        let lastFocusedApp, z, count
+
+        if (isAppScroll) {
+            lastFocusedApp = this.appLists[this.state.currentWs].listState.lastFocusedApp;
+            if (!lastFocusedApp) {
+                lastFocusedApp = this.appLists[this.state.currentWs].appList[0].groupState.appId
+            }
+            let focusedIndex = findIndex(this.appLists[this.state.currentWs].appList, function(appGroup) {
+                return appGroup.groupState.metaWindows.length > 0 && appGroup.groupState.appId === lastFocusedApp;
+            });
+            z = direction === 0 ? focusedIndex - 1 : focusedIndex + 1;
+            count = this.appLists[this.state.currentWs].appList.length - 1;
+        } else {
+            if (!source.groupState || source.groupState.metaWindows.length < 1) {
+                return;
+            }
+            let focusedIndex = findIndex(source.groupState.metaWindows, function(metaWindow) {
+                return metaWindow === source.groupState.lastFocused;
+            });
+            z = direction === 0 ? focusedIndex - 1 : focusedIndex + 1;
+            count = source.groupState.metaWindows.length - 1;
+        }
+
+        let limit = count * 2;
+
+        while ((isAppScroll
+            && (!this.appLists[this.state.currentWs].appList[z]
+                || !this.appLists[this.state.currentWs].appList[z].groupState.lastFocused))
+            || (!isAppScroll &&
+                (!source.groupState.metaWindows[z]
+                    || source.groupState.metaWindows[z] === source.groupState.lastFocused))) {
+            limit--;
+            if (direction === 0) {
+                z -= 1;
+            } else {
+                z += 1;
+            }
+            if (limit < 0) {
+                if (count === 0) {
+                    z = 0;
+                }
+                break;
+            } else if (z < 0) {
+                z = count;
+            } else if (z > count) {
+                z = 0;
+            }
+        }
+
+        let _window = isAppScroll ?
+            this.appLists[this.state.currentWs].appList[z].groupState.lastFocused
+            : source.groupState.metaWindows[z];
+        Main.activateWindow(_window, global.get_current_time());
+        setTimeout(() => this.state.set({scrollActive: false}, 4000));
+    }
+
+    handleDragOver(source, actor, x, y) {
+        if (!this.state.settings.enableDragging || this.state.panelEditMode) {
+            return DND.DragMotionResult.NO_DROP;
+        }
+
+        if (!source.actor) return DND.DragMotionResult.CONTINUE;
+
+        let appList = this.appLists[this.state.currentWs];
+        let children = appList.actor.get_children();
+        let windowPos = children.indexOf(source.actor);
+
+        let pos = 0;
+
+        let isHorizontal = appList.actor.height > appList.actor.width;
+        let axis = isHorizontal ? [y, 'y1'] : [x, 'x1'];
+        each(children, (child, i) => {
+            if (axis[0] > children[i].get_allocation_box()[axis[1]] + children[i].width / 2) {
+                pos = i;
+            }
+        });
+
+        if (pos !== this.state.dragPlaceholderPos) {
+            this.state.dragPlaceholderPos = pos;
+
+            // Don't allow positioning before or after self
+            if (windowPos !== -1 && pos === windowPos) {
+                if (this.state.dragPlaceholder) {
+                    this.state.dragPlaceholder.animateOutAndDestroy();
+                    this.state.animatingPlaceholdersCount++;
+                    this.state.dragPlaceholder.actor.connect(
+                        'destroy',
+                        () => {
+                            this.state.animatingPlaceholdersCount--;
+                        }
+                    );
+                }
+                this.state.dragPlaceholder = null;
+
+                return DND.DragMotionResult.CONTINUE;
+            }
+
+            // If the placeholder already exists, we just move
+            // it, but if we are adding it, expand its size in
+            // an animation
+            let fadeIn;
+            if (this.state.dragPlaceholder) {
+                this.state.dragPlaceholder.actor.destroy();
+                fadeIn = false;
+            } else {
+                fadeIn = true;
+            }
+
+            let childWidth = source.actor.width;
+            let childHeight = source.actor.height;
+            this.state.dragPlaceholder = new DND.GenericDragPlaceholderItem();
+            this.state.dragPlaceholder.child.width = childWidth;
+            this.state.dragPlaceholder.child.height = childHeight;
+            appList.actor.insert_child_at_index(
+                this.state.dragPlaceholder.actor,
+                this.state.dragPlaceholderPos
+            );
+
+            if (fadeIn) this.state.dragPlaceholder.animateIn();
+        }
+
+        return DND.DragMotionResult.MOVE_DROP;
+    }
+
+    // TODO: Figure out exactly which properties on this applet constructor the Cinnamon APIs needs for all modes of
+    // DND, so we can kill the _delegate reference. Long term, a PR to Cinnamon should be opened fixing circular
+    // object reference structures for the applet and desklet classes.
+    acceptDrop(source, actor, x) {
+        if (!this.state.settings.enableDragging || this.state.panelEditMode) {
+            return false;
+        }
+        if (typeof source.groupState === 'undefined') {
+            let appId = source.isDraggableApp ? source.get_app_id() : source.getId();
+            if (appId) {
+                this.acceptNewLauncher(appId);
+                return true;
+            }
+            return false;
+        }
+
+        let appList = this.appLists[this.state.currentWs];
+
+        if (!source.groupState.isFavoriteApp) {
+            if (this.state.dragPlaceholderPos !== -1) {
+                appList.actor.set_child_at_index(
+                    source.actor,
+                    this.state.dragPlaceholderPos
+                );
+            }
+            this.clearDragPlaceholder();
+        }
+        appList.actor.set_child_at_index(source.actor, this.state.dragPlaceholderPos);
+
+        // Don't allow favoriting of transient apps
+        if (!source.groupState.app || source.groupState.app.is_window_backed()) {
+            return false;
+        }
+
+        let refFav = findIndex(this.pinnedFavorites._favorites, (favorite) => favorite.id === source.groupState.appId);
+        let favPos = this.state.dragPlaceholderPos;
+
+        if (favPos === -1) {
+            let children = appList.actor.get_children();
+            let pos = 0;
+            for (let i = 0, len = children.length; i < len; i++) {
+                if (x > children[i].get_allocation_box().x1 + children[i].width / 2) {
+                    pos = i;
+                }
+            }
+            if (pos !== this.state.dragPlaceholderPos) {
+                favPos = pos;
+            }
+        }
+
+        Meta.later_add(Meta.LaterType.BEFORE_REDRAW, () => {
+            let opts = {
+                appId: source.groupState.appId,
+                app: source.groupState.app,
+                pos: favPos
+            };
+            if (refFav !== -1) {
+                this.pinnedFavorites.moveFavoriteToPos(opts);
+            } else if (this.state.settings.pinOnDrag) {
+                this.pinnedFavorites.addFavorite(opts);
+            }
+            return false;
+        });
+        this.clearDragPlaceholder();
+        return true;
+    }
+
+    clearDragPlaceholder() {
+        if (this.state.dragPlaceholder) {
+            this.state.dragPlaceholder.animateOutAndDestroy();
+            this.state.dragPlaceholder = null;
+            this.state.dragPlaceholderPos = -1;
+        }
+    }
+
+    acceptNewLauncher(path) {
+        this.pinnedFavorites.addFavorite({appId: path, pos: -1});
+        // Need to determine why the favorites setting signal doesn't emit outside the applet actions
+        this.updateFavorites();
+    }
+
+    onWorkspaceRemoved(metaScreen, index) {
+        if (this.appLists.length <= index) {
+            return;
+        }
+        let removedLists = [];
+        for (let i = 0; i < this.appLists.length; i++) {
+            let workspaceIndex = this.appLists[i].metaWorkspace.index();
+            if (workspaceIndex === -1) {
+                this.appLists[i].destroy();
+                this.appLists[i] = null;
+                removedLists.push(i);
+            } else {
+                this.appLists[i].index = workspaceIndex;
+            }
+        }
+        for (let i = 0; i < removedLists.length; i++) {
+            this.appLists.splice(removedLists[i], 1);
+        }
+        this.state.set({currentWs: global.screen.get_active_workspace_index()});
+    }
+
+    onSwitchWorkspace() {
+        this.state.set({currentWs: global.screen.get_active_workspace_index()});
+        let metaWorkspace = global.screen.get_workspace_by_index(this.state.currentWs);
+
+        // If the workspace we switched to isn't in our list,
+        // we need to create an AppList for it
+        let refWorkspace = findIndex(
+            this.appLists,
+            (item) => item.metaWorkspace && item.metaWorkspace === metaWorkspace
+        );
+
+        if (refWorkspace === -1) {
+            this.appLists.push(
+                new AppList({
+                    metaWorkspace: metaWorkspace,
+                    state: this.state,
+                    index: this.state.currentWs
+                })
+            );
+            refWorkspace = this.appLists.length - 1;
+        }
+
+        this.actor.remove_all_children();
+        this.actor.add_child(this.appLists[refWorkspace].actor);
+    }
+
+    onOverviewShow() {
+        this.actor.hide();
+    }
+
+    onOverviewHide() {
+        this.actor.show();
+    }
+}
+
+function main(metadata, orientation, panel_height, instance_id) {
+    return new GroupedWindowListApplet(metadata, orientation, panel_height, instance_id);
+}

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/constants.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/constants.js
@@ -1,0 +1,48 @@
+const constants = {
+    THUMBNAIL_ICON_SIZE: 16,
+    OPACITY_OPAQUE: 255,
+    BUTTON_BOX_ANIMATION_TIME: 0.15,
+    MAX_BUTTON_WIDTH: 150, // Pixels
+    FLASH_INTERVAL: 500,
+    ICON_HEIGHT_FACTOR: 0.64,
+    VERTICAL_ICON_HEIGHT_FACTOR: 0.75,
+    RESERVE_KEYS: ['willUnmount'],
+    TitleDisplay: {
+        None: 1,
+        App: 2,
+        Title: 3,
+        Focused: 4
+    },
+    NumberDisplay: {
+        Smart: 1,
+        Normal: 2,
+        None: 3,
+        All: 4
+    },
+    FavType: {
+        favorites: 0,
+        pinnedApps: 1,
+        none: 2
+    },
+    ffOptions: [
+        {id: 1, label: 'Most Visited'},
+        {id: 2, label: 'Recent History'},
+        {id: 3, label: 'Bookmarks'}
+    ],
+    menuItemTypeOptions: [
+        {id: 1, label: 'SYMBOLIC'},
+        {id: 2, label: 'FULLCOLOR'},
+        {id: 3, label: null}
+    ],
+    pseudoOptions: [
+        {id: 1, label: 'hover'},
+        {id: 2, label: 'focus'},
+        {id: 3, label: 'active'},
+        {id: 4, label: 'outlined'},
+        {id: 5, label: 'selected'},
+        {id: 6, label: 'checked'}
+    ],
+    autoStartStrDir: './.config/autostart'
+};
+
+module.exports = constants;

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/firefox.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/firefox.js
@@ -1,0 +1,141 @@
+/* jshint moz:true */
+let Gda;
+const GLib = imports.gi.GLib;
+
+const {tryFn} = require('./utils');
+
+tryFn(function() {
+    Gda = imports.gi.Gda;
+});
+
+function getFirefoxHistory(applet) {
+    let history = [];
+
+    if (!Gda) {
+        return null;
+    }
+
+    let cfgPath = GLib.build_filenamev([GLib.get_home_dir(), '.mozilla', 'firefox']);
+
+    let iniPath = GLib.build_filenamev([cfgPath, 'profiles.ini']);
+
+    let profilePath;
+
+    if (GLib.file_test(iniPath, GLib.FileTest.EXISTS)) {
+        let iniFile = new GLib.KeyFile();
+        let groups, nGroups;
+
+        iniFile.load_from_file(iniPath, GLib.KeyFileFlags.NONE);
+
+        [groups, nGroups] = iniFile.get_groups();
+
+        for (let i = 0; i < nGroups; i++) {
+            let isRelative, profileName, profileDir;
+
+            let hadException = tryFn(
+                function() {
+                    isRelative = iniFile.get_integer(groups[i], 'IsRelative');
+                    profileName = iniFile.get_string(groups[i], 'Name');
+                    profileDir = iniFile.get_string(groups[i], 'Path');
+                },
+                function() {
+                    return true;
+                }
+            );
+
+            if (hadException === true) {
+                continue;
+            }
+
+            if (profileName === 'default') {
+                if (isRelative) {
+                    profilePath = GLib.build_filenamev([cfgPath, profileDir]);
+                } else {
+                    profilePath = profileDir;
+                }
+            }
+        }
+    }
+
+    if (!profilePath) {
+        return history;
+    }
+
+    let filePath = GLib.build_filenamev([profilePath, 'places.sqlite']);
+
+    if (!GLib.file_test(filePath, GLib.FileTest.EXISTS)) {
+        return history;
+    }
+
+    var con, result;
+
+    let hadException = tryFn(
+        function() {
+            con = Gda.Connection.open_from_string(
+                'SQLite',
+                'DB_DIR=' + profilePath + ';DB_NAME=places.sqlite',
+                null,
+                Gda.ConnectionOptions.READ_ONLY
+            );
+        },
+        function() {
+            return history;
+        }
+    );
+
+    if (hadException != null) {
+        return hadException;
+    }
+
+    hadException = tryFn(
+        function() {
+            if (applet.firefoxMenu === 1) {
+                result = con.execute_select_command(
+                    'SELECT title,url FROM moz_places WHERE title IS NOT NULL ORDER BY visit_count DESC'
+                );
+            } else if (applet.firefoxMenu === 2) {
+                result = con.execute_select_command(
+                    'SELECT title,url FROM moz_places WHERE title IS NOT NULL ORDER BY last_visit_date DESC'
+                );
+            } else {
+                result = con.execute_select_command(
+                    'SELECT moz_bookmarks.title,moz_places.url FROM (moz_bookmarks INNER JOIN moz_places ON moz_bookmarks.fk=moz_places.id) WHERE moz_bookmarks.parent IS NOT 1 AND moz_bookmarks.parent IS NOT 2 AND moz_bookmarks.title IS NOT NULL ORDER BY moz_bookmarks.lastModified DESC'
+                );
+            }
+        },
+        function() {
+            con.close();
+            return history;
+        }
+    );
+
+    if (hadException != null) {
+        return hadException;
+    }
+
+    let nRows = result.get_n_rows();
+    let num = applet.appMenuNum;
+    if (nRows > num) {
+        nRows = num;
+    }
+
+    for (let row = 0; row < nRows; row++) {
+        let title, uri;
+
+        try {
+            title = result.get_value_at(0, row);
+            uri = result.get_value_at(1, row);
+        } catch (e) {
+            continue;
+        }
+        history.push({
+            uri: uri,
+            title: title
+        });
+    }
+
+    con.close();
+    return history;
+}
+
+module.exports = getFirefoxHistory;

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/gettext.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/gettext.js
@@ -1,0 +1,10 @@
+const Gettext = imports.gettext;
+function t(str) {
+    var resultConf = Gettext.dgettext('IcingTaskManager@json', str);
+    if (resultConf != str) {
+        return resultConf;
+    }
+    return Gettext.gettext(str);
+}
+
+module.exports = t;

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
@@ -1,0 +1,1139 @@
+const Clutter = imports.gi.Clutter;
+const Meta = imports.gi.Meta;
+const St = imports.gi.St;
+const Gio = imports.gi.Gio;
+const AppletManager = imports.ui.appletManager;
+const Main = imports.ui.main;
+const Tweener = imports.ui.tweener;
+const PopupMenu = imports.ui.popupMenu;
+const Applet = imports.ui.applet;
+const SignalManager = imports.misc.signalManager;
+
+const {each, find, findIndex, tryFn, unref, trySpawnCommandLine, spawn_async} = imports.misc.util;
+const {
+    OPACITY_OPAQUE,
+    RESERVE_KEYS,
+    menuItemTypeOptions,
+    ffOptions,
+    FavType,
+    autoStartStrDir
+} = require('./constants');
+
+const getFirefoxHistory = require('./firefox');
+
+const convertRange = function(value, r1, r2) {
+    return ((value - r1[0]) * (r2[1] - r2[0])) / (r1[1] - r1[0]) + r2[0];
+};
+
+const setOpacity = (peekTime, window_actor, targetOpacity) => {
+    const opacity = convertRange(targetOpacity, [0, 100], [0, 255]);
+    Tweener.addTween(window_actor, {
+        time: peekTime * 0.001,
+        transition: 'easeOutQuad',
+        opacity: opacity > 255 ? 255 : opacity
+    });
+};
+
+class AppMenuButtonRightClickMenu extends Applet.AppletPopupMenu {
+    constructor(params, orientation) {
+        super(params, orientation);
+        this.state = params.state;
+        this.groupState = params.groupState;
+
+        this.signals = new SignalManager.SignalManager(null);
+        this.signals.connect(this, 'open-state-changed', (...args) => this.onToggled(...args));
+    }
+
+    monitorMoveWindows(i) {
+        if (this.state.settings.monitorMoveAllWindows) {
+            for (let z = 0, len = this.groupState.metaWindows.length; z < len; z++) {
+                if (!this.groupState.metaWindows[z]) {
+                    continue;
+                }
+                let focused = 0;
+                if (this.groupState.metaWindows[z].has_focus()) {
+                    ++focused;
+                }
+                if (z === len - 1 && focused === 0) {
+                    Main.activateWindow(this.groupState.metaWindows[z], global.get_current_time());
+                }
+                this.groupState.metaWindows[z].move_to_monitor(i);
+            }
+        } else {
+            this.groupState.lastFocused.move_to_monitor(i);
+            Main.activateWindow(this.groupState.lastFocused, global.get_current_time());
+        }
+    }
+
+    populateMenu() {
+        this.signals.disconnectAllSignals();
+        this.signals.connect(
+            this,
+            'open-state-changed',
+            (...args) => this.onToggled(...args)
+        );
+
+        let item;
+        let length;
+        let hasWindows = this.groupState.metaWindows.length > 0;
+        let isWindowBacked = this.groupState.app.is_window_backed();
+
+        let createMenuItem = (opts = {label: '', icon: null}) => {
+            if (this.state.settings.menuItemType < 3 && opts.icon) {
+                let refMenuType = find(
+                    menuItemTypeOptions,
+                    (item) => item.id === this.state.settings.menuItemType
+                );
+                return new PopupMenu.PopupIconMenuItem(opts.label, opts.icon, St.IconType[refMenuType.label]);
+            } else {
+                return new PopupMenu.PopupMenuItem(opts.label);
+            }
+        };
+
+        if (hasWindows) {
+            // Monitors
+            if (Main.layoutManager.monitors.length > 1) {
+                let connectMonitorEvent = (item, i) => {
+                    this.signals.connect(item, 'activate', () => this.monitorMoveWindows(i));
+                };
+                for (let i = 0, len = Main.layoutManager.monitors.length; i < len; i++) {
+                    if (!this.groupState.lastFocused || i === this.groupState.lastFocused.get_monitor()) {
+                        continue;
+                    }
+                    item = createMenuItem({
+                        label: Main.layoutManager.monitors.length === 2 ?
+                            _('Move to the other monitor')
+                            : _('Move to monitor ') + (i + 1)
+                    });
+                    connectMonitorEvent(item, i);
+                    this.addMenuItem(item);
+                }
+            }
+            // Workspace
+            if ((length = global.screen.n_workspaces) > 1) {
+                if (this.groupState.lastFocused && this.groupState.lastFocused.is_on_all_workspaces()) {
+                    item = createMenuItem({label: _('Only on this workspace')});
+                    this.signals.connect(item, 'activate', () => {
+                        this.groupState.lastFocused.unstick();
+                        this.state.trigger('removeWindowFromOtherWorkspaces', this.groupState.lastFocused);
+                    });
+                    this.addMenuItem(item);
+                } else {
+                    item = createMenuItem({label: _('Visible on all workspaces')});
+                    this.signals.connect(item, 'activate', () => {
+                        this.groupState.lastFocused.stick();
+                        this.state.trigger('addWindowToAllWorkspaces', this.groupState.lastFocused);
+                    });
+                    this.addMenuItem(item);
+
+                    item = new PopupMenu.PopupSubMenuMenuItem(_('Move to another workspace'));
+                    this.addMenuItem(item);
+
+                    let connectWorkspaceEvent = (ws, j) => {
+                        this.signals.connect(ws, 'activate', () => {
+                            this.groupState.lastFocused.change_workspace(global.screen.get_workspace_by_index(j));
+                        });
+                    };
+                    for (let i = 0; i < length; i++) {
+                        // Make the index a local letiable to pass to function
+                        let j = i;
+                        let name = Main.workspace_names[i] ? Main.workspace_names[i] : Main._makeDefaultWorkspaceName(i);
+                        let ws = createMenuItem({label: _(name)});
+
+                        if (i === this.state.currentWs) {
+                            ws.setSensitive(false);
+                        }
+
+                        connectWorkspaceEvent(ws, j);
+                        item.menu.addMenuItem(ws);
+                    }
+                }
+            }
+            this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+        }
+
+        if (this.state.settings.showRecent) {
+            // Places
+            if (this.groupState.appId === 'nemo.desktop' || this.groupState.appId === 'nemo-home.desktop') {
+                let subMenu = new PopupMenu.PopupSubMenuMenuItem(_('Places'));
+                this.addMenuItem(subMenu);
+
+                let defualtPlaces = this.listDefaultPlaces();
+                let bookmarks = this.listBookmarks();
+                let devices = this.listDevices();
+                let places = defualtPlaces.concat(bookmarks).concat(devices);
+                let handlePlaceLaunch = (item, i) => {
+                    this.signals.connect(item, 'activate', () => places[i].launch());
+                };
+                for (let i = 0, len = places.length; i < len; i++) {
+                    item = createMenuItem({label: _(places[i].name), icon: 'folder'});
+                    handlePlaceLaunch(item, i);
+                    subMenu.menu.addMenuItem(item);
+                }
+                this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+            }
+
+            // History
+            if (
+                this.groupState.appId === 'firefox.desktop' ||
+                this.groupState.appId === 'firefox web browser.desktop'
+            ) {
+                let histories = null;
+                tryFn(() => {
+                    histories = getFirefoxHistory(this.state.settings);
+                });
+                let subMenu;
+
+                if (histories) {
+                    subMenu = new PopupMenu.PopupSubMenuMenuItem(
+                        _(ffOptions.find((ffOption) => ffOption.id === this.state.settings.firefoxMenu).label)
+                    );
+                    tryFn(() => {
+                        let handleHistoryLaunch = (item, i) => {
+                            this.signals.connect(item, 'activate', () => {
+                                Gio.app_info_launch_default_for_uri(
+                                    histories[i].uri,
+                                    global.create_app_launch_context()
+                                )
+                            });
+                        };
+                        for (let i = 0, len = histories.length; i < len; i++) {
+                            item = createMenuItem({label: _(histories[i].title), icon: 'go-next'});
+                            handleHistoryLaunch(item, i);
+                            subMenu.menu.addMenuItem(item);
+                        }
+                    });
+                } else {
+                    subMenu = createMenuItem({
+                        label: _('Bookmarks/History requires gir1.2-gda-5.0'),
+                        icon: 'help-about'
+                    });
+                }
+                this.addMenuItem(subMenu);
+                this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+            }
+
+            // Recent Files
+            let recentItems = this.state.trigger('getRecentItems');
+            let items = [];
+
+            for (let i = 0, len = recentItems.length; i < len; i++) {
+                let mimeType = recentItems[i].get_mime_type();
+                let appInfo = Gio.app_info_get_default_for_type(mimeType, false);
+                if (appInfo && this.groupState.appInfo && appInfo.get_id() === this.groupState.appId) {
+                    items.push(recentItems[i]);
+                }
+            }
+            let itemsLength = items.length;
+
+            if (itemsLength > 0) {
+                let subMenu = new PopupMenu.PopupSubMenuMenuItem(_('Recent'));
+                this.addMenuItem(subMenu);
+                let num = 10;
+                if (itemsLength > num) {
+                    itemsLength = num;
+                }
+                let handleRecentLaunch = (item, i) => {
+                    this.signals.connect(item, 'activate', () => {
+                        Gio.app_info_launch_default_for_uri(items[i].get_uri(), global.create_app_launch_context())
+                    });
+                };
+                for (let i = 0; i < itemsLength; i++) {
+                    item = createMenuItem({label: _(items[i].get_short_name()), icon: 'list-add'});
+                    handleRecentLaunch(item, i);
+                    subMenu.menu.addMenuItem(item);
+                }
+                this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+            }
+        }
+
+        // Preferences
+        let subMenu = new PopupMenu.PopupSubMenuMenuItem(_('Preferences'));
+        this.addMenuItem(subMenu);
+
+        item = createMenuItem({label: _('About...'), icon: 'dialog-question'});
+        this.signals.connect(item, 'activate', () => this.state.trigger('openAbout'));
+        subMenu.menu.addMenuItem(item);
+
+        item = createMenuItem({label: _('Configure...'), icon: 'system-run'});
+        this.signals.connect(item, 'activate', () => this.state.trigger('configureApplet'));
+        subMenu.menu.addMenuItem(item);
+
+        item = createMenuItem({label: _('Remove') + " 'Icing Task Manager'", icon: 'edit-delete'});
+        this.signals.connect(item, 'activate', () => {
+            AppletManager._removeAppletFromPanel(this.state.uuid, this.state.instance_id);
+        });
+        subMenu.menu.addMenuItem(item);
+
+        // Actions
+        tryFn(() => {
+            if (!this.groupState.appInfo) return;
+            let actions = this.groupState.appInfo.list_actions();
+            if (actions) {
+                this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+                let handleAction = (action) => {
+                    item = createMenuItem({
+                        label: _(this.groupState.appInfo.get_action_name(action)),
+                        icon: 'document-new'
+                    });
+                    this.signals.connect(item, 'activate', () => {
+                        this.groupState.appInfo.launch_action(action, global.create_app_launch_context());
+                    });
+                };
+
+                for (let i = 0, len = actions.length; i < len; i++) {
+                    handleAction(actions[i]);
+                    this.addMenuItem(item);
+                }
+                this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+            }
+            if (this.state.settings.launchNewInstance && (!actions || actions.length === 0) && !isWindowBacked) {
+                item = createMenuItem({label: _('New Window'), icon: 'document-new'});
+                this.signals.connect(item, 'activate', () => this.groupState.trigger('launchNewInstance'));
+                this.addMenuItem(item);
+                if (!actions || actions.length === 0) {
+                    this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+                }
+            }
+        }, () => {
+            if (isWindowBacked) {
+                this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+            }
+        });
+
+        // Pin/unpin, shortcut handling
+        if (!isWindowBacked) {
+            if (this.state.settings.showPinned !== FavType.none) {
+                let label = this.groupState.isFavoriteApp ? _('Unpin from Panel') : _('Pin to Panel');
+                this.pinToggleItem = createMenuItem({label: label, icon: 'bookmark-new'});
+                this.signals.connect(this.pinToggleItem, 'activate', (...args) => this.toggleFavorite(...args));
+                this.addMenuItem(this.pinToggleItem);
+            }
+            if (this.state.settings.autoStart) {
+                let label = this.groupState.autoStartIndex !== -1 ? _('Remove from Autostart') : _('Add to Autostart');
+                item = createMenuItem({label: label, icon: 'insert-object'});
+                this.signals.connect(item, 'activate', (...args) => this.toggleAutostart(...args));
+                this.addMenuItem(item);
+            }
+        } else {
+            this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+            item = createMenuItem({label: _('Create Shortcut'), icon: 'list-add'});
+            this.signals.connect(item, 'activate', (...args) => this.createShortcut(...args));
+            this.addMenuItem(item);
+        }
+        this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+
+        // Window controls
+        if (hasWindows) {
+            let metaWindowActor = this.groupState.lastFocused.get_compositor_private();
+            // Miscellaneous
+            if (metaWindowActor.opacity !== 255) {
+                item = createMenuItem({label: _('Restore to full opacity')});
+                this.signals.connect(item, 'activate', () => metaWindowActor.set_opacity(255));
+                this.addMenuItem(item);
+            }
+
+            if (this.groupState.lastFocused.minimized) {
+                item = createMenuItem({label: _('Restore'), icon: 'view-sort-descending'});
+                this.signals.connect(item, 'activate', () => {
+                    Main.activateWindow(this.groupState.lastFocused, global.get_current_time());
+                });
+            } else {
+                item = createMenuItem({label: _('Minimize'), icon: 'view-sort-ascending'});
+                this.signals.connect(item, 'activate', () => this.groupState.lastFocused.minimize());
+            }
+            this.addMenuItem(item);
+
+            if (this.groupState.lastFocused.get_maximized()) {
+                item = createMenuItem({label: _('Unmaximize'), icon: 'view-restore'});
+                this.signals.connect(item, 'activate', () => {
+                    this.groupState.lastFocused.unmaximize(
+                        Meta.MaximizeFlags.HORIZONTAL | Meta.MaximizeFlags.VERTICAL
+                    );
+                });
+            } else {
+                item = createMenuItem({label: _('Maximize'), icon: 'view-fullscreen'});
+                this.signals.connect(item, 'activate', () => {
+                    this.groupState.lastFocused.maximize(
+                        Meta.MaximizeFlags.HORIZONTAL | Meta.MaximizeFlags.VERTICAL
+                    );
+                });
+            }
+            this.addMenuItem(item);
+
+            if (this.groupState.metaWindows && this.groupState.metaWindows.length > 1) {
+                // Close others
+                item = createMenuItem({label: _('Close others'), icon: 'window-close'});
+                this.signals.connect(item, 'activate', () => {
+                    each(this.groupState.metaWindows, (metaWindow) => {
+                        if (!metaWindow === this.groupState.lastFocused && !metaWindow._needsAttention) {
+                            metaWindow.delete(global.get_current_time());
+                        }
+                    });
+                });
+                this.addMenuItem(item);
+                // Close all
+                item = createMenuItem({label: _('Close all'), icon: 'application-exit'});
+                this.signals.connect(item, 'activate', () => {
+                    if (!this.groupState.isFavoriteApp) {
+                        this.groupState.set({willUnmount: true});
+                    }
+                    this.groupState.app.request_quit();
+                });
+                this.addMenuItem(item);
+                this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+            } else {
+                item = createMenuItem({label: _('Close'), icon: 'edit-delete'});
+                this.signals.connect(item, 'activate', () => {
+                    this.groupState.lastFocused.delete(global.get_current_time());
+                });
+                this.addMenuItem(item);
+                this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+            }
+        }
+    }
+
+    onToggled(actor, isOpening) {
+        this.state.set({menuOpen: this.isOpen});
+
+        if (!isOpening) return;
+
+        this.removeAll();
+        this.populateMenu();
+    }
+
+    toggleAutostart() {
+        if (this.groupState.autoStartIndex !== -1) {
+            this.state.autoStartApps[this.groupState.autoStartIndex].file.delete(null);
+            this.state.autoStartApps[this.groupState.autoStartIndex] = undefined;
+            this.state.autoStartApps.splice(this.groupState.autoStartIndex, 1);
+            this.groupState.set({autoStartIndex: -1});
+        } else {
+            let filePath = this.groupState.appInfo.get_filename();
+            trySpawnCommandLine('bash -c "cp ' + filePath + ' ' + autoStartStrDir + '"');
+            setTimeout(() => {
+                this.state.trigger('getAutoStartApps');
+                this.groupState.set({autoStartIndex: this.state.autoStartApps.length - 1});
+            }, 500);
+        }
+    }
+
+    toggleFavorite() {
+        if (this.groupState.isFavoriteApp) {
+            this.state.trigger('removeFavorite', this.groupState.appId);
+        } else if (!this.groupState.app.is_window_backed()) {
+            this.state.trigger('addFavorite', {
+                appId: this.groupState.appId,
+                app: this.groupState.app,
+                pos: -1
+            });
+        }
+    }
+
+    createShortcut() {
+        let proc = this.groupState.lastFocused.get_pid();
+        let cmd = [
+            'bash',
+            '-c',
+            'python3 ~/.local/share/cinnamon/applets/IcingTaskManager@json/3.8/utils.py get_process ' + proc.toString()
+        ];
+        spawn_async(cmd, (stdout) => {
+            if (stdout) {
+                setTimeout(() => {
+                    this.state.trigger('addFavorite', {appId: stdout.trim(), app: null, pos: -1});
+                    this.state.trigger('refreshCurrentAppList');
+                }, 2000);
+            }
+        });
+    }
+
+    listDefaultPlaces(pattern) {
+        let defaultPlaces = Main.placesManager.getDefaultPlaces();
+        let res = [];
+        for (let i = 0, len = defaultPlaces.length; i < len; i++) {
+            if (!pattern || defaultPlaces[i].name.toLowerCase().indexOf(pattern) !== -1) {
+                res.push(defaultPlaces[i]);
+            }
+        }
+        return res;
+    }
+
+    listBookmarks(pattern) {
+        let bookmarks = Main.placesManager.getBookmarks();
+        let res = [];
+        for (let i = 0, len = bookmarks.length; i < len; i++) {
+            if (!pattern || bookmarks[i].name.toLowerCase().indexOf(pattern) !== -1) {
+                res.push(bookmarks[i]);
+            }
+        }
+        return res;
+    }
+
+    listDevices(pattern) {
+        let devices = Main.placesManager.getMounts();
+        let res = [];
+        for (let i = 0, len = devices.length; i < len; i++) {
+            if (!pattern || devices[i].name.toLowerCase().indexOf(pattern) !== -1) {
+                res.push(devices[i]);
+            }
+        }
+        return res;
+    }
+
+    destroy() {
+        this.signals.disconnectAllSignals();
+        Applet.AppletPopupMenu.prototype.destroy.call(this);
+        unref(this, RESERVE_KEYS);
+    }
+}
+
+class HoverMenuController extends PopupMenu.PopupMenuManager {
+    _onEventCapture() {
+        return false;
+    }
+}
+
+class WindowThumbnail {
+    constructor(params) {
+        this.state = params.state;
+        this.stateConnectId = this.state.connect({
+            scrollActive: () => {
+                if (this.state.overlayPreview) {
+                    this.destroyOverlayPreview();
+                }
+            }
+        });
+        this.groupState = params.groupState;
+        this.connectId = this.groupState.connect({
+            isFavoriteApp: () => this.handleFavorite(),
+            lastFocused: () => {
+                if (!this.groupState || !this.groupState.metaWindows || this.groupState.metaWindows.length === 0) {
+                    return;
+                }
+                this.isFocused = this.groupState.lastFocused === this.metaWindow;
+                this.onFocusWindowChange();
+            },
+            refreshThumbnails: () => this.refreshThumbnail()
+        });
+
+        this.metaWindow = params.metaWindow;
+        this.index = params.index;
+
+        this.metaWindowActor = null;
+        this.thumbnailPadding = 16;
+        this.willUnmount = false;
+        this.stopClick = false;
+        this.entered = false;
+        this.isFocused = false;
+        this.signals = new SignalManager.SignalManager(null);
+
+        // Inherit the theme from the alt-tab menu'
+        this.actor = new St.BoxLayout({
+            name: 'this.actor',
+            style_class: 'item-box',
+            reactive: true,
+            track_hover: true,
+            vertical: true,
+            can_focus: true
+        });
+        this.state.trigger('setThumbnailActorStyle', this.actor);
+        this.actor._delegate = null;
+        // Override with own theme.
+        this.actor.add_style_class_name('thumbnail-box');
+        this.thumbnailActor = new St.Bin({
+            style_class: 'thumbnail'
+        });
+
+        this.container = new St.BoxLayout();
+
+        this.bin = new St.BoxLayout({
+            y_expand: false
+        });
+
+        this.label = new St.Label({
+            style_class: this.icon ? 'thumbnail-label' : 'thumbnail-label-no-icon'
+        });
+
+        if (this.state.settings.showIcons) {
+            this.icon = this.groupState.app.create_icon_texture(16);
+            this.themeIcon = new St.BoxLayout({
+                style_class: 'thumbnail-icon'
+            });
+            this.themeIcon.add_actor(this.icon);
+            this.container.add_actor(this.themeIcon);
+            this.container.add_actor(this.label);
+        } else {
+            this.labelContainer = new St.Bin({
+                y_align: this.icon ? St.Align.START : St.Align.MIDDLE
+            });
+            this.labelContainer.add_actor(this.label);
+            this.container.add_actor(this.labelContainer);
+        }
+
+        this.button = new St.Button({
+            reactive: true
+        });
+
+        this.state.trigger('setThumbnailCloseButtonStyle', this.button);
+
+        this.button.set_opacity(0);
+        this.bin.add_actor(this.container);
+        this.bin.add_actor(this.button);
+        this.actor.add_actor(this.bin);
+        this.actor.add_actor(this.thumbnailActor);
+
+        setTimeout(() => this.handleFavorite(), 0);
+
+        this.signals.connect(this.actor, 'enter-event', (...args) => this.onEnter(...args));
+        this.signals.connect(this.actor, 'leave-event', (...args) => this.onLeave(...args));
+        this.signals.connect(this.button, 'button-release-event', (...args) => this.onCloseButtonRelease(...args));
+        this.signals.connect(this.actor, 'button-release-event', (...args) => this.connectToWindow(...args));
+        //update focused style
+        this.onFocusWindowChange();
+    }
+
+    onEnter(a, e) {
+        this.entered = true;
+        this.state.trigger('setThumbnailActorStyle', this.actor);
+        this.state.trigger('setThumbnailCloseButtonStyle', this.button);
+
+        // Cluter.CrossingEvent will always fire on every child actor of the actor connected to the signal, so we have
+        // to filter the bogus child hover events so the hoverpeek effect only occurs once while inside this.actor.
+
+        this.actor.add_style_pseudo_class('selected');
+        this.button.set_opacity(255);
+
+        if (!e) return;
+
+        let actorString = e.get_source().toString();
+        if (actorString.indexOf('this.actor') > -1
+            && (!this.lastEnterActor
+                || (this.lastEnterActor.indexOf('StButton') === -1)
+                    && this.lastEnterActor.indexOf('ClutterClone') === -1)) {
+            if (this.state.overlayPreview) {
+                this.destroyOverlayPreview();
+            }
+            this.hoverPeek(this.state.settings.peekOpacity);
+        }
+        this.lastEnterActor = actorString;
+    }
+
+    onLeave() {
+        this.entered = false;
+        this.actor.remove_style_pseudo_class('selected');
+        this.onFocusWindowChange();
+        this.button.set_opacity(0);
+    }
+
+    onWindowDemandsAttention(window) {
+        if (this._needsAttention) {
+            return false;
+        }
+        this._needsAttention = true;
+        if (this.metaWindow === window) {
+            this.actor.add_style_class_name('thumbnail-alerts');
+            return true;
+        }
+        return false;
+    }
+
+    onFocusWindowChange() {
+        if (this.willUnmount) return;
+        if (
+            this.isFocused &&
+            this.state.settings.highlightLastFocusedThumbnail &&
+            this.groupState.metaWindows.length > 1
+        ) {
+            this.actor.add_style_pseudo_class('outlined');
+        } else {
+            this.isFocused = false;
+            this.actor.remove_style_pseudo_class('outlined');
+        }
+    }
+
+    handleFavorite() {
+        if (!this.groupState) return;
+
+        if (this.groupState.metaWindows && this.groupState.metaWindows.length > 0) {
+            this.refreshThumbnail();
+        }
+    }
+
+    thumbnailIconSize() {
+        let thumbnailTheme = this.themeIcon.peek_theme_node();
+        if (thumbnailTheme) {
+            let width = thumbnailTheme.get_width();
+            let height = thumbnailTheme.get_height();
+            this.icon.set_size(width, height);
+        }
+    }
+
+    handleCloseClick() {
+        this.onLeave();
+        this.stopClick = true;
+        this.groupState.trigger('removeThumbnailFromMenu', this.metaWindow);
+        this.hoverPeek(OPACITY_OPAQUE);
+
+        this.metaWindow.delete(global.get_current_time());
+        if (!this.groupState.metaWindows || this.groupState.metaWindows.length <= 1) {
+            this.groupState.trigger('hoverMenuClose');
+        }
+    }
+
+    onCloseButtonRelease(actor, event) {
+        let button = event.get_button();
+        if (button === 1 && actor === this.button) {
+            this.handleCloseClick();
+        }
+    }
+
+    connectToWindow(actor, event) {
+        if (!this.metaWindow || !this.groupState.metaWindows || this.groupState.metaWindows.length === 0) {
+            this.groupState.trigger('hoverMenuClose');
+            return;
+        }
+        let button = typeof event === 'number' ? event : event.get_button();
+        if (button === 1 && !this.stopClick) {
+            Main.activateWindow(this.metaWindow, global.get_current_time());
+            this.groupState.trigger('hoverMenuClose');
+            this.onLeave();
+        } else if (button === 2 && !this.stopClick) {
+            this.handleCloseClick();
+        }
+        this.stopClick = false;
+    }
+
+    getThumbnail() {
+        if (!this.state.settings.showThumbs) {
+            return null;
+        }
+        // Create our own thumbnail if it doesn't exist
+        let isUpdate = false;
+        if (this.metaWindowActor) {
+            isUpdate = true;
+            this.signals.disconnect('size-changed', this.metaWindowActor);
+        }
+        this.metaWindowActor = this.metaWindow.get_compositor_private();
+        if (this.metaWindowActor) {
+            let windowTexture = this.metaWindowActor.get_texture();
+            let [width, height] = windowTexture.get_size();
+            this.signals.connect(this.metaWindowActor, 'size-changed', () => this.refreshThumbnail());
+            this.signals.connect(this.metaWindowActor, 'destroy', () => {
+                if (this.willUnmount || !this.groupState.trigger) return;
+                this.groupState.trigger('removeThumbnailFromMenu', this.metaWindow);
+                this.metaWindowActor = null;
+            });
+            let scale = Math.min(1.0, this.thumbnailWidth / width, this.thumbnailHeight / height);
+            if (isUpdate) {
+                this.thumbnailActor.child.source = windowTexture;
+                this.thumbnailActor.child.width = width * scale;
+                this.thumbnailActor.child.height = height * scale;
+            } else {
+                this.thumbnailActor.child = new Clutter.Clone({
+                    source: windowTexture,
+                    reactive: true,
+                    width: width * scale,
+                    height: height * scale
+                });
+            }
+        } else {
+            this.groupState.trigger('removeThumbnailFromMenu', this.metaWindow);
+        }
+    }
+
+    refreshThumbnail() {
+        if (this.willUnmount ||
+            !this.groupState ||
+            !this.groupState.app ||
+            !this.groupState.metaWindows ||
+            !this.metaWindow) {
+            return;
+        }
+
+        let monitor = Main.layoutManager.primaryMonitor;
+
+        let setThumbSize = (divider = 70, offset = 16) => {
+            this.thumbnailWidth = Math.floor((monitor.width / divider) * this.state.settings.thumbSize) + offset;
+            this.thumbnailHeight = Math.floor((monitor.height / divider) * this.state.settings.thumbSize) + offset;
+
+            let monitorSize, thumbnailSize, thumbMultiplier;
+            if (!this.state.isHorizontal) {
+                thumbMultiplier = 1.5;
+                monitorSize = monitor.height;
+                thumbnailSize = this.thumbnailHeight;
+            } else {
+                thumbMultiplier = 1;
+                monitorSize = monitor.width;
+                thumbnailSize = this.thumbnailWidth;
+            }
+
+            if (((thumbnailSize * thumbMultiplier) * this.groupState.metaWindows.length) + thumbnailSize > monitorSize) {
+                let divideMultiplier = !this.state.isHorizontal ? 4.5 : 1.1;
+                setThumbSize(divider * divideMultiplier, 16);
+                return;
+            } else {
+                this.thumbnailActor.width = this.thumbnailWidth;
+                this.container.style = `width: ${Math.floor(this.thumbnailWidth - 16)}px;`;
+                if (this.state.settings.verticalThumbs && this.state.settings.showThumbs) {
+                    this.thumbnailActor.height = this.thumbnailHeight;
+                } else if (this.state.settings.verticalThumbs) {
+                    this.thumbnailActor.height = 0;
+                }
+
+                // Replace the old thumbnail
+                if (this.labelContainer) {
+                    this.labelContainer.set_width(this.thumbnailWidth);
+                }
+                this.label.text = this.metaWindow.title || '';
+                this.getThumbnail();
+            }
+        };
+
+        setThumbSize();
+    }
+
+    hoverPeek(opacity) {
+        if (!this.state.settings.enablePeek || this.state.overlayPreview || this.state.scrollActive) {
+            return;
+        }
+        if (!this.metaWindowActor) {
+            this.metaWindowActor = this.metaWindow.get_compositor_private();
+        }
+        this.state.set({
+            overlayPreview: new Clutter.Clone({
+                source: this.metaWindowActor.get_texture(),
+                opacity: 0
+            })
+        });
+        let [x, y] = this.metaWindowActor.get_position();
+        this.state.overlayPreview.set_position(x, y);
+        global.overlay_group.add_child(this.state.overlayPreview);
+        global.overlay_group.set_child_above_sibling(this.state.overlayPreview, null);
+        setOpacity(this.state.settings.peekTime, this.state.overlayPreview, opacity);
+    }
+
+    destroyOverlayPreview() {
+        if (!this.state.overlayPreview) return;
+
+        global.overlay_group.remove_child(this.state.overlayPreview);
+        this.state.overlayPreview.destroy();
+        this.state.set({overlayPreview: null});
+    }
+
+    destroy() {
+        this.willUnmount = true;
+        if (!this.groupState) return;
+
+        this.state.disconnect(this.stateConnectId);
+        this.groupState.disconnect(this.connectId);
+        this.signals.disconnectAllSignals();
+        this.container.destroy();
+        this.bin.destroy();
+        this.actor.destroy();
+        unref(this, RESERVE_KEYS);
+    }
+}
+
+class AppThumbnailHoverMenu extends PopupMenu.PopupMenu {
+    _init(state, groupState) {
+        super._init.call(this, groupState.trigger('getActor'), state.orientation, 0.5);
+        this.state = state;
+        this.groupState = groupState;
+
+        this.connectId = this.groupState.connect({
+            hoverMenuClose: () => {
+                this.shouldClose = true;
+                this.close();
+            },
+            addThumbnailToMenu: (win) => this.addThumbnail(win),
+            removeThumbnailFromMenu: (win) => {
+                let index = findIndex(this.appThumbnails, (item) => item.metaWindow === win);
+                if (index > -1) {
+                    this.appThumbnails[index].destroy();
+                    this.appThumbnails[index] = undefined;
+                    this.appThumbnails.splice(index, 1);
+                }
+            }
+        });
+
+        this.appThumbnails = [];
+    }
+
+    onButtonPress() {
+        if (this.state.settings.onClickThumbs && this.box.get_children().length > 1) {
+            return;
+        }
+        this.shouldClose = true;
+        setTimeout(() => this.close(), this.state.settings.thumbTimeout);
+    }
+
+    onMenuEnter() {
+        if (this.state.panelEditMode ||
+            (!this.isOpen && this.state.settings.onClickThumbs) ||
+            this.state.menuOpen) {
+            return false;
+        }
+        this.shouldClose = false;
+        setTimeout(() => this.open(), this.state.settings.thumbTimeout);
+    }
+
+    onMenuLeave() {
+        if (this.state.menuOpen || this.state.panelEditMode) {
+            return false;
+        }
+        this.shouldClose = true;
+        setTimeout(() => this.close(), this.state.settings.thumbTimeout);
+    }
+
+    onKeyRelease(actor, event) {
+        let symbol = event.get_key_symbol();
+        if (this.isOpen && (symbol === Clutter.KEY_Super_L || symbol === Clutter.KEY_Super_R)) {
+            // Close this menu, if opened by super + #
+            this.close(true);
+        }
+        return true;
+    }
+
+    open (force) {
+        if (!force && (!this.actor
+          || this.willUnmount
+          || this.isOpen
+          || (this.shouldClose && !this.state.settings.onClickThumbs))) {
+            return;
+        }
+        if (!this.groupState.metaWindows || this.groupState.metaWindows.length === 0) {
+            this.groupState.tooltip.set_text(this.groupState.appName);
+            this.groupState.tooltip.show();
+        } else {
+            PopupMenu.PopupMenu.prototype.open.call(this, this.state.settings.animateThumbs);
+        }
+    }
+
+    close (force) {
+        if (!force && (!this.shouldClose
+            || (!this.shouldClose && this.state.settings.onClickThumbs))
+            || !this.groupState
+            || !this.groupState.tooltip) {
+            return;
+        }
+        if (!this.groupState.metaWindows || this.groupState.metaWindows.length === 0) {
+            this.groupState.tooltip.set_text('');
+            this.groupState.tooltip.hide();
+        }
+        if (this.isOpen) {
+            PopupMenu.PopupMenu.prototype.close.call(this, this.state.settings.animateThumbs);
+        }
+        for (let i = 0; i < this.appThumbnails.length; i++) {
+            this.appThumbnails[i].destroyOverlayPreview();
+        }
+    }
+
+    onKeyPress(actor, e) {
+        let symbol = e.get_key_symbol();
+        let i = findIndex(this.appThumbnails, (item) => item.entered === true);
+        let entered = i > -1;
+        if (!entered) {
+            i = findIndex(this.appThumbnails, function(thumbnail) {
+                return thumbnail.isFocused;
+            });
+            if (i === -1) {
+                i = 0;
+            }
+        }
+        let args;
+        let closeArg;
+        if (this.state.orientation === St.Side.TOP) {
+            closeArg = Clutter.KEY_Up;
+            args = [Clutter.KEY_Left, Clutter.KEY_Right];
+        } else if (this.state.orientation === St.Side.BOTTOM) {
+            closeArg = Clutter.KEY_Down;
+            args = [Clutter.KEY_Right, Clutter.KEY_Left];
+        } else if (this.state.orientation === St.Side.LEFT) {
+            closeArg = Clutter.KEY_Left;
+            args = [Clutter.KEY_Up, Clutter.KEY_Down];
+        } else if (this.state.orientation === St.Side.RIGHT) {
+            closeArg = Clutter.KEY_Right;
+            args = [Clutter.KEY_Down, Clutter.KEY_Up];
+        }
+        let index;
+        if (symbol === args[0]) {
+            if (!entered) {
+                index = i;
+            } else if (this.appThumbnails[i + 1] !== undefined) {
+                index = i + 1;
+            } else {
+                index = 0;
+            }
+        } else if (symbol === args[1]) {
+            if (!entered) {
+                index = i;
+            } else if (this.appThumbnails[i - 1] !== undefined) {
+                index = i - 1;
+            } else {
+                index = this.appThumbnails.length - 1;
+            }
+        } else if (symbol === Clutter.KEY_Return && entered) {
+            this.appThumbnails[i].connectToWindow(null, 1);
+        } else if (symbol === closeArg) {
+            this.appThumbnails[i].onLeave();
+            this.close(true);
+        } else {
+            return;
+        }
+        if (this.appThumbnails[index] !== undefined) {
+            this.appThumbnails[i].onLeave();
+            this.appThumbnails[index].onEnter();
+            if (this.appThumbnails[i].isFocused) {
+                this.appThumbnails[i].onFocusWindowChange();
+            }
+        }
+    }
+
+    fullyRefreshThumbnails() {
+        if (this.appThumbnails.length > 0) {
+            this.destroyThumbnails();
+        }
+        this.addWindowThumbnails(this.groupState.metaWindows);
+        this.setStyleOptions(false);
+    }
+
+    destroyThumbnails() {
+        this.box.destroy_children();
+        for (let i = 0; i < this.appThumbnails.length; i++) {
+            this.appThumbnails[i].destroy();
+            this.appThumbnails[i] = undefined;
+        }
+        this.appThumbnails = [];
+    }
+
+    updateThumbnails(exceptIndex) {
+        for (let i = 0; i < this.appThumbnails.length; i++) {
+            if (i !== exceptIndex) {
+                this.appThumbnails[i].refreshThumbnail();
+                this.box.set_child_at_index(this.appThumbnails[i].actor, i);
+            }
+        }
+    }
+
+    addThumbnail(metaWindow) {
+        if (this.state.settings.sortThumbs) {
+            this.appThumbnails.sort(function(a, b) {
+                if (!a.metaWindow || !b.metaWindow) {
+                    return -1;
+                }
+                return b.metaWindow.user_time - a.metaWindow.user_time;
+            });
+        }
+        let refThumb = findIndex(this.appThumbnails, (thumbnail) => thumbnail.metaWindow === metaWindow);
+        if (!this.appThumbnails[refThumb] && refThumb === -1) {
+            let thumbnail = new WindowThumbnail({
+                state: this.state,
+                groupState: this.groupState,
+                metaWindow: metaWindow,
+                index: this.appThumbnails.length // correct index before actual push
+            });
+            this.appThumbnails.push(thumbnail);
+            this.box.insert_actor(thumbnail.actor, -1);
+            // TBD: Update the thumbnail scaling for the other thumbnails belonging to this group.
+            // Since the total window count determines the scaling used, this needs to be done
+            // each time a window is added.
+            this.updateThumbnails(thumbnail.index);
+        } else if (this.appThumbnails[refThumb]) {
+            this.appThumbnails[refThumb].index = refThumb;
+            this.appThumbnails[refThumb].metaWindow = metaWindow;
+            this.appThumbnails[refThumb].refreshThumbnail();
+            this.box.set_child_at_index(this.appThumbnails[refThumb].actor, refThumb);
+        }
+    }
+
+    addWindowThumbnails() {
+        if (this.willUnmount || !this.box || !this.appThumbnails || !this.groupState || !this.groupState.metaWindows) {
+            return;
+        }
+
+        for (let i = 0, len = this.groupState.metaWindows.length; i < len; i++) {
+            this.addThumbnail(this.groupState.metaWindows[i]);
+        }
+    }
+
+    setStyleOptions(skipThumbnailIconResize) {
+        if (this.willUnmount || !this.box) return;
+
+        // The styling cannot be set correctly unless the menu is closed. Fortunately this
+        // can be closed and reopened too quickly for the user to notice.
+        if (this.isOpen) this.close(true);
+
+        this.box.show();
+        this.box.style = null;
+
+        let thumbnailTheme = this.box.peek_theme_node();
+        let padding = thumbnailTheme ? thumbnailTheme.get_horizontal_padding() : null;
+        let thumbnailPadding = padding && (padding > 1 && padding < 21) ? padding : 10;
+        this.box.style = `padding: ${thumbnailPadding / 2}px`;
+        let boxTheme = this.box.peek_theme_node();
+        padding = boxTheme ? boxTheme.get_vertical_padding() : null;
+        let boxPadding = padding && padding > 0 ? padding : 3;
+        this.box.style = `padding: ${boxPadding}px;`;
+
+        if (skipThumbnailIconResize) return;
+
+        if (this.state.settings.showIcons) {
+            for (let i = 0; i < this.appThumbnails.length; i++) {
+                if (this.appThumbnails[i]) {
+                    this.appThumbnails[i].thumbnailIconSize();
+                }
+            }
+        }
+        if (this.isOpen) this.open();
+    }
+
+    setVerticalSetting() {
+        if (this.state.orientation === St.Side.TOP || this.state.orientation === St.Side.BOTTOM) {
+            this.box.vertical = this.state.settings.verticalThumbs;
+        } else {
+            this.box.vertical = true;
+        }
+        this.fullyRefreshThumbnails();
+    }
+
+    updateThumbnailPadding() {
+        for (let i = 0; i < this.appThumbnails.length; i++) {
+            if (this.appThumbnails[i]) {
+                this.state.trigger('setThumbnailActorStyle', this.appThumbnails[i].actor);
+            }
+        }
+    }
+
+    updateThumbnailCloseButtonSize() {
+        for (let i = 0; i < this.appThumbnails.length; i++) {
+            if (this.appThumbnails[i]) {
+                this.state.trigger('setThumbnailCloseButtonStyle', this.appThumbnails[i].button);
+            }
+        }
+    }
+
+    destroy() {
+        this.willUnmount = true;
+        if (!this.box) {
+            return;
+        }
+        if (this.isOpen) {
+            this.close();
+        }
+        for (let w = 0, len = this.appThumbnails.length; w < len; w++) {
+            if (this.appThumbnails[w] !== undefined) {
+                if (this.appThumbnails[w].entered) {
+                    this.appThumbnails[w].onLeave();
+                }
+                this.appThumbnails[w].destroy(true);
+                this.appThumbnails[w] = null;
+                this.appThumbnails.splice(w, 1);
+            }
+        }
+        this.removeAll();
+        PopupMenu.PopupMenu.prototype.destroy.call(this);
+        this.groupState.disconnect(this.connectId);
+        unref(this, RESERVE_KEYS);
+    }
+}
+

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/metadata.json
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/metadata.json
@@ -1,0 +1,8 @@
+{
+    "name": "Grouped window list",
+    "role": "panellauncher",
+    "uuid": "grouped-window-list@cinnamon.org",
+    "description": "Main Cinnamon window list with app grouping",
+    "icon": "view-list",
+    "max-instances": -1
+}

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/settings-schema.json
@@ -1,0 +1,572 @@
+{
+  "layout": {
+    "type" : "layout",
+    "pages": ["generalPage", "panelPage", "thumbnailsPage", "contextMenuPage", "themePage"],
+    "generalPage": {
+      "type" : "page",
+      "title" : "General",
+      "sections": ["generalSection", "hotKeysSection"]
+    },
+    "panelPage": {
+      "type" : "page",
+      "title" : "Panel",
+      "sections": ["appButtonsSection"]
+    },
+    "thumbnailsPage": {
+      "type" : "page",
+      "title" : "Thumbnails",
+      "sections": ["thumbnailsSection", "hoverPeekSection"]
+    },
+    "contextMenuPage": {
+      "type" : "page",
+      "title" : "Context Menu",
+      "sections": ["contextMenuSection"]
+    },
+    "themePage": {
+      "type" : "page",
+      "title" : "Theming",
+      "sections": ["stylingSection", "iconSection", "presetSection"]
+    },
+    "generalSection": {
+      "type" : "section",
+      "title" : "Behavior",
+      "keys": [
+        "group-apps",
+        "scroll-behavior",
+        "left-click-action",
+        "middle-click-action",
+        "system-favorites",
+        "list-monitor-windows",
+        "show-all-workspaces",
+        "include-all-windows"
+      ]
+    },
+    "appButtonsSection": {
+      "type" : "section",
+      "title" : "App Buttons",
+      "keys": [
+        "enable-app-button-width",
+        "app-button-width",
+        "number-display",
+        "title-display",
+        "launcher-animation-effect",
+        "pinned-apps",
+        "show-alerts",
+        "show-pinned",
+        "enable-app-button-dragging",
+        "pinOnDrag"
+      ]
+    },
+    "hotKeysSection": {
+      "type" : "section",
+      "title" : "Hot Keys",
+      "keys": [
+        "cycleMenusHotkey",
+        "show-apps-order-hotkey",
+        "show-apps-order-timeout"
+      ]
+    },
+    "thumbnailsSection": {
+      "type" : "section",
+      "title" : "Thumbnails",
+      "keys": [
+        "thumbnail-timeout",
+        "thumbnail-size",
+        "thumbnail-close-button-size",
+        "thumbnail-padding",
+        "thumbnail-scroll-behavior",
+        "show-thumbnails",
+        "show-icons",
+        "animate-thumbnails",
+        "vertical-thumbnails",
+        "sort-thumbnails",
+        "highlight-last-focused-thumbnail",
+        "onclick-thumbnails"
+      ]
+    },
+    "hoverPeekSection": {
+      "type" : "section",
+      "title" : "Hover Peek",
+      "keys": [
+        "enable-hover-peek",
+        "hover-peek-time",
+        "hover-peek-opacity"
+      ]
+    },
+    "contextMenuSection": {
+      "type" : "section",
+      "title" : "",
+      "keys": [
+        "show-recent",
+        "firefox-menu",
+        "menuItemType",
+        "autostart-menu-item",
+        "launch-new-instance-menu-item",
+        "monitor-move-all-windows"
+      ]
+    },
+    "stylingSection": {
+      "type" : "section",
+      "title" : "Styling",
+      "keys": [
+        "show-active",
+        "hoverPseudoClass",
+        "focusPseudoClass",
+        "activePseudoClass",
+        "app-button-transition-duration"
+      ]
+    },
+    "iconSection": {
+      "type" : "section",
+      "title" : "Icons",
+      "keys": [
+        "icon-spacing",
+        "enable-iconSize",
+        "icon-size"
+      ]
+    },
+    "presetSection": {
+      "type" : "section",
+      "title" : "Recommended Presets",
+      "keys": [
+        "mintYPreset",
+        "mintXPreset"
+      ]
+    }
+  },
+  "number-display": {
+    "type": "combobox",
+    "default": 1,
+    "description": "Number display",
+    "options": {
+      "Smart": 1,
+      "Normal": 2,
+      "None": 3,
+      "All": 4
+    },
+    "tooltip": "normal: display window number, smart: display window number if more than one window, none: don't display number, all: display window number for favorites too"
+  },
+  "title-display": {
+    "type": "combobox",
+    "default": 1,
+    "description": "Title display",
+    "options": {
+      "None": 1,
+      "App": 2,
+      "Title": 3,
+      "Focused": 4
+    },
+    "tooltip": "focused: show focused window title, title: display the window title, app: diplay app name, none: don't display anything"
+  },
+  "scroll-behavior": {
+    "type": "combobox",
+    "default": 1,
+    "description": "Mouse wheel scroll behavior",
+    "options": {
+      "None": 1,
+      "Cycle apps": 2,
+      "Cycle windows": 3
+    },
+    "tooltip": "Choose if scrolling the mouse wheel cycles running apps, an app button's windows on hover, or is disabled."
+  },
+  "left-click-action": {
+    "type": "combobox",
+    "default": 2,
+    "description": "Left click action",
+    "options": {
+      "None": 1,
+      "Toggle activation of last focused window": 2,
+      "Cycle windows": 3
+    },
+    "tooltip": "Left click action"
+  },
+  "middle-click-action": {
+    "type": "combobox",
+    "default": 2,
+    "description": "Middle click action",
+    "options": {
+      "None": 1,
+      "Launch new app instance": 2,
+      "Close last focused window in group": 3
+    },
+    "tooltip": "Middle click action"
+  },
+  "pinned-apps": {
+    "type": "generic",
+    "default": []
+  },
+  "group-apps": {
+    "type": "checkbox",
+    "default": true,
+    "description": "Group apps",
+    "tooltip": "Group each app's set of windows."
+  },
+  "show-alerts": {
+    "type": "checkbox",
+    "default": true,
+    "description": "Show app alerts and notifications",
+    "tooltip": "If enabled, notifications and alerts will appear."
+  },
+  "show-pinned": {
+    "type": "checkbox",
+    "default": true,
+    "description": "Show pinned apps",
+    "tooltip": "Controls whether or not the pinned apps appear in the panel if they are not open."
+  },
+  "system-favorites": {
+    "type": "checkbox",
+    "default": false,
+    "description": "Use system favorites for pinned apps",
+    "tooltip": "Controls whether or not pinned apps consist of the system favorites list."
+  },
+  "show-all-workspaces": {
+    "type": "checkbox",
+    "default": false,
+    "description": "Show windows from all workspaces",
+    "tooltip": "Show windows from all workspaces"
+  },
+  "enable-app-button-dragging": {
+    "type": "checkbox",
+    "default": true,
+    "description": "Enable app button dragging",
+    "tooltip": "Enable app button dragging"
+  },
+  "pinOnDrag": {
+    "type": "checkbox",
+    "default": true,
+    "description": "Pin apps when dragged to a new position",
+    "tooltip": "Pin apps when dragged to a new position"
+  },
+  "launcher-animation-effect": {
+    "type": "combobox",
+    "default": 1,
+    "description": "Launcher animation effect",
+    "options": {
+      "None": 1,
+      "Fade": 2,
+      "Scale": 3
+    },
+    "tooltip": "Left click action"
+  },
+  "list-monitor-windows": {
+    "type": "checkbox",
+    "default": false,
+    "description": "Only list windows from the monitor displaying this instance",
+    "tooltip": "This option will only come into effect for monitors displaying an ITM instance."
+  },
+  "cycleMenusHotkey": {
+    "type": "keybinding",
+    "default": "<Super>space",
+    "description": "Global hotkey for cycling through thumbnail menus",
+    "tooltip": "This allows you to cycle through the menus without activating a window."
+  },
+  "show-apps-order-hotkey": {
+    "type": "keybinding",
+    "default": "<Super>grave",
+    "description": "Global hotkey to show the order of apps",
+    "tooltip": "When triggered, the window count label will be replaced with its order in the app list temporarily."
+  },
+  "show-apps-order-timeout": {
+    "type": "spinbutton",
+    "default": 2500,
+    "min": 100,
+    "max": 10000,
+    "step": 10,
+    "units": "milliseconds",
+    "description": "Duration of the apps order display on hotkey press",
+    "tooltip": "Determines the duration the window count labels are replaced with the app's order number."
+  },
+  "enable-app-button-width": {
+    "type": "checkbox",
+    "default": false,
+    "description": "Use a custom width for app buttons",
+    "tooltip": "When disabled, the app button width is determined by the panel height."
+  },
+  "app-button-width": {
+    "dependency": "enable-app-button-width",
+    "type": "spinbutton",
+    "default": 31,
+    "min": 1,
+    "max": 250,
+    "step": 2,
+    "units": "px",
+    "description": "App button width",
+    "tooltip": "Controls the width of the application button. This option only works for horizontal panels."
+  },
+  "thumbnail-timeout": {
+    "type": "spinbutton",
+    "default": 50,
+    "min": 0,
+    "max": 5000,
+    "step": 5,
+    "units": "milliseconds",
+    "description": "Thumbnail timeout",
+    "tooltip": "Controls how quickly an app's set of window thumbnails will fade out when the mouse leaves the app button."
+  },
+  "thumbnail-size": {
+    "type": "spinbutton",
+    "default": 6,
+    "min": 0,
+    "max": 100,
+    "step": 1,
+    "units": "size",
+    "description": "Thumbnail size",
+    "tooltip": "Controls the size of the thumbnails."
+  },
+  "thumbnail-close-button-size": {
+    "type": "spinbutton",
+    "default": 16,
+    "min": 8,
+    "max": 32,
+    "step": 1,
+    "units": "px",
+    "description": "Close button size",
+    "tooltip": "Controls how large the thumbnail close button is."
+  },
+  "thumbnail-padding": {
+    "type": "spinbutton",
+    "default": 1,
+    "min": 0,
+    "max": 12,
+    "step": 1,
+    "units": "px",
+    "description": "Thumbnail padding",
+    "tooltip": "Controls how much space will be around the window preview thumbnails."
+  },
+  "thumbnail-scroll-behavior": {
+    "type": "checkbox",
+    "default": false,
+    "description": "Cycle windows on mouse wheel scroll",
+    "tooltip": "Choose whether or not scrolling the mouse wheel cycles windows when hovering over a thumbnail menu."
+  },
+  "show-thumbnails": {
+    "type": "checkbox",
+    "default": true,
+    "description": "Show thumbnails",
+    "tooltip": "Show window thumbnails when hovering over an app button."
+  },
+  "show-icons": {
+    "type": "checkbox",
+    "default": true,
+    "description": "Show icons",
+    "tooltip": "Show the window's icon next to the title."
+  },
+  "animate-thumbnails": {
+    "type": "checkbox",
+    "default": false,
+    "description": "Animate thumbnails",
+    "tooltip": "If enabled, thumbnails will animate when appearing and disappearing."
+  },
+  "vertical-thumbnails": {
+    "type": "checkbox",
+    "default": false,
+    "description": "Enable vertical thumbnails",
+    "tooltip": "If enabled, thumbnails will stack vertically."
+  },
+  "sort-thumbnails": {
+    "type": "checkbox",
+    "default": false,
+    "description": "Sort windows for each app by last focused",
+    "tooltip": "Controls whether the order windows appear for an app is by last focused, or the order they were opened."
+  },
+  "highlight-last-focused-thumbnail": {
+    "type": "checkbox",
+    "default": true,
+    "description": "Highlight the last focused window within an app group",
+    "tooltip": "When enabled, the last window that was interacted with will be indicated."
+  },
+  "onclick-thumbnails": {
+    "type": "checkbox",
+    "default": false,
+    "description": "Open thumbnails on click",
+    "tooltip": "Open the thumbnails on click if there is more than one window open."
+  },
+  "include-all-windows": {
+    "type": "checkbox",
+    "default": true,
+    "description": "Include all app windows",
+    "tooltip": "Controls whether or not thumbnails for smalller child windows, such as exit confirmations and file dialogues will be included in the thumbnail list."
+  },
+  "show-recent": {
+    "type": "checkbox",
+    "default": true,
+    "description": "Show recent items",
+    "tooltip": "Controls whether recent items will appear in the context menu."
+  },
+  "menuItemType": {
+    "type": "combobox",
+    "default": 1,
+    "description": "Menu item type",
+    "options": {
+      "Symbolic icons": 1,
+      "Non-symbolic icons": 2,
+      "No icons": 3
+    },
+    "tooltip": "Determines whether menu item icons are symbolic, non-symbolic, or not shown."
+  },
+  "firefox-menu": {
+    "type": "combobox",
+    "dependency": "show-recent",
+    "default": 1,
+    "description": "Firefox context menu",
+    "options": {
+      "Most Visited": 1,
+      "Recent History": 2,
+      "Bookmarks": 3
+    },
+    "tooltip": "Most Visited: show the sites you visit most, Recent History: display the the last pages you visited, Bookmarks: show your favorite bookmarks."
+  },
+  "autostart-menu-item": {
+    "type": "checkbox",
+    "default": true,
+    "description": "Show autostart option",
+    "tooltip": "Shows the autostart toggle option in an app's context menu."
+  },
+  "launch-new-instance-menu-item": {
+    "type": "checkbox",
+    "default": false,
+    "description": "Show new window option",
+    "tooltip": "Shows the \"New Window\" option in an app's context menu if it doesn't already have one from the app's own action menu items."
+  },
+  "monitor-move-all-windows": {
+    "type": "checkbox",
+    "default": true,
+    "description": "Apply the monitor move option to all windows",
+    "tooltip": "When clicking \"Move to monitor\" in the context menu, this option will move all of an app's windows instead of just the last focused window from the app."
+  },
+  "enable-hover-peek": {
+    "type": "checkbox",
+    "default": true,
+    "description": "Show windows when hovered over",
+    "tooltip": "Controls whether or not windows display when hovered over."
+  },
+  "hover-peek-time": {
+    "type": "spinbutton",
+    "dependency": "enable-hover-peek",
+    "default": 300,
+    "min": 0,
+    "max": 1000,
+    "step": 5,
+    "units": "milliseconds",
+    "description": "Window fade time",
+    "tooltip": "Controls how quickly a window will fade on hover."
+  },
+  "hover-peek-opacity": {
+    "type": "spinbutton",
+    "dependency": "enable-hover-peek",
+    "default": 94,
+    "min": 0,
+    "max": 100,
+    "step": 1,
+    "units": "percent",
+    "description": "Window opacity",
+    "tooltip": "Opacity of the windows on hover."
+  },
+  "show-active": {
+    "type": "checkbox",
+    "default": false,
+    "description": "Show active app indicators",
+    "tooltip": "Active app styling will indicate if an app is active."
+  },
+  "icon-spacing": {
+    "type": "spinbutton",
+    "default": 3,
+    "min": 0,
+    "max": 15,
+    "step": 1,
+    "units": "px",
+    "description": "Icon spacing",
+    "tooltip": "Controls how much space is between the icons."
+  },
+  "icon-padding": {
+    "type": "spinbutton",
+    "default": 0,
+    "min": 0,
+    "max": 15,
+    "step": 1,
+    "units": "px",
+    "description": "Icon padding",
+    "tooltip": "Controls how much horizontal padding is inside the app buttons. Padding is only applied to instances of this applet on horizontal panels."
+  },
+  "enable-iconSize": {
+    "type": "checkbox",
+    "default": false,
+    "description": "Adjust icon size",
+    "tooltip": "Adjust icon size independent of Cinnamon's panel scaling."
+  },
+  "icon-size": {
+    "type": "spinbutton",
+    "dependency": "enable-iconSize",
+    "default": 28,
+    "min": 16,
+    "max": 128,
+    "step": 2,
+    "units": "px",
+    "description": "Icon size",
+    "tooltip": "Set icon size"
+  },
+  "hoverPseudoClass": {
+    "type": "combobox",
+    "default": 3,
+    "description": "App button hover pseudo class",
+    "options": {
+      "hover": 1,
+      "focus": 2,
+      "active": 3,
+      "outlined": 4,
+      "selected": 5,
+      "checked": 6
+    },
+    "tooltip": "Overrides the pseudo class for app buttons on hover."
+  },
+  "focusPseudoClass": {
+    "type": "combobox",
+    "default": 2,
+    "description": "App button focus pseudo class",
+    "options": {
+      "hover": 1,
+      "focus": 2,
+      "active": 3,
+      "outlined": 4,
+      "selected": 5,
+      "checked": 6
+    },
+    "tooltip": "Overrides the pseudo class for app button on focus."
+  },
+  "activePseudoClass": {
+    "type": "combobox",
+    "default": 4,
+    "description": "App button active pseudo class",
+    "options": {
+      "hover": 1,
+      "focus": 2,
+      "active": 3,
+      "outlined": 4,
+      "selected": 5,
+      "checked": 6
+    },
+    "tooltip": "Overrides the pseudo class for app buttons when they are active."
+  },
+  "app-button-transition-duration": {
+    "type": "spinbutton",
+    "default": 0,
+    "min": 0,
+    "max": 4000,
+    "step": 1,
+    "units": "ms",
+    "description": "App button transition duration",
+    "tooltip": "Overrides the theme's animation time for app buttons. If set to zero, the theme's transition duration will be used."
+  },
+  "mintYPreset": {
+    "type" : "button",
+    "description" : "Mint Y and Variants",
+    "callback" : "handleMintYThemePreset",
+    "tooltip" : "Mint Y and Variants"
+  },
+  "mintXPreset": {
+    "type" : "button",
+    "description" : "Mint X, Linux Mint, and Variants",
+    "callback" : "handleMintXThemePreset",
+    "tooltip" : "Mint X, Linux Mint, and Variants"
+  }
+}

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/store.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/store.js
@@ -1,0 +1,316 @@
+const {find, filter} = require('./utils');
+
+function intersect(array1, array2, difference = false) {
+    let result = [];
+    for (let i = 0; i < array1.length; i++) {
+        if ((!difference && array2.indexOf(array1[i]) > -1) || (difference && array2.indexOf(array1[i]) === -1)) {
+            result.push(array1[i]);
+        }
+    }
+    return result;
+}
+
+function clone(object, refs = [], cache = null) {
+    if (!cache) {
+        cache = object;
+    }
+    let copy;
+
+    if (!object || typeof object !== 'object' || object.prototype || object.toString().indexOf('[0x') > -1) {
+        return object;
+    }
+
+    if (object instanceof Date) {
+        copy = new Date();
+        copy.setTime(object.getTime());
+        return copy;
+    }
+
+    if (Array.isArray(object) || object instanceof Array) {
+        refs.push(object);
+        copy = [];
+        for (let i = 0; i < object.length; i++) {
+            if (refs.indexOf(object[i]) >= 0) {
+                // circular
+                return null;
+            }
+            copy[i] = clone(object[i], refs, cache);
+        }
+
+        refs.pop();
+        return copy;
+    }
+
+    refs.push(object);
+    copy = {};
+
+    if (object instanceof Error) {
+        copy.name = object.name;
+        copy.message = object.message;
+        copy.stack = object.stack;
+    }
+
+    let keys = Object.keys(object);
+    for (let i = 0; i < keys.length; i++) {
+        if (!Object.prototype.hasOwnProperty.call(object, keys[i])) {
+            continue;
+        }
+        if (refs.indexOf(object[keys[i]]) >= 0) {
+            return null;
+        }
+        copy[keys[i]] = clone(object[keys[i]], refs, cache);
+    }
+
+    refs.pop();
+    return copy;
+}
+
+function storeError(method, key, message) {
+    global.log(new Error('[store -> ' + method + ' -> ' + key + '] ' + message));
+}
+
+function getByPath(key, state) {
+    const path = key.split('.');
+    let object = clone(state);
+    for (let i = 0; i < path.length; i++) {
+        object = object[path[i]];
+        if (!object) {
+            return object;
+        }
+    }
+    return object;
+}
+
+/**
+ * init
+ * Initializes a store instance. It uses private scoping to prevent
+ * its context from leaking.
+ *
+ * @param {object} [state={}]
+ * @param {array} [listeners=[]] - Not intended to be set manually, but can be overriden.
+ * See _connect.
+ * @returns Initial state object with the public API.
+ */
+function init(state = {}, listeners = [], connections = 0) {
+    const publicAPI = Object.freeze({
+        get,
+        set,
+        exclude,
+        trigger,
+        connect,
+        disconnect,
+        destroy
+    });
+
+    function getAPIWithObject(object) {
+        return Object.assign(object, publicAPI);
+    }
+
+    /**
+     * dispatch
+     * Responsible for triggering callbacks stored in the listeners queue from set.
+     *
+     * @param {object} object
+     */
+    function dispatch(object) {
+        let keys = Object.keys(object);
+
+        for (let i = 0; i < listeners.length; i++) {
+            let commonKeys = intersect(keys, listeners[i].keys);
+            if (commonKeys.length === 0) {
+                continue;
+            }
+            if (listeners[i].callback) {
+                let partialState = {};
+                for (let z = 0; z < listeners[i].keys.length; z++) {
+                    partialState[listeners[i].keys[z]] = state[listeners[i].keys[z]];
+                }
+                listeners[i].callback(partialState);
+            }
+        }
+    }
+
+    /**
+     * get
+     * Retrieves a cloned property from the state object.
+     *
+     * @param {string} [key=null]
+     * @returns {object}
+     */
+    function get(key = null) {
+        if (!key || key === '*') {
+            return state;
+        }
+        if (key.indexOf('.') > -1) {
+            return getByPath(key, state);
+        }
+        return clone(state[key]);
+    }
+
+    /**
+     * set
+     * Copies a keyed object back into state, and
+     * calls dispatch to fire any connected callbacks.
+     *
+     * @param {object} object
+     * @param {boolean} forceDispatch
+     */
+    function set(object, forceDispatch) {
+        let keys = Object.keys(object);
+        let changed = false;
+        for (let i = 0; i < keys.length; i++) {
+            if (state[keys[i]] !== object[keys[i]]) {
+                changed = true;
+                state[keys[i]] = object[keys[i]];
+            }
+        }
+
+        if ((changed || forceDispatch) && listeners.length > 0) {
+            dispatch(object);
+        }
+
+        return publicAPI;
+    }
+
+    /**
+     * exclude
+     * Excludes a string array of keys from the state object.
+     *
+     * @param {array} excludeKeys
+     * @returns Partial or full state object with keys in
+     * excludeKeys excluded, along with the public API for chaining.
+     */
+    function exclude(excludeKeys) {
+        let object = {};
+        let keys = Object.keys(state);
+        for (let i = 0; i < keys.length; i++) {
+            if (excludeKeys.indexOf(keys[i]) === -1) {
+                object[keys[i]] = state[keys[i]];
+            }
+        }
+
+        return getAPIWithObject(object);
+    }
+
+    /**
+     * trigger
+     * Fires a callback event for any matching key in the listener queue.
+     * It supports passing through unlimited arguments to the callback.
+     * Useful for setting up actions.
+     *
+     * @param {string} key
+     * @param {any} args
+     * @returns {any} Return result of the callback.
+     */
+    function trigger() {
+        const [key, ...args] = Array.from(arguments);
+        let matchedListeners = filter(listeners, function(listener) {
+            return listener.keys.indexOf(key) > -1 && listener.callback;
+        });
+        if (matchedListeners.length === 0) {
+            storeError('trigger', key, 'Action not found.');
+        }
+        for (let i = 0, len = matchedListeners.length; i < len; i++) {
+            if (len > 1) {
+                matchedListeners[i].callback(...args);
+            } else {
+                return matchedListeners[i].callback(...args);
+            }
+        }
+    }
+
+    function _connect(keys, callback, id) {
+        let listener;
+
+        if (callback) {
+            listener = find(listeners, function(listener) {
+                return listener.callback === callback;
+            });
+        }
+        if (listener) {
+            let newKeys = intersect(keys, listener.keys, true);
+            listener.keys.concat(newKeys);
+        } else {
+            listeners.push({keys, callback, id});
+        }
+    }
+
+    /**
+     * connect
+     *
+     * @param {any} actions - can be a string, array, or an object.
+     * @param {function} callback - callback to be fired on either state
+     * property change, or through the trigger method.
+     * @returns Public API for chaining.
+     */
+    function connect(actions, callback) {
+        const id = connections++;
+        if (Array.isArray(actions)) {
+            _connect(actions, callback, id);
+        } else if (typeof actions === 'string') {
+            _connect([actions], callback, id);
+        } else if (typeof actions === 'object') {
+            let keys = Object.keys(actions);
+            for (let i = 0; i < keys.length; i++) {
+                _connect([keys[i]], actions[keys[i]], id);
+            }
+        }
+
+        return id;
+    }
+
+    function disconnectByKey(key) {
+        let listener = filter(listeners, function(listener) {
+            return listener.keys.indexOf(key) > -1;
+        });
+        let listenerIndex = listeners.indexOf(listener);
+        if (listenerIndex === -1) {
+            storeError('disconnect', key, 'Invalid disconnect key.');
+        }
+        listeners[listenerIndex] = undefined;
+        listeners.splice(listenerIndex, 1);
+    }
+
+    /**
+     * disconnect
+     * Removes a callback listener from the queue.
+     *
+     * @param {string} key
+     */
+    function disconnect(key) {
+        if (typeof key === 'string') {
+            disconnectByKey(key);
+        } else if (Array.isArray(key)) {
+            for (let i = 0; i < key.length; i++) {
+                disconnectByKey(key[i]);
+            }
+        } else if (typeof key === 'number') {
+            let len = listeners.slice().length;
+            for (let i = 0; i < len; i++) {
+                if (!listeners[i] || listeners[i].id !== key) {
+                    continue;
+                }
+                listeners[i] = undefined;
+                listeners.splice(i, 1);
+            }
+        }
+    }
+
+    /**
+     * destroy
+     * Assigns undefined to all state properties and listeners. Intended
+     * to be used at the end of the application life cycle.
+     *
+     */
+    function destroy() {
+        let keys = Object.keys(state);
+        for (let i = 0; i < keys.length; i++) {
+            state[keys[i]] = undefined;
+        }
+        for (let i = 0; i < listeners.length; i++) {
+            listeners[i] = undefined;
+        }
+    }
+
+    return getAPIWithObject(state);
+}

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/stylesheet.css
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/stylesheet.css
@@ -1,0 +1,40 @@
+.thumbnail-row .thumbnail-alerts {
+  background: rgba(255,52,52,0.3);
+}
+.thumbnail-icon {
+  width: 16px;
+  height: 16px;
+}
+.thumbnail-label {
+  padding-left: 4px;
+}
+.thumbnail-label-no-icon {
+  padding-left: 4px;
+}
+.app-list-item-box {
+  z-index: -9;
+}
+.window-icon-list-numlabel {
+  z-index: 99;
+  text-shadow: black 1px 0px 2px
+}
+.window-icon-list-buttonbox {
+  spacing: 2px;
+}
+.panel-top .window-list-item-box:closed,
+.panel-bottom .window-list-item-box:closed,
+.panel-left .window-list-item-box:closed,
+.panel-right .window-list-item-box:closed {
+  background-gradient-direction: vertical !important;
+  background-gradient-start: rgba(0,0,0,0.0) !important;
+  background-gradient-end: rgba(0,0,0,0.0) !important;
+  border-radius: 0px 0px 0px 0px !important;
+  border-image: none !important;
+  border-color: rgba(0,0,0,0.0) !important;
+  box-shadow: inset 0px 0px 0px 0px rgba(0,0,0,0.0) !important;
+}
+.window-list-item-demands-attention {
+}
+.app-button-label {
+  padding-left: 4px;
+}

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/utils.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/utils.js
@@ -1,0 +1,198 @@
+const GObject = imports.gi.GObject;
+const Gettext = imports.gettext;
+const Mainloop = imports.mainloop;
+
+const setTimeout = function(func, ms) {
+    let args = [];
+    if (arguments.length > 2) {
+        args = args.slice.call(arguments, 2);
+    }
+
+    let id = Mainloop.timeout_add(
+        ms,
+        () => {
+            func.apply(null, args);
+            return false; // Stop repeating
+        },
+        null
+    );
+
+    return id;
+};
+
+const clearTimeout = function(id) {
+    Mainloop.source_remove(id);
+};
+
+const setInterval = function(func, ms) {
+    let args = [];
+    if (arguments.length > 2) {
+        args = args.slice.call(arguments, 2);
+    }
+
+    let id = Mainloop.timeout_add(
+        ms,
+        () => {
+            func.apply(null, args);
+            return true; // Repeat
+        },
+        null
+    );
+
+    return id;
+};
+
+const clearInterval = function(id) {
+    Mainloop.source_remove(id);
+};
+
+function throttle(fn, interval, callFirst) {
+    let wait = false;
+    let callNow = false;
+    return function() {
+        callNow = callFirst && !wait;
+        let context = this;
+        let args = arguments;
+        if (!wait) {
+            wait = true;
+            setTimeout(function() {
+                wait = false;
+                if (!callFirst) {
+                    return fn.apply(context, args);
+                }
+            }, interval);
+        }
+        if (callNow) {
+            callNow = false;
+            return fn.apply(this, arguments);
+        }
+    };
+}
+
+const t = function(str) {
+    var resultConf = Gettext.dgettext('IcingTaskManager@json', str);
+    if (resultConf != str) {
+        return resultConf;
+    }
+    return Gettext.gettext(str);
+};
+
+// Native objects such as CinnamonApps and MetaWindows stringify with a unique identifier.
+const isEqual = function(a, b) {
+    if (!a) {
+        a = 'null';
+    }
+    if (!b) {
+        b = 'null';
+    }
+    return a.toString() === b.toString();
+};
+
+const each = function(obj, cb) {
+    if (Array.isArray(obj)) {
+        for (let i = 0, len = obj.length; i < len; i++) {
+            let returnValue = cb(obj[i], i);
+            if (returnValue === false) {
+                return;
+            } else if (returnValue === null) {
+                break;
+            } else if (returnValue === true) {
+                continue;
+            }
+        }
+    } else {
+        for (let key in obj) {
+            cb(obj[key], key);
+        }
+    }
+};
+
+const findIndex = function(arr, cb) {
+    for (let i = 0, len = arr.length; i < len; i++) {
+        if (cb(arr[i], i, arr)) {
+            return i;
+        }
+    }
+    return -1;
+};
+
+const find = function(arr, cb) {
+    for (let i = 0, len = arr.length; i < len; i++) {
+        if (cb(arr[i], i, arr)) {
+            return arr[i];
+        }
+    }
+    return null;
+};
+
+const filter = function(arr, cb) {
+    let result = [];
+    for (let i = 0, len = arr.length; i < len; i++) {
+        if (cb(arr[i], i, arr)) {
+            result.push(arr[i]);
+        }
+    }
+    return result;
+};
+
+const map = function(arr, fn) {
+    if (arr == null) {
+        return [];
+    }
+
+    let len = arr.length;
+    let out = Array(len);
+
+    for (let i = 0; i < len; i++) {
+        out[i] = fn(arr[i], i, arr);
+    }
+
+    return out;
+};
+
+const tryFn = function(fn, errCb) {
+    try {
+        return fn();
+    } catch (e) {
+        if (typeof errCb === 'function') {
+            return errCb(e);
+        }
+    }
+};
+
+const unref = function(object) {
+    // Some actors being destroyed have a cascading effect (e.g. PopupMenu items),
+    // so it is safest to wait for the next 'tick' before removing references.
+    setTimeout(() => {
+        let keys = Object.keys(object);
+        for (let i = 0; i < keys.length; i++) {
+            if (keys[i] !== 'willUnmount') {
+                object[keys[i]] = null;
+            }
+        }
+    }, 0);
+};
+
+const getFocusState = function(metaWindow) {
+    if (!metaWindow || metaWindow.minimized) {
+        return false;
+    }
+
+    if (metaWindow.appears_focused) {
+        return true;
+    }
+
+    let transientHasFocus = false;
+    metaWindow.foreach_transient(function(transient) {
+        if (transient && transient.appears_focused) {
+            transientHasFocus = true;
+            return false;
+        }
+        return true;
+    });
+    return transientHasFocus;
+};
+
+const isFinalized = function(obj) {
+    return obj && GObject.Object.prototype.toString.call(obj).indexOf('FINALIZED') > -1;
+};

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/utils.py
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/utils.py
@@ -1,0 +1,114 @@
+#!/usr/bin/python3
+
+import subprocess
+import os
+import json
+import sys
+import random
+
+cli = sys.argv
+
+def parseArgs(command):
+    return command.split(' ')
+
+def spawn(command):
+    try:
+        process = subprocess.run(
+            parseArgs(command),
+            stdout=subprocess.PIPE,
+            check=True
+        )
+    except Exception:
+        raise subprocess.CalledProcessError(1, command)
+    out = process.stdout.decode('utf-8')
+    return out
+
+"""
+Utility script that creates GDesktop files for Wine and other window backed applications.
+"""
+def handleCli():
+
+    if cli[1] == 'get_process':
+        process = spawn('cat /proc/{}/cmdline'.format(cli[2]))
+
+        if '.exe' in process:
+            if 'Z:' in process:
+                process = process.split('Z:')[1]
+
+            process = process.replace('\\', '/')
+            process = process.split('.exe')[0] + '.exe'
+            process = 'wine '+process.replace(' ', '\ ')
+
+        process = json.dumps(process)
+        if '\\u0000' in process:
+            process = process.replace('\\u0000', ' ')
+        process = json.loads(process)
+
+        if not '.exe' in process:
+            process = process[:-1]
+
+        if process == 'python mainwindow.py':
+            process = 'playonlinux'
+
+        try:
+            procArray = process.split('/')
+            paLen = len(procArray)
+            processName = procArray[paLen - 1].title()
+
+            # Since this is a window backed app, make sure it has an icon association.
+
+            iconsDir = '{}/.local/share/icons/hicolor/48x48/apps/'.format(os.getenv('HOME'))
+
+            if '\\ ' in processName:
+                processName = processName.replace('\\ ', ' ')
+
+            if '.Exe' in processName:
+                processName = processName.replace('.Exe', '')
+
+            iconFile = processName+'.png'
+
+            if ' ' in iconFile:
+                iconFile = iconFile.replace(' ', '')
+
+            icon = iconsDir+iconFile
+
+            try:
+                try:
+                    spawn('gnome-exe-thumbnailer {} {}'.format(process.split('wine ')[1], icon))
+                except IndexError:
+                    spawn('gnome-exe-thumbnailer {} {}'.format(process, icon))
+            except subprocess.CalledProcessError:
+                icon = None
+
+            gMenu = '[Desktop Entry]\n' \
+                    'Type=Application\n' \
+                    'Encoding=UTF-8\n' \
+                    'Name={}\n' \
+                    'Comment={}\n' \
+                    'Exec={}\n' \
+                    'Terminal=false\n' \
+                    'StartupNotify=true\n'.format(processName, processName, process)
+
+            if icon:
+                gMenu += 'Icon={}\n'.format(icon)
+
+
+            if '.exe' in process:
+                gMenu += 'GenericName=Wine application\n' \
+                         'Categories=Wine;\n' \
+                         'MimeType=application/x-ms-dos-executable;application/x-msi;application/x-ms-shortcut; \n' \
+
+            desktopFile = 'icing_{}.desktop'.format(str(random.random()).split('.')[1])
+            desktopPath = '{}/.local/share/applications/{}'.format(os.getenv('HOME'), desktopFile)
+
+            with open(desktopPath, 'w', encoding='utf-8') as desktop:
+                print(gMenu)
+                desktop.write(gMenu)
+                spawn('chmod +x {}'.format(desktopPath))
+                print(desktopFile)
+
+        except KeyError as e:
+            print(e)
+            return
+
+handleCli()

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,100 @@
+const gulp = require('gulp');
+const clear = require('clear');
+const {exec} = require('child_process');
+
+const getArgs = function() {
+    const argv = require('yargs')
+    .option('uuid', {
+        alias: 'u'
+    })
+    .option('type', {
+        alias: 't'
+    })
+    .argv;
+    return [argv.u, argv.t];
+}
+
+
+gulp.task('install', (done) => {
+    const [UUID, TYPE] = getArgs();
+    exec(
+        `cp -arf ./files/usr/share/cinnamon/${TYPE}s/${UUID} /usr/share/cinnamon/${TYPE}s`,
+        function(err, stdout, stderr) {
+            console.log(stdout);
+            console.log(stderr);
+            done();
+        }
+    );
+});
+
+const reload = function(done) {
+    const [UUID, TYPE] = getArgs();
+    exec(
+        'dbus-send --session --dest=org.Cinnamon.LookingGlass --type=method_call '
+        + '/org/Cinnamon/LookingGlass org.Cinnamon.LookingGlass.ReloadExtension '
+        + `string:'${UUID}' string:'${TYPE.toUpperCase()}'`,
+        function(err, stdout, stderr) {
+            console.log(stdout);
+            console.log(stderr);
+            done();
+        }
+    );
+};
+
+gulp.task('reload', gulp.series('install', reload));
+
+gulp.task('watch', (done) => {
+    const [UUID, TYPE] = getArgs();
+    console.log(`Watching glob pattern: ${`./files/usr/share/cinnamon/${TYPE}s/${UUID}/**/**/*.{js,json,py,css,po}`}`)
+    gulp.watch(`./files/usr/share/cinnamon/${TYPE}s/${UUID}/**/**/*.{js,json,py,css,po}`)
+    .on('change', gulp.parallel('reload'));
+    done();
+});
+
+gulp.task('clear-terminal', (done) => {
+    clear();
+    done();
+});
+
+gulp.task('spawn-watch', gulp.series('clear-terminal', (done) => {
+    let [, , , uuid, type] = process.argv;
+    let spawnWatch = () => {
+        let proc = require('child_process').spawn('gulp', ['watch', uuid, type], {stdio: 'inherit'});
+        proc.on('close', function(code) {
+            spawnWatch();
+        });
+    };
+    spawnWatch();
+    done();
+}));
+
+gulp.task('help', gulp.series('clear-terminal', (done) => {
+    console.log(
+        `Usage: gulp spawn-watch [flags]
+
+        This file uses gulp to provide a watch task for xlet development.
+        It will copy the xlet files to /usr/share/cinnamon and auto-reload
+        the applet on code change.
+
+        Install gulp globally.
+
+        npm: 'npm install -g gulp@^4.0.0'
+        yarn: 'yarn global add gulp@^4.0.0'
+
+        You must give your user ownership of /usr/share/cinnamon.
+
+        To do that, run: 'sudo chown -R $USER:$USER /usr/share/cinnamon'
+
+        To use this script, run 'gulp spawn-watch --uuid <xlet uuid> --type <xlet type>'.
+        Example: 'gulp spawn-watch --uuid grouped-window-list@cinnamon.org --type applet'
+
+        Options:
+            --uuid, u               UUID of the xlet to watch.
+            --type, t              Type of the xlet
+        `
+    );
+    process.exit(0);
+    done();
+}));
+
+gulp.task('default', gulp.series('spawn-watch', (done) => done()));

--- a/js/misc/state.js
+++ b/js/misc/state.js
@@ -1,0 +1,316 @@
+const {find, filter} = imports.misc.util;
+
+function intersect(array1, array2, difference = false) {
+    let result = [];
+    for (let i = 0; i < array1.length; i++) {
+        if ((!difference && array2.indexOf(array1[i]) > -1) || (difference && array2.indexOf(array1[i]) === -1)) {
+            result.push(array1[i]);
+        }
+    }
+    return result;
+}
+
+function clone(object, refs = [], cache = null) {
+    if (!cache) {
+        cache = object;
+    }
+    let copy;
+
+    if (!object || typeof object !== 'object' || object.prototype || object.toString().indexOf('[0x') > -1) {
+        return object;
+    }
+
+    if (object instanceof Date) {
+        copy = new Date();
+        copy.setTime(object.getTime());
+        return copy;
+    }
+
+    if (Array.isArray(object) || object instanceof Array) {
+        refs.push(object);
+        copy = [];
+        for (let i = 0; i < object.length; i++) {
+            if (refs.indexOf(object[i]) >= 0) {
+                // circular
+                return null;
+            }
+            copy[i] = clone(object[i], refs, cache);
+        }
+
+        refs.pop();
+        return copy;
+    }
+
+    refs.push(object);
+    copy = {};
+
+    if (object instanceof Error) {
+        copy.name = object.name;
+        copy.message = object.message;
+        copy.stack = object.stack;
+    }
+
+    let keys = Object.keys(object);
+    for (let i = 0; i < keys.length; i++) {
+        if (!Object.prototype.hasOwnProperty.call(object, keys[i])) {
+            continue;
+        }
+        if (refs.indexOf(object[keys[i]]) >= 0) {
+            return null;
+        }
+        copy[keys[i]] = clone(object[keys[i]], refs, cache);
+    }
+
+    refs.pop();
+    return copy;
+}
+
+function storeError(method, key, message) {
+    global.log(new Error('[store -> ' + method + ' -> ' + key + '] ' + message));
+}
+
+function getByPath(key, state) {
+    const path = key.split('.');
+    let object = clone(state);
+    for (let i = 0; i < path.length; i++) {
+        object = object[path[i]];
+        if (!object) {
+            return object;
+        }
+    }
+    return object;
+}
+
+/**
+ * init
+ * Initializes a store instance. It uses private scoping to prevent
+ * its context from leaking.
+ *
+ * @param {object} [state={}]
+ * @param {array} [listeners=[]] - Not intended to be set manually, but can be overriden.
+ * See _connect.
+ * @returns Initial state object with the public API.
+ */
+function createStore(state = {}, listeners = [], connections = 0) {
+    const publicAPI = Object.freeze({
+        get,
+        set,
+        exclude,
+        trigger,
+        connect,
+        disconnect,
+        destroy
+    });
+
+    function getAPIWithObject(object) {
+        return Object.assign(object, publicAPI);
+    }
+
+    /**
+     * dispatch
+     * Responsible for triggering callbacks stored in the listeners queue from set.
+     *
+     * @param {object} object
+     */
+    function dispatch(object) {
+        let keys = Object.keys(object);
+
+        for (let i = 0; i < listeners.length; i++) {
+            let commonKeys = intersect(keys, listeners[i].keys);
+            if (commonKeys.length === 0) {
+                continue;
+            }
+            if (listeners[i].callback) {
+                let partialState = {};
+                for (let z = 0; z < listeners[i].keys.length; z++) {
+                    partialState[listeners[i].keys[z]] = state[listeners[i].keys[z]];
+                }
+                listeners[i].callback(partialState);
+            }
+        }
+    }
+
+    /**
+     * get
+     * Retrieves a cloned property from the state object.
+     *
+     * @param {string} [key=null]
+     * @returns {object}
+     */
+    function get(key = null) {
+        if (!key || key === '*') {
+            return state;
+        }
+        if (key.indexOf('.') > -1) {
+            return getByPath(key, state);
+        }
+        return clone(state[key]);
+    }
+
+    /**
+     * set
+     * Copies a keyed object back into state, and
+     * calls dispatch to fire any connected callbacks.
+     *
+     * @param {object} object
+     * @param {boolean} forceDispatch
+     */
+    function set(object, forceDispatch) {
+        let keys = Object.keys(object);
+        let changed = false;
+        for (let i = 0; i < keys.length; i++) {
+            if (state[keys[i]] !== object[keys[i]]) {
+                changed = true;
+                state[keys[i]] = object[keys[i]];
+            }
+        }
+
+        if ((changed || forceDispatch) && listeners.length > 0) {
+            dispatch(object);
+        }
+
+        return publicAPI;
+    }
+
+    /**
+     * exclude
+     * Excludes a string array of keys from the state object.
+     *
+     * @param {array} excludeKeys
+     * @returns Partial or full state object with keys in
+     * excludeKeys excluded, along with the public API for chaining.
+     */
+    function exclude(excludeKeys) {
+        let object = {};
+        let keys = Object.keys(state);
+        for (let i = 0; i < keys.length; i++) {
+            if (excludeKeys.indexOf(keys[i]) === -1) {
+                object[keys[i]] = state[keys[i]];
+            }
+        }
+
+        return getAPIWithObject(object);
+    }
+
+    /**
+     * trigger
+     * Fires a callback event for any matching key in the listener queue.
+     * It supports passing through unlimited arguments to the callback.
+     * Useful for setting up actions.
+     *
+     * @param {string} key
+     * @param {any} args
+     * @returns {any} Return result of the callback.
+     */
+    function trigger() {
+        const [key, ...args] = Array.from(arguments);
+        let matchedListeners = filter(listeners, function(listener) {
+            return listener.keys.indexOf(key) > -1 && listener.callback;
+        });
+        if (matchedListeners.length === 0) {
+            storeError('trigger', key, 'Action not found.');
+        }
+        for (let i = 0, len = matchedListeners.length; i < len; i++) {
+            if (len > 1) {
+                matchedListeners[i].callback(...args);
+            } else {
+                return matchedListeners[i].callback(...args);
+            }
+        }
+    }
+
+    function _connect(keys, callback, id) {
+        let listener;
+
+        if (callback) {
+            listener = find(listeners, function(listener) {
+                return listener.callback === callback;
+            });
+        }
+        if (listener) {
+            let newKeys = intersect(keys, listener.keys, true);
+            listener.keys.concat(newKeys);
+        } else {
+            listeners.push({keys, callback, id});
+        }
+    }
+
+    /**
+     * connect
+     *
+     * @param {any} actions - can be a string, array, or an object.
+     * @param {function} callback - callback to be fired on either state
+     * property change, or through the trigger method.
+     * @returns Public API for chaining.
+     */
+    function connect(actions, callback) {
+        const id = connections++;
+        if (Array.isArray(actions)) {
+            _connect(actions, callback, id);
+        } else if (typeof actions === 'string') {
+            _connect([actions], callback, id);
+        } else if (typeof actions === 'object') {
+            let keys = Object.keys(actions);
+            for (let i = 0; i < keys.length; i++) {
+                _connect([keys[i]], actions[keys[i]], id);
+            }
+        }
+
+        return id;
+    }
+
+    function disconnectByKey(key) {
+        let listener = filter(listeners, function(listener) {
+            return listener.keys.indexOf(key) > -1;
+        });
+        let listenerIndex = listeners.indexOf(listener);
+        if (listenerIndex === -1) {
+            storeError('disconnect', key, 'Invalid disconnect key.');
+        }
+        listeners[listenerIndex] = undefined;
+        listeners.splice(listenerIndex, 1);
+    }
+
+    /**
+     * disconnect
+     * Removes a callback listener from the queue.
+     *
+     * @param {string} key
+     */
+    function disconnect(key) {
+        if (typeof key === 'string') {
+            disconnectByKey(key);
+        } else if (Array.isArray(key)) {
+            for (let i = 0; i < key.length; i++) {
+                disconnectByKey(key[i]);
+            }
+        } else if (typeof key === 'number') {
+            let len = listeners.slice().length;
+            for (let i = 0; i < len; i++) {
+                if (!listeners[i] || listeners[i].id !== key) {
+                    continue;
+                }
+                listeners[i] = undefined;
+                listeners.splice(i, 1);
+            }
+        }
+    }
+
+    /**
+     * destroy
+     * Assigns undefined to all state properties and listeners. Intended
+     * to be used at the end of the application life cycle.
+     *
+     */
+    function destroy() {
+        let keys = Object.keys(state);
+        for (let i = 0; i < keys.length; i++) {
+            state[keys[i]] = undefined;
+        }
+        for (let i = 0; i < listeners.length; i++) {
+            listeners[i] = undefined;
+        }
+    }
+
+    return getAPIWithObject(state);
+}

--- a/js/misc/util.js
+++ b/js/misc/util.js
@@ -12,6 +12,7 @@
 const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
 const Gir = imports.gi.GIRepository;
+const Mainloop = imports.mainloop;
 const Main = imports.ui.main;
 
 // http://daringfireball.net/2010/07/improved_regex_for_matching_urls
@@ -392,7 +393,7 @@ function queryCollection(collection, query, indexOnly = false) {
  * @callback (function): The function to call on every iteration,
  * should return a boolean value.
  *
- * Returns (number): the index of @array.
+ * Returns (number): the index of @array, else -1.
  */
 function findIndex(array, callback) {
     for (let i = 0, len = array.length; i < len; i++) {
@@ -402,6 +403,240 @@ function findIndex(array, callback) {
     }
     return -1;
 }
+
+/**
+ * find:
+ * @array (array): Array to be iterated.
+ * @callback (function): The function to call on every iteration,
+ * should return a boolean value.
+ *
+ * Returns (any): Returns the matched element, else null.
+ */
+function find(arr, callback) {
+    for (let i = 0, len = arr.length; i < len; i++) {
+        if (callback(arr[i], i, arr)) {
+            return arr[i];
+        }
+    }
+    return null;
+};
+
+/**
+ * each:
+ * @array (array|object): Array or object to be iterated.
+ * @callback (function): The function to call on every iteration.
+ *
+ * Iteratee functions may exit iteration early by explicitly returning false.
+ */
+function each(obj, callback) {
+    if (Array.isArray(obj)) {
+        for (let i = 0, len = obj.length; i < len; i++) {
+            let returnValue = callback(obj[i], i);
+            if (returnValue === false) {
+                return;
+            }
+        }
+    } else {
+        let keys = Object.keys(obj);
+        for (let i = 0, len = obj.length; i < len; i++) {
+            let key = keys[i];
+            callback(obj[key], key);
+        }
+    }
+};
+
+/**
+ * filter:
+ * @array (array): Array to be iterated.
+ * @callback (function): The function to call on every iteration.
+ *
+ * Returns (array): Returns the new filtered array.
+ */
+function filter(arr, callback) {
+    let result = [];
+    for (let i = 0, len = arr.length; i < len; i++) {
+        if (callback(arr[i], i, arr)) {
+            result.push(arr[i]);
+        }
+    }
+    return result;
+};
+
+/**
+ * map:
+ * @array (array): Array to be iterated.
+ * @callback (function): The function to call on every iteration.
+ *
+ * Returns (array): Returns the new mapped array.
+ */
+function map(arr, callback) {
+    if (arr == null) {
+        return [];
+    }
+
+    let len = arr.length;
+    let out = Array(len);
+
+    for (let i = 0; i < len; i++) {
+        out[i] = callback(arr[i], i, arr);
+    }
+
+    return out;
+};
+
+/**
+ * tryFn:
+ * @callback (function): Function to wrap in a try-catch block.
+ * @errCallback (function): The function to call on error.
+ *
+ * Try-catch can degrade performance in the function scope it is
+ * called in. By using a wrapper for try-catch, the function scope is
+ * reduced to the wrapper and not a potentially performance critical
+ * function calling the wrapper. Use of try-catch in any form will
+ * be slower than writing defensive code.
+ *
+ * Returns (any): The output of whichever callback gets called.
+ */
+function tryFn(callback, errCallback) {
+    try {
+        return callback();
+    } catch (e) {
+        if (typeof errCb === 'function') {
+            return errCallback(e);
+        }
+    }
+};
+
+/**
+ * setTimeout:
+ * @callback (function): Function to call at the end of the timeout.
+ * @ms (number): Milliseconds until the timeout expires.
+ *
+ * Convenience wrapper for a Mainloop.timeout_add loop that
+ * return false.
+ *
+ * Returns (number): The ID of the loop.
+ */
+function setTimeout(callback, ms) {
+    let args = [];
+    if (arguments.length > 2) {
+        args = args.slice.call(arguments, 2);
+    }
+
+    let id = Mainloop.timeout_add(ms, () => {
+        callback.call(null, ...args);
+        return false; // Stop repeating
+    }, null);
+
+    return id;
+};
+
+/**
+ * clearTimeout:
+ * @id (number): The ID of the loop to remove.
+ *
+ * Convenience wrapper for Mainloop.source_remove.
+ */
+function clearTimeout(id) {
+    if (id) Mainloop.source_remove(id);
+};
+
+
+/**
+ * setInterval:
+ * @callback (function): Function to call on every interval.
+ * @ms (number): Milliseconds between invocations.
+ *
+ * Convenience wrapper for a Mainloop.timeout_add loop that
+ * return true.
+ *
+ * Returns (number): The ID of the loop.
+ */
+function setInterval(callback, ms) {
+    let args = [];
+    if (arguments.length > 2) {
+        args = args.slice.call(arguments, 2);
+    }
+
+    let id = Mainloop.timeout_add(ms, () => {
+        callback.call(null, ...args);
+        return true; // Repeat
+    }, null);
+
+    return id;
+};
+
+/**
+ * clearInterval:
+ * @id (number): The ID of the loop to remove.
+ *
+ * Convenience wrapper for Mainloop.source_remove.
+ */
+function clearInterval(id) {
+    if (id) Mainloop.source_remove(id);
+};
+
+/**
+ * throttle:
+ * @callback (function): Function to throttle.
+ * @interval (number): Milliseconds to throttle invocations to.
+ * @callFirst (boolean): Specify invoking on the leading edge of the timeout.
+ *
+ * Try-catch can degrade performance in the function scope it is
+ * called in. By using a wrapper for try-catch, the function scope is
+ * reduced to the wrapper and not a potentially performance critical
+ * function calling the wrapper. Use of try-catch in any form will
+ * be slower than writing defensive code.
+ *
+ * Returns (any): The output of @callback.
+ */
+function throttle(callback, interval, callFirst) {
+    let wait = false;
+    let callNow = false;
+    return function() {
+        callNow = callFirst && !wait;
+        let context = this;
+        let args = arguments;
+        if (!wait) {
+            wait = true;
+            setTimeout(function() {
+                wait = false;
+                if (!callFirst) {
+                    return callback.apply(context, args);
+                }
+            }, interval);
+        }
+        if (callNow) {
+            callNow = false;
+            return callback.apply(this, arguments);
+        }
+    };
+}
+
+/**
+ * unref:
+ * @object (object): Object to be nullified.
+ * @reserved (array): List of special keys (string) that should not be assigned null.
+ *
+ * This will iterate @object and assign null to every property
+ * value except for keys specified in the @reserved array. Calling unref()
+ * in an object that has many references can make garbage collection easier
+ * for the engine. This should be used at the end of the lifecycle for
+ * classes that do not reconstruct very frequently, as GC thrashing can
+ * reduce performance.
+ */
+function unref(object, reserved = []) {
+    // Some actors being destroyed have a cascading effect (e.g. PopupMenu items),
+    // so it is safest to wait for the next 'tick' before removing references.
+    setTimeout(() => {
+        let keys = Object.keys(object);
+        for (let i = 0; i < keys.length; i++) {
+            if (!reserved.includes(keys[i])) {
+                object[keys[i]] = null;
+            }
+        }
+    }, 0);
+};
 
 const READWRITE = GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE;
 

--- a/js/ui/environment.js
+++ b/js/ui/environment.js
@@ -45,10 +45,11 @@ function _patchContainerClass(containerClass) {
     };
 }
 
+function readOnlyError(property) {
+    global.logError(`The ${property} object is read-only.`);
+};
+
 function init() {
-    const readOnlyError = function(property) {
-        global.logError(`The ${property} object is read-only.`);
-    };
     // Add some bindings to the global JS namespace; (gjs keeps the web
     // browser convention of having that namespace be called 'window'.)
     Object.defineProperty(window, 'global', {

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -116,6 +116,8 @@ const Keybindings = imports.ui.keybindings;
 const Settings = imports.ui.settings;
 const Systray = imports.ui.systray;
 const Accessibility = imports.ui.accessibility;
+const {readOnlyError} = imports.ui.environment;
+const {installPolyfills} = imports.ui.overrides;
 
 var LAYOUT_TRADITIONAL = "traditional";
 var LAYOUT_FLIPPED = "flipped";
@@ -286,6 +288,8 @@ function start() {
     global.logWarning = _logWarning;
     global.logError = _logError;
     global.log = _logInfo;
+
+    installPolyfills(readOnlyError, _log);
 
     let cinnamonStartTime = new Date().getTime();
 

--- a/js/ui/overrides.js
+++ b/js/ui/overrides.js
@@ -195,6 +195,57 @@ function overrideJS() {
     Object.defineProperty(Object.prototype, "maybeGet", {enumerable: false});
 }
 
+function installPolyfills(readOnlyError) {
+    // Add a few ubiquitous JS namespaces to the global scope.
+
+    // util.js depends on a fully setup environment, so cannot be
+    // in the top-level scope here.
+    const {setTimeout, clearTimeout, setInterval, clearInterval} = imports.misc.util;
+
+    // These abstractions around Mainloop are safer and easier
+    // to use for people learning GObject introspection bindings.
+    Object.defineProperty(window, 'setTimeout', {
+        get: function() {
+            return setTimeout;
+        },
+        set: function() {
+            readOnlyError('setTimeout');
+        },
+        configurable: false,
+        enumerable: false
+    });
+    Object.defineProperty(window, 'clearTimeout', {
+        get: function() {
+            return clearTimeout;
+        },
+        set: function() {
+            readOnlyError('clearTimeout');
+        },
+        configurable: false,
+        enumerable: false
+    });
+    Object.defineProperty(window, 'setInterval', {
+        get: function() {
+            return setInterval;
+        },
+        set: function() {
+            readOnlyError('setInterval');
+        },
+        configurable: false,
+        enumerable: false
+    });
+    Object.defineProperty(window, 'clearInterval', {
+        get: function() {
+            return clearInterval;
+        },
+        set: function() {
+            readOnlyError('clearInterval');
+        },
+        configurable: false,
+        enumerable: false
+    });
+}
+
 function overrideTweener() {
     if (Tweener.restrictedWords.min != null) {
         return;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5172 @@
+{
+  "name": "cinnamon",
+  "version": "3.6.7",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0-beta.44",
+      "resolved": "http://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
+      "integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "7.0.0-beta.44"
+      }
+    },
+    "@babel/generator": {
+      "version": "7.0.0-beta.44",
+      "resolved": "http://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
+      "integrity": "sha512-5xVb7hlhjGcdkKpMXgicAVgx8syK5VJz193k0i/0sLP6DzE6lRrU1K3B/rFefgdo9LPGMAOOOAWW4jycj07ShQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.44",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.2.0",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.0.0-beta.44",
+      "resolved": "http://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
+      "integrity": "sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "7.0.0-beta.44",
+        "@babel/template": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0-beta.44",
+      "resolved": "http://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
+      "integrity": "sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.0.0-beta.44",
+      "resolved": "http://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
+      "integrity": "sha512-aQ7QowtkgKKzPGf0j6u77kBMdUFVBKNHw2p/3HX/POt5/oz8ec5cs0GwlgM8Hz7ui5EwJnzyfRmkNF1Nx1N7aA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0-beta.44",
+      "resolved": "http://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
+      "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.0"
+      }
+    },
+    "@babel/template": {
+      "version": "7.0.0-beta.44",
+      "resolved": "http://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
+      "integrity": "sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44",
+        "babylon": "7.0.0-beta.44",
+        "lodash": "^4.2.0"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.0.0-beta.44",
+      "resolved": "http://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
+      "integrity": "sha512-UHuDz8ukQkJCDASKHf+oDt3FVUzFd+QYfuBIsiNu/4+/ix6pP/C+uQZJ6K1oEfbCMv/IKWbgDEh7fcsnIE5AtA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.44",
+        "@babel/generator": "7.0.0-beta.44",
+        "@babel/helper-function-name": "7.0.0-beta.44",
+        "@babel/helper-split-export-declaration": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44",
+        "babylon": "7.0.0-beta.44",
+        "debug": "^3.1.0",
+        "globals": "^11.1.0",
+        "invariant": "^2.2.0",
+        "lodash": "^4.2.0"
+      }
+    },
+    "@babel/types": {
+      "version": "7.0.0-beta.44",
+      "resolved": "http://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
+      "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.2.0",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "acorn": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
+      "requires": {
+        "acorn": "^3.0.4"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        }
+      }
+    },
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "dev": true,
+      "requires": {
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
+      }
+    },
+    "ajv-keywords": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+      "dev": true
+    },
+    "ansi-colors": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "^0.1.0"
+      }
+    },
+    "ansi-escapes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+      "dev": true
+    },
+    "ansi-gray": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+      "dev": true
+    },
+    "anymatch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+      "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+      "dev": true,
+      "requires": {
+        "micromatch": "^3.1.4",
+        "normalize-path": "^2.1.1"
+      }
+    },
+    "append-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
+      "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
+      "dev": true,
+      "requires": {
+        "buffer-equal": "^1.0.0"
+      }
+    },
+    "archy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "dev": true
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true
+    },
+    "arr-filter": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/arr-filter/-/arr-filter-1.1.2.tgz",
+      "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
+      "dev": true,
+      "requires": {
+        "make-iterator": "^1.0.0"
+      }
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "arr-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/arr-map/-/arr-map-2.0.2.tgz",
+      "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
+      "dev": true,
+      "requires": {
+        "make-iterator": "^1.0.0"
+      }
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
+    "array-each": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
+      "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
+      "dev": true
+    },
+    "array-initial": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/array-initial/-/array-initial-1.1.0.tgz",
+      "integrity": "sha1-L6dLJnOTccOUe9enrcc74zSz15U=",
+      "dev": true,
+      "requires": {
+        "array-slice": "^1.0.0",
+        "is-number": "^4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
+        }
+      }
+    },
+    "array-last": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/array-last/-/array-last-1.3.0.tgz",
+      "integrity": "sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==",
+      "dev": true,
+      "requires": {
+        "is-number": "^4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
+        }
+      }
+    },
+    "array-slice": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
+      "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
+      "dev": true
+    },
+    "array-sort": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-sort/-/array-sort-1.0.0.tgz",
+      "integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
+      "dev": true,
+      "requires": {
+        "default-compare": "^1.0.0",
+        "get-value": "^2.0.6",
+        "kind-of": "^5.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "^1.0.1"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
+    "async-done": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/async-done/-/async-done-1.3.1.tgz",
+      "integrity": "sha512-R1BaUeJ4PMoLNJuk+0tLJgjmEqVsdN118+Z8O+alhnQDQgy0kmD5Mqi0DNEmMx2LM0Ed5yekKu+ZXYvIHceicg==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.2",
+        "process-nextick-args": "^1.0.7",
+        "stream-exhaust": "^1.0.1"
+      },
+      "dependencies": {
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+          "dev": true
+        }
+      }
+    },
+    "async-each": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+      "dev": true
+    },
+    "async-settle": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-settle/-/async-settle-1.0.0.tgz",
+      "integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
+      "dev": true,
+      "requires": {
+        "async-done": "^1.2.2"
+      }
+    },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "babel-core": {
+      "version": "6.26.3",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "^6.26.0",
+        "babel-generator": "^6.26.0",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "convert-source-map": "^1.5.1",
+        "debug": "^2.6.9",
+        "json5": "^0.5.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "path-is-absolute": "^1.0.1",
+        "private": "^0.1.8",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.7"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "babel-eslint": {
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.6.tgz",
+      "integrity": "sha512-aCdHjhzcILdP8c9lej7hvXKvQieyRt20SF102SIGyY4cUIiw6UaAtK4j2o3dXX74jEmy0TJ0CEhv4fTIM3SzcA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.44",
+        "@babel/traverse": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44",
+        "babylon": "7.0.0-beta.44",
+        "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "^1.0.0"
+      }
+    },
+    "babel-generator": {
+      "version": "6.26.1",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+      "dev": true,
+      "requires": {
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.7",
+        "trim-right": "^1.0.1"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+          "dev": true
+        }
+      }
+    },
+    "babel-helpers": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-register": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+      "dev": true,
+      "requires": {
+        "babel-core": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.15"
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      }
+    },
+    "babel-template": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+          "dev": true
+        }
+      }
+    },
+    "babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "9.18.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
+      },
+      "dependencies": {
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+          "dev": true
+        }
+      }
+    },
+    "babylon": {
+      "version": "7.0.0-beta.44",
+      "resolved": "http://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+      "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
+      "dev": true
+    },
+    "bach": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/bach/-/bach-1.2.0.tgz",
+      "integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
+      "dev": true,
+      "requires": {
+        "arr-filter": "^1.1.1",
+        "arr-flatten": "^1.0.1",
+        "arr-map": "^2.0.0",
+        "array-each": "^1.0.0",
+        "array-initial": "^1.0.0",
+        "array-last": "^1.1.1",
+        "async-done": "^1.2.2",
+        "async-settle": "^1.0.0",
+        "now-and-later": "^2.0.0"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "requires": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "binary-extensions": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
+      "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "dev": true,
+      "requires": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "buffer-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
+      "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "requires": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      }
+    },
+    "caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "requires": {
+        "callsites": "^0.2.0"
+      }
+    },
+    "callsites": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "dev": true
+    },
+    "chokidar": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
+      "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
+      "dev": true,
+      "requires": {
+        "anymatch": "^2.0.0",
+        "async-each": "^1.0.0",
+        "braces": "^2.3.0",
+        "fsevents": "^1.2.2",
+        "glob-parent": "^3.1.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "lodash.debounce": "^4.0.8",
+        "normalize-path": "^2.1.1",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0",
+        "upath": "^1.0.5"
+      }
+    },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "dev": true
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "clear": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/clear/-/clear-0.1.0.tgz",
+      "integrity": "sha512-qMjRnoL+JDPJHeLePZJuao6+8orzHMGP04A8CdwCNsKhRbOnKRjefxONR7bwILT3MHecxKBjHkKL/tkZ8r4Uzw==",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "cliui": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+      "dev": true,
+      "requires": {
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0",
+        "wrap-ansi": "^2.0.0"
+      }
+    },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "dev": true
+    },
+    "clone-buffer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+      "dev": true
+    },
+    "clone-stats": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+      "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+      "dev": true
+    },
+    "cloneable-readable": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
+      "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "process-nextick-args": "^2.0.0",
+        "readable-stream": "^2.3.5"
+      }
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "collection-map": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-map/-/collection-map-1.0.0.tgz",
+      "integrity": "sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=",
+      "dev": true,
+      "requires": {
+        "arr-map": "^2.0.2",
+        "for-own": "^1.0.0",
+        "make-iterator": "^1.0.0"
+      }
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "requires": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true
+    },
+    "component-emitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "convert-source-map": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+      "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
+    "copy-props": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/copy-props/-/copy-props-2.0.4.tgz",
+      "integrity": "sha512-7cjuUME+p+S3HZlbllgsn2CDwS+5eCCX16qBgNC4jgSTf49qR1VKy/Zhl400m0IQXl/bPGEVqncgUUMjrr4s8A==",
+      "dev": true,
+      "requires": {
+        "each-props": "^1.3.0",
+        "is-plain-object": "^2.0.1"
+      }
+    },
+    "core-js": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "d": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "dev": true,
+      "requires": {
+        "es5-ext": "^0.10.9"
+      }
+    },
+    "debug": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "dev": true,
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "decamelize": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
+      "integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
+      "dev": true,
+      "requires": {
+        "xregexp": "4.0.0"
+      }
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "default-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/default-compare/-/default-compare-1.0.0.tgz",
+      "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^5.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "default-resolution": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/default-resolution/-/default-resolution-2.0.0.tgz",
+      "integrity": "sha1-vLgrqnKtebQmp2cy8aga1t8m1oQ=",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "del": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "dev": true,
+      "requires": {
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
+      }
+    },
+    "detect-file": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+      "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+      "dev": true
+    },
+    "detect-indent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+      "dev": true,
+      "requires": {
+        "repeating": "^2.0.0"
+      }
+    },
+    "doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
+    "duplexify": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
+      "integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "each-props": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/each-props/-/each-props-1.3.2.tgz",
+      "integrity": "sha512-vV0Hem3zAGkJAyU7JSjixeU66rwdynTAa1vofCrSA5fEln+m67Az9CcnkVD776/fsN/UjIWmBDoNRS6t6G9RfA==",
+      "dev": true,
+      "requires": {
+        "is-plain-object": "^2.0.1",
+        "object.defaults": "^1.1.0"
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.46",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.46.tgz",
+      "integrity": "sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1",
+        "next-tick": "1"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
+    "es6-weak-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.14",
+        "es6-iterator": "^2.0.1",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "eslint": {
+      "version": "4.19.1",
+      "resolved": "http://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+      "dev": true,
+      "requires": {
+        "ajv": "^5.3.0",
+        "babel-code-frame": "^6.22.0",
+        "chalk": "^2.1.0",
+        "concat-stream": "^1.6.0",
+        "cross-spawn": "^5.1.0",
+        "debug": "^3.1.0",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^3.7.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^3.5.4",
+        "esquery": "^1.0.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.0.1",
+        "ignore": "^3.3.3",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^3.0.6",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.9.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "regexpp": "^1.0.1",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.3.0",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "~2.0.1",
+        "table": "4.0.2",
+        "text-table": "~0.2.0"
+      }
+    },
+    "eslint-scope": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "dev": true,
+      "requires": {
+        "acorn": "^5.5.0",
+        "acorn-jsx": "^3.0.0"
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.0.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "execa": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+      "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        }
+      }
+    },
+    "expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "expand-tilde": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "^1.0.1"
+      }
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
+      "requires": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "external-editor": {
+      "version": "2.2.0",
+      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.4.0",
+        "iconv-lite": "^0.4.17",
+        "tmp": "^0.0.33"
+      }
+    },
+    "extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "dev": true,
+      "requires": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "fancy-log": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+      "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
+      "dev": true,
+      "requires": {
+        "ansi-gray": "^0.1.1",
+        "color-support": "^1.1.3",
+        "time-stamp": "^1.0.0"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
+      }
+    },
+    "fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^3.0.0"
+      }
+    },
+    "findup-sync": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+      "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+      "dev": true,
+      "requires": {
+        "detect-file": "^1.0.0",
+        "is-glob": "^3.1.0",
+        "micromatch": "^3.0.4",
+        "resolve-dir": "^1.0.1"
+      },
+      "dependencies": {
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.0"
+          }
+        }
+      }
+    },
+    "fined": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fined/-/fined-1.1.0.tgz",
+      "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "^2.0.2",
+        "is-plain-object": "^2.0.3",
+        "object.defaults": "^1.1.0",
+        "object.pick": "^1.2.0",
+        "parse-filepath": "^1.0.1"
+      }
+    },
+    "flagged-respawn": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.0.tgz",
+      "integrity": "sha1-Tnmumy6zi/hrO7Vr8+ClaqX8q9c=",
+      "dev": true
+    },
+    "flat-cache": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "dev": true,
+      "requires": {
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
+      }
+    },
+    "flush-write-stream": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
+      "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.4"
+      }
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "for-own": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+      "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.1"
+      }
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "^0.2.2"
+      }
+    },
+    "fs-mkdirp-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
+      "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "through2": "^2.0.3"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "^2.9.2",
+        "node-pre-gyp": "^0.10.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "iconv-lite": {
+          "version": "0.4.21",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safer-buffer": "^2.1.0"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "minipass": {
+          "version": "2.2.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "needle": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.10.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.0",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.1.10",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "^0.5.1",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "glob": "^7.0.5"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "4.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.2.4",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "^1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        }
+      }
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+      "dev": true
+    },
+    "get-stream": {
+      "version": "3.0.0",
+      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+      "dev": true
+    },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "dev": true,
+      "requires": {
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
+      },
+      "dependencies": {
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.0"
+          }
+        }
+      }
+    },
+    "glob-stream": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
+      "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
+      "dev": true,
+      "requires": {
+        "extend": "^3.0.0",
+        "glob": "^7.1.1",
+        "glob-parent": "^3.1.0",
+        "is-negated-glob": "^1.0.0",
+        "ordered-read-streams": "^1.0.0",
+        "pumpify": "^1.3.5",
+        "readable-stream": "^2.1.5",
+        "remove-trailing-separator": "^1.0.1",
+        "to-absolute-glob": "^2.0.0",
+        "unique-stream": "^2.0.2"
+      }
+    },
+    "glob-watcher": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-5.0.1.tgz",
+      "integrity": "sha512-fK92r2COMC199WCyGUblrZKhjra3cyVMDiypDdqg1vsSDmexnbYivK1kNR4QItiNXLKmGlqan469ks67RtNa2g==",
+      "dev": true,
+      "requires": {
+        "async-done": "^1.2.0",
+        "chokidar": "^2.0.0",
+        "just-debounce": "^1.0.0",
+        "object.defaults": "^1.1.0"
+      }
+    },
+    "global-modules": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+      "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+      "dev": true,
+      "requires": {
+        "global-prefix": "^1.0.1",
+        "is-windows": "^1.0.1",
+        "resolve-dir": "^1.0.0"
+      }
+    },
+    "global-prefix": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+      "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "^2.0.2",
+        "homedir-polyfill": "^1.0.1",
+        "ini": "^1.3.4",
+        "is-windows": "^1.0.1",
+        "which": "^1.2.14"
+      }
+    },
+    "globals": {
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz",
+      "integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA==",
+      "dev": true
+    },
+    "globby": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "dev": true,
+      "requires": {
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "glogg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
+      "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
+      "dev": true,
+      "requires": {
+        "sparkles": "^1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
+    },
+    "gulp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/gulp/-/gulp-4.0.0.tgz",
+      "integrity": "sha1-lXZsYB2t5Kd+0+eyttwDiBtZY2Y=",
+      "dev": true,
+      "requires": {
+        "glob-watcher": "^5.0.0",
+        "gulp-cli": "^2.0.0",
+        "undertaker": "^1.0.0",
+        "vinyl-fs": "^3.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+          "dev": true
+        },
+        "gulp-cli": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.0.1.tgz",
+          "integrity": "sha512-RxujJJdN8/O6IW2nPugl7YazhmrIEjmiVfPKrWt68r71UCaLKS71Hp0gpKT+F6qOUFtr7KqtifDKaAJPRVvMYQ==",
+          "dev": true,
+          "requires": {
+            "ansi-colors": "^1.0.1",
+            "archy": "^1.0.0",
+            "array-sort": "^1.0.0",
+            "color-support": "^1.1.3",
+            "concat-stream": "^1.6.0",
+            "copy-props": "^2.0.1",
+            "fancy-log": "^1.3.2",
+            "gulplog": "^1.0.0",
+            "interpret": "^1.1.0",
+            "isobject": "^3.0.1",
+            "liftoff": "^2.5.0",
+            "matchdep": "^2.0.0",
+            "mute-stdout": "^1.0.0",
+            "pretty-hrtime": "^1.0.0",
+            "replace-homedir": "^1.0.0",
+            "semver-greatest-satisfied-range": "^1.1.0",
+            "v8flags": "^3.0.1",
+            "yargs": "^7.1.0"
+          },
+          "dependencies": {
+            "yargs": {
+              "version": "7.1.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+              "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+              "dev": true,
+              "requires": {
+                "camelcase": "^3.0.0",
+                "cliui": "^3.2.0",
+                "decamelize": "^1.1.1",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^1.4.0",
+                "read-pkg-up": "^1.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^1.0.2",
+                "which-module": "^1.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^5.0.0"
+              }
+            }
+          }
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+          "dev": true,
+          "requires": {
+            "invert-kv": "^1.0.0"
+          }
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+          "dev": true,
+          "requires": {
+            "lcid": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+          "dev": true
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^3.0.0"
+          }
+        }
+      }
+    },
+    "gulp-babel": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/gulp-babel/-/gulp-babel-6.1.3.tgz",
+      "integrity": "sha512-tm15R3rt4gO59WXCuqrwf4QXJM9VIJC+0J2NPYSC6xZn+cZRD5y5RPGAiHaDxCJq7Rz5BDljlrk3cEjWADF+wQ==",
+      "dev": true,
+      "requires": {
+        "babel-core": "^6.23.1",
+        "object-assign": "^4.0.1",
+        "plugin-error": "^1.0.1",
+        "replace-ext": "0.0.1",
+        "through2": "^2.0.0",
+        "vinyl-sourcemaps-apply": "^0.2.0"
+      }
+    },
+    "gulplog": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+      "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+      "dev": true,
+      "requires": {
+        "glogg": "^1.0.0"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
+    },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "requires": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "home-or-tmp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
+      }
+    },
+    "homedir-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+      "dev": true,
+      "requires": {
+        "parse-passwd": "^1.0.0"
+      }
+    },
+    "hosted-git-info": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ignore": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^2.0.4",
+        "figures": "^2.0.0",
+        "lodash": "^4.3.0",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rx-lite": "^4.0.8",
+        "rx-lite-aggregates": "^4.0.8",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^4.0.0",
+        "through": "^2.3.6"
+      }
+    },
+    "interpret": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+      "dev": true
+    },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "invert-kv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+      "dev": true
+    },
+    "is-absolute": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+      "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+      "dev": true,
+      "requires": {
+        "is-relative": "^1.0.0",
+        "is-windows": "^1.0.1"
+      }
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-binary-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^1.0.0"
+      }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "^1.0.0"
+      }
+    },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+      "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-negated-glob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
+      "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
+      "dev": true
+    },
+    "is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+      "dev": true,
+      "requires": {
+        "is-path-inside": "^1.0.0"
+      }
+    },
+    "is-path-inside": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "^1.0.1"
+      }
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "is-relative": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+      "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+      "dev": true,
+      "requires": {
+        "is-unc-path": "^1.0.0"
+      }
+    },
+    "is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-unc-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+      "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+      "dev": true,
+      "requires": {
+        "unc-path-regex": "^0.1.2"
+      }
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
+    "is-valid-glob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
+      "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "jsesc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+      "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
+      "requires": {
+        "jsonify": "~0.0.0"
+      }
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "json5": {
+      "version": "0.5.1",
+      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+      "dev": true
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
+    "just-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.0.0.tgz",
+      "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=",
+      "dev": true
+    },
+    "kind-of": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "dev": true
+    },
+    "last-run": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/last-run/-/last-run-1.1.1.tgz",
+      "integrity": "sha1-RblpQsF7HHnHchmCWbqUO+v4yls=",
+      "dev": true,
+      "requires": {
+        "default-resolution": "^2.0.0",
+        "es6-weak-map": "^2.0.1"
+      }
+    },
+    "lazystream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+      "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.0.5"
+      }
+    },
+    "lcid": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+      "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+      "dev": true,
+      "requires": {
+        "invert-kv": "^2.0.0"
+      }
+    },
+    "lead": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lead/-/lead-1.0.0.tgz",
+      "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
+      "dev": true,
+      "requires": {
+        "flush-write-stream": "^1.0.2"
+      }
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
+    "liftoff": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
+      "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
+      "dev": true,
+      "requires": {
+        "extend": "^3.0.0",
+        "findup-sync": "^2.0.0",
+        "fined": "^1.0.1",
+        "flagged-respawn": "^1.0.0",
+        "is-plain-object": "^2.0.4",
+        "object.map": "^1.0.0",
+        "rechoir": "^0.6.2",
+        "resolve": "^1.1.7"
+      }
+    },
+    "load-json-file": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
+      }
+    },
+    "locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
+    },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "dev": true
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "lru-cache": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "make-iterator": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
+      "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^6.0.2"
+      }
+    },
+    "map-age-cleaner": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.2.tgz",
+      "integrity": "sha512-UN1dNocxQq44IhJyMI4TU8phc2m9BddacHRPRjKGLYaF0jqd3xLz0jS0skpAU9WgYyoR4gHtUpzytNBS385FWQ==",
+      "dev": true,
+      "requires": {
+        "p-defer": "^1.0.0"
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "^1.0.0"
+      }
+    },
+    "matchdep": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/matchdep/-/matchdep-2.0.0.tgz",
+      "integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
+      "dev": true,
+      "requires": {
+        "findup-sync": "^2.0.0",
+        "micromatch": "^3.0.4",
+        "resolve": "^1.4.0",
+        "stack-trace": "0.0.10"
+      }
+    },
+    "mem": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.0.0.tgz",
+      "integrity": "sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==",
+      "dev": true,
+      "requires": {
+        "map-age-cleaner": "^0.1.1",
+        "mimic-fn": "^1.0.0",
+        "p-is-promise": "^1.1.0"
+      }
+    },
+    "micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      }
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mixin-deep": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "ms": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+      "dev": true
+    },
+    "mute-stdout": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mute-stdout/-/mute-stdout-1.0.1.tgz",
+      "integrity": "sha512-kDcwXR4PS7caBpuRYYBUz9iVixUk3anO3f5OYFiIPwK/20vCzKCHyKoulbiDY1S53zD2bxUpxN/IJ+TnXjfvxg==",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
+    "nan": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+      "dev": true,
+      "optional": true
+    },
+    "nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      }
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
+      "requires": {
+        "remove-trailing-separator": "^1.0.1"
+      }
+    },
+    "now-and-later": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.0.tgz",
+      "integrity": "sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.2"
+      }
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "^2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "object-keys": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
+      "dev": true
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.0"
+      }
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "object.defaults": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
+      "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
+      "dev": true,
+      "requires": {
+        "array-each": "^1.0.1",
+        "array-slice": "^1.0.0",
+        "for-own": "^1.0.0",
+        "isobject": "^3.0.0"
+      }
+    },
+    "object.map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
+      "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
+      "dev": true,
+      "requires": {
+        "for-own": "^1.0.0",
+        "make-iterator": "^1.0.0"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "object.reduce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object.reduce/-/object.reduce-1.0.1.tgz",
+      "integrity": "sha1-b+NI8qx/oPlcpiEiZZkJaCW7A60=",
+      "dev": true,
+      "requires": {
+        "for-own": "^1.0.0",
+        "make-iterator": "^1.0.0"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
+      }
+    },
+    "ordered-read-streams": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
+      "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.0.1"
+      }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "os-locale": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.0.1.tgz",
+      "integrity": "sha512-7g5e7dmXPtzcP4bgsZ8ixDVqA7oWYuEz4lOSujeWyliPai4gfVDiFIcwBg3aGCPnmSGfzOKTK3ccPn0CKv3DBw==",
+      "dev": true,
+      "requires": {
+        "execa": "^0.10.0",
+        "lcid": "^2.0.0",
+        "mem": "^4.0.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+      "dev": true
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "p-is-promise": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+      "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+      "dev": true,
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^2.0.0"
+      }
+    },
+    "p-try": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+      "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
+      "dev": true
+    },
+    "parse-filepath": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
+      "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
+      "dev": true,
+      "requires": {
+        "is-absolute": "^1.0.0",
+        "map-cache": "^0.2.0",
+        "path-root": "^0.1.1"
+      }
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.2.0"
+      }
+    },
+    "parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "dev": true
+    },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
+    },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "path-root": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+      "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
+      "dev": true,
+      "requires": {
+        "path-root-regex": "^0.1.0"
+      }
+    },
+    "path-root-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+      "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
+      "dev": true
+    },
+    "path-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "plugin-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
+      "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^1.0.1",
+        "arr-diff": "^4.0.0",
+        "arr-union": "^3.1.0",
+        "extend-shallow": "^3.0.2"
+      }
+    },
+    "pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "pretty-hrtime": {
+      "version": "1.0.3",
+      "resolved": "http://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+      "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
+      "dev": true
+    },
+    "private": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
+    },
+    "progress": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
+      "integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==",
+      "dev": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "pump": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "pumpify": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+      "dev": true,
+      "requires": {
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
+      }
+    },
+    "read-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "dev": true,
+      "requires": {
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "readdirp": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "micromatch": "^3.1.10",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
+    "regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
+    },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "regexpp": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+      "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+      "dev": true
+    },
+    "remove-bom-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
+      "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
+      "dev": true,
+      "requires": {
+        "is-buffer": "^1.1.5",
+        "is-utf8": "^0.2.1"
+      }
+    },
+    "remove-bom-stream": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz",
+      "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
+      "dev": true,
+      "requires": {
+        "remove-bom-buffer": "^3.0.0",
+        "safe-buffer": "^5.1.0",
+        "through2": "^2.0.3"
+      }
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "repeat-element": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "requires": {
+        "is-finite": "^1.0.0"
+      }
+    },
+    "replace-ext": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+      "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+      "dev": true
+    },
+    "replace-homedir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/replace-homedir/-/replace-homedir-1.0.0.tgz",
+      "integrity": "sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=",
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "^1.0.1",
+        "is-absolute": "^1.0.0",
+        "remove-trailing-separator": "^1.1.0"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "dev": true
+    },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
+      }
+    },
+    "resolve": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.5"
+      }
+    },
+    "resolve-dir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "^2.0.0",
+        "global-modules": "^1.0.0"
+      }
+    },
+    "resolve-from": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "dev": true
+    },
+    "resolve-options": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-options/-/resolve-options-1.1.0.tgz",
+      "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
+      "dev": true,
+      "requires": {
+        "value-or-function": "^3.0.0"
+      }
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.5"
+      }
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
+    },
+    "rx-lite": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+      "dev": true
+    },
+    "rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "dev": true,
+      "requires": {
+        "rx-lite": "*"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "~0.1.10"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+      "dev": true
+    },
+    "semver-greatest-satisfied-range": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/semver-greatest-satisfied-range/-/semver-greatest-satisfied-range-1.1.0.tgz",
+      "integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
+      "dev": true,
+      "requires": {
+        "sver-compat": "^1.5.0"
+      }
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "set-value": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
+      "requires": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.2.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "source-map-resolve": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+      "dev": true,
+      "requires": {
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
+    },
+    "source-map-support": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.5.6"
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
+    },
+    "sparkles": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
+      "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==",
+      "dev": true
+    },
+    "spdx-correct": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
+      "integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz",
+      "integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w==",
+      "dev": true
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.0"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "dev": true
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "stream-exhaust": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
+      "integrity": "sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw==",
+      "dev": true
+    },
+    "stream-shift": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        }
+      }
+    },
+    "strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "dev": true,
+      "requires": {
+        "is-utf8": "^0.2.0"
+      }
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "sver-compat": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sver-compat/-/sver-compat-1.5.0.tgz",
+      "integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "^2.0.1",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "table": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^5.2.3",
+        "ajv-keywords": "^2.1.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
+        "slice-ansi": "1.0.0",
+        "string-width": "^2.1.1"
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "through2": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
+      }
+    },
+    "through2-filter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
+      "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
+      "dev": true,
+      "requires": {
+        "through2": "~2.0.0",
+        "xtend": "~4.0.0"
+      }
+    },
+    "time-stamp": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+      "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
+      "dev": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
+    "to-absolute-glob": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
+      "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
+      "dev": true,
+      "requires": {
+        "is-absolute": "^1.0.0",
+        "is-negated-glob": "^1.0.0"
+      }
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      }
+    },
+    "to-through": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-through/-/to-through-2.0.0.tgz",
+      "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
+      "dev": true,
+      "requires": {
+        "through2": "^2.0.3"
+      }
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "unc-path-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+      "dev": true
+    },
+    "undertaker": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/undertaker/-/undertaker-1.2.0.tgz",
+      "integrity": "sha1-M52kZGJS0ILcN45wgGcpl1DhG0k=",
+      "dev": true,
+      "requires": {
+        "arr-flatten": "^1.0.1",
+        "arr-map": "^2.0.0",
+        "bach": "^1.0.0",
+        "collection-map": "^1.0.0",
+        "es6-weak-map": "^2.0.1",
+        "last-run": "^1.1.0",
+        "object.defaults": "^1.0.0",
+        "object.reduce": "^1.0.0",
+        "undertaker-registry": "^1.0.0"
+      }
+    },
+    "undertaker-registry": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/undertaker-registry/-/undertaker-registry-1.0.1.tgz",
+      "integrity": "sha1-XkvaMI5KiirlhPm5pDWaSZglzFA=",
+      "dev": true
+    },
+    "union-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^0.4.3"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "set-value": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
+          }
+        }
+      }
+    },
+    "unique-stream": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
+      "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
+      "dev": true,
+      "requires": {
+        "json-stable-stringify": "^1.0.0",
+        "through2-filter": "^2.0.0"
+      }
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "requires": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        }
+      }
+    },
+    "upath": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
+      "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
+      "dev": true
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
+    },
+    "use": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "v8flags": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.1.tgz",
+      "integrity": "sha512-iw/1ViSEaff8NJ3HLyEjawk/8hjJib3E7pvG4pddVXfUg1983s3VGsiClDjhK64MQVDGqc1Q8r18S4VKQZS9EQ==",
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "^1.0.1"
+      }
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "value-or-function": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz",
+      "integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=",
+      "dev": true
+    },
+    "vinyl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+      "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+      "dev": true,
+      "requires": {
+        "clone": "^2.1.1",
+        "clone-buffer": "^1.0.0",
+        "clone-stats": "^1.0.0",
+        "cloneable-readable": "^1.0.0",
+        "remove-trailing-separator": "^1.0.1",
+        "replace-ext": "^1.0.0"
+      },
+      "dependencies": {
+        "replace-ext": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+          "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+          "dev": true
+        }
+      }
+    },
+    "vinyl-fs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
+      "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
+      "dev": true,
+      "requires": {
+        "fs-mkdirp-stream": "^1.0.0",
+        "glob-stream": "^6.1.0",
+        "graceful-fs": "^4.0.0",
+        "is-valid-glob": "^1.0.0",
+        "lazystream": "^1.0.0",
+        "lead": "^1.0.0",
+        "object.assign": "^4.0.4",
+        "pumpify": "^1.3.5",
+        "readable-stream": "^2.3.3",
+        "remove-bom-buffer": "^3.0.0",
+        "remove-bom-stream": "^1.2.0",
+        "resolve-options": "^1.1.0",
+        "through2": "^2.0.0",
+        "to-through": "^2.0.0",
+        "value-or-function": "^3.0.0",
+        "vinyl": "^2.0.0",
+        "vinyl-sourcemap": "^1.1.0"
+      }
+    },
+    "vinyl-sourcemap": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
+      "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
+      "dev": true,
+      "requires": {
+        "append-buffer": "^1.0.2",
+        "convert-source-map": "^1.5.0",
+        "graceful-fs": "^4.1.6",
+        "normalize-path": "^2.1.1",
+        "now-and-later": "^2.0.0",
+        "remove-bom-buffer": "^3.0.0",
+        "vinyl": "^2.0.0"
+      }
+    },
+    "vinyl-sourcemaps-apply": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
+      "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.5.1"
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
+    },
+    "xregexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
+      "integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg==",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
+    },
+    "y18n": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    },
+    "yargs": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.2.tgz",
+      "integrity": "sha512-e7SkEx6N6SIZ5c5H22RTZae61qtn3PYUE8JYbBFlK9sYmh3DMQ6E5ygtaG/2BW0JZi4WGgTR2IV5ChqlqrDGVQ==",
+      "dev": true,
+      "requires": {
+        "cliui": "^4.0.0",
+        "decamelize": "^2.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^3.0.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^2.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^3.2.1 || ^4.0.0",
+        "yargs-parser": "^10.1.0"
+      }
+    },
+    "yargs-parser": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+      "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^4.1.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
   "homepage": "https://github.com/linuxmint/Cinnamon#readme",
   "devDependencies": {
     "babel-eslint": "^8.2.1",
-    "eslint": "^4.15.0"
+    "clear": "0.1.0",
+    "eslint": "^4.15.0",
+    "gulp": "^4.0.0",
+    "gulp-babel": "^6.1.2",
+    "yargs": "^12.0.2"
   }
 }


### PR DESCRIPTION
This PR includes a modified version of Icing Task Manager that adheres to the Cinnamon style guide. There are other additions as well.

- Changed the name to "Grouped window list".
- Adds most of the utility functions found in ITM's utils.js file to misc/util.
- Adds wrappers for `Mainloop.timeout_add` to util.js with `setTimeout` and `setInterval` that the applet uses. I also decided to make them available globally. My reasoning for this is because they are ubiquitous in all browsers and NodeJS. I have been cleaning up some of the older unmaintained third party xlets recently, and have been coming across a surprising amount of xlets that do not stop looping after they are removed from Cinnamon. These abstractions make using Mainloop safer and easier.
- Adds a utility for live-reloading Cinnamon xlets on code change with Gulp. I've been developing my applets this way for a while, and figured it should be in Cinnamon. I modified the configuration to support Gulp 4, and to be able to watch any xlet through command arguments.

To use this, you will need NodeJS. I recommend [v10](https://github.com/nodesource/distributions).
- Run `npm install -g gulp@^4.0.0`
- In the Cinnamon directory run `npm install`.
- To start the task that will watch and reload on code changes, run `gulp spawn-watch --uuid="<xlet uuid>" --type="<xlet type>"`. For example, to develop the applet this PR is adding you would run `gulp spawn-watch --uuid="grouped-window-list@cinnamon.org" --type="applet"`

Currently, nothing has been removed from the code, but there are a few niche options that I am considering for removal, and don't think are appropriate with good defaults for most people. Its good to have a balance between flexibility and ease of use, and too many options can make using software tedious sometimes - hurting the user experience. Here's a few things I'm thinking about:

- [ ] Removal of Firefox bookmarks, history, and most visited. This code is heavy and I'm not confident we need to shove potentially thousands of items in a context sub-menu.
- [ ] Removal of menu item icon type toggling option.
- [ ] Simplifying the options so they are less overwhelming.
- [ ] Patch cinnamon.css with the theme support ITM needs for all of its app states, which should make most of the theme options unnecessary.
- [ ] Add better icon scaling that doesn't need manual configuration.

I am inviting anyone who is interested to suggest items to add to the to-do list, submit patches to this branch, and looking forward to seeing what ideas you guys have for this code base - whether they are technical or design related. 