### PR TITLE
gwl: Simplify thumbnail layout

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -1312,9 +1312,15 @@ StScrollBar StButton#vhandle:hover {
 /* ===================================================================
  * Grouped window list (grouped-window-list@cinnamon.org)
  * ===================================================================*/
-
-.grouped-window-list-thumbnail-label {
-    padding-left: 4px;
+.grouped-window-list-thumbnail-title {
+    spacing: 2px; /* Separate title from close button */
+}
+.grouped-window-list-thumbnail-close {
+    color: #ccc;
+}
+.grouped-window-list-thumbnail-close:hover {
+    color: #fff;
+    text-shadow: white 0px 0px 5px;
 }
 .grouped-window-list-number-label {
     z-index: 99;

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -905,7 +905,7 @@ class AppGroup {
 
         each(this.hoverMenu.appThumbnails, (thumbnail) => {
             if (thumbnail.metaWindow === metaWindow) {
-                thumbnail.labelContainer.child.set_text(metaWindow.title);
+                thumbnail.label.set_text(metaWindow.title);
                 return false;
             }
         });

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -250,8 +250,7 @@ class GroupedWindowListApplet extends Applet.Applet {
             lastCycled: null,
             lastTitleDisplay: null,
             scrollActive: false,
-            thumbnailMenuOpen: false,
-            thumbnailCloseButtonOffset: global.ui_scale > 1 ? -10 : 0
+            thumbnailMenuOpen: false
         });
 
         // key-function pairs of actions that can be triggered from the store's callback queue. This allows the
@@ -1003,7 +1002,6 @@ class GroupedWindowListApplet extends Applet.Applet {
     }
 
     onUIScaleChange() {
-        this.state.set({thumbnailCloseButtonOffset: global.ui_scale > 1 ? -10 : 0});
         this.refreshAllAppLists();
     }
 

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/constants.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/constants.js
@@ -1,10 +1,5 @@
-const CLOSE_BTN_SIZE = 22;
 const constants = {
-    CLOSE_BTN_SIZE,
-    CLOSED_BUTTON_STYLE: 'padding: 0px; width: ' + CLOSE_BTN_SIZE + 'px; height: '
-        + CLOSE_BTN_SIZE + 'px; max-width: ' + CLOSE_BTN_SIZE
-        + 'px; max-height: ' + CLOSE_BTN_SIZE + 'px; ' + '-cinnamon-close-overlap: 0px;' +
-        'background-size: ' + CLOSE_BTN_SIZE + 'px ' + CLOSE_BTN_SIZE + 'px;',
+    CLOSE_BTN_SIZE: 22,
     THUMBNAIL_ICON_SIZE: 16,
     OPACITY_OPAQUE: 255,
     BUTTON_BOX_ANIMATION_TIME: 0.15,


### PR DESCRIPTION
 * Remove unnecessary layout elements inside elements.
 * Add a close clone to the left to properly center the title.
 * Remove close button blurriness.