### PR TITLE
st-theme-node: Fix border color blending

### DIFF
--- a/src/st/st-theme-node-drawing.c
+++ b/src/st/st-theme-node-drawing.c
@@ -219,14 +219,16 @@ premultiply (ClutterColor *color)
 static void
 unpremultiply (ClutterColor *color)
 {
-  if (color->alpha != 0)
+  guint alpha = color->alpha;
+  guint round = alpha / 2;
+
+  if (alpha)
     {
-      color->red = (color->red * 255 + 127) / color->alpha;
-      color->green = (color->green * 255 + 127) / color->alpha;
-      color->blue = (color->blue * 255 + 127) / color->alpha;
+      color->red = (color->red * 255 + round) / alpha;
+      color->green = (color->green * 255 + round) / alpha;
+      color->blue = (color->blue * 255 + round) / alpha;
     }
 }
-
 static void
 over (const ClutterColor *source,
       const ClutterColor *destination,
@@ -240,9 +242,9 @@ over (const ClutterColor *source,
   premultiply (&dst);
 
   result->alpha = src.alpha + NORM ((255 - src.alpha) * dst.alpha);
-  result->red   = src.red +   NORM ((255 - src.alpha) * dst.red);
+  result->red   = src.red   + NORM ((255 - src.alpha) * dst.red);
   result->green = src.green + NORM ((255 - src.alpha) * dst.green);
-  result->blue  = src.blue +  NORM ((255 - src.alpha) * dst.blue);
+  result->blue  = src.blue  + NORM ((255 - src.alpha) * dst.blue);
 
   unpremultiply (result);
 }


### PR DESCRIPTION
The old unpremultiply function was out of range in some cases, like light colors with low opacity, resulting in an overflow and incorrect border colors.

For example:
```
border-color: rgba(250, 250, 250, .1)
background-color: transparent

In unpremultiply:
    fr = (r * 255 + 127) / a = 260 > 255
    where r = 250 * 0.1 = 25
          a = 255 * 0.1 = 25

Result:
    rgb = 260 & 255 = 4
    border-color: rgba(4, 4, 4, .1)
```
A visible example of what this fixes is the "empty gap" under hovered window list items when using the Mint-Y theme.

Here is a visual comparison of the old function (red) vs the new one (green) with an alpha value of 8. Notice how the old function exceeded the maximum 255 and it wasn't 0 with a component value of 0.

![screenshot from 2018-11-06 00-21-46](https://user-images.githubusercontent.com/10391266/48033031-fdba8b00-e159-11e8-974e-b1ed08087404.png)

This is the excess of a white color in function of alpha (the resulting color is 255 + e(α)). Obviously this is wrong because colors can't exceed 255.

![screenshot_20181112-082815_1_1_1](https://user-images.githubusercontent.com/10391266/48332794-6079be00-e655-11e8-85bb-821fe8f663d1.png)
