### PR TITLE
window-list: Prevent _addWindow from getting called before windows finish mapping

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -724,11 +724,6 @@ class AppMenuButton {
         let tracker = Cinnamon.WindowTracker.get_default();
         let app = tracker.get_window_app(this.metaWindow);
 
-        if (!app) {
-            setTimeout(() => this.setIcon(), 0);
-            return;
-        }
-
         this.icon_size = this._applet.icon_size;
 
         let icon = app ?
@@ -1101,6 +1096,7 @@ class CinnamonWindowListApplet extends Applet.Applet {
     }
 
     _onWindowMonitorChanged(screen, metaWindow, monitor) {
+        if (!metaWindow.get_compositor_private().visible) return;
         if (this._shouldAdd(metaWindow))
             this._addWindow(metaWindow, false);
         else


### PR DESCRIPTION
This fixes up #8123. Some applications cause `setIcon` to recurse too much. 

The `window-monitor-changed` signal is emitted before CinnamonWindowTracker has been notified via workspace signals, and as a result the CinnamonApp object doesn't yet exist for the window at this point.

Tested per-monitor window support on three panels on different monitors, and not seeing regressions. This includes calling `move_to_monitor` on a minimized window.

C/O @itzexor