### PR TITLE
Refactor spawnCommandLineAsync for stdout/stderr output

### DIFF
--- a/js/misc/util.js
+++ b/js/misc/util.js
@@ -177,14 +177,14 @@ function spawnCommandLineAsync(command, callback, opts = {}) {
     let cancellable = new Gio.Cancellable();
 
     subprocess.communicate_utf8_async(input, cancellable, (obj, res) => {
-        let exitCode, stdout, stderr;
+        let success, stdout, stderr, exitCode;
         // This will throw on cancel with "Gio.IOErrorEnum: Operation was cancelled"
-        tryFn(() => [, stdout, stderr] = obj.communicate_utf8_finish(res));
+        tryFn(() => [success, stdout, stderr] = obj.communicate_utf8_finish(res));
         if (typeof callback === 'function' && !cancellable.is_cancelled()) {
             if (stderr && stderr.indexOf('bash: ') > -1) {
                 stderr = stderr.replace(/bash: /, '');
             }
-            exitCode = subprocess.get_exit_status();
+            exitCode = success ? subprocess.get_exit_status() : -1;
             callback(stdout, stderr, exitCode);
         }
         subprocess.cancellable = null;

--- a/js/misc/util.js
+++ b/js/misc/util.js
@@ -159,10 +159,10 @@ function trySpawnCommandLine(command_line) {
  * @callback (function): called on success or failure
  * @opts (object): options: argv, flags, input
  *
- * Runs @command in the background. Callback has two arguments -
+ * Runs @command in the background. Callback has three arguments -
  * stdout, stderr, and exitCode.
  *
- * Returns (object): Gio.Subprocess instances
+ * Returns (object): a Gio.Subprocess instance
  */
 function spawnCommandLineAsync(command, callback, opts = {}) {
     let {argv, flags, input} = opts;

--- a/js/misc/util.js
+++ b/js/misc/util.js
@@ -10,6 +10,7 @@
  */
 
 const GLib = imports.gi.GLib;
+const Gio = imports.gi.Gio;
 const GObject = imports.gi.GObject;
 const Gir = imports.gi.GIRepository;
 const Mainloop = imports.mainloop;
@@ -154,33 +155,43 @@ function trySpawnCommandLine(command_line) {
 
 /**
  * spawnCommandLineAsync:
- * @command_line: a command line
- * @callback (function): called on success
- * @errback (function): called on error
+ * @command: a command
+ * @callback (function): called on success or failure
+ * @opts (object): options: argv, flags, input
  *
- * Runs @command_line in the background. If the process exits without
- * error, a callback will be called, or an error callback will be
- * called if one is provided.
+ * Runs @command in the background. Callback has two arguments -
+ * stdout, stderr, and exitCode.
+ *
+ * Returns (object): Gio.Subprocess instances
  */
-function spawnCommandLineAsync(command_line, callback, errback) {
-    let pid;
+function spawnCommandLineAsync(command, callback, opts = {}) {
+    let {argv, flags, input} = opts;
+    if (!input) input = null;
 
-    let [success, argv] = GLib.shell_parse_argv(command_line);
-    pid = trySpawn(argv, true);
-
-    GLib.child_watch_add(GLib.PRIORITY_DEFAULT, pid, function(pid, status) {
-        GLib.spawn_close_pid(pid);
-
-        if (status !== 0) {
-            if (typeof errback === 'function') {
-                errback();
-            }
-        } else {
-            if (typeof callback === 'function') {
-                callback();
-            }
-        }
+    let subprocess = new Gio.Subprocess({
+        argv: argv ? argv : ['bash', '-c', command],
+        flags: flags ? flags
+            : Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDIN_PIPE | Gio.SubprocessFlags.STDERR_PIPE,
     });
+    subprocess.init(null);
+    let cancellable = new Gio.Cancellable();
+
+    subprocess.communicate_utf8_async(input, cancellable, (obj, res) => {
+        let exitCode, stdout, stderr;
+        // This will throw on cancel with "Gio.IOErrorEnum: Operation was cancelled"
+        tryFn(() => [, stdout, stderr] = obj.communicate_utf8_finish(res));
+        if (typeof callback === 'function' && !cancellable.is_cancelled()) {
+            if (stderr && stderr.indexOf('bash: ') > -1) {
+                stderr = stderr.replace(/bash: /, '');
+            }
+            exitCode = subprocess.get_exit_status();
+            callback(stdout, stderr, exitCode);
+        }
+        subprocess.cancellable = null;
+    });
+    subprocess.cancellable = cancellable;
+
+    return subprocess;
 }
 
 function _handleSpawnError(command, err) {

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -1394,11 +1394,14 @@ function popModal(actor, timestamp) {
     modalCount -= 1;
 
     let record = modalActorFocusStack[focusIndex];
-    record.actor.disconnect(record.destroyId);
+    if (record.destroyId) record.actor.disconnect(record.destroyId);
+    record.destroyId = 0;
 
     if (focusIndex == modalActorFocusStack.length - 1) {
-        if (record.focus)
+        if (record.focusDestroyId) {
             record.focus.disconnect(record.focusDestroyId);
+            record.focusDestroyId = 0;
+        }
         global.stage.set_key_focus(record.focus);
     } else {
         let t = modalActorFocusStack[modalActorFocusStack.length - 1];

--- a/js/ui/modalDialog.js
+++ b/js/ui/modalDialog.js
@@ -23,7 +23,7 @@ const OPEN_AND_CLOSE_TIME = 0.1;
 const FADE_IN_BUTTONS_TIME = 0.33;
 const FADE_OUT_DIALOG_TIME = 1.0;
 
-const State = {
+var State = {
     OPENED: 0,
     CLOSED: 1,
     OPENING: 2,


### PR DESCRIPTION
This replaces `trySpawnCommandLine` in the run dialog with `spawnCommandLineAsync`, and adjusts the code there to work with an asynchronous callback.

This also refactors `spawnCommandLineAsync` so it uses Gio.Subprocess, which allows us to receive stdout and stderr output while remaining asynchronous. The only xlet using spawnCommandLineAsync is multi-core-sys-monitor, and its using it in a compatible way. Not seeing any zombies left over from its usage on this branch.

Ref https://github.com/linuxmint/mint-19.1-beta/issues/52