### PR TITLE
st-polygon: Fix memory leak during picking

### DIFF
--- a/src/st/st-polygon.c
+++ b/src/st/st-polygon.c
@@ -24,24 +24,17 @@
  *
  * #StPolygon is similar to #ClutterCairoTexture in that
  * it allows drawing via Cairo; the primary difference is that
- * it is dynamically sized.  To use, connect to the #StPolygon::repaint
- * signal, and inside the signal handler, call
- * st_polygon_get_context() to get the Cairo context to draw to.  The
- * #StPolygon::repaint signal will be emitted by default when the area is
- * resized or the CSS style changes; you can use the
+ * it is dynamically sized.
+ * The #StPolygon::repaint signal will be emitted by default when
+ * the area is resized or the CSS style changes; you can use the
  * st_polygon_queue_repaint() as well.
  */
 
 #include "st-polygon.h"
 
-#include <cairo.h>
-
 G_DEFINE_TYPE(StPolygon, st_polygon, CLUTTER_TYPE_ACTOR);
 
 struct _StPolygonPrivate {
-  CoglHandle texture;
-  CoglHandle material;
-  cairo_t *context;
   guint needs_repaint : 1;
   guint in_repaint : 1;
 
@@ -201,9 +194,10 @@ st_polygon_paint (ClutterActor *self)
         coords[6] = priv->urc_x;
         coords[7] = priv->urc_y;
 
-        CoglPath *selection_path = cogl2_path_new();
+        CoglPath *selection_path = cogl_path_new();
         cogl_path_polygon (selection_path, (float *)coords, 4);
         cogl_path_fill (selection_path);
+        cogl_object_unref (selection_path);
     }
 }
 
@@ -233,9 +227,10 @@ st_polygon_pick (ClutterActor       *self,
                               pick_color->blue,
                               pick_color->alpha);
 
-    CoglPath *selection_path = cogl2_path_new();
+    CoglPath *selection_path = cogl_path_new();
     cogl_path_polygon (selection_path, (float *)coords, 4);
     cogl_path_fill (selection_path);
+    cogl_object_unref (selection_path);
 }
 
 static void
@@ -363,7 +358,6 @@ st_polygon_init (StPolygon *area)
 {
   area->priv = G_TYPE_INSTANCE_GET_PRIVATE (area, ST_TYPE_POLYGON,
                                             StPolygonPrivate);
-  area->priv->texture = COGL_INVALID_HANDLE;
   area->priv->debug = FALSE;
 }
 

--- a/src/st/st-polygon.h
+++ b/src/st/st-polygon.h
@@ -22,7 +22,6 @@
 #define __ST_POLYGON_H__
 
 #include <clutter/clutter.h>
-#include <cairo.h>
 
 #define ST_TYPE_POLYGON                 (st_polygon_get_type ())
 #define ST_POLYGON(obj)                 (G_TYPE_CHECK_INSTANCE_CAST ((obj), ST_TYPE_POLYGON, StPolygon))


### PR DESCRIPTION
This was caused by an [API update](https://github.com/linuxmint/Cinnamon/commit/f891384cdfd544fe65ea778823ed26cb46f240e4#diff-49572b95ade43576dc999b552d001660R236) when switching to Muffin's own private version of Cogl, and can be seen when moving the cursor over categories in the menu.

This also removes some unused properties of the private struct, and cairo headers. 