### PR TITLE
PopupMenu: update position and fix size before tweening out

### DIFF
--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -2325,10 +2325,9 @@ var PopupMenu = class PopupMenu extends PopupMenuBase {
         if (this._activeMenuItem)
             this._activeMenuItem.setActive(false);
 
-        this.actor.set_position(...this._calculatePosition());
-        this.actor.set_size(...this.actor.get_size());
-
         if (animate && global.settings.get_boolean("desktop-effects-on-menus")) {
+            this.actor.set_position(...this._calculatePosition());
+            this.actor.set_size(...this.actor.get_size());
             this.animating = true;
             let tweenParams = {
                 transition: "easeInQuad",

--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -2325,6 +2325,9 @@ var PopupMenu = class PopupMenu extends PopupMenuBase {
         if (this._activeMenuItem)
             this._activeMenuItem.setActive(false);
 
+        this.actor.set_position(...this._calculatePosition());
+        this.actor.set_size(...this.actor.get_size());
+
         if (animate && global.settings.get_boolean("desktop-effects-on-menus")) {
             this.animating = true;
             let tweenParams = {
@@ -2349,6 +2352,7 @@ var PopupMenu = class PopupMenu extends PopupMenuBase {
                     this.animating = false;
                     this.actor.hide();
                     this.actor.remove_clip();
+                    this.actor.set_size(-1, -1);
                 }
             }
 


### PR DESCRIPTION
We update the position on allocate() but skip this if we're tweening.
Updating it here ensures it's correct before we start animating,
and setting a fixed size should keep it from automatically resizing.

master:
![menu-master](https://user-images.githubusercontent.com/11601860/48821238-469f4180-ed0d-11e8-8f73-e3c4ef74eaaf.gif)

this branch:
![menu-patch](https://user-images.githubusercontent.com/11601860/48821239-469f4180-ed0d-11e8-8b95-ceab4c70b9ba.gif)
