### PR TITLE
windowManager: Add an effects blacklist

### DIFF
--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -521,13 +521,10 @@ WindowManager.prototype = {
     },
 
     _startWindowEffect: function(cinnamonwm, name, actor, args, overwriteKey){
-        // If we have no actor, abort the effect
-        if (!actor) return;
+        if (!actor) return; // If we have no actor, abort the effect
 
         let effect = this.effects[name];
-        let shouldAnimate = this._shouldAnimate(actor, name);
-
-        if (!shouldAnimate) {
+        if (!this._shouldAnimate(actor, name)) {
             cinnamonwm[effect.wmCompleteName](actor);
             return;
         }

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -52,6 +52,8 @@ const ZONE_TR = 5;
 const ZONE_BR = 6;
 const ZONE_BL = 7;
 
+const EFFECTS_BLACKLIST = ['xpad'];
+
 function getTopInvisibleBorder(metaWindow) {
     let outerRect = metaWindow.get_outer_rect();
     let inputRect = metaWindow.get_input_rect();
@@ -495,13 +497,16 @@ WindowManager.prototype = {
         this._animationBlockCount = Math.max(0, this._animationBlockCount - 1);
     },
 
-    _shouldAnimate : function(actor) {
+    _shouldAnimate: function(actor, name) {
         if (Main.modalCount) {
             // system is in modal state
             return false;
         }
         if (Main.software_rendering)
             return false;
+        if (name === 'map' && EFFECTS_BLACKLIST.indexOf(actor.meta_window.wm_class) > -1) {
+            return false;
+        }
         if (!actor)
             return global.settings.get_boolean("desktop-effects");
         let type = actor.meta_window.get_window_type();
@@ -521,7 +526,7 @@ WindowManager.prototype = {
 
     _startWindowEffect: function(cinnamonwm, name, actor, args, overwriteKey){
         let effect = this.effects[name];
-        if(!this._shouldAnimate(actor)){
+        if (!this._shouldAnimate(actor, name)) {
             cinnamonwm[effect.wmCompleteName](actor);
             return;
         }

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -498,13 +498,13 @@ WindowManager.prototype = {
     },
 
     _shouldAnimate: function(actor, name) {
-        if (!actor) return null;
         if (Main.modalCount) return false; // system is in modal state
         if (Main.software_rendering) return false;
 
         if (name === 'map' && EFFECTS_BLACKLIST.indexOf(actor.meta_window.wm_class) > -1) {
             return false;
         }
+
         let type = actor.meta_window.window_type;
         if (type == Meta.WindowType.NORMAL) {
             return global.settings.get_boolean("desktop-effects");
@@ -521,11 +521,11 @@ WindowManager.prototype = {
     },
 
     _startWindowEffect: function(cinnamonwm, name, actor, args, overwriteKey){
+        // If we have no actor, abort the effect
+        if (!actor) return;
+
         let effect = this.effects[name];
         let shouldAnimate = this._shouldAnimate(actor, name);
-
-        // If we have no actor, abort the effect
-        if (shouldAnimate === null) return;
 
         if (!shouldAnimate) {
             cinnamonwm[effect.wmCompleteName](actor);

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -498,18 +498,14 @@ WindowManager.prototype = {
     },
 
     _shouldAnimate: function(actor, name) {
-        if (Main.modalCount) {
-            // system is in modal state
-            return false;
-        }
-        if (Main.software_rendering)
-            return false;
+        if (!actor) return null;
+        if (Main.modalCount) return false; // system is in modal state
+        if (Main.software_rendering) return false;
+
         if (name === 'map' && EFFECTS_BLACKLIST.indexOf(actor.meta_window.wm_class) > -1) {
             return false;
         }
-        if (!actor)
-            return global.settings.get_boolean("desktop-effects");
-        let type = actor.meta_window.get_window_type();
+        let type = actor.meta_window.window_type;
         if (type == Meta.WindowType.NORMAL) {
             return global.settings.get_boolean("desktop-effects");
         }
@@ -526,7 +522,12 @@ WindowManager.prototype = {
 
     _startWindowEffect: function(cinnamonwm, name, actor, args, overwriteKey){
         let effect = this.effects[name];
-        if (!this._shouldAnimate(actor, name)) {
+        let shouldAnimate = this._shouldAnimate(actor, name);
+
+        // If we have no actor, abort the effect
+        if (shouldAnimate === null) return;
+
+        if (!shouldAnimate) {
             cinnamonwm[effect.wmCompleteName](actor);
             return;
         }

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -501,6 +501,10 @@ WindowManager.prototype = {
         if (Main.modalCount) return false; // system is in modal state
         if (Main.software_rendering) return false;
 
+        if (actor === true) { // workspace switch case
+            return global.settings.get_boolean("desktop-effects");
+        }
+
         if (name === 'map' && EFFECTS_BLACKLIST.indexOf(actor.meta_window.wm_class) > -1) {
             return false;
         }
@@ -727,7 +731,7 @@ WindowManager.prototype = {
     },
 
     _switchWorkspace : function(cinnamonwm, from, to, direction) {
-        if (!this._shouldAnimate()) {
+        if (!this._shouldAnimate(true)) {
             this.showWorkspaceOSD();
             cinnamonwm.completed_switch_workspace();
             return;


### PR DESCRIPTION
This overrides the mapping effect for xpad because it [toggles the visibility](https://bazaar.launchpad.net/~xpad-team/xpad/trunk/view/head:/src/xpad-pad.c#L531) of its windows after re-decorating them, which causes artifacts in Muffin.

Ref https://github.com/linuxmint/muffin/issues/388