### PR TITLE
gwl: Fix incorrect window accounting in multi-workspace cases

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appList.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appList.js
@@ -366,8 +366,11 @@ class AppList {
         if (!this.state) return;
 
         if ((metaWindow.is_on_all_workspaces() || this.state.settings.showAllWorkspaces)
-            && !metaWindow.__gwlFinalize__) {
-            metaWindow.__gwlFinalize__ = true;
+            && !this.state.removingWindowFromWorkspaces) {
+            // Abort the remove if the window is just changing workspaces, window
+            // should always remain indexed on all workspaces while its mapped.
+            if (!metaWindow.showing_on_its_workspace()) return;
+            this.state.removingWindowFromWorkspaces = true;
             this.state.trigger('removeWindowFromAllWorkspaces', metaWindow);
             return;
         }
@@ -387,6 +390,7 @@ class AppList {
                 return false;
             }
         });
+
         if (refApp > -1) {
             this.appList[refApp].windowRemoved(metaWorkspace, metaWindow, refWindow, (appId, isFavoriteApp) => {
                 if (this.state.settings.titleDisplay > 1) {

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appList.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appList.js
@@ -239,8 +239,11 @@ class AppList {
 
         if (metaWindow && !this.shouldWindowBeAdded(metaWindow)) return;
 
-        if (this.state.appletReady && this.state.settings.showAllWorkspaces && metaWindow && !metaWindow.__gwlInit__) {
-            metaWindow.__gwlInit__ = true;
+        if (metaWindow
+            && this.state.appletReady
+            && this.state.settings.showAllWorkspaces
+            && !this.state.addingWindowToWorkspaces) {
+            this.state.addingWindowToWorkspaces = true;
             this.state.trigger('addWindowToAllWorkspaces', metaWindow, app, isFavoriteApp);
         }
         // Check to see if the window that was added already has an app group.

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -252,6 +252,7 @@ class GroupedWindowListApplet extends Applet.Applet {
             scrollActive: false,
             thumbnailMenuOpen: false,
             thumbnailCloseButtonOffset: global.ui_scale > 1 ? -10 : 0,
+            addingWindowToWorkspaces: false,
             removingWindowFromWorkspaces: false,
         });
 
@@ -272,6 +273,7 @@ class GroupedWindowListApplet extends Applet.Applet {
                 each(this.appLists, function(appList) {
                     appList.windowAdded(appList.metaWorkspace, win, app, isFavoriteApp);
                 });
+                this.state.addingWindowToWorkspaces = false;
             },
             removeWindowFromAllWorkspaces: (win) => {
                 each(this.appLists, function(appList) {

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -251,7 +251,8 @@ class GroupedWindowListApplet extends Applet.Applet {
             lastTitleDisplay: null,
             scrollActive: false,
             thumbnailMenuOpen: false,
-            thumbnailCloseButtonOffset: global.ui_scale > 1 ? -10 : 0
+            thumbnailCloseButtonOffset: global.ui_scale > 1 ? -10 : 0,
+            removingWindowFromWorkspaces: false,
         });
 
         // key-function pairs of actions that can be triggered from the store's callback queue. This allows the
@@ -276,6 +277,7 @@ class GroupedWindowListApplet extends Applet.Applet {
                 each(this.appLists, function(appList) {
                     appList.windowRemoved(appList.metaWorkspace, win);
                 });
+                this.state.removingWindowFromWorkspaces = false;
             },
             removeWindowFromOtherWorkspaces: (win) => {
                 each(this.appLists, (appList) => {
@@ -284,6 +286,7 @@ class GroupedWindowListApplet extends Applet.Applet {
                     }
                     appList.windowRemoved(appList.metaWorkspace, win);
                 });
+                this.state.removingWindowFromWorkspaces = false;
             },
             refreshCurrentAppList: () => this.refreshCurrentAppList(),
             getCurrentAppList: () => this.getCurrentAppList(),

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
@@ -709,7 +709,7 @@ class WindowThumbnail {
         } else {
             this.metaWindowActor = this.metaWindow.get_compositor_private();
         }
-        if (this.metaWindowActor) {
+        if (this.metaWindowActor && !this.metaWindowActor.is_finalized()) {
             this.signals.connect(this.metaWindowActor, 'size-changed', () => this.refreshThumbnail());
 
             let windowTexture = this.metaWindowActor.get_texture();
@@ -810,7 +810,10 @@ class WindowThumbnail {
     }
 
     hoverPeek(opacity) {
-        if (!this.state.settings.enablePeek || this.state.overlayPreview || this.state.scrollActive) {
+        if (!this.state.settings.enablePeek
+            || this.state.overlayPreview
+            || this.state.scrollActive
+            || (this.metaWindowActor && this.metaWindowActor.is_finalized())) {
             return;
         }
         if (!this.metaWindowActor) {

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
@@ -138,14 +138,15 @@ class AppMenuButtonRightClickMenu extends Applet.AppletPopupMenu {
                         // Make the index a local variable to pass to function
                         let j = i;
                         let name = Main.workspace_names[i] ? Main.workspace_names[i] : Main._makeDefaultWorkspaceName(i);
-                        let ws = createMenuItem({label: _(name)});
+                        let menuItem = createMenuItem({label: _(name)});
+                        let ws = this.groupState.lastFocused.get_workspace();
 
-                        if (i === this.groupState.lastFocused.get_workspace().index()) {
-                            ws.setSensitive(false);
+                        if (ws && i === ws.index()) {
+                            menuItem.setSensitive(false);
                         }
 
-                        connectWorkspaceEvent(ws, j);
-                        item.menu.addMenuItem(ws);
+                        connectWorkspaceEvent(menuItem, j);
+                        item.menu.addMenuItem(menuItem);
                     }
                 }
             }

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
@@ -713,6 +713,7 @@ class WindowThumbnail {
             this.signals.connect(this.metaWindowActor, 'size-changed', () => this.refreshThumbnail());
 
             let windowTexture = this.metaWindowActor.get_texture();
+            if (!windowTexture) return;
             let [width, height] = windowTexture.get_size();
             let scale = Math.min(1.0, thumbnailWidth / width, thumbnailHeight / height) * global.ui_scale;
             width = Math.round(width * scale);


### PR DESCRIPTION
- Fixes windows not being removed from all workspaces when "Show windows from all workspaces" is enabled.
- Fixes the 'insensitive' workspace option in the context menu not being based on the workspace the last focused window is actually on.
- Removes property assignment on the MetaWindow object - state props should stay localized to the applet.
- Fixes windows being removed from the active workspace when a window's
"Visible on all workspaces" option is toggled while "Show windows from all workspaces" is enabled.
- Fixes null MetaWindowActor TypeError in `AppMenuButtonRightClickMenu.prototype.populateMenu`.

Closes #8190 
Closes #8252