### PR TITLE
gwl: Fix incorrect app group button widths on close with labels enabled

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -446,12 +446,14 @@ class AppGroup {
     }
 
     showLabel(animate = false) {
-        if (!this.label
+        if (this.labelVisible
+            || !this.label
             || !this.state.isHorizontal
             || this.label.is_finalized()
             || !this.label.realized) {
             return;
         }
+
         let width = MAX_BUTTON_WIDTH * global.ui_scale;
 
         this.labelVisible = true;
@@ -482,6 +484,7 @@ class AppGroup {
     hideLabel() {
         if (!this.label || this.label.is_finalized() || !this.label.realized) return;
 
+        this.label.set_text('');
         this.labelVisible = false;
         this.label.width = 1;
         this.label.hide();
@@ -965,7 +968,7 @@ class AppGroup {
             return;
         }
 
-        if (this.groupState.metaWindows.length === 0) {
+        if (!metaWindow || this.groupState.metaWindows.length === 0) {
             this.hideLabel();
         } else if (this.state.settings.titleDisplay === TitleDisplay.Title) {
             this.setText(metaWindow.title);
@@ -978,9 +981,13 @@ class AppGroup {
         } else if (this.state.settings.titleDisplay === TitleDisplay.Focused) {
             this.setText(metaWindow.title);
             if (focus === undefined) focus = getFocusState(metaWindow);
-            if (focus) {
+            if (focus
+                && this.groupState.metaWindows.length > 0) {
                 this.showLabel(animate);
-            } else {
+            // If a skip-taskbar window is focused from this group, do nothing.
+            // Show the last trackable window's label because the application is focused.
+            } else if (global.display.focus_window
+                && this.groupState.appId.indexOf(global.display.focus_window.wm_class.toLowerCase()) === -1) {
                 this.hideLabel();
             }
             // Re-orient the menu after the focus button expands

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appList.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appList.js
@@ -395,13 +395,13 @@ class AppList {
 
                 isFavoriteApp = isFavoriteApp && (this.state.settings.groupApps || this.getWindowCount(appId) === 0);
                 if (isFavoriteApp) {
-                    this.appList[refApp].groupState.set({groupReady: false});
+                    this.appList[refApp].groupState.set({groupReady: false, lastFocused: null});
                     this.appList[refApp].actor.set_style_pseudo_class('closed');
                     this.appList[refApp].actor.remove_style_class_name('grouped-window-list-item-demands-attention');
-                    if (this.state.settings.titleDisplay > 1) {
-                        this.appList[refApp].hideLabel(true);
-                    }
                     this.appList[refApp].setActiveStatus(false);
+                    if (this.state.settings.titleDisplay > 1) {
+                        this.appList[refApp].hideLabel();
+                    }
                     return;
                 }
                 this.appList[refApp].destroy(true);


### PR DESCRIPTION
- Prevents showing already visible labels, and sets `lastFocused` to `null` in the group's state when the last window from the group is closed.
- `titleDisplay` mode 4 - Ignores skip-taskbar windows when handling the focused window's label, otherwise it will cause the label to be shown just before its hidden, but with no window title because we don't have the skip-taskbar window in the index.

Tested all label options. 

Fixes https://blog.linuxmint.com/?p=3661#comment-146711