### PR TITLE
cs_default.py: Add a SettingsWidget() for a default calculator application

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_default.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_default.py
@@ -279,15 +279,12 @@ class DefaultTerminalButton(Gtk.AppChooserButton): #TODO: See if we can get this
 class DefaultCalculatorButton(Gtk.AppChooserButton):
     def __init__(self):
         super(DefaultCalculatorButton, self).__init__()
-        self.set_show_default_item(True)
-        self.set_show_dialog_item(True)
-        self.connect("changed", self.onChanged)
-
         apps = Gio.app_info_get_all()
         self.this_item = []
         self.active_items = []
         self.settings = Gio.Settings.new(CALCULATOR_SCHEMA)
         self.key_value = self.settings.get_string("exec")
+        self.connect("changed", self.onChanged)
         count_up = 0
 
         while (self.this_item is not None and count_up < len(apps)):
@@ -537,9 +534,9 @@ class Module:
                 if not button.get_active():
                     settings.add_row(widget)
 
-            widget = SettingsWidget()
 
             # Terminal
+            widget = SettingsWidget()
             button = DefaultTerminalButton()
             label = MnemonicLabel(_("Te_rminal"), button)
             size_group.add_widget(button)
@@ -548,12 +545,13 @@ class Module:
             settings.add_row(widget)
 
             # Calculator
+            widget = SettingsWidget()
             button = DefaultCalculatorButton()
             label = MnemonicLabel(_("_Calculator"), button)
             size_group.add_widget(button)
             widget.pack_start(label, False, False, 0)
             widget.pack_end(button, False, False, 0)
-            setting.add_row(widget)
+            settings.add_row(widget)
 
             # Removable media
 


### PR DESCRIPTION
* Exposes a SettingsWidget() in Preferred Applications to control the default calculator application schema defined in commit [5b9ca20](https://github.com/linuxmint/cinnamon-desktop/commit/5b9ca2075dcfa9a23bdc9542cac90e6fc7252086) for [linuxmint/cinnamon-desktop](https://github.com/linuxmint/cinnamon-desktop)
* In order to function properly, this PR is dependent on the merger of commit 5b9ca20 into [linuxmint/cinnamon-desktop:master](https://github.com/linuxmint/cinnamon-desktop/tree/master) to define the schema, as well as the merger of commit [c84fa48](https://github.com/linuxmint/cinnamon-settings-daemon/commit/c84fa482bf392430fba6b89d3efb7f4b19cf1386) into [linuxmint/cinnamon-settings-daemon:master](https://github.com/linuxmint/cinnamon-settings-daemon/tree/master) to honor the schema
* Relevant PRs
  1. https://github.com/linuxmint/cinnamon-desktop/pull/120
  2. https://github.com/linuxmint/cinnamon-settings-daemon/pull/240