### PR TITLE
Cinnamon Settings: Make directly launched modules feel like standalone apps

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
@@ -195,6 +195,14 @@ class MainWindow:
         self.builder.add_from_file(config.currentPath + "/cinnamon-settings.ui")
         self.window = XApp.GtkWindow(window_position=Gtk.WindowPosition.CENTER,
                                      default_width=800, default_height=600)
+
+        if len(sys.argv) > 1:
+            # If we're launching a module directly, set the WM class so GWL
+            # can consider it as a standalone app and give it its own
+            # group.
+            wm_class = "cinnamon-settings %s" % sys.argv[1]
+            self.window.set_wmclass(wm_class, wm_class)
+
         main_box = self.builder.get_object("main_box")
         self.window.add(main_box)
         self.top_bar = self.builder.get_object("top_bar")
@@ -230,8 +238,6 @@ class MainWindow:
         self.search_entry.connect("icon-press", self.onClearSearchBox)
 
         self.window.connect("destroy", self.quit)
-        self.window.connect("key-press-event", self.on_keypress)
-        self.window.connect("button-press-event", self.on_buttonpress)
         self.window.show()
 
         self.builder.connect_signals(self)
@@ -318,6 +324,7 @@ class MainWindow:
 
         # Select the first sidePage
         if len(sys.argv) > 1 and sys.argv[1] in sidePagesIters:
+            self.button_back.hide()
             (iter, cat) = sidePagesIters[sys.argv[1]]
             path = self.store[cat].get_path(iter)
             if path:
@@ -326,6 +333,8 @@ class MainWindow:
                 self.search_entry.grab_focus()
         else:
             self.search_entry.grab_focus()
+            self.window.connect("key-press-event", self.on_keypress)
+            self.window.connect("button-press-event", self.on_buttonpress)
 
     def on_keypress(self, widget, event):
         grab = False


### PR DESCRIPTION
When a module is launched directly:

- Give it its own wm_class
- Don't show a back button

This fixes an issue when launching different modules from Menu->Preferences would end up in one single app group in GWL, all using the icon of the first launched module.