### PR TITLE
network-applet: use new network-wireless-signal-secure icons

### DIFF
--- a/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
@@ -113,12 +113,6 @@ NMNetworkMenuItem.prototype = {
                                          style_class: 'popup-menu-icon' });
         this._icons.add_actor(this._signalIcon);
 
-        this._secureIcon = new St.Icon({ style_class: 'popup-menu-icon' });
-        if (this.bestAP._secType != NMAccessPointSecurity.UNKNOWN &&
-            this.bestAP._secType != NMAccessPointSecurity.NONE)
-            this._secureIcon.icon_name = 'network-wireless-encrypted';
-        this._icons.add_actor(this._secureIcon);
-
         this._accessPoints = [ ];
         for (let i = 0; i < accessPoints.length; i++) {
             let ap = accessPoints[i];
@@ -145,6 +139,9 @@ NMNetworkMenuItem.prototype = {
     _getIcon: function() {
         if (this.bestAP.mode == NM80211Mode.ADHOC)
             return 'network-workgroup';
+        else if (this.bestAP._secType != NMAccessPointSecurity.UNKNOWN &&
+            this.bestAP._secType != NMAccessPointSecurity.NONE)
+            return 'network-wireless-signal-' + signalToIcon(this.bestAP.strength) + '-secure';
         else
             return 'network-wireless-signal-' + signalToIcon(this.bestAP.strength);
     },

--- a/files/usr/share/cinnamon/applets/network@cinnamon.org/icons/network-wireless-signal-excellent-secure-symbolic.svg
+++ b/files/usr/share/cinnamon/applets/network@cinnamon.org/icons/network-wireless-signal-excellent-secure-symbolic.svg
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   version="1.1"
+   style="enable-background:new"
+   id="svg7384"
+   height="16"
+   sodipodi:docname="network-wireless-signal-excellent-secure-symbolic.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="732"
+     id="namedview20"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="7.8983051"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7384" />
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <title
+     id="title8473">Gnome Symbolic Icons</title>
+  <defs
+     id="defs7386" />
+  <g
+     id="g837">
+    <path
+       clip-path="none"
+       d="m 8,11 a 1.9999995,1.9999995 0 0 0 -2,2 1.9999995,1.9999995 0 0 0 2,2 1.9999995,1.9999995 0 0 0 1.03125,-0.289062 V 11.289062 A 1.9999995,1.9999995 0 0 0 8,11 Z"
+       id="path6305-1"
+       style="display:inline;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:1.99999952"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 7.99999,2.00021 c -2.81422,0 -5.17173,1 -7,2.58557 v 1.41443 h 1.48072 c 1.51928,-1.26466 3.21936,-2 5.51928,-2 2.29992,0 4,0.77953 5.51928,2 h 1.48072 V 4.61893 c -1.64044,-1.46575 -4.18578,-2.61872 -7,-2.61872 z"
+       id="rect11714-8"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 8,5 C 5.83336,5 3.98018,5.73878 3,7 V 8 H 5 C 5.78878,7.39348 6.75887,7 8,7 c 1.24113,0 2.21938,0.39348 3,1 h 1.19531 C 12.45413,7.92706 12.72053,7.875 13,7.875 V 7 C 12.00522,5.7771 10.1266,5 8,5 Z"
+       id="rect11703-79"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate"
+       inkscape:connector-curvature="0" />
+    <path
+       clip-path="none"
+       d="M 8,8 C 6.74267,8 5.78429,8.31165 5,9 v 1 h 3 0.375 1.76562 C 10.27205,9.569419 10.49447,9.180978 10.79297,8.857422 10.0116,8.290384 9.15604,8 8,8 Z"
+       id="path6297-2"
+       mask="none"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:2.32782054;marker:none;enable-background:accumulate"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 13,8.875 c -1.08877,0 -2,0.87892 -2,1.96875 V 11.9375 H 10.03125 V 16 H 16 V 11.9375 H 14.96875 V 10.84375 C 14.96875,9.75392 14.08877,8.875 13,8.875 Z m 0,1 c 0.54629,0 0.96875,0.41732 0.96875,0.96875 V 11.9375 H 12 V 10.84375 C 12,10.29232 12.45371,9.875 13,9.875 Z"
+       id="path20685-3-8-7"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     transform="translate(-212,-8)"
+     id="layer7" />
+  <g
+     transform="translate(-212,-8)"
+     id="layer6" />
+  <g
+     transform="translate(-212,-8)"
+     id="layer5" />
+  <g
+     transform="translate(-212,-8)"
+     id="layer9" />
+  <g
+     transform="translate(-212,-8)"
+     id="layer2" />
+  <g
+     transform="translate(-212,-8)"
+     id="layer8" />
+  <g
+     transform="translate(-212,-8)"
+     id="layer3" />
+  <g
+     transform="translate(-212,-8)"
+     id="layer4" />
+</svg>

--- a/files/usr/share/cinnamon/applets/network@cinnamon.org/icons/network-wireless-signal-good-secure-symbolic.svg
+++ b/files/usr/share/cinnamon/applets/network@cinnamon.org/icons/network-wireless-signal-good-secure-symbolic.svg
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   version="1.1"
+   style="enable-background:new"
+   id="svg7384"
+   height="16"
+   sodipodi:docname="network-wireless-signal-good-secure-symbolic.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="732"
+     id="namedview20"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="7.8983051"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7384" />
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <title
+     id="title8473">Gnome Symbolic Icons</title>
+  <defs
+     id="defs7386" />
+  <g
+     id="g851">
+    <path
+       inkscape:connector-curvature="0"
+       clip-path="none"
+       d="m 8,11 a 1.9999995,1.9999995 0 0 0 -2,2 1.9999995,1.9999995 0 0 0 2,2 1.9999995,1.9999995 0 0 0 1.03125,-0.289062 V 11.289062 A 1.9999995,1.9999995 0 0 0 8,11 Z"
+       id="path6305-5-3"
+       style="display:inline;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:1.99999952" />
+    <path
+       inkscape:connector-curvature="0"
+       d="m 7.99999,2.00021 c -2.81422,0 -5.17173,1 -7,2.58557 v 1.41443 h 1.48072 c 1.51928,-1.26466 3.21936,-2 5.51928,-2 2.29992,0 4,0.77953 5.51928,2 h 1.48072 V 4.61893 c -1.64044,-1.46575 -4.18578,-2.61872 -7,-2.61872 z"
+       id="rect11714-9-6"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.35;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate" />
+    <path
+       inkscape:connector-curvature="0"
+       d="M 8,5 C 5.83336,5 3.98018,5.73878 3,7 V 8 H 5 C 5.78878,7.39348 6.75887,7 8,7 c 1.24113,0 2.21938,0.39348 3,1 h 1.19531 C 12.45413,7.92706 12.72053,7.875 13,7.875 V 7 C 12.00522,5.7771 10.1266,5 8,5 Z"
+       id="rect11703-2-0"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate" />
+    <path
+       inkscape:connector-curvature="0"
+       clip-path="none"
+       d="M 8,8 C 6.74267,8 5.78429,8.31165 5,9 v 1 h 3 0.375 1.76562 C 10.27205,9.569419 10.49447,9.180978 10.79297,8.857422 10.0116,8.290384 9.15604,8 8,8 Z"
+       id="path6297-8-6"
+       mask="none"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:2.32782054;marker:none;enable-background:accumulate" />
+    <path
+       inkscape:connector-curvature="0"
+       d="m 13,8.875 c -1.08877,0 -2,0.87892 -2,1.96875 V 11.9375 H 10.03125 V 16 H 16 V 11.9375 H 14.96875 V 10.84375 C 14.96875,9.75392 14.08877,8.875 13,8.875 Z m 0,1 c 0.54629,0 0.96875,0.41732 0.96875,0.96875 V 11.9375 H 12 V 10.84375 C 12,10.29232 12.45371,9.875 13,9.875 Z"
+       id="path20685-3-8-9"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+  </g>
+  <g
+     transform="translate(-232,-8)"
+     id="layer7" />
+  <g
+     transform="translate(-232,-8)"
+     id="layer6" />
+  <g
+     transform="translate(-232,-8)"
+     id="layer5" />
+  <g
+     transform="translate(-232,-8)"
+     id="layer9" />
+  <g
+     transform="translate(-232,-8)"
+     id="layer2" />
+  <g
+     transform="translate(-232,-8)"
+     id="layer8" />
+  <g
+     transform="translate(-232,-8)"
+     id="layer3" />
+  <g
+     transform="translate(-232,-8)"
+     id="layer4" />
+</svg>

--- a/files/usr/share/cinnamon/applets/network@cinnamon.org/icons/network-wireless-signal-none-secure-symbolic.svg
+++ b/files/usr/share/cinnamon/applets/network@cinnamon.org/icons/network-wireless-signal-none-secure-symbolic.svg
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   version="1.1"
+   style="enable-background:new"
+   id="svg7384"
+   height="16"
+   sodipodi:docname="network-wireless-signal-none-secure-symbolic.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="732"
+     id="namedview20"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="7.8983051"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7384" />
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <title
+     id="title8473">Gnome Symbolic Icons</title>
+  <defs
+     id="defs7386" />
+  <g
+     id="g837">
+    <path
+       clip-path="none"
+       d="m 8,11 a 1.9999995,1.9999995 0 0 0 -2,2 1.9999995,1.9999995 0 0 0 2,2 1.9999995,1.9999995 0 0 0 1.03125,-0.289062 V 11.289062 A 1.9999995,1.9999995 0 0 0 8,11 Z"
+       id="path6305-6-5"
+       style="display:inline;opacity:0.35;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:1.99999952"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 7.99999,2.0002 c -2.81422,0 -5.17173,1 -7,2.58557 V 6.0002 h 1.48072 c 1.51928,-1.26466 3.21936,-2 5.51928,-2 2.29992,0 4,0.77953 5.51928,2 h 1.48072 V 4.61892 c -1.64044,-1.46575 -4.18578,-2.61872 -7,-2.61872 z"
+       id="rect11714-5-0"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.35;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 8,5 C 5.83336,5 3.98018,5.73878 3,7 V 8 H 5 C 5.78878,7.39348 6.75887,7 8,7 c 1.24113,0 2.21938,0.39348 3,1 h 1.19531 C 12.45413,7.92706 12.72053,7.875 13,7.875 V 7 C 12.00522,5.7771 10.1266,5 8,5 Z"
+       id="rect11703-8-3"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.35;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate"
+       inkscape:connector-curvature="0" />
+    <path
+       clip-path="none"
+       d="M 8,8 C 6.74267,8 5.78429,8.31165 5,9 v 1 h 3 0.375 1.76562 C 10.27205,9.569419 10.49447,9.180978 10.79297,8.857422 10.0116,8.290384 9.15604,8 8,8 Z"
+       id="path6297-5-6"
+       mask="none"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.35;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:2.32782054;marker:none;enable-background:accumulate"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 13,8.875 c -1.08877,0 -2,0.87892 -2,1.96875 V 11.9375 H 10.03125 V 16 H 16 V 11.9375 H 14.96875 V 10.84375 C 14.96875,9.75392 14.08877,8.875 13,8.875 Z m 0,1 c 0.54629,0 0.96875,0.41732 0.96875,0.96875 V 11.9375 H 12 V 10.84375 C 12,10.29232 12.45371,9.875 13,9.875 Z"
+       id="path20685-3-1"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     transform="translate(-292,-8)"
+     id="layer7" />
+  <g
+     transform="translate(-292,-8)"
+     id="layer6" />
+  <g
+     transform="translate(-292,-8)"
+     id="layer5" />
+  <g
+     transform="translate(-292,-8)"
+     id="layer9" />
+  <g
+     transform="translate(-292,-8)"
+     id="layer2" />
+  <g
+     transform="translate(-292,-8)"
+     id="layer8" />
+  <g
+     transform="translate(-292,-8)"
+     id="layer3" />
+  <g
+     transform="translate(-292,-8)"
+     id="layer4" />
+</svg>

--- a/files/usr/share/cinnamon/applets/network@cinnamon.org/icons/network-wireless-signal-ok-secure-symbolic.svg
+++ b/files/usr/share/cinnamon/applets/network@cinnamon.org/icons/network-wireless-signal-ok-secure-symbolic.svg
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   version="1.1"
+   style="enable-background:new"
+   id="svg7384"
+   height="16"
+   sodipodi:docname="network-wireless-signal-ok-secure-symbolic.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="732"
+     id="namedview20"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="7.8983051"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7384" />
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <title
+     id="title8473">Gnome Symbolic Icons</title>
+  <defs
+     id="defs7386" />
+  <g
+     id="g837">
+    <path
+       clip-path="none"
+       d="m 8,11 a 1.9999995,1.9999995 0 0 0 -2,2 1.9999995,1.9999995 0 0 0 2,2 1.9999995,1.9999995 0 0 0 1.03125,-0.289062 V 11.289062 A 1.9999995,1.9999995 0 0 0 8,11 Z"
+       id="path6305-3-9"
+       style="display:inline;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:1.99999952"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 7.99999,2.00021 c -2.81422,0 -5.17173,1 -7,2.58557 v 1.41443 h 1.48072 c 1.51928,-1.26466 3.21936,-2 5.51928,-2 2.29992,0 4,0.77953 5.51928,2 h 1.48072 V 4.61893 c -1.64044,-1.46575 -4.18578,-2.61872 -7,-2.61872 z"
+       id="rect11714-2-1"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.35;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 8,5 C 5.83336,5 3.98018,5.73878 3,7 V 8 H 5 C 5.78878,7.39348 6.75887,7 8,7 c 1.24113,0 2.21938,0.39348 3,1 h 1.19531 C 12.45413,7.92706 12.72053,7.875 13,7.875 V 7 C 12.00522,5.7771 10.1266,5 8,5 Z"
+       id="rect11703-9-2"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.35;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate"
+       inkscape:connector-curvature="0" />
+    <path
+       clip-path="none"
+       d="M 8,8 C 6.74267,8 5.78429,8.31165 5,9 v 1 h 3 0.375 1.76562 C 10.27205,9.569419 10.49447,9.180978 10.79297,8.857422 10.0116,8.290384 9.15604,8 8,8 Z"
+       id="path6297-0-7"
+       mask="none"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:2.32782054;marker:none;enable-background:accumulate"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 13,8.875 c -1.08877,0 -2,0.87892 -2,1.96875 V 11.9375 H 10.03125 V 16 H 16 V 11.9375 H 14.96875 V 10.84375 C 14.96875,9.75392 14.08877,8.875 13,8.875 Z m 0,1 c 0.54629,0 0.96875,0.41732 0.96875,0.96875 V 11.9375 H 12 V 10.84375 C 12,10.29232 12.45371,9.875 13,9.875 Z"
+       id="path20685-3-8"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     transform="translate(-252,-8)"
+     id="layer7" />
+  <g
+     transform="translate(-252,-8)"
+     id="layer6" />
+  <g
+     transform="translate(-252,-8)"
+     id="layer5" />
+  <g
+     transform="translate(-252,-8)"
+     id="layer9" />
+  <g
+     transform="translate(-252,-8)"
+     id="layer2" />
+  <g
+     transform="translate(-252,-8)"
+     id="layer8" />
+  <g
+     transform="translate(-252,-8)"
+     id="layer3" />
+  <g
+     transform="translate(-252,-8)"
+     id="layer4" />
+</svg>

--- a/files/usr/share/cinnamon/applets/network@cinnamon.org/icons/network-wireless-signal-weak-secure-symbolic.svg
+++ b/files/usr/share/cinnamon/applets/network@cinnamon.org/icons/network-wireless-signal-weak-secure-symbolic.svg
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   version="1.1"
+   style="enable-background:new"
+   id="svg7384"
+   height="16"
+   sodipodi:docname="network-wireless-signal-weak-secure-symbolic.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="732"
+     id="namedview20"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="-3.8644068"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7384" />
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <title
+     id="title8473">Gnome Symbolic Icons</title>
+  <defs
+     id="defs7386" />
+  <g
+     id="g837">
+    <path
+       clip-path="none"
+       d="m 8,11 a 1.9999995,1.9999995 0 0 0 -2,2 1.9999995,1.9999995 0 0 0 2,2 1.9999995,1.9999995 0 0 0 1.03125,-0.289062 V 11.289062 A 1.9999995,1.9999995 0 0 0 8,11 Z"
+       id="path6305-8-7"
+       style="display:inline;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:1.99999952"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 7.99999,2.00021 c -2.81422,0 -5.17173,1 -7,2.58557 v 1.41443 h 1.48072 c 1.51928,-1.26466 3.21936,-2 5.51928,-2 2.29992,0 4,0.77953 5.51928,2 h 1.48072 V 4.61893 c -1.64044,-1.46575 -4.18578,-2.61872 -7,-2.61872 z"
+       id="rect11714-96-5"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.35;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 8,5 C 5.83336,5 3.98018,5.73878 3,7 V 8 H 5 C 5.78878,7.39348 6.75887,7 8,7 c 1.24113,0 2.21938,0.39348 3,1 h 1.19531 C 12.45413,7.92706 12.72053,7.875 13,7.875 V 7 C 12.00522,5.7771 10.1266,5 8,5 Z"
+       id="rect11703-6-3"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.35;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;marker:none;enable-background:accumulate"
+       inkscape:connector-curvature="0" />
+    <path
+       clip-path="none"
+       d="M 8,8 C 6.74267,8 5.78429,8.31165 5,9 v 1 h 3 0.375 1.76562 C 10.27205,9.569419 10.49447,9.180978 10.79297,8.857422 10.0116,8.290384 9.15604,8 8,8 Z"
+       id="path6297-21-5"
+       mask="none"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.35;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:2.32782054;marker:none;enable-background:accumulate"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 13,8.875 c -1.08877,0 -2,0.87892 -2,1.96875 V 11.9375 H 10.03125 V 16 H 16 V 11.9375 H 14.96875 V 10.84375 C 14.96875,9.75392 14.08877,8.875 13,8.875 Z m 0,1 c 0.54629,0 0.96875,0.41732 0.96875,0.96875 V 11.9375 H 12 V 10.84375 C 12,10.29232 12.45371,9.875 13,9.875 Z"
+       id="path20685-3"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     transform="translate(-272,-8)"
+     id="layer7" />
+  <g
+     transform="translate(-272,-8)"
+     id="layer6" />
+  <g
+     transform="translate(-272,-8)"
+     id="layer5" />
+  <g
+     transform="translate(-272,-8)"
+     id="layer9" />
+  <g
+     transform="translate(-272,-8)"
+     id="layer2" />
+  <g
+     transform="translate(-272,-8)"
+     id="layer8" />
+  <g
+     transform="translate(-272,-8)"
+     id="layer3" />
+  <g
+     transform="translate(-272,-8)"
+     id="layer4" />
+</svg>


### PR DESCRIPTION
The network applet shows a lock icon besides the wireless signal icon.
Use the new network-wireless-signal-secure icon instead.

Also add fallback icons (Adwaita style) for icon themes, which don't have this icons.
Mint-Y already has those new icons.

The fallback icons are used now in Cinnamon 4.0.1, because @mtwebster fixed the fallback icons issue: https://github.com/linuxmint/Cinnamon/commit/ffc4c9565e2dadde507eb89c7d8efb55ef0d139e