### PR TITLE
gwl: Fix panel buttons allocation

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -1328,7 +1328,6 @@ StScrollBar StButton#vhandle:hover {
     background-color: #000000;
 }
 .grouped-window-list-button-label {
-    padding-left: 4px;
 }
 .grouped-window-list-thumbnail-alert {
     background: rgba(255,52,52,0.3);

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -252,7 +252,16 @@ class AppGroup {
 
         this.setIcon();
         this.updateIconBoxClip();
+        this.setIconPadding();
         this.setMargin();
+    }
+
+    setIconPadding() {
+        if (this.state.isHorizontal) {
+            this.actor.style = 'padding-right: 0px; padding-left: 0px;';
+        } else {
+            this.actor.style = 'padding-bottom: 0px; padding-bottom: 0px;';
+        }
     }
 
     setMargin() {
@@ -350,9 +359,10 @@ class AppGroup {
     getPreferredWidth(actor, forHeight, alloc) {
         let [iconWidth] = this.iconBox.get_preferred_width(forHeight);
 
-        alloc.min_size = iconWidth;
+        // alloc.min_size = iconWidth; // future: use same allocation as the rest of the applets
+        alloc.min_size = this.state.trigger('getPanelHeight');
         if (this.isButtonIconOnly()) {
-            alloc.natural_size = iconWidth;
+            alloc.natural_size = alloc.min_size;
         } else {
             let [labelWidth] = this.label.get_preferred_width(forHeight);
             alloc.natural_size = Math.min(MAX_BUTTON_WIDTH, iconWidth + this.spacing + labelWidth);
@@ -382,6 +392,11 @@ class AppGroup {
         childBox.y2 = childBox.y1 + Math.min(naturalHeight, allocHeight);
 
         if (this.labelVisible && this.groupState.metaWindows.length > 0) {
+             /* Same padding top/bottom and right/left since we nullify padding
+                (only for buttons with labels) */
+            box.x1 = Math.max(box.x1, yPadding);
+            box.x2 = Math.min(box.x2, this.actor.width - yPadding);
+
             if (direction === Clutter.TextDirection.LTR) {
                 childBox.x1 = box.x1;
             } else {

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -151,9 +151,9 @@ class AppGroup {
             style_class: 'grouped-window-list-button-label',
             important: true,
             text: '',
-            show_on_set_parent: this.state.settings.titleDisplay > 1
+            show_on_set_parent: this.state.settings.titleDisplay > 1,
+            x_align: Clutter.ActorAlign.FILL
         });
-        this.label.x_align = St.Align.START;
         this.actor.add_child(this.label);
 
         this.groupState.set({tooltip: new Tooltips.PanelItemTooltip({actor: this.actor}, '', this.state.orientation)});
@@ -245,7 +245,8 @@ class AppGroup {
 
         let panelHeight = this.state.trigger('getPanelHeight');
         if (this.state.isHorizontal) {
-            this.actor.set_size(-1, panelHeight);
+            let width = this.isButtonIconOnly() ? -1 : MAX_BUTTON_WIDTH;
+            this.actor.set_size(width, panelHeight);
         } else {
             this.actor.set_size(panelHeight, -1);
         }
@@ -459,6 +460,7 @@ class AppGroup {
 
     showLabel(animate = false) {
         if (!this.label
+            || this.labelVisible
             || !this.state.isHorizontal
             || this.label.is_finalized()
             || !this.label.realized) {
@@ -473,11 +475,11 @@ class AppGroup {
 
         if (!animate) {
             this.label.show();
-            this.label.width = width;
+            this.actor.set_width(width);
             return;
         }
 
-        Tweener.addTween(this.label, {
+        Tweener.addTween(this.actor, {
             width,
             time: BUTTON_BOX_ANIMATION_TIME,
             transition: 'easeOutQuad',
@@ -491,9 +493,8 @@ class AppGroup {
 
     hideLabel() {
         if (!this.label || this.label.is_finalized() || !this.label.realized) return;
-
         this.labelVisible = false;
-        this.label.width = 1;
+        this.actor.set_width(-1);
         this.label.hide();
     }
 


### PR DESCRIPTION
 * Don't use buttons margin to also separate the label from the icon
 * Don't reuse the badge allocation box, otherwise the label starts in the middle of the icon (this was fixed with an aproximation leading to huge spacings).
 * Use the CSS spacing property to separate the icon from the label, like the normal window list does.
 * Properly center icons in vertical panels.