### PR TITLE
utils: Simplify URL regex to only support one layer of parentheses

### DIFF
--- a/js/misc/util.js
+++ b/js/misc/util.js
@@ -16,7 +16,7 @@ const Mainloop = imports.mainloop;
 const Main = imports.ui.main;
 
 // http://daringfireball.net/2010/07/improved_regex_for_matching_urls
-const _balancedParens = '\\((?:[^\\s()<>]+|(?:\\(?:[^\\s()<>]+\\)))*\\)';
+const _balancedParens = '\\([^\\s()<>]+\\)';
 const _leadingJunk = '[\\s`(\\[{\'\\"<\u00AB\u201C\u2018]';
 const _notTrailingJunk = '[^\\s`!()\\[\\]{};:\'\\".,<>?\u00AB\u00BB\u201C\u201D\u2018\u2019]';
 

--- a/tests/unit/url.js
+++ b/tests/unit/url.js
@@ -38,6 +38,10 @@ const tests = [
       output: [ { url: 'http://www.gnome.org:99/port', pos: 10 } ] },
     { input: 'This is an ftp://www.gnome.org/ test.',
       output: [ { url: 'ftp://www.gnome.org/', pos: 11 } ] },
+    { input: 'https://www.gnome.org/(some_url,_with_very_unusual_characters)',
+      output: [ { url: 'https://www.gnome.org/(some_url,_with_very_unusual_characters)', pos: 0 } ] },
+    { input: 'https://www.gnome.org/(some_url_with_unbalanced_parenthesis',
+      output: [ { url: 'https://www.gnome.org/', pos: 0 } ] },
 
     { input: 'Visit http://www.gnome.org/ and http://developer.gnome.org',
       output: [ { url: 'http://www.gnome.org/', pos: 6 },


### PR DESCRIPTION
Cherry-picked from https://github.com/gnome/gnome-shell/commit/5cc42b18b0e6ced675af446d0d38fd3a354a25f9

Closes #8078 