### PR TITLE
cinnamon-app: Get a fallback icon from Muffin for some window-backed apps

### DIFF
--- a/src/cinnamon-app.c
+++ b/src/cinnamon-app.c
@@ -193,7 +193,7 @@ window_backed_app_get_icon (CinnamonApp *app,
 
   size *= scale;
 
-  if (!meta_window_set_icon (window, size, size))
+  if (!meta_window_create_icon (window, size, size))
     {
       GIcon *icon = g_themed_icon_new ("application-x-executable");
       actor = g_object_new (ST_TYPE_ICON, "gicon", icon, "icon-size", size, NULL);

--- a/src/cinnamon-app.c
+++ b/src/cinnamon-app.c
@@ -193,6 +193,14 @@ window_backed_app_get_icon (CinnamonApp *app,
 
   size *= scale;
 
+  if (!meta_window_set_icon (window, size, size))
+    {
+      GIcon *icon = g_themed_icon_new ("application-x-executable");
+      actor = g_object_new (ST_TYPE_ICON, "gicon", icon, "icon-size", size, NULL);
+      g_object_unref (icon);
+      return actor;
+    }
+
   actor = st_texture_cache_bind_pixbuf_property (st_texture_cache_get_default (),
                                                  G_OBJECT (window), "icon");
   g_object_set (actor, "width", (float) size, "height", (float) size, NULL);


### PR DESCRIPTION
In https://github.com/linuxmint/muffin/pull/399 icons are no longer created for every window because Cinnamon does this most of the time. For window backed apps however, Cinnamon needs to fallback to Muffin's icon. Instead of creating a Muffin icon for every window, this will create them as needed, or in this case, when we have a non-Xapp window-backed app.