### PR TITLE
gwl: Improve thumbnail menu input and button label handling

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -78,7 +78,8 @@ class AppGroup {
         this.groupState.connect({
             isFavoriteApp: () => this.handleFavorite(true),
             getActor: () => this.actor,
-            launchNewInstance: () => this.launchNewInstance()
+            launchNewInstance: () => this.launchNewInstance(),
+            checkFocusStyle: () => this.checkFocusStyle()
         });
 
         this.signals = new SignalManager(null);
@@ -562,6 +563,10 @@ class AppGroup {
     }
 
     onFocusChange(hasFocus) {
+        if (hasFocus === undefined) {
+            hasFocus = this.listState.lastFocusedApp === this.groupState.appId;
+        }
+
         // If any of the windows associated with our app have focus,
         // we should set ourselves to active
         if (hasFocus) {

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -967,6 +967,8 @@ class AppGroup {
             } else {
                 this.hideLabel(true);
             }
+            // Re-orient the menu after the focus button expands
+            this.hoverMenu.setStyleOptions(false);
         }
     }
 

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -381,6 +381,7 @@ class AppGroup {
         let childBox = new Clutter.ActorBox();
         let direction = this.actor.get_text_direction();
         let {iconSpacing} = this.state.settings;
+        let panelHeight = this.state.trigger('getPanelHeight');
 
         // Set the icon to be left-justified (or right-justified) and centered vertically
         let [minWidth, minHeight, naturalWidth, naturalHeight] = this.iconBox.get_preferred_size();
@@ -412,6 +413,7 @@ class AppGroup {
         this.badge.allocate(childBox, flags);
 
         if (this.labelVisible) {
+            let spacing = iconSpacing + Math.round(panelHeight / 1.5);
             [minWidth, minHeight, naturalWidth, naturalHeight] = this.label.get_preferred_size();
 
             yPadding = Math.floor(Math.max(0, allocHeight - naturalHeight) / 2);
@@ -419,10 +421,10 @@ class AppGroup {
             childBox.y2 = childBox.y1 + Math.min(naturalHeight, allocHeight);
             if (direction === Clutter.TextDirection.LTR) {
                 // Reuse the values from the previous allocation
-                childBox.x1 = Math.min(childBox.x2 + (iconSpacing * 4), box.x2);
+                childBox.x1 = Math.min(childBox.x2 + spacing, box.x2);
                 childBox.x2 = box.x2;
             } else {
-                childBox.x2 = Math.max(childBox.x1 - (iconSpacing * 4), box.x1);
+                childBox.x2 = Math.max(childBox.x1 - spacing, box.x1);
                 childBox.x1 = box.x1;
             }
 

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -1024,13 +1024,6 @@ class AppGroup {
         }
     }
 
-    handleTitleDisplayChange() {
-        each(this.groupState.metaWindows, (win) => {
-            this.onWindowTitleChanged(win, true);
-            this.handleButtonLabel(win);
-        });
-    }
-
     animate(step = 0) {
         let effect = this.state.settings.launcherAnimationEffect;
 

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -390,6 +390,7 @@ class AppGroup {
         let allocHeight = box.y2 - box.y1;
         let childBox = new Clutter.ActorBox();
         let direction = this.actor.get_text_direction();
+        let {iconSpacing, titleDisplay} = this.state.settings;
 
         // Set the icon to be left-justified (or right-justified) and centered vertically
         let [iconNaturalWidth, iconNaturalHeight] = this.iconBox.get_preferred_size();
@@ -437,13 +438,25 @@ class AppGroup {
             });
         }
 
-        if (this.progressOverlay.visible) {
+        if (!this.progressOverlay.visible) {
+            return;
+        }
+
+        if (titleDisplay > 1) {
+            childBox.x1 = -(this.iconBox.width / iconSpacing) - badgeOffset;
+            childBox.y1 = 0;
+            childBox.x2 = this.actor.width;
+            childBox.y2 = this.actor.height;
+            let clipWidth = Math.max((this.actor.width) * (this._progress / 100.0), 1.0);
+            this.progressOverlay.set_clip(0, 0, clipWidth, this.actor.height);
+        } else {
             childBox.x1 = -this.padding;
             childBox.y1 = 0;
-            childBox.y2 = this.container.height;
             childBox.x2 = Math.max(this.container.width * (this._progress / 100.0), 1.0);
-            this.progressOverlay.allocate(childBox, flags);
+            childBox.y2 = this.container.height;
         }
+
+        this.progressOverlay.allocate(childBox, flags);
     }
 
     _showLabel(animate = false) {

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -460,6 +460,7 @@ class AppGroup {
         this.label.set_style('padding-right: 4px;');
 
         if (!animate) {
+            this.label.width = this.labelWidth || this.actor.width - this.iconBox.width;
             this.label.show();
             return;
         }
@@ -488,15 +489,13 @@ class AppGroup {
     hideLabel(animate) {
         if (!this.label || this.label.is_finalized() || !this.label.realized) return false;
 
-        if (this.label.text == null) {
-            this.label.set_text('');
-        }
         this.labelVisible = false;
         if (!animate) {
-            this.label.width = 1;
             this.label.hide();
             return false;
         }
+
+        let {width} = this.label;
 
         Tweener.addTween(this.label, {
             width: 1,
@@ -505,7 +504,7 @@ class AppGroup {
             onCompleteScope: this,
             onComplete() {
                 this.label.hide();
-                this.label.set_style('padding-right: 0px;');
+                this.labelWidth = width;
             }
         });
         return false;
@@ -909,7 +908,7 @@ class AppGroup {
                 || !metaWindow.title
                 || (this.groupState.metaWindows.length === 0 && this.groupState.isFavoriteApp)
                     || !this.state.isHorizontal)) {
-            this.hideLabel();
+            this.hideLabel(false);
             return;
         }
 

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -1069,7 +1069,6 @@ class AppGroup {
         this.hoverMenu.destroy();
         this.listState.trigger('removeChild', this.actor);
         this.actor.destroy();
-        this.actor.destroy();
 
         if (!skipRefCleanup) {
             this.groupState.destroy();

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -462,7 +462,7 @@ class AppGroup {
         this.label.set_style('padding-right: 4px;');
 
         if (!animate) {
-            this.label.width = this.labelWidth || this.actor.width - this.iconBox.width;
+            this.label.width = 150 * global.ui_scale;
             this.label.show();
             return;
         }
@@ -493,20 +493,17 @@ class AppGroup {
 
         this.labelVisible = false;
         if (!animate) {
+            this.label.width = 1;
             this.label.hide();
             return false;
         }
-
-        let {width} = this.label;
 
         Tweener.addTween(this.label, {
             width: 1,
             time: BUTTON_BOX_ANIMATION_TIME,
             transition: 'easeOutQuad',
-            onCompleteScope: this,
-            onComplete() {
+            onComplete: () => {
                 this.label.hide();
-                this.labelWidth = width;
             }
         });
         return false;
@@ -966,9 +963,10 @@ class AppGroup {
                 this.showLabel();
             }
         } else if (this.state.settings.titleDisplay === TitleDisplay.Focused) {
+            this.setText(metaWindow.title);
+
             if (focus === undefined) focus = getFocusState(metaWindow);
             if (focus) {
-                this.setText(metaWindow.title);
                 this.showLabel(true);
             } else {
                 this.hideLabel(true);

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -255,7 +255,9 @@ class AppGroup {
     }
 
     setIconPadding(panelHeight) {
-        this.iconBox.style = this.actor.style = 'padding: 0px;';
+        this.iconBox.style = 'padding: 0px';
+        if (!this.state.isHorizontal) return;
+        this.actor.style = 'padding-left: 0px; padding-right: 0px;';
     }
 
     setMargin() {

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -986,7 +986,7 @@ class AppGroup {
             return;
         }
         this.onWindowTitleChanged(this.groupState.lastFocused);
-        this.onFocusWindowChange(this.groupState.lastFocused);
+        this.onFocusChange();
         this.checkFocusStyle();
     }
 

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -951,7 +951,13 @@ class AppGroup {
     }
 
     handleButtonLabel(metaWindow, focus) {
-        if (this.state.settings.titleDisplay === TitleDisplay.Title) {
+        if (this.state.settings.titleDisplay === TitleDisplay.None) {
+            return;
+        }
+
+        if (this.groupState.metaWindows.length === 0) {
+            this.hideLabel(false);
+        } else if (this.state.settings.titleDisplay === TitleDisplay.Title) {
             this.setText(metaWindow.title);
             this.showLabel();
         } else if (this.state.settings.titleDisplay === TitleDisplay.App) {
@@ -969,8 +975,6 @@ class AppGroup {
             }
             // Re-orient the menu after the focus button expands
             this.hoverMenu.setStyleOptions(false);
-        } else if (this.labelVisible) {
-            this.hideLabel(false);
         }
     }
 

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -71,7 +71,8 @@ class AppGroup {
             willUnmount: false,
             tooltip: null,
             verticalThumbs: this.state.settings.verticalThumbs,
-            groupReady: false
+            groupReady: false,
+            thumbnailMenuEntered:  false
         });
 
         this.groupState.connect({
@@ -164,7 +165,7 @@ class AppGroup {
         }, this.state.orientation);
 
         // Set up the hover menu
-        this.hoverMenuManager = new HoverMenuController({actor: this.actor});
+        this.hoverMenuManager = new HoverMenuController(this.actor, this.groupState);
         this.rightClickMenuManager = new PopupMenu.PopupMenuManager({actor: this.actor});
         this.hoverMenu = new AppThumbnailHoverMenu(this.state, this.groupState);
         this.hoverMenu.actor.hide();

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -1012,6 +1012,13 @@ class AppGroup {
         }
     }
 
+    handleTitleDisplayChange() {
+        each(this.groupState.metaWindows, (win) => {
+            this.onWindowTitleChanged(win, true);
+            this.handleButtonLabel(win);
+        });
+    }
+
     animate(step = 0) {
         let effect = this.state.settings.launcherAnimationEffect;
 

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -247,7 +247,7 @@ class GroupedWindowListApplet extends Applet.Applet {
             settings: {},
             homeDir: GLib.get_home_dir(),
             overlayPreview: null,
-            lastCycled: null,
+            lastCycled: -1,
             lastTitleDisplay: null,
             scrollActive: false,
             thumbnailMenuOpen: false,

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -13,7 +13,6 @@ const {AppletSettings} = imports.ui.settings;
 const {SignalManager} = imports.misc.signalManager;
 const {each, find, findIndex, filter, throttle, unref, trySpawnCommandLine} = imports.misc.util;
 const {createStore} = imports.misc.state;
-const Mainloop = imports.mainloop;
 
 const AppList = require('./appList');
 const {
@@ -249,6 +248,7 @@ class GroupedWindowListApplet extends Applet.Applet {
             homeDir: GLib.get_home_dir(),
             overlayPreview: null,
             lastCycled: -1,
+            lastTitleDisplay: null,
             scrollActive: false,
             thumbnailMenuOpen: false,
             thumbnailCloseButtonOffset: global.ui_scale > 1 ? -10 : 0
@@ -371,7 +371,7 @@ class GroupedWindowListApplet extends Applet.Applet {
             {key: 'show-thumbnails', value: 'showThumbs', cb: this.updateVerticalThumbnailState},
             {key: 'animate-thumbnails', value: 'animateThumbs', cb: null},
             {key: 'number-display', value: 'numDisplay', cb: this.updateWindowNumberState},
-            {key: 'title-display', value: 'titleDisplay', cb: this.refreshCurrentAppList},
+            {key: 'title-display', value: 'titleDisplay', cb: this.updateTitleDisplay},
             {key: 'scroll-behavior', value: 'scrollBehavior', cb: null},
             {key: 'icon-spacing', value: 'iconSpacing', cb: this.updateSpacing},
             {key: 'show-recent', value: 'showRecent', cb: null},
@@ -390,6 +390,8 @@ class GroupedWindowListApplet extends Applet.Applet {
                 settingsProps[i].cb ? (...args) => settingsProps[i].cb.call(this, ...args) : null
             );
         }
+
+        this.state.set({lastTitleDisplay: this.state.settings.titleDisplay});
     }
 
     on_applet_added_to_panel() {
@@ -577,8 +579,7 @@ class GroupedWindowListApplet extends Applet.Applet {
 
     refreshCurrentAppList() {
         let appList = this.appLists[this.state.currentWs];
-
-        if (appList) Mainloop.idle_add_full(Mainloop.PRIORITY_LOW, () => appList.refreshList());
+        if (appList) setTimeout(() => appList.refreshList(), 0);
     }
 
     refreshAllAppLists() {
@@ -639,6 +640,21 @@ class GroupedWindowListApplet extends Applet.Applet {
                 }
             });
         });
+    }
+
+    updateTitleDisplay(titleDisplay) {
+        if (titleDisplay === TitleDisplay.None
+            || this.state.lastTitleDisplay === TitleDisplay.None) {
+            this.refreshCurrentAppList();
+        }
+        let appList = this.getCurrentAppList().appList;
+        each(appList, (appGroup) => {
+            if (titleDisplay === TitleDisplay.Focused) {
+                appGroup.hideLabel(false);
+            }
+            appGroup.handleTitleDisplayChange();
+        });
+        this.state.set({lastTitleDisplay: titleDisplay});
     }
 
     getAppFromWMClass(specialApps, metaWindow) {

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -263,7 +263,7 @@ class GroupedWindowListApplet extends Applet.Applet {
             getPanel: () => (this.panel ? this.panel : null),
             getPanelHeight: () => this._panelHeight,
             getPanelIconSize: () => this.getPanelIconSize(),
-            getPanelMonitor: () => Main.layoutManager.monitors[this.panel.monitorIndex],
+            getPanelMonitor: () => this.panel ? Main.layoutManager.monitors[this.panel.monitorIndex] : null,
             getAppSystem: () => Cinnamon.AppSystem.get_default(),
             getAppFromWMClass: (specialApps, metaWindow) => this.getAppFromWMClass(specialApps, metaWindow),
             getTracker: () => this.tracker,

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
@@ -978,6 +978,9 @@ class AppThumbnailHoverMenu extends PopupMenu.PopupMenu {
     }
 
     onKeyPress(actor, e) {
+        let {orientation} = this.state;
+        let {vertical} = this.box;
+
         let symbol = e.get_key_symbol();
         let i = findIndex(this.appThumbnails, (item) => item.entered === true);
         let entered = i > -1;
@@ -991,19 +994,25 @@ class AppThumbnailHoverMenu extends PopupMenu.PopupMenu {
         }
         let args;
         let closeArg;
-        if (this.state.orientation === St.Side.TOP) {
+        if (orientation === St.Side.TOP) {
             closeArg = Clutter.KEY_Up;
             args = [Clutter.KEY_Left, Clutter.KEY_Right];
-        } else if (this.state.orientation === St.Side.BOTTOM) {
+        } else if (orientation === St.Side.BOTTOM) {
             closeArg = Clutter.KEY_Down;
             args = [Clutter.KEY_Right, Clutter.KEY_Left];
-        } else if (this.state.orientation === St.Side.LEFT) {
+        } else if (orientation === St.Side.LEFT) {
             closeArg = Clutter.KEY_Left;
             args = [Clutter.KEY_Up, Clutter.KEY_Down];
-        } else if (this.state.orientation === St.Side.RIGHT) {
+        } else if (orientation === St.Side.RIGHT) {
             closeArg = Clutter.KEY_Right;
             args = [Clutter.KEY_Down, Clutter.KEY_Up];
         }
+
+        // Panel is oriented horizontally, but the menu is vertical
+        if (vertical && (orientation === St.Side.TOP || orientation === St.Side.BOTTOM)) {
+            args = [Clutter.KEY_Down, Clutter.KEY_Up];
+        }
+
         let index;
         if (symbol === args[0]) {
             if (!entered) {

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
@@ -473,6 +473,7 @@ class HoverMenuController extends PopupMenu.PopupMenuManager {
             thumbnailMenuEntered: ({thumbnailMenuEntered}) => {
                 this.shouldGrab = thumbnailMenuEntered;
                 this._onMenuOpenState(this._menus[0], this._menus[0].isOpen);
+                this.groupState.trigger('checkFocusStyle');
                 if (!this.grabbed) return;
                 if (!thumbnailMenuEntered) this._ungrab();
             }

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
@@ -739,6 +739,7 @@ class WindowThumbnail {
         }
 
         let monitor = this.state.trigger('getPanelMonitor');
+        if (!monitor) return;
 
         if (!this.thumbnailActor || this.thumbnailActor.is_finalized()) return;
 

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
@@ -1,4 +1,3 @@
-const Cinnamon = imports.gi.Cinnamon;
 const Clutter = imports.gi.Clutter;
 const Meta = imports.gi.Meta;
 const St = imports.gi.St;

--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -3336,9 +3336,10 @@ var PopupMenuManager = class PopupMenuManager {
         return this._init.apply(this, arguments);
     }
 
-    _init(owner) {
+    _init(owner, shouldGrab = true) {
         this._owner = owner;
         this.grabbed = false;
+        this.shouldGrab = shouldGrab;
 
         this._eventCaptureId = 0;
         this._enterEventId = 0;
@@ -3387,6 +3388,9 @@ var PopupMenuManager = class PopupMenuManager {
             this._signals.disconnect(null, menu.sourceActor);
 
         this._menus.splice(position, 1);
+
+        // Make sure destroy is called after the last menu is removed/destroyed.
+        if (this._menus.length === 0) this.destroy();
     }
 
     _grab() {
@@ -3428,6 +3432,8 @@ var PopupMenuManager = class PopupMenuManager {
                 this._didPop = true;
             }
         }
+
+        if (!this.shouldGrab) return;
 
         // Check what the focus was before calling pushModal/popModal
         let focus = global.stage.key_focus;


### PR DESCRIPTION
This makes it so hovering over an app button doesn't immediately give the opening thumbnail menu exclusive input focus. Until the user decides to interact with the menu, we should assume they are typing in another window.

When a menu is opened via Super + space toggling, it will always grab input.

In addition, other fixes in this PR includes:

- Button labels randomly showing the window title when the app title is set.
- Button labels not always showing the focused window label when the fourth option is set.
- Focus style on app buttons not showing when the applet first loads.
- Incorrect key navigation on vertical thumbnail menus when the panel is oriented horizontally.