### PR TITLE
cs_keyboard.py: Fix category search in layout tab

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_keyboard.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_keyboard.py
@@ -333,6 +333,7 @@ class Module:
             cat_column.set_property('min-width', 200)
 
             self.cat_tree.append_column(cat_column)
+            self.cat_tree.set_search_column(1)
             self.cat_tree.connect("cursor-changed", self.onCategoryChanged)
 
             kb_name_cell = Gtk.CellRendererText()


### PR DESCRIPTION
Sets correct search column for interactive search.

Closes https://github.com/linuxmint/Cinnamon/issues/8152