### PR TITLE
cs_themes.py: speed up loading

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/ChooserButtonWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/ChooserButtonWidgets.py
@@ -97,41 +97,6 @@ class PictureChooserButton(BaseChooserButton):
         else:
             self.button_image.set_size_request(-1, button_picture_size)
 
-        self.connect_after("draw", self.on_draw)
-
-    def on_draw(self, widget, cr, data=None):
-        if self.progress == 0:
-            return False
-        box = widget.get_allocation()
-
-        context = widget.get_style_context()
-        c = context.get_background_color(Gtk.StateFlags.SELECTED)
-
-        max_length = box.width * .6
-        start = (box.width - max_length) / 2
-        y = box.height - 5
-
-        cr.save()
-
-        cr.set_source_rgba(c.red, c.green, c.blue, c.alpha)
-        cr.set_line_width(3)
-        cr.set_line_cap(1)
-        cr.move_to(start, y)
-        cr.line_to(start + (self.progress * max_length), y)
-        cr.stroke()
-
-        cr.restore()
-        return False
-
-    def increment_loading_progress(self, inc):
-        progress = self.progress + inc
-        self.progress = min(1.0, progress)
-        self.queue_draw()
-
-    def reset_loading_progress(self):
-        self.progress = 0.0
-        self.queue_draw()
-
     def set_picture_from_file (self, path):
         pixbuf = None
         message = ""


### PR DESCRIPTION
Defer loading the download page and chooser entries until after the page is loaded.

The spices/downloader stuff takes a long time to load, and ends up freezing
the ui a bit when the Themes page is selected.  Load it after any animations
have completed.

The chooser buttons are trying to all load at once.  Instead load them
sequentially and display a spinner until loading is complete.