### PR TITLE
perf: Add a simple benchmark utility for prototype methods

### DIFF
--- a/js/perf/core.js
+++ b/js/perf/core.js
@@ -1,5 +1,6 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
+const {get_monotonic_time} = imports.gi.GLib;
 const Main = imports.ui.main;
 const Scripting = imports.ui.scripting;
 
@@ -234,16 +235,17 @@ function benchmarkPrototype(object, threshold = 3) {
         }
         object.prototype[key] = new Proxy(fn, {
             apply(target, thisA, args) {
-                let now = Date.now();
+                let now = get_monotonic_time();
                 let val = target.apply(thisA, args);
-                let time = Date.now() - now;
+                let time = get_monotonic_time() - now;
                 if (time >= threshold) {
                     times.push(time);
                     let total = 0;
                     for (let z = 0; z < times.length; z++) total += times[z];
 
-                    let max = Math.max(...times);
-                    let avg = (total / times.length).toFixed(2);
+                    let max = (Math.max(...times) / 1000).toFixed(2);
+                    let avg = ((total / times.length) / 1000).toFixed(2);
+                    time = (time / 1000).toFixed(2);
 
                     let output = `${thisA.constructor.name}.${key}: ${time}ms `
                         + `(MAX: ${max}ms AVG: ${avg}ms)`;

--- a/js/perf/core.js
+++ b/js/perf/core.js
@@ -225,6 +225,7 @@ function clutter_stagePaintDone(time) {
  */
 function benchmarkPrototype(object, threshold = 3) {
     let keys = Object.getOwnPropertyNames(object.prototype);
+    let times = [];
     for (let i = 0; i < keys.length; i++) {
         let key = keys[i];
         let fn = object.prototype[key];
@@ -236,7 +237,18 @@ function benchmarkPrototype(object, threshold = 3) {
                 let now = Date.now();
                 let val = target.apply(thisA, args);
                 let time = Date.now() - now;
-                if (time >= threshold) global.log(`${key} took ${time}ms`);
+                if (time >= threshold) {
+                    times.push(time);
+                    let total = 0;
+                    for (let z = 0; z < times.length; z++) total += times[z];
+
+                    let max = Math.max(...times);
+                    let avg = (total / times.length).toFixed(2);
+
+                    let output = `${thisA.constructor.name}.${key}: ${time}ms `
+                        + `(MAX: ${max}ms AVG: ${avg}ms)`;
+                    global.log(output)
+                }
                 return val;
             }
         });


### PR DESCRIPTION
This uses a proxy to intercept and time function invocations within a given object.

Example usage in GWL:

```js
imports.perf.core.benchmarkPrototype(AppGroup, 4);
```

Output:

```
Cjs-Message: 09:28:03.887: JS LOG: [LookingGlass/info] AppGroup.onFocusChange: 6ms (MAX: 26ms AVG: 5.63ms)
Cjs-Message: 09:28:03.887: JS LOG: [LookingGlass/info] AppGroup.onFocusWindowChange: 6ms (MAX: 26ms AVG: 5.63ms)
Cjs-Message: 09:28:03.890: JS LOG: [LookingGlass/info] AppGroup.onFocusChange: 4ms (MAX: 26ms AVG: 5.62ms)
Cjs-Message: 09:28:03.891: JS LOG: [LookingGlass/info] AppGroup.onFocusWindowChange: 4ms (MAX: 26ms AVG: 5.61ms)
Cjs-Message: 09:28:08.119: JS LOG: [LookingGlass/info] AppGroup.windowAdded: 30ms (MAX: 30ms AVG: 5.77ms)
Cjs-Message: 09:28:11.324: JS LOG: [LookingGlass/info] AppGroup.onFocusChange: 4ms (MAX: 30ms AVG: 5.75ms)
```