### PR TITLE
gwl: Only use notify::icon signal for un-grouped apps

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -800,7 +800,10 @@ class AppGroup {
             this.signals.connect(metaWindow, 'notify::appears-focused', (...args) => this.onFocusWindowChange(...args));
             this.signals.connect(metaWindow, 'notify::gtk-application-id', (w) => this.onAppChange(w));
             this.signals.connect(metaWindow, 'notify::wm-class', (w) => this.onAppChange(w));
-            this.signals.connect(metaWindow, 'notify::icon', (w) => this.setIcon(w));
+
+            if (!this.state.settings.groupApps) {
+                this.signals.connect(metaWindow, 'notify::icon', (w) => this.setIcon(w));
+            }
 
             if (metaWindow.progress !== undefined) {
                 this._progress = metaWindow.progress;


### PR DESCRIPTION
This can be confusing since the icon may not reflect the currently focused window.