### PR TITLE
gwl: Fix a couple ungrouped mode bugs, fix thumbnail menu positioning on window add/remove

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -812,10 +812,13 @@ class AppGroup {
             }
 
             // Set the initial button label as not all windows will get updated via signals initially.
-            if (this.state.settings.titleDisplay > 1) this.onWindowTitleChanged(metaWindow);
+            if (this.state.settings.titleDisplay > 1) {
+                this.onWindowTitleChanged(metaWindow);
+                this.state.trigger('updateThumbnailsStyle');
+            }
             if (refWindow === -1) {
                 metaWindows.push(metaWindow);
-                if (this.hoverMenu) trigger('addThumbnailToMenu', metaWindow)
+                if (this.hoverMenu) trigger('addThumbnailToMenu', metaWindow);
             }
             this.calcWindowNumber();
             this.onFocusChange();

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -796,9 +796,8 @@ class AppGroup {
         }
     }
 
-    windowAdded(metaWindow, _metaWindows) {
+    windowAdded(metaWindow) {
         let {metaWindows, trigger, set} = this.groupState;
-        if (_metaWindows) metaWindows = _metaWindows;
         let refWindow = metaWindows.indexOf(metaWindow);
         if (metaWindow) {
             this.signals.connect(metaWindow, 'notify::title', (...args) => this.onWindowTitleChanged(...args));

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -857,7 +857,6 @@ class AppGroup {
                     this.groupState.trigger('removeThumbnailFromMenu', metaWindow);
                 }
                 cb(this.groupState.appId, this.groupState.isFavoriteApp);
-                if (this.groupState.isFavoriteApp) this.setActiveStatus(false);
             }
         }
     }

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appList.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appList.js
@@ -324,9 +324,9 @@ class AppList {
             }
         } else if (metaWindow && this.shouldWindowBeAdded(metaWindow)) {
             if (this.state.settings.groupApps) {
-                this.appList[refApp].windowAdded(metaWindow, null);
+                this.appList[refApp].windowAdded(metaWindow);
             } else if (transientFavorite && this.appList[refApp].groupState.metaWindows.length === 0) {
-                this.appList[refApp].windowAdded(metaWindow, [metaWindow]);
+                this.appList[refApp].windowAdded(metaWindow);
             } else if (refWindow === -1) {
                 initApp([metaWindow], metaWindow);
             }

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appList.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appList.js
@@ -66,6 +66,15 @@ class AppList {
         this.refreshList();
     }
 
+    getWindowCount(appId) {
+        let windowCount = 0;
+        each(this.appList, function(appGroup) {
+            if (appGroup.groupState.appId !== appId) return;
+            windowCount += appGroup.groupState.metaWindows.length;
+        });
+        return windowCount;
+    }
+
     closeAllHoverMenus(cb) {
         for (let i = 0, len = this.appList.length; i < len; i++) {
             let {hoverMenu, groupState} = this.appList[i];
@@ -361,19 +370,11 @@ class AppList {
             return;
         }
 
-        let wmClass = metaWindow.get_wm_class(),
-            refApp = -1,
-            refWindow = -1,
-            windowCount = 0;
-
+        let refApp = -1, refWindow = -1;
         each(this.appList, (appGroup, i) => {
             let shouldReturn = false;
             each(appGroup.groupState.metaWindows, (win, z) => {
-                if (win.get_wm_class() === wmClass) {
-                    ++windowCount;
-                }
                 if (win === metaWindow) {
-                    ++windowCount;
                     refApp = i;
                     refWindow = z;
                     shouldReturn = this.state.settings.groupApps;
@@ -386,13 +387,15 @@ class AppList {
         });
         if (refApp > -1) {
             this.appList[refApp].windowRemoved(metaWorkspace, metaWindow, refWindow, (appId, isFavoriteApp) => {
-                if (isFavoriteApp || (isFavoriteApp && !this.state.settings.groupApps && windowCount === 0)) {
+                isFavoriteApp = isFavoriteApp && (this.state.settings.groupApps || this.getWindowCount(appId) === 0);
+                if (isFavoriteApp) {
                     this.appList[refApp].groupState.set({groupReady: false});
                     this.appList[refApp].actor.set_style_pseudo_class('closed');
                     this.appList[refApp].actor.remove_style_class_name('grouped-window-list-item-demands-attention');
                     if (this.state.settings.titleDisplay > 1) {
                         this.appList[refApp].hideLabel(true);
                     }
+                    this.appList[refApp].setActiveStatus(false);
                     return;
                 }
                 this.appList[refApp].destroy(true);

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appList.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appList.js
@@ -387,6 +387,10 @@ class AppList {
         });
         if (refApp > -1) {
             this.appList[refApp].windowRemoved(metaWorkspace, metaWindow, refWindow, (appId, isFavoriteApp) => {
+                if (this.state.settings.titleDisplay > 1) {
+                    this.state.trigger('updateThumbnailsStyle');
+                }
+
                 isFavoriteApp = isFavoriteApp && (this.state.settings.groupApps || this.getWindowCount(appId) === 0);
                 if (isFavoriteApp) {
                     this.appList[refApp].groupState.set({groupReady: false});

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -301,7 +301,8 @@ class GroupedWindowListApplet extends Applet.Applet {
             getFavorites: () => this.pinnedFavorites._favorites,
             cycleWindows: (e, source) => this.handleScroll(e, source),
             openAbout: () => this.openAbout(),
-            configureApplet: () => this.configureApplet()
+            configureApplet: () => this.configureApplet(),
+            updateThumbnailsStyle: () => null // Silence missing key warnings
         });
 
         this.settings = new AppletSettings(this.state.settings, metadata.uuid, instance_id);

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
@@ -858,6 +858,13 @@ class AppThumbnailHoverMenu extends PopupMenu.PopupMenu {
         this.state = state;
         this.groupState = groupState;
 
+        this.stateConnectId = this.state.connect({
+            updateThumbnailsStyle: () => {
+                if (this.groupState.metaWindows.length === 0) return;
+                this.setStyleOptions();
+            }
+        });
+
         this.connectId = this.groupState.connect({
             hoverMenuClose: () => {
                 this.shouldClose = true;
@@ -1196,6 +1203,7 @@ class AppThumbnailHoverMenu extends PopupMenu.PopupMenu {
         }
         this.removeAll();
         super.destroy();
+        this.state.disconnect(this.stateConnectId);
         this.groupState.disconnect(this.connectId);
         unref(this, RESERVE_KEYS);
     }


### PR DESCRIPTION
- Fixes the thumbnail not showing for the first app group instance.
- Fixes multiple buttons of the same pinned app persisting in the panel after their window is closed, when Cinnamon is restarted and multiple windows from the same app are open.
- Fixes incorrect thumbnail menu positioning when windows are added or removed while button labels are enabled.

Closes #8119 
Closes https://github.com/linuxmint/mint-19.1-beta/issues/44