### PR TITLE
systray-applet: more spacing between icons

### DIFF
--- a/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
@@ -52,10 +52,10 @@ class CinnamonSystrayApplet extends Applet.Applet {
         this.icon_size = this.getPanelIconSize(St.IconType.FULLCOLOR) * global.ui_scale;
 
         if (this.orientation == St.Side.TOP || this.orientation == St.Side.BOTTOM) {
-            manager = new Clutter.BoxLayout( { spacing: 2,
+            manager = new Clutter.BoxLayout( { spacing: 4,
                                                orientation: Clutter.Orientation.HORIZONTAL });
         } else {
-            manager = new Clutter.BoxLayout( { spacing: 2,
+            manager = new Clutter.BoxLayout( { spacing: 4,
                                                orientation: Clutter.Orientation.VERTICAL });
         }
         this.manager = manager;


### PR DESCRIPTION
right now the icons look pretty squashed, especially with small icon
sizes