### PR TITLE
systray: stop indicator icons coming up oversize

### DIFF
--- a/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
@@ -113,7 +113,7 @@ class CinnamonSystrayApplet extends Applet.Applet {
 
     _onIndicatorAdded(manager, appIndicator) {
         if (!(appIndicator.id in this._shellIndicators)) {
-            let indicatorActor = appIndicator.getActor(this.icon_size);
+            let indicatorActor = appIndicator.getActor(this.icon_size / global.ui_scale);
 
             this._shellIndicators.push({
                 id: appIndicator.id,


### PR DESCRIPTION
in HiDPI.  checked out with Tomboy and Redshift