### PR TITLE
Default theme: document css used by symbolic icons

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -1672,7 +1672,7 @@ StScrollBar StButton#vhandle:hover {
 }
 .applet-box.vertical:hover > .applet-label {
 }
-.applet-icon {
+.applet-icon {   /* symbolic icons will use system-status-icon instead */
     color: #ccc;
     icon-size: 22px;
 }


### PR DESCRIPTION
Shows the different CSS used by full colour or symbolic icons, a non-obvious split that needs inspection of the code to find out otherwise.