### PR TITLE
gwl: Open new windows by holding ctrl and left clicking

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -149,8 +149,6 @@ class AppGroup {
         this.signals.connect(this.actor, 'get-preferred-width', (...args) => this.getPreferredWidth(...args));
         this.signals.connect(this.actor, 'get-preferred-height', (...args) => this.getPreferredHeight(...args));
         this.signals.connect(this.actor, 'allocate', (...args) => this.allocate(...args));
-        this.signals.connect(this.actor, 'enter-event', (...args) => this.onEnter(...args));
-        this.signals.connect(this.actor, 'leave-event', (...args) => this.onLeave(...args));
         this.signals.connect(this.actor, 'button-release-event', (...args) => this.onAppButtonRelease(...args));
         this.signals.connect(this.actor, 'button-press-event', (...args) => this.onAppButtonPress(...args));
         this.signals.connect(this._draggable, 'drag-begin', (...args) => this.onDragBegin(...args));

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -654,7 +654,8 @@ class AppGroup {
         let nWindows = this.groupState.metaWindows.length;
 
         let shouldStartInstance = (
-            (button === 1
+            (button === 1 && this.state.ctrlKey)
+            || (button === 1
                 && this.groupState.isFavoriteApp
                 && nWindows === 0
                 && (this.state.settings.leftClickAction === 2 || nWindows < 1))

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -325,8 +325,8 @@ class GroupedWindowListApplet extends Applet.Applet {
         this.getAutoStartApps();
         this.onSwitchWorkspace = throttle(this.onSwitchWorkspace, 100, true);
         this.signals.connect(this.actor, 'scroll-event', (c, e) => this.handleScroll(e));
-        this.signals.connect(this.actor, 'enter-event', () => this.handleKeyGrab());
-        this.signals.connect(this.actor, 'leave-event', () => this.handleKeyUngrab());
+        this.signals.connect(this.actor, 'enter-event', () => setTimeout(() => this.handleKeyGrab(), 0));
+        this.signals.connect(this.actor, 'leave-event', () => setTimeout(() => this.handleKeyUngrab(), 0));
         this.signals.connect(global, 'scale-changed', (...args) => this.onUIScaleChange(...args));
         this.signals.connect(global.window_manager, 'switch-workspace', (...args) => this.onSwitchWorkspace(...args));
         this.signals.connect(global.screen, 'workspace-removed', (...args) => this.onWorkspaceRemoved(...args));

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -812,13 +812,6 @@ class GroupedWindowListApplet extends Applet.Applet {
     }
 
     handleKeyUngrab(actor, event) {
-        let sourceActor = event.get_source();
-        if (sourceActor instanceof Cinnamon.GenericContainer) {
-            let currentAppList = this.getCurrentAppList();
-            let appGroup = find(currentAppList.appList, (appGroup) => appGroup.actor === sourceActor);
-            appGroup.onLeave(actor, event);
-        }
-
         if (this.grabbed) {
             if (actor === null) { // null: passThrough, false: key event
                 setTimeout(() => this.grabbed = false, 1000);
@@ -829,6 +822,13 @@ class GroupedWindowListApplet extends Applet.Applet {
             this.signals.disconnect('key-press-event', this.actor);
             this.signals.disconnect('key-release-event', this.actor);
             Main.popModal(this.actor);
+        }
+
+        let sourceActor = event.get_source();
+        if (sourceActor instanceof Cinnamon.GenericContainer) {
+            let currentAppList = this.getCurrentAppList();
+            let appGroup = find(currentAppList.appList, (appGroup) => appGroup.actor === sourceActor);
+            appGroup.onLeave(actor, event);
         }
 
         return true;


### PR DESCRIPTION
The top level applet actor will grab input on hover, and ungrab if the CTRL modifier isn't held. This way it won't conflict with the intent of #8057.