### PR TITLE
js/ui/panel.js - Delete annoying message in .xsession-errors

### DIFF
--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -2426,7 +2426,7 @@ Panel.prototype = {
     },
 
     _onFocusChanged: function() {
-        if (global.display.focus_window &&
+        if (global.display.focus_window && this._focusWindow !== undefined &&
             this._focusWindow == global.display.focus_window.get_compositor_private())
             return;
 


### PR DESCRIPTION
Hi,

This simple modification delete error messages in .xsession-errors like:

`Cjs-Message: 11:39:25.446: JS WARNING: [/usr/share/cinnamon/js/ui/panel.js 2429]: reference to undefined property "_focusWindow"`

Best regards.
Claudiux
