### PR TITLE
gwl: Translate preferences context menu item

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
@@ -157,7 +157,7 @@ class AppMenuButtonRightClickMenu extends Applet.AppletPopupMenu {
         this.signals.connect(item, 'activate', () => this.state.trigger('configureApplet'));
         subMenu.menu.addMenuItem(item);
 
-        item = createMenuItem({label: _(`Remove '%s'`).format(_('Grouped window list')), icon: 'edit-delete'});
+        item = createMenuItem({label: _("Remove '%s'").format(_("Grouped window list")), icon: 'edit-delete'});
         this.signals.connect(item, 'activate', () => {
             AppletManager._removeAppletFromPanel(this.state.uuid, this.state.instance_id);
         });

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
@@ -157,7 +157,7 @@ class AppMenuButtonRightClickMenu extends Applet.AppletPopupMenu {
         this.signals.connect(item, 'activate', () => this.state.trigger('configureApplet'));
         subMenu.menu.addMenuItem(item);
 
-        item = createMenuItem({label: _('Remove') + " 'Grouped window list'", icon: 'edit-delete'});
+        item = createMenuItem({label: _(`Remove '%s'`).format(_('Grouped window list')), icon: 'edit-delete'});
         this.signals.connect(item, 'activate', () => {
             AppletManager._removeAppletFromPanel(this.state.uuid, this.state.instance_id);
         });


### PR DESCRIPTION
This should work without any additional translations because `Remove '%s'` is translated in the panel launchers applet.

C/O @itzexor 