### PR TITLE
panel/theme: Use just a single relative percentage for sizing symbolic icons.

### DIFF
--- a/data/org.cinnamon.gschema.xml.in
+++ b/data/org.cinnamon.gschema.xml.in
@@ -672,44 +672,9 @@
       </description>
     </key>
 
-    <key name="symbolic-size-16" type="i">
-      <default>16</default>
-      <summary>The size to scale symbolic icons when fullcolor icons are 16px</summary>
-      <description>
-        The size to scale symbolic icons when fullcolor icons are 16px
-      </description>
-    </key>
-
-    <key name="symbolic-size-22" type="i">
-      <default>22</default>
-      <summary>The size to scale symbolic icons when fullcolor icons are 22px</summary>
-      <description>
-        The size to scale symbolic icons when fullcolor icons are 22px
-      </description>
-    </key>
-
-    <key name="symbolic-size-24" type="i">
-      <default>22</default>
-      <summary>The size to scale symbolic icons when fullcolor icons are 24px</summary>
-      <description>
-        The size to scale symbolic icons when fullcolor icons are 24px
-      </description>
-    </key>
-
-    <key name="symbolic-size-32" type="i">
-      <default>30</default>
-      <summary>The size to scale symbolic icons when fullcolor icons are 32px</summary>
-      <description>
-        The size to scale symbolic icons when fullcolor icons are 32px
-      </description>
-    </key>
-
-    <key name="symbolic-size-48" type="i">
-      <default>42</default>
-      <summary>The size to scale symbolic icons when fullcolor icons are 48px</summary>
-      <description>
-        The size to scale symbolic icons when fullcolor icons are 48px
-      </description>
+    <key name="symbolic-relative-size" type="d">
+      <default>0.9</default>
+      <summary>Relative size of symbolic icons to the zone's icon size</summary>
     </key>
 
   </schema>

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_panel.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_panel.py
@@ -136,6 +136,12 @@ class Module:
             self.sidePage.add_widget(page)
             section = page.add_section(_("General Panel Options"))
 
+            widget = GSettingsRange(_("Symbolic icon size adjustment"),
+                                    "org.cinnamon.theme", "symbolic-relative-size",
+                                    _("Smaller"), _("Larger"),
+                                    0.4, 1.0, step=0.1, show_value=False)
+            section.add_row(widget)
+
             buttons = SettingsWidget()
             self.add_panel_button = Gtk.Button(label=_("Add new panel"))
 

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_panel.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_panel.py
@@ -140,6 +140,9 @@ class Module:
                                     "org.cinnamon.theme", "symbolic-relative-size",
                                     _("Smaller"), _("Larger"),
                                     0.4, 1.0, step=0.1, show_value=False)
+            widget.add_mark(0.9, Gtk.PositionType.TOP, None)
+            widget.set_rounding(2)
+
             section.add_row(widget)
 
             buttons = SettingsWidget()

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
@@ -89,21 +89,6 @@ class Module:
             widget = GSettingsSwitch(_("Show icons on buttons"), "org.cinnamon.settings-daemon.plugins.xsettings", "buttons-have-icons")
             settings.add_row(widget)
 
-            widget = GSettingsSpinButton(_("Size of symbolic icons when icons are 16px"), "org.cinnamon.theme", "symbolic-size-16", mini=1, maxi=64, step=1)
-            settings.add_row(widget)
-
-            widget = GSettingsSpinButton(_("Size of symbolic icons when icons are 22px"), "org.cinnamon.theme", "symbolic-size-22", mini=1, maxi=64, step=1)
-            settings.add_row(widget)
-
-            widget = GSettingsSpinButton(_("Size of symbolic icons when icons are 24px"), "org.cinnamon.theme", "symbolic-size-24", mini=1, maxi=64, step=1)
-            settings.add_row(widget)
-
-            widget = GSettingsSpinButton(_("Size of symbolic icons when icons are 32px"), "org.cinnamon.theme", "symbolic-size-32", mini=1, maxi=64, step=1)
-            settings.add_row(widget)
-
-            widget = GSettingsSpinButton(_("Size of symbolic icons when icons are 48px"), "org.cinnamon.theme", "symbolic-size-48", mini=1, maxi=64, step=1)
-            settings.add_row(widget)
-
             self.builder = self.sidePage.builder
 
             for path in [os.path.expanduser("~/.themes"), os.path.expanduser("~/.icons")]:

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -248,12 +248,7 @@ function toStandardIconSize(maxSize) {
  */
 function getSymbolicIconSize(iconSize, settings) {
     iconSize = Math.floor(iconSize);
-    if (iconSize < 22) return settings.get_int("symbolic-size-16");
-    else if (iconSize < 24) return settings.get_int("symbolic-size-22");
-    else if (iconSize < 32) return settings.get_int("symbolic-size-24");
-    else if (iconSize < 48) return settings.get_int("symbolic-size-32");
-    // Panel icons reach 32 at most with the largest panel, also on hidpi
-    return settings.get_int("symbolic-size-48");
+    return Math.floor(iconSize * settings.get_double("symbolic-relative-size"))
 }
 
 function setHeightForPanel(panel) {
@@ -1999,11 +1994,7 @@ Panel.prototype = {
         this._signalManager.connect(global.settings, "changed::panel-edit-mode", this._onPanelEditModeChanged, this);
         this._signalManager.connect(global.settings, "changed::no-adjacent-panel-barriers", this._updatePanelBarriers, this);
 
-        this._signalManager.connect(this.themeSettings, "changed::symbolic-size-16", this._onPanelZoneIconSizesChanged, this);
-        this._signalManager.connect(this.themeSettings, "changed::symbolic-size-22", this._onPanelZoneIconSizesChanged, this);
-        this._signalManager.connect(this.themeSettings, "changed::symbolic-size-24", this._onPanelZoneIconSizesChanged, this);
-        this._signalManager.connect(this.themeSettings, "changed::symbolic-size-32", this._onPanelZoneIconSizesChanged, this);
-        this._signalManager.connect(this.themeSettings, "changed::symbolic-size-48", this._onPanelZoneIconSizesChanged, this);
+        this._signalManager.connect(this.themeSettings, "changed::symbolic-relative-size", this._onPanelZoneIconSizesChanged, this);
 
         this._onPanelZoneIconSizesChanged();
     },
@@ -2941,7 +2932,7 @@ Panel.prototype = {
             global.log(`[Panel ${this.panelId}] Creating a new zone configuration`);
         }
 
-        if (typeof key === 'string' && key.includes('symbolic-size')) changed = true;
+        if (typeof key === 'string' && key.includes('symbolic-relative-size')) changed = true;
 
         if (changed) this.emit('icon-size-changed');
     },


### PR DESCRIPTION
This is a bit simpler for the user, and we also place the setting for it in panel
settings, since icon sizes are there already.

top is existing new layout, bottom is with this change in effect at default value:
![before-after](https://user-images.githubusercontent.com/262776/48918327-c0444600-ee59-11e8-9426-01cf2baca854.png)
