### PR TITLE
gwl: Fix the thumbnail menu not closing when using Super + # keys

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -755,6 +755,10 @@ class AppGroup {
         if (this.groupState.isFavoriteApp && this.groupState.metaWindows.length === 0) {
             this.launchNewInstance();
         } else {
+            if (this.appKeyTimeout) {
+                clearTimeout(this.appKeyTimeout);
+                this.appKeyTimeout = 0;
+            }
             if (this.groupState.metaWindows.length > 1) {
                 if (!this.hoverMenu) this.initThumbnailMenu();
                 this.hoverMenu.open(true);
@@ -762,6 +766,15 @@ class AppGroup {
                 this.listState.trigger('closeAllHoverMenus');
             }
             this.windowHandle();
+            this.appKeyTimeout = setTimeout(() => {
+                if (this.groupState.thumbnailMenuEntered) {
+                    clearTimeout(this.appKeyTimeout);
+                    this.appKeyTimeout = 0;
+                    return;
+                }
+                this.hoverMenu.close(true);
+                this.appKeyTimeout = 0;
+            }, this.state.settings.showAppsOrderTimeout);
         }
     }
 

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
@@ -894,6 +894,12 @@ class AppThumbnailHoverMenu extends PopupMenu.PopupMenu {
         this.fullyRefreshThumbnails();
     }
 
+    addQueuedThumbnails() {
+        if (this.queuedWindows.length === 0) return;
+        each(this.queuedWindows, (win) => this.addThumbnail(win));
+        this.queuedWindows = [];
+    }
+
     onButtonPress() {
         if (this.state.settings.onClickThumbs && this.box.get_children().length > 1) {
             return;
@@ -918,10 +924,7 @@ class AppThumbnailHoverMenu extends PopupMenu.PopupMenu {
             timeout = this.state.settings.thumbTimeout;
         }
 
-        if (this.queuedWindows.length > 0) {
-            each(this.queuedWindows, (win) => this.addThumbnail(win));
-            this.queuedWindows = [];
-        }
+        this.addQueuedThumbnails();
 
         if (actor != null) {
             this.groupState.set({thumbnailMenuEntered: this.isOpen});
@@ -964,6 +967,7 @@ class AppThumbnailHoverMenu extends PopupMenu.PopupMenu {
             this.groupState.tooltip.set_text(this.groupState.appName);
             this.groupState.tooltip.show();
         } else {
+            if (force) this.addQueuedThumbnails();
             this.state.set({thumbnailMenuOpen: true});
             super.open(this.state.settings.animateThumbs);
         }


### PR DESCRIPTION
This will use a timeout using the show apps timeout setting, and will be interrupted if the cursor enters the thumbnail menu.

It also fixes an issue with queued thumbnails not being processed if the thumbnail menu opens from any other method than a mouse event.

Closes https://github.com/linuxmint/mint-19.1-beta/issues/32