### PR TITLE
gwl: Remove unnecesary styles that make themes look bad by default

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -1410,13 +1410,6 @@ StScrollBar StButton#vhandle:hover {
 }
 
 .grouped-window-list-thumbnail-menu {
-    background: rgba(80,80,80,0.8);
-    border: 1px solid #a5a5a5;
-    border-radius: 8px;
-    padding: 20px;
-    font-size: 9pt;
-    color: white;
-    text-shadow: black 0px 0px 2px;
 }
 .grouped-window-list-thumbnail-menu .item-box {
     padding: 8px;


### PR DESCRIPTION
As the thumbnails container is already a menu, themes are already styling it, so no need to duplicate the menu background, which themes have to revert. That is totally unnecessary.

The class can be kept though, in case any theme wants to do anything special.