### PR TITLE
melange: clean up a bunch of deprecation warnings

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-looking-glass/cinnamon-looking-glass.py
+++ b/files/usr/share/cinnamon/cinnamon-looking-glass/cinnamon-looking-glass.py
@@ -16,10 +16,10 @@ import pyinotify
 import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gio, Gtk, GObject, Gdk, GLib
-import dbus, dbus.service, dbus.glib
+from dbus.mainloop.glib import DBusGMainLoop
+import dbus, dbus.service
 import pageutils
 from lookingglass_proxy import LookingGlassProxy
-from dbus.mainloop.glib import DBusGMainLoop
 import signal
 signal.signal(signal.SIGINT, signal.SIG_DFL)
 
@@ -275,7 +275,7 @@ class FileWatcherView(Gtk.ScrolledWindow):
 
 class ClosableTabLabel(Gtk.Box):
     __gsignals__ = {
-        "close-clicked": (GObject.SIGNAL_RUN_FIRST, GObject.TYPE_NONE, ()),
+        "close-clicked": (GObject.SignalFlags.RUN_FIRST, GObject.TYPE_NONE, ()),
     }
     def __init__(self, label_text):
         Gtk.Box.__init__(self)
@@ -340,7 +340,7 @@ class MelangeApp(dbus.service.Object):
         self.commandline.grab_focus()
 
     def run(self):
-        self.window = Gtk.Window(Gtk.WindowType.TOPLEVEL)
+        self.window = Gtk.Window(type=Gtk.WindowType.TOPLEVEL)
         self.window.set_title("Melange")
         self.window.set_icon_name("system-search")
         self.window.set_default_size(1000, 400)
@@ -361,7 +361,7 @@ class MelangeApp(dbus.service.Object):
 
         numRows = 3
         numColumns = 6
-        table = Gtk.Table(numRows, numColumns, False)
+        table = Gtk.Table(n_rows=numRows, n_columns=numColumns, homogeneous=False)
         table.set_margin_start(6)
         table.set_margin_end(6)
         table.set_margin_top(6)
@@ -374,7 +374,7 @@ class MelangeApp(dbus.service.Object):
         self.notebook.set_show_border(True)
         self.notebook.set_show_tabs(True)
 
-        label = Gtk.Label("Melange")
+        label = Gtk.Label(label="Melange")
         label.set_markup("<u>Melange - Cinnamon Debugger</u> ")
         label.show()
         self.notebook.set_action_widget(label, Gtk.PackType.END)
@@ -409,7 +409,7 @@ class MelangeApp(dbus.service.Object):
         table.attach(self.commandline, column, column+1, 1, 2, Gtk.AttachOptions.EXPAND|Gtk.AttachOptions.FILL, 0, 3, 2)
         column += 1
 
-        self.statusLabel = Gtk.Label("Status")
+        self.statusLabel = Gtk.Label(label="Status")
         self.statusLabel.set_markup(" <span foreground='red'>[ Cinnamon is OFFLINE! ]</span> ")
         self.statusLabel.set_tooltip_text("The connection to cinnamon is broken")
         self.statusLabel.set_no_show_all(True)
@@ -417,16 +417,16 @@ class MelangeApp(dbus.service.Object):
         column += 1
 
         box = Gtk.HBox()
-        settings = Gio.Settings("org.cinnamon.desktop.keybindings")
+        settings = Gio.Settings(schema="org.cinnamon.desktop.keybindings")
         arr = settings.get_strv("looking-glass-keybinding")
         if len(arr) > 0:
             # only the first mapped keybinding
             [accelKey, mask] = Gtk.accelerator_parse(arr[0])
             if accelKey == 0 and mask == 0:
                 # failed to parse, fallback to plain accel string
-                label = Gtk.Label(arr[0])
+                label = Gtk.Label(label=arr[0])
             else:
-                label = Gtk.Label(Gtk.accelerator_get_label(accelKey, mask))
+                label = Gtk.Label(label=Gtk.accelerator_get_label(accelKey, mask))
             label.set_tooltip_text("Toggle shortcut")
             box.pack_start(label, False, False, 3)
 
@@ -440,7 +440,7 @@ class MelangeApp(dbus.service.Object):
         self.window.set_focus(self.commandline)
 
     def createMenuItem(self, text, callback):
-        item = Gtk.MenuItem(text)
+        item = Gtk.MenuItem(label=text)
         item.connect("activate", callback)
         return item
 
@@ -456,7 +456,7 @@ class MelangeApp(dbus.service.Object):
         menu.append(self.createMenuItem('Quit', self.onDelete))
         menu.show_all()
 
-        button = Gtk.MenuButton("Actions \u25BE")
+        button = Gtk.MenuButton(label="Actions \u25BE")
         button.set_popup(menu)
         return button
 
@@ -529,14 +529,14 @@ If you defined a hotkey for Melange, pressing it while Melange is visible it wil
         self.window.hide()
 
     def createDummyPage(self, text, description):
-        label = Gtk.Label(text)
-        self.notebook.append_page(Gtk.Label(description), label)
+        label = Gtk.Label(label=text)
+        self.notebook.append_page(Gtk.Label(label=description), label)
 
     def createPage(self, text, moduleName):
         module = __import__("page_%s" % moduleName)
         module.lookingGlassProxy = self.lookingGlassProxy
         module.melangeApp = self
-        label = Gtk.Label(text)
+        label = Gtk.Label(label=text)
         page = module.ModulePage(self)
         self.pages[moduleName] = page
         self.notebook.append_page(page, label)


### PR DESCRIPTION
so they don't spam the logs every time the program is run.

```
$ cinnamon-looking-glass 
/usr/share/cinnamon/cinnamon-looking-glass/cinnamon-looking-glass.py:21: DeprecationWarning: Importing dbus.glib to use the GLib main loop with dbus-python is deprecated.
Instead, use this sequence:

    from dbus.mainloop.glib import DBusGMainLoop

    DBusGMainLoop(set_as_default=True)

  import dbus, dbus.service, dbus.glib
/usr/share/cinnamon/cinnamon-looking-glass/cinnamon-looking-glass.py:280: PyGIDeprecationWarning: GObject.SIGNAL_RUN_FIRST is deprecated; use GObject.SignalFlags.RUN_FIRST instead
  "close-clicked": (GObject.SIGNAL_RUN_FIRST, GObject.TYPE_NONE, ()),
/usr/share/cinnamon/cinnamon-looking-glass/cinnamon-looking-glass.py:345: PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "type" or use a class specific constructor. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  self.window = Gtk.Window(Gtk.WindowType.TOPLEVEL)
/usr/share/cinnamon/cinnamon-looking-glass/cinnamon-looking-glass.py:366: PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "n_rows, n_columns, homogeneous" or use a class specific constructor. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  table = Gtk.Table(numRows, numColumns, False)
/usr/share/cinnamon/cinnamon-looking-glass/cinnamon-looking-glass.py:379: PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "label" or use a class specific constructor. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  label = Gtk.Label("Melange")
/usr/share/cinnamon/cinnamon-looking-glass/cinnamon-looking-glass.py:541: PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "label" or use a class specific constructor. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  label = Gtk.Label(text)
/usr/share/cinnamon/cinnamon-looking-glass/cinnamon-looking-glass.py:414: PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "label" or use a class specific constructor. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  self.statusLabel = Gtk.Label("Status")
/usr/share/cinnamon/cinnamon-looking-glass/cinnamon-looking-glass.py:422: PyGIDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "schema" or use a class specific constructor. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  settings = Gio.Settings("org.cinnamon.desktop.keybindings")
/usr/share/cinnamon/cinnamon-looking-glass/cinnamon-looking-glass.py:431: PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "label" or use a class specific constructor. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  label = Gtk.Label(Gtk.accelerator_get_label(accelKey, mask))
/usr/share/cinnamon/cinnamon-looking-glass/cinnamon-looking-glass.py:445: PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "label" or use a class specific constructor. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  item = Gtk.MenuItem(text)
/usr/share/cinnamon/cinnamon-looking-glass/cinnamon-looking-glass.py:461: PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "label" or use a class specific constructor. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  button = Gtk.MenuButton("Actions \u25BE")
```