### PR TITLE
window-list: Fix icons not appearing for some apps

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -724,6 +724,11 @@ class AppMenuButton {
         let tracker = Cinnamon.WindowTracker.get_default();
         let app = tracker.get_window_app(this.metaWindow);
 
+        if (!app) {
+            setTimeout(() => this.setIcon(), 0);
+            return;
+        }
+
         this.icon_size = this._applet.icon_size;
 
         let icon = app ?
@@ -993,7 +998,7 @@ class CinnamonWindowListApplet extends Applet.Applet {
         this.settings.bind("window-preview-show-label", "showLabel", this._onPreviewChanged);
         this.settings.bind("window-preview-scale", "previewScale", this._onPreviewChanged);
 
-        this.signals.connect(global.screen, 'window-added', this._onWindowAddedAsync, this);
+        this.signals.connect(global.screen, 'window-added', this._onWindowAdded, this);
         this.signals.connect(global.screen, 'window-monitor-changed', this._onWindowMonitorChanged, this);
         this.signals.connect(global.screen, 'window-workspace-changed', this._onWindowWorkspaceChanged, this);
         this.signals.connect(global.screen, 'window-skip-taskbar-changed', this._onWindowSkipTaskbarChanged, this);
@@ -1088,10 +1093,6 @@ class CinnamonWindowListApplet extends Applet.Applet {
         let themeNode = this.actor.get_theme_node();
         let spacing = themeNode.get_length('spacing');
         this.manager.set_spacing(spacing * global.ui_scale);
-    }
-
-    _onWindowAddedAsync(screen, metaWindow, monitor) {
-        Mainloop.timeout_add(20, Lang.bind(this, this._onWindowAdded, screen, metaWindow, monitor));
     }
 
     _onWindowAdded(screen, metaWindow, monitor) {


### PR DESCRIPTION
Caused by https://github.com/linuxmint/muffin/pull/391 - this is the only xlet using MetaScreen's window-added signal that's affected.

Closes https://github.com/linuxmint/muffin/issues/393