### PR TITLE
[js] Use push instead of unshift for array

### DIFF
--- a/js/ui/cinnamonMountOperation.js
+++ b/js/ui/cinnamonMountOperation.js
@@ -29,12 +29,13 @@ function _setLabelText(label, text) {
 function _setButtonsForChoices(dialog, choices) {
     let buttons = [];
 
-    for (let idx = 0; idx < choices.length; idx++) {
-        let button = idx;
-        buttons.unshift({ label: choices[idx],
-                          action: Lang.bind(dialog, function() {
-                              dialog.emit('response', button);
-                          })});
+    for (let idx = choices.length - 1; idx >= 0; idx--) {
+        buttons.push({
+            label: choices[idx],
+            action: Lang.bind(dialog, () => {
+                dialog.emit('response', idx);
+            })
+        });
     }
 
     dialog.setButtons(buttons);


### PR DESCRIPTION
I refactored it to avoid unshift for array for performance reason.