### PR TITLE
gwl: Add support for dragging files to windows from the thumbnail menu

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -68,7 +68,8 @@ class AppGroup {
             tooltip: null,
             verticalThumbs: this.state.settings.verticalThumbs,
             groupReady: false,
-            thumbnailMenuEntered:  false
+            thumbnailMenuEntered: false,
+            fileDrag: false
         });
 
         this.groupState.connect({
@@ -621,8 +622,19 @@ class AppGroup {
             || this.state.panelEditMode) {
             return DND.DragMotionResult.CONTINUE;
         }
-        if (this.groupState.metaWindows.length > 0 && this.groupState.lastFocused) {
-            Main.activateWindow(this.groupState.lastFocused, global.get_current_time());
+        let nWindows = this.groupState.metaWindows.length;
+        if (nWindows > 0 && this.groupState.lastFocused) {
+            if (nWindows === 1) {
+                Main.activateWindow(this.groupState.lastFocused, global.get_current_time());
+            } else {
+                if (this.groupState.fileDrag) {
+                    this.listState.trigger('closeAllHoverMenus');
+                }
+                // Open the thumbnail window and activate the window corresponding to the dragged over thumbnail.
+                if (!this.hoverMenu) this.initThumbnailMenu();
+                this.groupState.set({fileDrag: true});
+                this.hoverMenu.open(true);
+            }
         }
         return true;
     }

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -630,7 +630,7 @@ class AppGroup {
                 if (this.groupState.fileDrag) {
                     this.listState.trigger('closeAllHoverMenus');
                 }
-                // Open the thumbnail window and activate the window corresponding to the dragged over thumbnail.
+                // Open the thumbnail menu and activate the window corresponding to the dragged over thumbnail.
                 if (!this.hoverMenu) this.initThumbnailMenu();
                 this.groupState.set({fileDrag: true});
                 this.hoverMenu.open(true);

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
@@ -895,6 +895,11 @@ class AppThumbnailHoverMenu extends PopupMenu.PopupMenu {
                     this.interval = setInterval(() => {
                         let [x, y, mask] = global.get_pointer();
                         let draggedOverActor = global.stage.get_actor_at_pos(Clutter.PickMode.ALL, x, y);
+                        if (draggedOverActor instanceof Meta.ShapedTexture) {
+                            this.groupState.set({fileDrag: false});
+                            this.close(true);
+                            return;
+                        }
                         each(this.appThumbnails, function(thumbnail) {
                             if (thumbnail.thumbnailActor === draggedOverActor) {
                                 Main.activateWindow(thumbnail.metaWindow, global.get_current_time());

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
@@ -887,6 +887,25 @@ class AppThumbnailHoverMenu extends PopupMenu.PopupMenu {
                 this.setVerticalSetting();
                 if (isOpen) this.open(true);
             },
+            fileDrag: ({fileDrag}) => {
+                if (fileDrag) {
+                    // When a drag operation from another app is started, no events fire, so we have to grab the
+                    // cursor, find the actor by coordinates, and then look up the thumbnail actor. Do this on a
+                    // 50ms loop until the menu closes so we continue getting data in the absence of events.
+                    this.interval = setInterval(() => {
+                        let [x, y, mask] = global.get_pointer();
+                        let draggedOverActor = global.stage.get_actor_at_pos(Clutter.PickMode.ALL, x, y);
+                        each(this.appThumbnails, function(thumbnail) {
+                            if (thumbnail.thumbnailActor === draggedOverActor) {
+                                Main.activateWindow(thumbnail.metaWindow, global.get_current_time());
+                                return false;
+                            }
+                        });
+                    }, 50);
+                } else if (this.interval) {
+                    clearInterval(this.interval);
+                }
+            }
         });
 
         this.appThumbnails = [];
@@ -987,6 +1006,10 @@ class AppThumbnailHoverMenu extends PopupMenu.PopupMenu {
         }
         for (let i = 0; i < this.appThumbnails.length; i++) {
             this.appThumbnails[i].destroyOverlayPreview();
+        }
+
+        if (this.groupState.fileDrag) {
+            this.groupState.set({fileDrag: false});
         }
     }
 


### PR DESCRIPTION
This provides a way to drag files to windows when there are multiple windows in an app group. Clutter does not propagate events when files are dragged, but through polling and stage calls, we can get enough info to figure out which thumbnail actor is hovered over.

Closes https://github.com/linuxmint/mint-19.1-beta/issues/23