### PR TITLE
Slideshow applet: Show current file name in popupmenu

### DIFF
--- a/files/usr/share/cinnamon/applets/slideshow@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/slideshow@cinnamon.org/applet.js
@@ -11,7 +11,7 @@ class CinnamonSlideshowApplet extends Applet.IconApplet {
         super(orientation, panel_height, instanceId);
 
         this._slideshowSettings = new Gio.Settings({ schema_id: 'org.cinnamon.desktop.background.slideshow' });
-
+        
         if (this._slideshowSettings.get_boolean("slideshow-enabled")) {
             if (!this._slideshowSettings.get_boolean("slideshow-paused")) {
                 this.set_applet_icon_symbolic_name('slideshow-play');
@@ -34,6 +34,10 @@ class CinnamonSlideshowApplet extends Applet.IconApplet {
 
         this._applet_context_menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
+        this._update_background_name();
+        
+        this._applet_context_menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+
         this.next_image_context_menu_item = new PopupMenu.PopupIconMenuItem(_("Next Background"),
                 "media-seek-forward",
                 St.IconType.SYMBOLIC);
@@ -49,6 +53,8 @@ class CinnamonSlideshowApplet extends Applet.IconApplet {
             Util.spawnCommandLine("cinnamon-settings backgrounds");
         }));
         this._applet_context_menu.addMenuItem(this.open_settings_context_menu_item);
+        
+        this._applet_context_menu.connect('open-state-changed', () => this._update_background_name());
     }
 
     on_applet_clicked(event) {
@@ -101,6 +107,18 @@ class CinnamonSlideshowApplet extends Applet.IconApplet {
 
     get_next_image() {
         Main.slideshowManager.getNextImage();
+    }
+    
+
+    _update_background_name() {
+        if (!this._current_background_menu) {
+            this._current_background_menu = new PopupMenu.PopupMenuItem("");
+            this._applet_context_menu.addMenuItem(this._current_background_menu);
+        }
+        const settings = new Gio.Settings({ schema_id: 'org.cinnamon.desktop.background' });
+        const file = decodeURIComponent(settings.get_string('picture-uri') || '');
+        const background = file.split('/').pop();
+        this._current_background_menu.label.set_text(_('Current background: ') + background);
     }
 }
 

--- a/files/usr/share/cinnamon/applets/slideshow@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/slideshow@cinnamon.org/applet.js
@@ -10,8 +10,9 @@ class CinnamonSlideshowApplet extends Applet.IconApplet {
     constructor(metadata, orientation, panel_height, instanceId) {
         super(orientation, panel_height, instanceId);
 
-        this._slideshowSettings = new Gio.Settings({ schema_id: 'org.cinnamon.desktop.background.slideshow' });
-        
+        this._slideshowSettings = new Gio.Settings({ schema_id: "org.cinnamon.desktop.background.slideshow" });
+        this._backgroundSettings = new Gio.Settings({ schema_id: "org.cinnamon.desktop.background" });
+
         if (this._slideshowSettings.get_boolean("slideshow-enabled")) {
             if (!this._slideshowSettings.get_boolean("slideshow-paused")) {
                 this.set_applet_icon_symbolic_name('slideshow-play');
@@ -34,6 +35,8 @@ class CinnamonSlideshowApplet extends Applet.IconApplet {
 
         this._applet_context_menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
+        this._current_background_menu = new PopupMenu.PopupMenuItem("");
+        this._applet_context_menu.addMenuItem(this._current_background_menu);
         this._update_background_name();
         
         this._applet_context_menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
@@ -111,14 +114,9 @@ class CinnamonSlideshowApplet extends Applet.IconApplet {
     
 
     _update_background_name() {
-        if (!this._current_background_menu) {
-            this._current_background_menu = new PopupMenu.PopupMenuItem("");
-            this._applet_context_menu.addMenuItem(this._current_background_menu);
-        }
-        const settings = new Gio.Settings({ schema_id: 'org.cinnamon.desktop.background' });
-        const file = decodeURIComponent(settings.get_string('picture-uri') || '');
-        const background = file.split('/').pop();
-        this._current_background_menu.label.set_text(_('Current background: ') + background);
+        const file = decodeURIComponent(this._backgroundSettings.get_string("picture-uri") || "");
+        const background = file.split("/").pop();
+        this._current_background_menu.label.set_text(_("Current background: ") + background);
     }
 }
 


### PR DESCRIPTION
I've added an item in the popup menu to show the current file name.
This is quite useful when you have a big set of wallpaper, and you want to know which one is displayed.

It's updated when menu opens, so it stays up to date when:
- users change the wallpaper by hitting "Next"
- wallpaper is changed automatically

I don't know yet how to provide the translation for `Current background:`, advises are welcome!

![image](https://user-images.githubusercontent.com/186268/48248492-d1bc3580-e3f7-11e8-8c18-eaddc907c175.png)
