### PR TITLE
Stock theme - fix expo workspace entry not expanding to fit scaled fonts

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -1799,7 +1799,7 @@ StScrollBar StButton#vhandle:hover {
     caret-color: rgb(128, 128, 128);
     caret-size: 1px;
     width: 250px;
-    height: 1.5em;
+    height: 1em;
     box-shadow: inset 0px 2px 4px rgba(0,0,0,0.6);
     text-align: center;
 }

--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -1799,7 +1799,7 @@ StScrollBar StButton#vhandle:hover {
     caret-color: rgb(128, 128, 128);
     caret-size: 1px;
     width: 250px;
-    height: 15px;
+    height: 1.5em;
     box-shadow: inset 0px 2px 4px rgba(0,0,0,0.6);
     text-align: center;
 }


### PR DESCRIPTION
Fixes https://github.com/linuxmint/Cinnamon/issues/8111

Also see https://github.com/linuxmint/mint-themes/pull/175