### PR TITLE
gwl: Simplify AppList.prototype.windowAdded

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -279,7 +279,7 @@ class AppGroup {
         let icon;
 
         if (this.groupState.app) {
-            if (metaWindow) {
+            if (metaWindow && !this.state.settings.groupApps) {
                 icon = this.groupState.app.create_icon_texture_for_window(this.iconSize, metaWindow);
             } else {
                 icon = this.groupState.app.create_icon_texture(this.iconSize);

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -279,7 +279,7 @@ class AppGroup {
         let icon;
 
         if (this.groupState.app) {
-            if (metaWindow && !this.state.settings.groupApps) {
+            if (metaWindow && (!this.state.settings.groupApps || this.groupState.app.is_window_backed())) {
                 icon = this.groupState.app.create_icon_texture_for_window(this.iconSize, metaWindow);
             } else {
                 icon = this.groupState.app.create_icon_texture(this.iconSize);


### PR DESCRIPTION
This moves the initial window load handling for pinned apps from `windowAdded` to `loadFavorites`, which allows removing some of the redundant logic. A side effect of this is the window icon will always load instead of the app icon, so that was changed in `setIcon` to only use the window icon for ungrouped apps.