### PR TITLE
AppletManager: perform _removeAppletFromPanel on idle

### DIFF
--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -4,6 +4,7 @@ const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
 const St = imports.gi.St;
 
+const Mainloop = imports.mainloop;
 const Main = imports.ui.main;
 const Applet = imports.ui.applet;
 const Extension = imports.ui.extension;
@@ -597,11 +598,12 @@ function createApplet(extension, appletDefinition, panel = null) {
 }
 
 function _removeAppletFromPanel(uuid, applet_id) {
-    let definition = queryCollection(definitions, {uuid, applet_id});
-    if (!definition) {
+    Mainloop.idle_add(() => {
+        let definition = queryCollection(definitions, {uuid, applet_id});
+        if (definition)
+            removeApplet(definition);
         return false;
-    }
-    removeApplet(definition);
+    });
 }
 
 function saveAppletsPositions() {


### PR DESCRIPTION
This is called by applets, from a menu item typically. This makes
sure the menu has enough time to animate properly instead of the
applet being removed while it's still in the menu item handler.

Fixes incorrect menu animation on remove applet from panel since
2cfff16c8c93b7063e21aa40e83ff3b9eaac14de