### PR TITLE
gwl: Always persist pinned apps' positioning after drag, fix duplicate thumbnails on init in vertical menu orientation

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -66,7 +66,9 @@ class AppGroup {
             autoStartIndex: findIndex(this.state.autoStartApps, (app) => app.id === params.appId),
             willUnmount: false,
             tooltip: null,
-            verticalThumbs: this.state.settings.verticalThumbs,
+            // Not to be confused with the vertical thumbnail setting, this is for overriding horizontal
+            // orientation when there are too many thumbnails to fit the monitor without making them tiny.
+            verticalThumbs: false,
             groupReady: false,
             thumbnailMenuEntered:  false
         });

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -345,7 +345,6 @@ class GroupedWindowListApplet extends Applet.Applet {
             {key: 'show-alerts', value: 'showAlerts', cb: this.updateAttentionState},
             {key: 'group-apps', value: 'groupApps', cb: this.refreshCurrentAppList},
             {key: 'enable-app-button-dragging', value: 'enableDragging', cb: null},
-            {key: 'pinOnDrag', value: 'pinOnDrag', cb: null},
             {key: 'launcher-animation-effect', value: 'launcherAnimationEffect', cb: null},
             {key: 'pinned-apps', value: 'pinnedApps', cb: null},
             {key: 'middle-click-action', value: 'middleClickAction', cb: null},
@@ -899,8 +898,7 @@ class GroupedWindowListApplet extends Applet.Applet {
 
 
             // Handle favoriting if pin on drag is enabled
-            if (this.state.settings.pinOnDrag
-                && !source.groupState.app.is_window_backed()) {
+            if (!source.groupState.app.is_window_backed()) {
                 let opts = {
                     appId: source.groupState.appId,
                     app: source.groupState.app,
@@ -909,8 +907,6 @@ class GroupedWindowListApplet extends Applet.Applet {
                 let refFav = findIndex(this.pinnedFavorites._favorites, (favorite) => favorite.id === source.groupState.appId);
                 if (refFav > -1) {
                     this.pinnedFavorites.moveFavoriteToPos(opts);
-                } else if (this.state.settings.pinOnDrag) {
-                    this.pinnedFavorites.addFavorite(opts);
                 }
             }
 

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -889,6 +889,7 @@ class GroupedWindowListApplet extends Applet.Applet {
         Meta.later_add(Meta.LaterType.BEFORE_REDRAW, () => {
             // Move the button
             currentAppList.actor.set_child_at_index(source.actor, pos);
+            currentAppList.updateAppGroupIndexes();
             // Refresh the group's thumbnails so hoverMenu is aware of the position change
             // In the case of dragging a group that has a delay before Cinnamon can grab its
             // thumbnail texture, e.g., LibreOffice, defer the refresh.

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/settings-schema.json
@@ -46,8 +46,7 @@
         "pinned-apps",
         "show-alerts",
         "show-pinned",
-        "enable-app-button-dragging",
-        "pinOnDrag"
+        "enable-app-button-dragging"
       ]
     },
     "hotKeysSection": {
@@ -174,11 +173,6 @@
     "type": "checkbox",
     "default": true,
     "description": "Enable app button dragging"
-  },
-  "pinOnDrag": {
-    "type": "checkbox",
-    "default": false,
-    "description": "Pin apps when dragged to a new position"
   },
   "launcher-animation-effect": {
     "type": "combobox",


### PR DESCRIPTION
Un-pinned apps can still be re-arranged, but they need to be explicitly pinned from the context menu for their positions to persist.

Also fixes duplicate thumbnails appearing on init in the vertical menu orientation.

Closes https://github.com/linuxmint/mint-19.1-beta/issues/9