### PR TITLE
gwl: Fix icon alignment in left oriented panels

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -398,7 +398,11 @@ class AppGroup {
             }
             childBox.x2 = Math.min(childBox.x1 + naturalWidth, box.x2);
         } else {
-            [childBox.x1, childBox.x2] = center(allocWidth, naturalWidth);
+            let offset = 0;
+            if (this.state.orientation === St.Side.LEFT) {
+                offset += this.actor.style_length('border-left-width') * 2;
+            }
+            [childBox.x1, childBox.x2] = center(allocWidth + offset, naturalWidth);
         }
 
         this.iconBox.allocate(childBox, flags);


### PR DESCRIPTION
Tested this with a variety of panel/icon sizes, third party themes, and high DPI - should work consistently.

Before:
![before](https://user-images.githubusercontent.com/6859057/49239383-47e50400-f3c8-11e8-82f5-0be2d91ebf11.png)

After:
![after](https://user-images.githubusercontent.com/6859057/49239390-4c112180-f3c8-11e8-88a1-c155441194a7.png)