### PR TITLE
cinnamonDBus: Handle stale xlet settings

### DIFF
--- a/js/ui/cinnamonDBus.js
+++ b/js/ui/cinnamonDBus.js
@@ -351,6 +351,13 @@ CinnamonDBus.prototype = {
     },
 
     updateSetting: function(uuid, instance_id, key, payload) {
+        if (!Main.settingsManager.uuids[uuid]) {
+            global.logWarning(
+                `[CinnamonDBus] [${uuid}] Unable to find UUID from SettingsManager - ` +
+                'this is likely due to configuring settings from a removed xlet.'
+            );
+            return;
+        }
         Main.settingsManager.uuids[uuid][instance_id].remoteUpdate(key, payload);
     },
 


### PR DESCRIPTION
```
(cinnamon:4616): Cjs-WARNING **: 22:43:21.150: JS ERROR: Exception in method call: updateSetting: TypeError: Main.settingsManager.uuids[uuid][instance_id] is undefined
CinnamonDBus.prototype.updateSetting@/usr/share/cinnamon/js/ui/cinnamonDBus.js:354:9
_handleMethodCall@resource:///org/cinnamon/cjs/modules/overrides/Gio.js:256:22
_wrapJSObject/<@resource:///org/cinnamon/cjs/modules/overrides/Gio.js:326:16
```