### PR TITLE
GWL: Upscale thumbnail size options and add Largest option

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/settings-schema.json
@@ -245,12 +245,13 @@
   },
   "thumbnail-size": {
     "type": "combobox",
-    "default": 6,
+    "default": 9,
     "description": "Thumbnail size",
     "options": {
-      "Small": 3,
-      "Medium": 6,
-      "Large": 9
+      "Small": 6,
+      "Medium": 9,
+      "Large": 12,
+      "Largest": 15
     },
     "tooltip": "Controls the size of the thumbnails."
   },


### PR DESCRIPTION
Thumbnail sizes, other than the Large option were in my opinion too small to be useful.

This commit adds a 'Largest' option to match the regular window-list applets 4 options and changes the range to 6 (small) to 15 (largest) with 9(medium) as the default.

These are still not as large as the equivalent window-list applet thumbnails, to avoid unnecessary resizing when grouped thumbnails exceed the monitor height or width.