### PR TITLE
gwl: Use icon-changed signal for Muffin #399

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -837,9 +837,7 @@ class AppGroup {
             this.signals.connect(metaWindow, 'notify::gtk-application-id', (w) => this.onAppChange(w));
             this.signals.connect(metaWindow, 'notify::wm-class', (w) => this.onAppChange(w));
 
-            if (!this.state.settings.groupApps) {
-                this.signals.connect(metaWindow, 'icon-changed', (w) => this.onIconChanged(w));
-            }
+            this.signals.connect(metaWindow, 'icon-changed', (w) => this.setIcon(w));
 
             if (metaWindow.progress !== undefined) {
                 this._progress = metaWindow.progress;

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -838,7 +838,7 @@ class AppGroup {
             this.signals.connect(metaWindow, 'notify::wm-class', (w) => this.onAppChange(w));
 
             if (!this.state.settings.groupApps) {
-                this.signals.connect(metaWindow, 'notify::icon', (w) => this.setIcon(w));
+                this.signals.connect(metaWindow, 'icon-changed', (w) => this.onIconChanged(w));
             }
 
             if (metaWindow.progress !== undefined) {

--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -340,7 +340,7 @@ class AppMenuButton {
         this.window_signals.connect(this.metaWindow, 'notify::title', this.setDisplayTitle, this);
         this.window_signals.connect(this.metaWindow, "notify::minimized", this.setDisplayTitle, this);
         this.window_signals.connect(this.metaWindow, "notify::tile-type", this.setDisplayTitle, this);
-        this.window_signals.connect(this.metaWindow, "notify::icon", this.setIcon, this);
+        this.window_signals.connect(this.metaWindow, "icon-changed", this.setIcon, this);
         this.window_signals.connect(this.metaWindow, "notify::appears-focused", this.onFocus, this);
         this.window_signals.connect(this.metaWindow, "unmanaged", this.onUnmanaged, this);
     }


### PR DESCRIPTION
This changes the `notify::icon` signals to `icon-changed`, which depends on https://github.com/linuxmint/muffin/pull/399. This was merged into this PR to avoid a conflict.