### PR TITLE
[WIP] settings: Make file I/O asynchronous

### DIFF
--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/calendar.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/calendar.js
@@ -387,7 +387,7 @@ class Calendar {
             this.actor.add(button,
                            { row: row, col: offsetCols + (7 + iter.getDay() - this._weekStart) % 7 });
 
-            if (this.state.show_week_numbers && iter.getDay() == 4) {
+            if (this.state.show_week_numbers && iter.getDay() === 4) {
                 let label = new St.Label({ text: iter.toLocaleFormat('%V'),
                                            style_class: 'calendar-day-base calendar-week-number'});
                 this.actor.add(label,

--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/calendar.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/calendar.js
@@ -64,17 +64,17 @@ function _formatEventTime(event, clockFormat) {
         ret = C_("event list time", "All Day");
     } else {
         switch (clockFormat) {
-        case '24h':
-            /* Translators: Shown in calendar event list, if 24h format */
-            ret = event.date.toLocaleFormat(C_("event list time", "%H:%M"));
-            break;
+            case '24h':
+                /* Translators: Shown in calendar event list, if 24h format */
+                ret = event.date.toLocaleFormat(C_("event list time", "%H:%M"));
+                break;
 
-        default:
-            /* explicit fall-through */
-        case '12h':
-            /* Transators: Shown in calendar event list, if 12h format */
-            ret = event.date.toLocaleFormat(C_("event list time", "%l:%M %p"));
-            break;
+            default:
+                /* explicit fall-through */
+            case '12h':
+                /* Transators: Shown in calendar event list, if 12h format */
+                ret = event.date.toLocaleFormat(C_("event list time", "%l:%M %p"));
+                break;
         }
     }
     return ret;
@@ -141,9 +141,10 @@ class Calendar {
         this._weekStart = Cinnamon.util_get_week_start();
         this._weekdate = NaN;
         this._digitWidth = NaN;
-        this.settings = settings;
 
-        this.settings.bindWithObject(this, "show-week-numbers", "show_week_numbers", this._onSettingsChange);
+        this.state = {};
+
+        settings.bindWithObject(this.state, "show-week-numbers", "show_week_numbers", this._onSettingsChange);
         this.desktop_settings = new Gio.Settings({ schema_id: DESKTOP_SCHEMA });
         this.desktop_settings.connect("changed::" + FIRST_WEEKDAY_KEY, Lang.bind(this, this._onSettingsChange));
 
@@ -151,16 +152,16 @@ class Calendar {
 
         let var_name = 'calendar:MY';
         switch (Gettext_gtk30.gettext(var_name)) {
-        case 'calendar:MY':
-            this._headerMonthFirst = true;
-            break;
-        case 'calendar:YM':
-            this._headerMonthFirst = false;
-            break;
-        default:
-            log('Translation of "calendar:MY" in GTK+ is not correct');
-            this._headerMonthFirst = true;
-            break;
+            case 'calendar:MY':
+                this._headerMonthFirst = true;
+                break;
+            case 'calendar:YM':
+                this._headerMonthFirst = false;
+                break;
+            default:
+                log('Translation of "calendar:MY" in GTK+ is not correct');
+                this._headerMonthFirst = true;
+                break;
         }
 
         // Start off with the current date
@@ -195,7 +196,7 @@ class Calendar {
     }
 
     _buildHeader() {
-        let offsetCols = this.show_week_numbers ? 1 : 0;
+        let offsetCols = this.state.show_week_numbers ? 1 : 0;
         this.actor.destroy_all_children();
 
         // Top line of the calendar '<| September |> <| 2009 |>'
@@ -270,21 +271,21 @@ class Calendar {
     }
 
     _setWeekdateHeaderWidth() {
-        if (!isNaN(this._digitWidth) && this.show_week_numbers && this._weekdateHeader) {
+        if (!isNaN(this._digitWidth) && this.state.show_week_numbers && this._weekdateHeader) {
             this._weekdateHeader.set_width (this._digitWidth * WEEKDATE_HEADER_WIDTH_DIGITS);
         }
     }
 
     _onScroll (actor, event) {
         switch (event.get_scroll_direction()) {
-        case Clutter.ScrollDirection.UP:
-        case Clutter.ScrollDirection.LEFT:
-            this._onPrevMonthButtonClicked();
-            break;
-        case Clutter.ScrollDirection.DOWN:
-        case Clutter.ScrollDirection.RIGHT:
-            this._onNextMonthButtonClicked();
-            break;
+            case Clutter.ScrollDirection.UP:
+            case Clutter.ScrollDirection.LEFT:
+                this._onPrevMonthButtonClicked();
+                break;
+            case Clutter.ScrollDirection.DOWN:
+            case Clutter.ScrollDirection.RIGHT:
+                this._onNextMonthButtonClicked();
+                break;
         }
     }
 
@@ -382,11 +383,11 @@ class Calendar {
 
             button.style_class = styleClass;
 
-            let offsetCols = this.show_week_numbers ? 1 : 0;
+            let offsetCols = this.state.show_week_numbers ? 1 : 0;
             this.actor.add(button,
                            { row: row, col: offsetCols + (7 + iter.getDay() - this._weekStart) % 7 });
 
-            if (this.show_week_numbers && iter.getDay() == 4) {
+            if (this.state.show_week_numbers && iter.getDay() == 4) {
                 let label = new St.Label({ text: iter.toLocaleFormat('%V'),
                                            style_class: 'calendar-day-base calendar-week-number'});
                 this.actor.add(label,

--- a/files/usr/share/cinnamon/applets/expo@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/expo@cinnamon.org/applet.js
@@ -1,43 +1,44 @@
-const Applet = imports.ui.applet;
-const Lang = imports.lang;
-const Main = imports.ui.main;
-const Settings = imports.ui.settings;
+const {IconApplet} = imports.ui.applet;
+const {expo} = imports.ui.main;
+const {AppletSettings} = imports.ui.settings;
 
-class CinnamonExpoApplet extends Applet.IconApplet {
+class CinnamonExpoApplet extends IconApplet {
     constructor(metadata, orientation, panel_height, instance_id) {
         super(orientation, panel_height, instance_id);
 
-        try {
-            this.set_applet_icon_symbolic_name("cinnamon-expo");
-            this.set_applet_tooltip(_("Expo"));
-            this._hover_activates = false;
+        this.set_applet_icon_symbolic_name('cinnamon-expo');
+        this.set_applet_tooltip(_('Expo'));
 
-            this.settings = new Settings.AppletSettings(this, metadata.uuid, this.instance_id);
+        this.state = {hoverActivates: false};
 
-            this.settings.bind("activate-on-hover", "_hover_activates");
+        let settings = new AppletSettings(this.state, metadata.uuid, this.instance_id, true);
+        settings.promise.then(() => {
+            settings.bind('activate-on-hover', 'hoverActivates', null);
 
-            this.actor.connect('enter-event', Lang.bind(this, this._onEntered));
-        }
-        catch (e) {
-            global.logError(e);
-        }
+            this.actor.connect('enter-event', () => this._onEntered());
+            this.settings = settings;
+        });
     }
 
     on_applet_clicked(event) {
-        if (this._hover_activates)
+        if (this.state.hoverActivates)
             return;
         this.doAction();
     }
 
-    _onEntered(event) {
-        if (!this._hover_activates || global.settings.get_boolean("panel-edit-mode"))
+    on_applet_removed_from_panel() {
+        this.settings.finalize();
+    }
+
+    _onEntered() {
+        if (!this.state.hoverActivates || global.settings.get_boolean('panel-edit-mode'))
             return;
         this.doAction();
     }
 
     doAction() {
-        if (!Main.expo.animationInProgress)
-            Main.expo.toggle();
+        if (!expo.animationInProgress)
+            expo.toggle();
     }
 }
 

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -895,8 +895,11 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
 
         this.actor.connect('key-press-event', Lang.bind(this, this._onSourceKeyPress));
 
-        this.settings = new Settings.AppletSettings(this, "menu@cinnamon.org", instance_id);
+        this.settings = new Settings.AppletSettings(this, "menu@cinnamon.org", instance_id, true);
+        this.settings.promise.then(() => this.settingsInit());
+    }
 
+    settingsInit() {
         this.settings.bind("show-places", "showPlaces", this._refreshBelowApps);
 
         this._appletEnterEventId = 0;

--- a/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
@@ -1,22 +1,20 @@
-const Applet = imports.ui.applet;
-const Main = imports.ui.main;
-const Gtk = imports.gi.Gtk;
-const Gio = imports.gi.Gio;
-const PopupMenu = imports.ui.popupMenu;
-const St = imports.gi.St;
-const Mainloop = imports.mainloop;
-const Urgency = imports.ui.messageTray.Urgency;
-const NotificationDestroyedReason = imports.ui.messageTray.NotificationDestroyedReason;
+const {TextIconApplet, AppletPopupMenu, AllowedLayout} = imports.ui.applet;
+const {messageTray} = imports.ui.main;
+const {PolicyType} = imports.gi.Gtk;
+const {Settings} = imports.gi.Gio;
+const {PopupMenuManager, PopupMenuItem, PopupSeparatorMenuItem} = imports.ui.popupMenu;
+const {BoxLayout, ScrollView, Icon, IconType, Align, Side} = imports.gi.St;
+const {Urgency, NotificationDestroyedReason} = imports.ui.messageTray;
 const {AppletSettings} = imports.ui.settings;
-const Gettext = imports.gettext.domain("cinnamon-applets");
+const {ngettext} = imports.gettext.domain("cinnamon-applets");
 
 const PANEL_EDIT_MODE_KEY = "panel-edit-mode";
 
-class CinnamonNotificationsApplet extends Applet.TextIconApplet {
+class CinnamonNotificationsApplet extends TextIconApplet {
     constructor(metadata, orientation, panel_height, instanceId) {
         super(orientation, panel_height, instanceId);
 
-        this.setAllowedLayout(Applet.AllowedLayout.BOTH);
+        this.setAllowedLayout(AllowedLayout.BOTH);
 
         this.state = {};
 
@@ -35,10 +33,10 @@ class CinnamonNotificationsApplet extends Applet.TextIconApplet {
         this.settings.bind("ignoreTransientNotifications", "ignoreTransientNotifications");
         this.settings.bind("showEmptyTray", "showEmptyTray", () => this._show_hide_tray());
 
-        this.menuManager = new PopupMenu.PopupMenuManager(this);
+        this.menuManager = new PopupMenuManager(this);
 
         // Events
-        Main.messageTray.connect('notify-applet-update', (m, n) => this._notification_added(m, n));
+        this.trayId = messageTray.connect('notify-applet-update', (m, n) => this._notification_added(m, n));
         global.settings.connect('changed::' + PANEL_EDIT_MODE_KEY, () => this._on_panel_edit_mode_changed());
 
         // States
@@ -55,23 +53,23 @@ class CinnamonNotificationsApplet extends Applet.TextIconApplet {
         this.set_applet_tooltip(_("Notifications"));
 
         // Setup the notification container.
-        this._maincontainer = new St.BoxLayout({name: 'traycontainer', vertical: true});
-        this._notificationbin = new St.BoxLayout({vertical:true});
-        this.button_label_box = new St.BoxLayout();
+        this._maincontainer = new BoxLayout({name: 'traycontainer', vertical: true});
+        this._notificationbin = new BoxLayout({vertical:true});
+        this.button_label_box = new BoxLayout();
 
         // Setup the tray icon.
-        this.menu_label = new PopupMenu.PopupMenuItem(stringify(this.notifications.length));
+        this.menu_label = new PopupMenuItem(stringify(this.notifications.length));
         this.menu_label.actor.reactive = false;
         this.menu_label.actor.can_focus = false;
         this.menu_label.label.add_style_class_name('popup-subtitle-menu-item');
 
-        this.clear_separator = new PopupMenu.PopupSeparatorMenuItem();
+        this.clear_separator = new PopupSeparatorMenuItem();
 
-        this.clear_action = new PopupMenu.PopupMenuItem(_("Clear notifications"));
+        this.clear_action = new PopupMenuItem(_("Clear notifications"));
         this.clear_action.connect('activate', () => this._clear_all());
         this.clear_action.actor.hide();
 
-        if (this._orientation == St.Side.BOTTOM) {
+        if (this._orientation == Side.BOTTOM) {
             this.menu.addMenuItem(this.menu_label);
             this.menu.addActor(this._maincontainer);
             this.menu.addMenuItem(this.clear_separator);
@@ -83,18 +81,18 @@ class CinnamonNotificationsApplet extends Applet.TextIconApplet {
             this.menu.addActor(this._maincontainer);
         }
 
-        this.scrollview = new St.ScrollView({ x_fill: true, y_fill: true, y_align: St.Align.START, style_class: "vfade"});
+        this.scrollview = new ScrollView({ x_fill: true, y_fill: true, y_align: Align.START, style_class: "vfade"});
         this._maincontainer.add(this.scrollview);
         this.scrollview.add_actor(this._notificationbin);
-        this.scrollview.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC);
+        this.scrollview.set_policy(PolicyType.NEVER, PolicyType.AUTOMATIC);
 
         let vscroll = this.scrollview.get_vscroll_bar();
         vscroll.connect('scroll-start', () => this.menu.passEvents = true);
         vscroll.connect('scroll-stop', () => this.menu.passEvents = false);
 
         // Alternative tray icons.
-        this._crit_icon = new St.Icon({icon_name: 'critical-notif', icon_type: St.IconType.SYMBOLIC, reactive: true, track_hover: true, style_class: 'system-status-icon' });
-        this._alt_crit_icon = new St.Icon({icon_name: 'alt-critical-notif', icon_type: St.IconType.SYMBOLIC, reactive: true, track_hover: true, style_class: 'system-status-icon' });
+        this._crit_icon = new Icon({icon_name: 'critical-notif', icon_type: IconType.SYMBOLIC, reactive: true, track_hover: true, style_class: 'system-status-icon' });
+        this._alt_crit_icon = new Icon({icon_name: 'alt-critical-notif', icon_type: IconType.SYMBOLIC, reactive: true, track_hover: true, style_class: 'system-status-icon' });
 
         this._on_panel_edit_mode_changed();
     }
@@ -231,7 +229,7 @@ class CinnamonNotificationsApplet extends Applet.TextIconApplet {
         if (this.menu) {
             this.menu.destroy();
         }
-        this.menu = new Applet.AppletPopupMenu(this, orientation);
+        this.menu = new AppletPopupMenu(this, orientation);
         this.menuManager.addMenu(this.menu);
         this._display();
     }
@@ -241,8 +239,17 @@ class CinnamonNotificationsApplet extends Applet.TextIconApplet {
         this.menu.toggle();
     }
 
+    on_applet_reloaded() {
+        global.notificationsAppletReloading = true;
+    }
+
     on_applet_removed_from_panel() {
+        if (this.trayId && !global.notificationsAppletReloading) {
+            messageTray.disconnect('notify-applet-update', this.trayId);
+            this.trayId = 0;
+        }
         this.settings.finalize();
+        global.notificationsAppletReloading = false;
     }
 
     _update_timestamp() {
@@ -265,7 +272,7 @@ class CinnamonNotificationsApplet extends Applet.TextIconApplet {
             this._applet_icon_box.child = this._alt_crit_icon;
         }
         this._blink_toggle = !this._blink_toggle;
-        Mainloop.timeout_add_seconds(1, () => this.critical_blink());
+        setTimeout(() => this.critical_blink(), 1000);
     }
 }
 
@@ -292,7 +299,7 @@ function stringify(count) {
 }
 
 function timeify(orig_time) {
-    let settings = new Gio.Settings({schema_id: 'org.cinnamon.desktop.interface'});
+    let settings = new Settings({schema_id: 'org.cinnamon.desktop.interface'});
     let use_24h = settings.get_boolean('clock-use-24h');
     let now = new Date();
     let diff = Math.floor((now.getTime() - orig_time.getTime()) / 1000); // get diff in seconds
@@ -307,11 +314,11 @@ function timeify(orig_time) {
             str += " (" + _("just now") + ")";
             break;
         } case (diff > 15 && diff <= 59): {
-            str += " (" + Gettext.ngettext("%d second ago", "%d seconds ago", diff).format(diff) + ")";
+            str += " (" + ngettext("%d second ago", "%d seconds ago", diff).format(diff) + ")";
             break;
         } case (diff > 59 && diff <= 3540): {
             let diff_minutes = Math.floor(diff / 60);
-            str += " (" + Gettext.ngettext("%d minute ago", "%d minutes ago", diff_minutes).format(diff_minutes) + ")";
+            str += " (" + ngettext("%d minute ago", "%d minutes ago", diff_minutes).format(diff_minutes) + ")";
             break;
         }
     }

--- a/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
@@ -314,7 +314,11 @@ class CinnamonPanelLaunchersApplet extends Applet.Applet {
         this.myactor = new St.BoxLayout({ style_class: 'panel-launchers',
                                           important: true });
 
-        this.settings = new Settings.AppletSettings(this, metadata.uuid, instance_id);
+        this.settings = new Settings.AppletSettings(this, metadata.uuid, instance_id, true);
+        this.settings.promise.then(() => this.settingsInit(metadata, orientation));
+    }
+
+    settingsInit(metadata, orientation) {
         this.settings.bind("launcherList", "launcherList", this._onSettingsChanged);
         this.settings.bind("allow-dragging", "allowDragging", this._updateLauncherDrag);
 
@@ -415,6 +419,10 @@ class CinnamonPanelLaunchersApplet extends Applet.Applet {
     on_panel_icon_size_changed(size) {
         this.icon_size = size;
         this.reload();
+    }
+
+    on_applet_removed_from_panel() {
+        this.settings.finalize();
     }
 
     on_orientation_changed(neworientation) {

--- a/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
@@ -316,8 +316,11 @@ class CinnamonPowerApplet extends Applet.TextIconApplet {
 
         this.metadata = metadata;
 
-        this.settings = new Settings.AppletSettings(this, metadata.uuid, instanceId);
+        this.settings = new Settings.AppletSettings(this, metadata.uuid, instanceId, true);
+        this.settings.promise.then(() => this.settingsInit(metadata, orientation));
+    }
 
+    settingsInit(metadata, orientation) {
         Main.systrayManager.registerRole("power", metadata.uuid);
         Main.systrayManager.registerRole("battery", metadata.uuid);
 
@@ -633,6 +636,7 @@ class CinnamonPowerApplet extends Applet.TextIconApplet {
 
     on_applet_removed_from_panel() {
         Main.systrayManager.unregisterId(this.metadata.uuid);
+        this.settings.finalize();
     }
 }
 

--- a/files/usr/share/cinnamon/applets/scale@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/scale@cinnamon.org/applet.js
@@ -1,43 +1,45 @@
-const Applet = imports.ui.applet;
-const Lang = imports.lang;
-const Main = imports.ui.main;
-const Settings = imports.ui.settings;
+const {IconApplet} = imports.ui.applet;
+const {overview} = imports.ui.main;
+const {AppletSettings} = imports.ui.settings;
 
-class CinnamonScaleApplet extends Applet.IconApplet {
+class CinnamonScaleApplet extends IconApplet {
     constructor(metadata, orientation, panel_height, instance_id) {
         super(orientation, panel_height, instance_id);
 
-        try {
-            this.set_applet_icon_symbolic_name("cinnamon-scale");
-            this.set_applet_tooltip(_("Scale"));
-            this._hover_activates = false;
+        this.set_applet_icon_symbolic_name('cinnamon-scale');
+        this.set_applet_tooltip(_('Scale'));
 
-            this.settings = new Settings.AppletSettings(this, metadata.uuid, this.instance_id);
+        this.state = {
+            hoverActivates: false
+        };
 
-            this.settings.bind("activate-on-hover", "_hover_activates");
+        this.settings = new AppletSettings(this.state, metadata.uuid, this.instance_id, true);
+        this.settings.promise.then(() => {
+            this.settings.bind('activate-on-hover', 'hoverActivates');
 
-            this.actor.connect('enter-event', Lang.bind(this, this._onEntered));
-        }
-        catch (e) {
-            global.logError(e);
-        }
+            this.actor.connect('enter-event', () => this._onEntered());
+        });
     }
 
     on_applet_clicked(event) {
-        if (this._hover_activates)
+        if (this.state.hoverActivates)
             return;
         this.doAction();
     }
 
-    _onEntered(event) {
-        if (!this._hover_activates || global.settings.get_boolean("panel-edit-mode"))
+    on_applet_removed_from_panel() {
+        this.settings.finalize();
+    }
+
+    _onEntered() {
+        if (!this.state.hoverActivates || global.settings.get_boolean('panel-edit-mode'))
             return;
         this.doAction();
     }
 
     doAction() {
-        if (!Main.overview.animationInProgress)
-            Main.overview.toggle();
+        if (!overview.animationInProgress)
+            overview.toggle();
     }
 }
 

--- a/files/usr/share/cinnamon/applets/settings-example@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/settings-example@cinnamon.org/applet.js
@@ -16,41 +16,42 @@ class CinnamonSettingsExampleApplet extends Applet.TextIconApplet {
         this.menuManager.addMenu(this.menu);
 
         /* Initialize your settings handler instance      this,            the uuid              instance id  */
-        this.settings = new Settings.AppletSettings(this, "settings-example@cinnamon.org", instance_id);
+        this.settings = new Settings.AppletSettings(this, "settings-example@cinnamon.org", instance_id, true);
+        this.settings.connect('ready', () => {
+            /* Now we'll proceed with setting up individual setting bindings. */
 
-        /* Now we'll proceed with setting up individual setting bindings. */
+            this.settings.bind("icon-name",                // The setting key, from the setting schema file
+            "icon_name",                // The property to bind the setting to - in this case it will initialize this.icon_name to the setting value
+            this.on_settings_changed,   // The method to call when this.icon_name has changed, so you can update your applet
+            null);                      // Any extra information you want to pass to the callback (optional - pass null or just leave out this last argument)
 
-        this.settings.bind("icon-name",                // The setting key, from the setting schema file
-                           "icon_name",                // The property to bind the setting to - in this case it will initialize this.icon_name to the setting value
-                           this.on_settings_changed,   // The method to call when this.icon_name has changed, so you can update your applet
-                           null);                      // Any extra information you want to pass to the callback (optional - pass null or just leave out this last argument)
+            this.settings.bind("scale-demo", "scale_val", this.on_settings_changed);
+            this.settings.bind("color", "bg_color", this.on_settings_changed);
+            this.settings.bind("spinner-number", "spinner_number", this.on_settings_changed);
+            this.settings.bind("combo-selection", "combo_choice", this.on_settings_changed);
+            this.settings.bind("use-custom-label",  "use_custom", this.on_settings_changed);
+            this.settings.bind("custom-label", "custom_label", this.on_settings_changed);
+            this.settings.bind("tween-function", "tween_function", this.on_settings_changed);
+            this.settings.bind("keybinding-test", "keybinding", this.on_keybinding_changed);
 
-        this.settings.bind("scale-demo", "scale_val", this.on_settings_changed);
-        this.settings.bind("color", "bg_color", this.on_settings_changed);
-        this.settings.bind("spinner-number", "spinner_number", this.on_settings_changed);
-        this.settings.bind("combo-selection", "combo_choice", this.on_settings_changed);
-        this.settings.bind("use-custom-label",  "use_custom", this.on_settings_changed);
-        this.settings.bind("custom-label", "custom_label", this.on_settings_changed);
-        this.settings.bind("tween-function", "tween_function", this.on_settings_changed);
-        this.settings.bind("keybinding-test", "keybinding", this.on_keybinding_changed);
+            this.settings.connect("changed::signal-test", Lang.bind(this, this.on_signal_test_fired));
 
-        this.settings.connect("changed::signal-test", Lang.bind(this, this.on_signal_test_fired));
+            /* Lets create and add our menu items - we'll set their true values after */
 
-        /* Lets create and add our menu items - we'll set their true values after */
+            this.spinner_val_demo = new PopupMenu.PopupMenuItem("");
+            this.combo_val_demo = new PopupMenu.PopupMenuItem("");
+            this.slider_demo = new PopupMenu.PopupSliderMenuItem(0);
+            this.slider_demo.connect("value-changed", Lang.bind(this, this.on_slider_changed));
 
-        this.spinner_val_demo = new PopupMenu.PopupMenuItem("");
-        this.combo_val_demo = new PopupMenu.PopupMenuItem("");
-        this.slider_demo = new PopupMenu.PopupSliderMenuItem(0);
-        this.slider_demo.connect("value-changed", Lang.bind(this, this.on_slider_changed));
-
-        this.menu.addMenuItem(this.spinner_val_demo);
-        this.menu.addMenuItem(this.combo_val_demo);
-        this.menu.addMenuItem(this.slider_demo);
+            this.menu.addMenuItem(this.spinner_val_demo);
+            this.menu.addMenuItem(this.combo_val_demo);
+            this.menu.addMenuItem(this.slider_demo);
 
 
-        /* Let's set up our applet's initial state now that we have our setting properties defined */
-        this.on_keybinding_changed();
-        this.on_settings_changed();
+            /* Let's set up our applet's initial state now that we have our setting properties defined */
+            this.on_keybinding_changed();
+            this.on_settings_changed();
+        });
     }
 
     on_keybinding_changed() {

--- a/files/usr/share/cinnamon/applets/show-desktop@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/show-desktop@cinnamon.org/applet.js
@@ -1,5 +1,5 @@
 const Applet = imports.ui.applet;
-const { AppletSettings } = imports.ui.settings;  // Needed for settings API
+const {AppletSettings} = imports.ui.settings;  // Needed for settings API
 const Mainloop = imports.mainloop;
 const Tweener = imports.ui.tweener;
 const Main = imports.ui.main;
@@ -7,20 +7,23 @@ const PopupMenu = imports.ui.popupMenu;
 const St = imports.gi.St;
 const Clutter = imports.gi.Clutter;
 const Lang = imports.lang;
-const SignalManager = imports.misc.signalManager;
+const {SignalManager} = imports.misc.signalManager;
 
 class CinnamonShowDesktopApplet extends Applet.IconApplet {
     constructor(orientation, panel_height, instance_id) {
         super(orientation, panel_height, instance_id);
 
-        this.settings = new AppletSettings(this, "show-desktop@cinnamon.org", instance_id);
+        this.settings = new AppletSettings(this, "show-desktop@cinnamon.org", instance_id, true);
+        this.settings.promise.then(() => this.settingsInit());
+    }
 
-        this.settings.bind("peek-at-desktop", "peek_at_desktop");
-        this.settings.bind("peek-delay", "peek_delay");
-        this.settings.bind("peek-opacity", "peek_opacity");
-        this.settings.bind("peek-blur", "peek_blur");
+    settingsInit() {
+        this.settings.bind('peek-at-desktop', 'peek_at_desktop');
+        this.settings.bind('peek-delay', 'peek_delay');
+        this.settings.bind('peek-opacity', 'peek_opacity');
+        this.settings.bind('peek-blur', 'peek_blur');
 
-        this.signals = new SignalManager.SignalManager(null);
+        this.signals = new SignalManager(null);
         this.actor.connect('enter-event', Lang.bind(this, this._on_enter));
         this.actor.connect('leave-event', Lang.bind(this, this._on_leave));
         this.signals.connect(global.stage, 'notify::key-focus', this._on_leave, this);
@@ -42,6 +45,7 @@ class CinnamonShowDesktopApplet extends Applet.IconApplet {
 
     on_applet_removed_from_panel() {
         this.signals.disconnectAllSignals();
+        this.settings.finalize();
     }
 
     show_all_windows(time) {

--- a/files/usr/share/cinnamon/applets/show-desktop@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/show-desktop@cinnamon.org/applet.js
@@ -1,15 +1,13 @@
-const Applet = imports.ui.applet;
+const {IconApplet} = imports.ui.applet;
 const {AppletSettings} = imports.ui.settings;  // Needed for settings API
-const Mainloop = imports.mainloop;
-const Tweener = imports.ui.tweener;
-const Main = imports.ui.main;
-const PopupMenu = imports.ui.popupMenu;
-const St = imports.gi.St;
-const Clutter = imports.gi.Clutter;
-const Lang = imports.lang;
+const {addTween} = imports.ui.tweener;
+const {deskletContainer} = imports.ui.main;
+const {PopupIconMenuItem} = imports.ui.popupMenu;
+const {IconType} = imports.gi.St;
+const {BlurEffect} = imports.gi.Clutter;
 const {SignalManager} = imports.misc.signalManager;
 
-class CinnamonShowDesktopApplet extends Applet.IconApplet {
+class CinnamonShowDesktopApplet extends IconApplet {
     constructor(orientation, panel_height, instance_id) {
         super(orientation, panel_height, instance_id);
 
@@ -24,20 +22,19 @@ class CinnamonShowDesktopApplet extends Applet.IconApplet {
         this.settings.bind('peek-blur', 'peek_blur');
 
         this.signals = new SignalManager(null);
-        this.actor.connect('enter-event', Lang.bind(this, this._on_enter));
-        this.actor.connect('leave-event', Lang.bind(this, this._on_leave));
-        this.signals.connect(global.stage, 'notify::key-focus', this._on_leave, this);
+        this.actor.connect('enter-event', () => this._on_enter());
+        this.actor.connect('leave-event', () => this._on_leave());
+        this.signals.connect(global.stage, 'notify::key-focus', () => this._on_leave());
 
         this._did_peek = false;
-        this._peek_timeout_id = 0;
 
         this.set_applet_icon_name("user-desktop");
         this.set_applet_tooltip(_("Click to show the desktop or middle-click to show the desklets"));
 
-        let showDeskletsOption = new PopupMenu.PopupIconMenuItem(
+        let showDeskletsOption = new PopupIconMenuItem(
             _('Show Desklets'),
             'cs-desklets',
-            St.IconType.SYMBOLIC
+            IconType.SYMBOLIC
         );
         showDeskletsOption.connect('activate', () => this.toggleShowDesklets());
         this._applet_context_menu.addMenuItem(showDeskletsOption);
@@ -54,29 +51,23 @@ class CinnamonShowDesktopApplet extends Applet.IconApplet {
             let window = windows[i].meta_window;
             let compositor = windows[i];
             if(window.get_title() == "Desktop"){
-                Tweener.addTween(compositor, { opacity: 255, time: time, transition: "easeOutSine" });
+                addTween(compositor, { opacity: 255, time: time, transition: "easeOutSine" });
             }
             if (this.peek_blur && compositor.eff) {
                 compositor.remove_effect(compositor.eff);
             }
         }
-        Tweener.addTween(global.window_group, { opacity: 255, time: time, transition: "easeOutSine" });
+        addTween(global.window_group, { opacity: 255, time: time, transition: "easeOutSine" });
     }
 
-    _on_enter(event) {
+    _on_enter() {
         if (this.peek_at_desktop) {
-
-            if (this._peek_timeout_id > 0) {
-                Mainloop.source_remove(this._peek_timeout_id);
-                this._peek_timeout_id = 0;
-            }
-
-            this._peek_timeout_id = Mainloop.timeout_add(this.peek_delay, Lang.bind(this, function() {
+            setTimeout(() => {
                 if (this.actor.hover &&
                     !this._applet_context_menu.isOpen &&
                     !global.settings.get_boolean("panel-edit-mode")) {
 
-                    Tweener.addTween(global.window_group,
+                    addTween(global.window_group,
                                      {opacity: this.peek_opacity, time: 0.275, transition: "easeInSine"});
 
                     let windows = global.get_window_actors();
@@ -85,46 +76,36 @@ class CinnamonShowDesktopApplet extends Applet.IconApplet {
 
                         if (this.peek_blur) {
                             if (!compositor.eff)
-                                compositor.eff = new Clutter.BlurEffect();
+                                compositor.eff = new BlurEffect();
                             compositor.add_effect_with_name('peek-blur', compositor.eff);
                         }
                     }
                     this._did_peek = true;
                 }
-                this._peek_timeout_id = 0;
-                return false;
-            }));
+            }, this.peek_delay);
         }
     }
 
-    _on_leave(event) {
+    _on_leave() {
         if (this._did_peek) {
             this.show_all_windows(0.2);
             this._did_peek = false;
-        }
-        if (this._peek_timeout_id > 0) {
-            Mainloop.source_remove(this._peek_timeout_id);
-            this._peek_timeout_id = 0;
         }
     }
 
     on_applet_clicked(event) {
         global.screen.toggle_desktop(global.get_current_time());
         this.show_all_windows(0);
-        if (this._peek_timeout_id > 0) {
-            Mainloop.source_remove(this._peek_timeout_id);
-            this._peek_timeout_id = 0;
-        }
         this._did_peek = false;
     }
 
     on_applet_middle_clicked(event) {
-        Main.deskletContainer.toggle();
+        deskletContainer.toggle();
     }
 
     toggleShowDesklets() {
-        if (!Main.deskletContainer.isModal) {
-            Main.deskletContainer.raise();
+        if (!deskletContainer.isModal) {
+            deskletContainer.get_parent().set_child_above_sibling(deskletContainer, null)
         }
     }
 }

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -1,4 +1,4 @@
-const Applet = imports.ui.applet;
+const {TextIconApplet, AppletPopupMenu, AllowedLayout} = imports.ui.applet;
 const Mainloop = imports.mainloop;
 const Gio = imports.gi.Gio;
 const Interfaces = imports.misc.interfaces;
@@ -12,7 +12,7 @@ const GLib = imports.gi.GLib;
 const Cvc = imports.gi.Cvc;
 const Tooltips = imports.ui.tooltips;
 const Main = imports.ui.main;
-const Settings = imports.ui.settings;
+const {AppletSettings} = imports.ui.settings;
 const Slider = imports.ui.slider;
 
 const MEDIA_PLAYER_2_PATH = "/org/mpris/MediaPlayer2";
@@ -871,14 +871,18 @@ class MediaPlayerLauncher extends PopupMenu.PopupBaseMenuItem {
     }
 }
 
-class CinnamonSoundApplet extends Applet.TextIconApplet {
+class CinnamonSoundApplet extends TextIconApplet {
     constructor(metadata, orientation, panel_height, instanceId) {
         super(orientation, panel_height, instanceId);
 
-        this.setAllowedLayout(Applet.AllowedLayout.BOTH);
+        this.setAllowedLayout(AllowedLayout.BOTH);
 
         this.metadata = metadata;
-        this.settings = new Settings.AppletSettings(this, metadata.uuid, instanceId);
+        this.settings = new AppletSettings(this, metadata.uuid, instanceId, true);
+        this.settings.promise.then(() => this.settingsInit(orientation));
+    }
+
+    settingsInit(orientation) {
         this.settings.bind("showtrack", "showtrack", this.on_settings_changed);
         this.settings.bind("middleClickAction", "middleClickAction");
         this.settings.bind("horizontalScroll", "horizontalScroll")
@@ -900,7 +904,7 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
         if (this.hideSystray) this.registerSystrayIcons();
 
         this.menuManager = new PopupMenu.PopupMenuManager(this);
-        this.menu = new Applet.AppletPopupMenu(this, orientation);
+        this.menu = new AppletPopupMenu(this, orientation);
         this.menuManager.addMenu(this.menu);
 
         this.set_applet_icon_symbolic_name('audio-x-generic');
@@ -1059,6 +1063,8 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
 
         for(let i in this._players)
             this._players[i].destroy();
+
+        this.settings.finalize();
     }
 
     on_applet_clicked(event) {
@@ -1143,7 +1149,7 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
             this._players[this._activePlayer]._mediaServerPlayer.NextRemote();
         }
 
-        return Applet.Applet.prototype._onButtonPressEvent.call(this, actor, event);
+        return super._onButtonPressEvent(actor, event);
     }
 
     setIcon(icon, source) {

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -487,16 +487,16 @@ class Player extends PopupMenuSection {
         // We'll update this later with a proper name
         this._name = this._busName;
 
-        getDBusProxyWithOwnerAsync(MEDIA_PLAYER_2_NAME, this._busName, (p, e) => this.dbusCallback(p, e));
-        getDBusProxyWithOwnerAsync(MEDIA_PLAYER_2_PLAYER_NAME, this._busName, (p, e) => this.dbusCallback(p, e));
-        getDBusPropertiesAsync(this._busName, MEDIA_PLAYER_2_PATH, (p, e) => this.dbusCallback(p, e));
+        getDBusProxyWithOwnerAsync(MEDIA_PLAYER_2_NAME, this._busName, (p, e) => this.dbusCallback(p, e, '_mediaServer'));
+        getDBusProxyWithOwnerAsync(MEDIA_PLAYER_2_PLAYER_NAME, this._busName, (p, e) => this.dbusCallback(p, e, '_mediaServerPlayer'));
+        getDBusPropertiesAsync(this._busName, MEDIA_PLAYER_2_PATH, (p, e) => this.dbusCallback(p, e, '_prop'));
     }
 
-    dbusCallback(proxy, error) {
+    dbusCallback(proxy, error, prop) {
         if (error) {
             log(error);
         } else {
-            this._mediaServer = proxy;
+            this[prop] = proxy;
             this._dbus_acquired();
         }
     }

--- a/files/usr/share/cinnamon/applets/spacer@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/spacer@cinnamon.org/applet.js
@@ -1,22 +1,25 @@
-const Applet = imports.ui.applet;
-const St = imports.gi.St;
-const Settings = imports.ui.settings;
+const {IconApplet} = imports.ui.applet;
+const {Bin, Side} = imports.gi.St;
+const {AppletSettings} = imports.ui.settings;
 
-class CinnamonSpacerApplet extends Applet.IconApplet {
+class CinnamonSpacerApplet extends IconApplet {
     constructor(metadata, orientation, panelHeight, instance_id) {
         super(orientation, panelHeight, instance_id);
         this.actor.track_hover = false;
 
-        this.bin = new St.Bin();
+        this.bin = new Bin();
         this.actor.add(this.bin);
 
-        this.settings = new Settings.AppletSettings(this, "spacer@cinnamon.org", this.instance_id);
+        this.state = {};
 
-        this.settings.bind("width", "width", this.width_changed);
+        this.settings = new AppletSettings(this.state, 'spacer@cinnamon.org', this.instance_id, true);
+        this.settings.promise.then(() => {
+            this.settings.bind('width', 'width', () => this.width_changed());
 
-        this.orientation = orientation;
+            this.orientation = orientation;
 
-        this.width_changed();
+            this.width_changed();
+        });
     }
 
     on_orientation_changed(neworientation) {
@@ -25,7 +28,7 @@ class CinnamonSpacerApplet extends Applet.IconApplet {
         if (this.bin) {
             this.bin.destroy();
 
-            this.bin = new St.Bin();
+            this.bin = new Bin();
             this.actor.add(this.bin);
 
             this.width_changed();
@@ -33,10 +36,10 @@ class CinnamonSpacerApplet extends Applet.IconApplet {
     }
 
     width_changed() {
-        if (this.orientation == St.Side.TOP || this.orientation == St.Side.BOTTOM)
-            this.bin.width = this.width;
+        if (this.orientation == Side.TOP || this.orientation == Side.BOTTOM)
+            this.bin.width = this.state.width;
         else
-            this.bin.height = this.width;
+            this.bin.height = this.state.width;
     }
 
     on_applet_removed_from_panel() {

--- a/files/usr/share/cinnamon/applets/user@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/user@cinnamon.org/applet.js
@@ -1,4 +1,4 @@
-const Applet = imports.ui.applet;
+const {TextIconApplet, AppletPopupMenu, AllowedLayout} = imports.ui.applet;
 const Lang = imports.lang;
 const St = imports.gi.St;
 const PopupMenu = imports.ui.popupMenu;
@@ -8,22 +8,25 @@ const Gio = imports.gi.Gio;
 const AccountsService = imports.gi.AccountsService;
 const GnomeSession = imports.misc.gnomeSession;
 const ScreenSaver = imports.misc.screenSaver;
-const Settings = imports.ui.settings;
+const {AppletSettings} = imports.ui.settings;
 
-class CinnamonUserApplet extends Applet.TextIconApplet {
+class CinnamonUserApplet extends TextIconApplet {
     constructor(orientation, panel_height, instance_id) {
         super(orientation, panel_height, instance_id);
 
-        this.setAllowedLayout(Applet.AllowedLayout.BOTH);
+        this.setAllowedLayout(AllowedLayout.BOTH);
 
         this._session = new GnomeSession.SessionManager();
         this._screenSaverProxy = new ScreenSaver.ScreenSaverProxy();
-        this.settings = new Settings.AppletSettings(this, "user@cinnamon.org", instance_id);
+        this.settings = new AppletSettings(this, 'user@cinnamon.org', instance_id, true);
+        this.settings.promise.then(() => this.settingsInit(orientation));
+    }
 
+    settingsInit(orientation) {
         this.set_applet_icon_symbolic_name("avatar-default");
 
         this.menuManager = new PopupMenu.PopupMenuManager(this);
-        this.menu = new Applet.AppletPopupMenu(this, orientation);
+        this.menu = new AppletPopupMenu(this, orientation);
         this.menuManager.addMenu(this.menu);
         this._contentSection = new PopupMenu.PopupMenuSection();
         this.menu.addMenuItem(this._contentSection);

--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -1011,6 +1011,7 @@ class CinnamonWindowListApplet extends Applet.Applet {
 
         this.on_orientation_changed(orientation);
         this._updateAttentionGrabber();
+        this._onPreviewChanged();
     }
 
     on_applet_added_to_panel(userEnabled) {

--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -982,8 +982,11 @@ class CinnamonWindowListApplet extends Applet.Applet {
         this._windows = [];
         this._monitorWatchList = [];
 
-        this.settings = new Settings.AppletSettings(this, "window-list@cinnamon.org", this.instance_id);
+        this.settings = new Settings.AppletSettings(this, 'window-list@cinnamon.org', this.instance_id, true);
+        this.settings.promise.then(() => this.settingsInit(orientation));
+    }
 
+    settingsInit(orientation) {
         this.settings.bind("show-all-workspaces", "showAllWorkspaces");
         this.settings.bind("enable-alerts", "enableAlerts", this._updateAttentionGrabber);
         this.settings.bind("enable-scrolling", "scrollable", this._onEnableScrollChanged);

--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
@@ -238,8 +238,12 @@ class CinnamonWorkspaceSwitcher extends Applet.Applet {
         if (global.display.focus_window)
             this._focusWindow = global.display.focus_window.get_compositor_private();
 
-        this.settings = new Settings.AppletSettings(this, metadata.uuid, instance_id);
-        this.settings.bind("display_type", "display_type", this.queueCreateButtons);
+        this.settings = new Settings.AppletSettings(this, metadata.uuid, instance_id, true);
+        this.settings.promise.then(() => this.settingsInit());
+    }
+
+    settingsInit() {
+        this.settings.bind("display_type", "display_type", this._createButtons);
 
         this.actor.connect('scroll-event', this.hook.bind(this));
 

--- a/files/usr/share/cinnamon/desklets/clock@cinnamon.org/desklet.js
+++ b/files/usr/share/cinnamon/desklets/clock@cinnamon.org/desklet.js
@@ -28,6 +28,12 @@ class CinnamonClockDesklet extends Desklet {
         this.settings.bind('use-custom-format', 'use_custom_format', () => this._onSettingsChanged());
 
         this._menu.addSettingsAction(_('Date and Time Settings'), 'calendar');
+
+        this._onSettingsChanged();
+
+        if (this.clock_notify_id == 0) {
+            this.clock_notify_id = this.clock.connect("notify::clock", () => this._clockNotify());
+        }
     }
 
     _clockNotify(obj, pspec, data) {
@@ -38,14 +44,6 @@ class CinnamonClockDesklet extends Desklet {
         this._date.style = `font-size:${this.state.size}pt;color:${this.state.color}`;
         this._updateFormatString();
         this._updateClock();
-    }
-
-    on_desklet_added_to_desktop() {
-        this._onSettingsChanged();
-
-        if (this.clock_notify_id == 0) {
-            this.clock_notify_id = this.clock.connect("notify::clock", () => this._clockNotify());
-        }
     }
 
     on_desklet_removed() {

--- a/files/usr/share/cinnamon/desklets/clock@cinnamon.org/desklet.js
+++ b/files/usr/share/cinnamon/desklets/clock@cinnamon.org/desklet.js
@@ -1,27 +1,33 @@
 
-const St = imports.gi.St;
-const CinnamonDesktop = imports.gi.CinnamonDesktop;
+const {Label} = imports.gi.St;
+const {WallClock} = imports.gi.CinnamonDesktop;
 
-const Desklet = imports.ui.desklet;
-const Settings = imports.ui.settings;
+const {Desklet} = imports.ui.desklet;
+const {DeskletSettings} = imports.ui.settings;
 
-class CinnamonClockDesklet extends Desklet.Desklet {
+class CinnamonClockDesklet extends Desklet {
     constructor(metadata, desklet_id) {
         super(metadata, desklet_id);
-        this._date = new St.Label({style_class: "clock-desklet-label"});
+        this._date = new Label({style_class: 'clock-desklet-label'});
         this.setContent(this._date);
         this.setHeader(_("Clock"));
 
-        this.clock = new CinnamonDesktop.WallClock();
+        this.clock = new WallClock();
         this.clock_notify_id = 0;
 
-        this.settings = new Settings.DeskletSettings(this, this.metadata["uuid"], desklet_id);
-        this.settings.bind("date-format", "format");
-        this.settings.bind("font-size", "size", this._onSettingsChanged);
-        this.settings.bind("text-color", "color", this._onSettingsChanged);
-        this.settings.bind("use-custom-format", "use_custom_format", this._onSettingsChanged);
+        this.state = {};
 
-        this._menu.addSettingsAction(_("Date and Time Settings"), "calendar")
+        this.settings = new DeskletSettings(this.state, metadata.uuid, desklet_id, true);
+        this.settings.promise.then(() => this.settingsInit());
+    }
+
+    settingsInit() {
+        this.settings.bind('date-format', 'format');
+        this.settings.bind('font-size', 'size', () => this._onSettingsChanged());
+        this.settings.bind('text-color', 'color', () => this._onSettingsChanged());
+        this.settings.bind('use-custom-format', 'use_custom_format', () => this._onSettingsChanged());
+
+        this._menu.addSettingsAction(_('Date and Time Settings'), 'calendar');
     }
 
     _clockNotify(obj, pspec, data) {
@@ -29,7 +35,7 @@ class CinnamonClockDesklet extends Desklet.Desklet {
     }
 
     _onSettingsChanged() {
-        this._date.style="font-size: " + this.size + "pt;\ncolor: " + this.color;
+        this._date.style = `font-size:${this.state.size}pt;color:${this.state.color}`;
         this._updateFormatString();
         this._updateClock();
     }
@@ -47,11 +53,12 @@ class CinnamonClockDesklet extends Desklet.Desklet {
             this.clock.disconnect(this.clock_notify_id);
             this.clock_notify_id = 0;
         }
+        this.settings.finalize();
     }
 
     _updateFormatString() {
-        if (this.use_custom_format) {
-            if (!this.clock.set_format_string(this.format)) {
+        if (this.state.use_custom_format) {
+            if (!this.clock.set_format_string(this.state.format)) {
                 global.logError("Clock desklet: bad format - check your string.");
                 this.clock.set_format_string("~FORMAT ERROR~ %l:%M %p");
             }
@@ -61,7 +68,7 @@ class CinnamonClockDesklet extends Desklet.Desklet {
     }
 
     _updateClock() {
-        if (this.use_custom_format) {
+        if (this.state.use_custom_format) {
             this._date.set_text(this.clock.get_clock());
         } else {
             let default_format = this.clock.get_default_time_format();

--- a/files/usr/share/cinnamon/desklets/photoframe@cinnamon.org/desklet.js
+++ b/files/usr/share/cinnamon/desklets/photoframe@cinnamon.org/desklet.js
@@ -1,29 +1,35 @@
 const Gio = imports.gi.Gio;
 const St = imports.gi.St;
-const Desklet = imports.ui.desklet;
+const {Desklet} = imports.ui.desklet;
 const Lang = imports.lang;
 const Mainloop = imports.mainloop;
 const Clutter = imports.gi.Clutter;
 const GLib = imports.gi.GLib;
 const Tweener = imports.ui.tweener;
 const Util = imports.misc.util;
-const Settings = imports.ui.settings;
+const {DeskletSettings} = imports.ui.settings;
 
-class CinnamonPhotoFrameDesklet extends Desklet.Desklet {
+class CinnamonPhotoFrameDesklet extends Desklet {
     constructor(metadata, desklet_id) {
         super(metadata, desklet_id);
 
         this.metadata = metadata;
         this.update_id = 0;
 
-        this.settings = new Settings.DeskletSettings(this, this.metadata.uuid, this.instance_id);
-        this.settings.bind('directory', 'dir', this.on_setting_changed);
-        this.settings.bind('shuffle', 'shuffle', this.on_setting_changed);
-        this.settings.bind('delay', 'delay', this.on_setting_changed);
-        this.settings.bind('height', 'height', this.on_setting_changed);
-        this.settings.bind('width', 'width', this.on_setting_changed);
-        this.settings.bind('fade-delay', 'fade_delay', this.on_setting_changed);
-        this.settings.bind('effect', 'effect', this.on_setting_changed);
+        this.state = {};
+
+        this.settings = new DeskletSettings(this.state, metadata.uuid, this.instance_id, true);
+        this.settings.promise.then(() => this.settingsInit());
+    }
+
+    settingsInit() {
+        this.settings.bind('directory', 'dir', () => this.on_setting_changed());
+        this.settings.bind('shuffle', 'shuffle', () => this.on_setting_changed());
+        this.settings.bind('delay', 'delay', () => this.on_setting_changed());
+        this.settings.bind('height', 'height', () => this.on_setting_changed());
+        this.settings.bind('width', 'width', () => this.on_setting_changed());
+        this.settings.bind('fade-delay', 'fade_delay', () => this.on_setting_changed());
+        this.settings.bind('effect', 'effect', () => this.on_setting_changed());
 
         this.dir_monitor_id = 0;
         this.dir_monitor = null;
@@ -48,6 +54,8 @@ class CinnamonPhotoFrameDesklet extends Desklet.Desklet {
     }
 
     _setup_dir_monitor() {
+        let {dir} = this.state;
+
         if (this.dir_monitor_id != 0 && this.dir_monitor) {
             this.dir_monitor.disconnect(this.dir_monitor_id);
             this.dir_monitor_id = 0;
@@ -57,17 +65,17 @@ class CinnamonPhotoFrameDesklet extends Desklet.Desklet {
            was changed to use a URI instead of a path. This check is just
            to ensure that people upgrading cinnamon versions will get the
            existing path converted to a proper URI */
-        if (this.dir.indexOf('://') === -1) {
-            let file = Gio.file_new_for_path(this.dir);
-            this.dir = file.get_uri();
+        if (dir.indexOf('://') === -1) {
+            let file = Gio.file_new_for_path(dir);
+            this.state.dir = file.get_uri();
         }
 
-        if (this.dir === ' ') {
+        if (dir === ' ') {
             let file = Gio.file_new_for_path(GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_PICTURES));
-            this.dir = file.get_uri();
+            this.state.dir = file.get_uri();
         }
 
-        this.dir_file = Gio.file_new_for_uri(this.dir);
+        this.dir_file = Gio.file_new_for_uri(dir);
         this.dir_monitor = this.dir_file.monitor_directory(0, null);
         this.dir_monitor_id = this.dir_monitor.connect('changed', Lang.bind(this, this.on_setting_changed));
     }
@@ -103,19 +111,21 @@ class CinnamonPhotoFrameDesklet extends Desklet.Desklet {
     }
 
     setup_display() {
+        let {width, height, effect, dir} = this.state;
+
         this._photoFrame = new St.Bin({style_class: 'photoframe-box', x_align: St.Align.START});
 
         this._bin = new St.Bin();
-        this._bin.set_size(this.width, this.height);
+        this._bin.set_size(width, height);
 
         this._images = [];
         this._photoFrame.set_child(this._bin);
         this.setContent(this._photoFrame);
 
-        if (this.effect == 'black-and-white') {
+        if (effect === 'black-and-white') {
             let effect = new Clutter.DesaturateEffect();
             this._bin.add_effect(effect);
-        } else if (this.effect == 'sepia') {
+        } else if (effect === 'sepia') {
             let color = new Clutter.Color();
             color.from_hls(17.0, 0.59, 0.4);
             let colorize_effect = new Clutter.ColorizeEffect(color);
@@ -130,7 +140,7 @@ class CinnamonPhotoFrameDesklet extends Desklet.Desklet {
         }
 
         if (this.dir_file.query_exists(null)) {
-            this._scan_dir(this.dir);
+            this._scan_dir(dir);
 
             this.updateInProgress = false;
             this.currentPicture = null;
@@ -142,25 +152,26 @@ class CinnamonPhotoFrameDesklet extends Desklet.Desklet {
 
     _update_loop() {
         this._update();
-        this.update_id = Mainloop.timeout_add_seconds(this.delay, Lang.bind(this, this._update_loop));
+        this.update_id = Mainloop.timeout_add_seconds(this.state.delay, Lang.bind(this, this._update_loop));
     }
 
     _size_pic(image) {
         image.disconnect(image._notif_id);
 
-        let height, width;
+        let {height, width} = this.state;
+        let _width, _height;
         let imageRatio = image.width / image.height;
-        let frameRatio = this.width / this.height;
+        let frameRatio = width / height;
 
         if (imageRatio > frameRatio) {
-            width = this.width;
-            height = this.width / imageRatio;
+            _width = width;
+            _height = width / imageRatio;
         } else {
-            height = this.height;
-            width = this.height * imageRatio;
+            _height = height;
+            _width = height * imageRatio;
         }
 
-        image.set_size(width, height);
+        image.set_size(_width, _height);
     }
 
     _update() {
@@ -168,8 +179,9 @@ class CinnamonPhotoFrameDesklet extends Desklet.Desklet {
             return;
         }
         this.updateInProgress = true;
+        let {shuffle, fade_delay} = this.state;
         let image_path;
-        if (!this.shuffle) {
+        if (!shuffle) {
             image_path = this._images.shift();
             this._images.push(image_path);
         } else {
@@ -192,16 +204,16 @@ class CinnamonPhotoFrameDesklet extends Desklet.Desklet {
         this.currentPicture = image;
         this.currentPicture.path = image_path;
 
-        if (this.fade_delay > 0) {
+        if (fade_delay > 0) {
             Tweener.addTween(this._bin, {
                 opacity: 0,
-                time: this.fade_delay,
+                time: fade_delay,
                 transition: 'easeInSine',
                 onComplete: () => {
                     this._bin.set_child(this.currentPicture);
                     Tweener.addTween(this._bin, {
                         opacity: 255,
-                        time: this.fade_delay,
+                        time: fade_delay,
                         transition: 'easeInSine'
                     });
                 }
@@ -230,7 +242,7 @@ class CinnamonPhotoFrameDesklet extends Desklet.Desklet {
 
     _loadImage(filePath) {
         try {
-            let image = St.TextureCache.get_default().load_uri_async(filePath, this.width, this.height);
+            let image = St.TextureCache.get_default().load_uri_async(filePath, this.state.width, this.state.height);
 
             image._notif_id = image.connect('notify::size', Lang.bind(this, this._size_pic));
 

--- a/files/usr/share/cinnamon/desklets/photoframe@cinnamon.org/desklet.js
+++ b/files/usr/share/cinnamon/desklets/photoframe@cinnamon.org/desklet.js
@@ -5,6 +5,12 @@ const {
     FileType
 } = imports.gi.Gio;
 const {
+    BrightnessContrastEffect,
+    Color,
+    ColorizeEffect,
+    DesaturateEffect
+} = imports.gi.Clutter;
+const {
     Align,
     Bin,
     TextureCache
@@ -119,14 +125,14 @@ class CinnamonPhotoFrameDesklet extends Desklet {
         this.setContent(this._photoFrame);
 
         if (effect === 'black-and-white') {
-            let effect = new Clutter.DesaturateEffect();
+            let effect = new DesaturateEffect();
             this._bin.add_effect(effect);
         } else if (effect === 'sepia') {
-            let color = new Clutter.Color();
+            let color = new Color();
             color.from_hls(17.0, 0.59, 0.4);
-            let colorize_effect = new Clutter.ColorizeEffect(color);
-            let contrast_effect = new Clutter.BrightnessContrastEffect();
-            let desaturate_effect = new Clutter.DesaturateEffect();
+            let colorize_effect = new ColorizeEffect(color);
+            let contrast_effect = new BrightnessContrastEffect();
+            let desaturate_effect = new DesaturateEffect();
             desaturate_effect.set_factor(0.41);
             contrast_effect.set_brightness_full(0.1, 0.1, 0.1);
             contrast_effect.set_contrast_full(0.1, 0.1, 0.1);

--- a/js/ui/settings.js
+++ b/js/ui/settings.js
@@ -251,10 +251,6 @@ function has_required_fields(props, key) {
     return true;
 }
 
-function XletSettingsBase(bindObject, uuid, instanceId, async) {
-    this._init(bindObject, uuid, instanceId, async);
-}
-
 /**
  * #XletSettingsBase:
  * @short_description: Object for handling xlet settings updates
@@ -264,8 +260,8 @@ function XletSettingsBase(bindObject, uuid, instanceId, async) {
  * directly, but rather through one of the wrapper classes (#AppletSettings,
  * #DeskletSettings, or #ExtensionSettings)
  */
-XletSettingsBase.prototype = {
-    _init: function(bindObject, uuid, instanceId, async = false) {
+class XletSettingsBase {
+    constructor(bindObject, uuid, instanceId, async = false) {
         this.isReady = false;
         this.bindObject = bindObject;
         this.uuid = uuid;
@@ -274,14 +270,16 @@ XletSettingsBase.prototype = {
         else this.instanceId = this.uuid;
         this.bindings = {};
         this.settingsData = {};
+        this.promise = null;
 
-        if (this._ensureSettingsFiles()) this._register();
-    },
+        if (async) this.promise = this._ensureSettingsFiles();
+        else if (this._ensureSettingsFiles()) this._register();
+    }
 
-    _register: function() {
+    _register() {
         Main.settingsManager.register(this.uuid, this.instanceId, this);
         this.isReady = true;
-    },
+    }
 
     /**
      * bindWithObject:
@@ -299,7 +297,7 @@ XletSettingsBase.prototype = {
      *
      * Returns (boolean): Whether the bind was successful
      */
-    bindWithObject: function(bindObject, key, applet_prop, callback, user_data) {
+    bindWithObject(bindObject, key, applet_prop, callback, user_data) {
         if (!this.isReady) {
             settings_not_initialized_error(this.uuid);
             return false;
@@ -338,7 +336,7 @@ XletSettingsBase.prototype = {
             this.settingsData[key].value.save = Lang.bind(this, this._saveToFile);
         }
         return true;
-    },
+    }
 
     /**
      * bind:
@@ -352,9 +350,9 @@ XletSettingsBase.prototype = {
      *
      * Returns (boolean): Whether the bind was successful
      */
-    bind: function(key, applet_prop, callback, user_data) {
+    bind(key, applet_prop, callback, user_data) {
         return this.bindWithObject(this.bindObject, key, applet_prop, callback, user_data)
-    },
+    }
 
     /**
      * bindProperty:
@@ -371,9 +369,9 @@ XletSettingsBase.prototype = {
      *
      * Returns (boolean): Whether the bind was successful
      */
-    bindProperty: function(direction, key, applet_prop, callback, user_data) {
+    bindProperty(direction, key, applet_prop, callback, user_data) {
         return this.bind(key, applet_prop, callback, user_data);
-    },
+    }
 
     /**
      * unbindWithObject:
@@ -387,7 +385,7 @@ XletSettingsBase.prototype = {
      *
      * Returns (boolean): Whether the unbind was successful.
      */
-    unbindWithObject: function(bindObject, key) {
+    unbindWithObject(bindObject, key) {
         if ((key in this.bindings)) {
             for (let i in this.bindings[key]) {
                 let info = this.bindings[key][i];
@@ -400,7 +398,7 @@ XletSettingsBase.prototype = {
 
         binding_not_found_error(key, this.uuid);
         return false;
-    },
+    }
 
     /**
      * unbind:
@@ -412,7 +410,7 @@ XletSettingsBase.prototype = {
      *
      * Returns (boolean): Whether the unbind was successful.
      */
-    unbind: function(key) {
+    unbind(key) {
         if ((key in this.bindings)) {
             for (let i in this.bindings[key]) {
                 let info = this.bindings[key][i];
@@ -425,7 +423,7 @@ XletSettingsBase.prototype = {
 
         binding_not_found_error(key, this.uuid);
         return false;
-    },
+    }
 
     /**
      * unbindProperty:
@@ -437,9 +435,9 @@ XletSettingsBase.prototype = {
      *
      * Returns (boolean): Whether the unbind was successful.
      */
-    unbindProperty: function (key) {
+    unbindProperty(key) {
         this.unbind(key);
-    },
+    }
 
     /**
      * unbindAll:
@@ -449,7 +447,7 @@ XletSettingsBase.prototype = {
      *
      * Returns (boolean): Whether the unbind was successful.
      */
-    unbindAll: function (key) {
+    unbindAll(key) {
         if (!(key in this.bindings)) {
             binding_not_found_error(key, this.uuid);
             return false;
@@ -461,19 +459,19 @@ XletSettingsBase.prototype = {
         }
         delete this.bindings[key];
         return true;
-    },
+    }
 
-    _getValue: function(key) {
+    _getValue(key) {
         let value = this.settingsData[key].value;
         return value;
-    },
+    }
 
-    _setValue: function(value, key) {
+    _setValue(value, key) {
         if (this.settingsData[key].value != value || typeof(value) == "object") {
             this.settingsData[key].value = value;
             this._saveToFile();
         }
-    },
+    }
 
     /**
      * getValue:
@@ -483,13 +481,13 @@ XletSettingsBase.prototype = {
      *
      * Returns: The current value of the setting
      */
-    getValue: function(key) {
+    getValue(key) {
         if (key in this.settingsData) return this._getValue(key);
         else {
             key_not_found_error(key, this.uuid);
             return null;
         }
-    },
+    }
 
     /**
      * setValue:
@@ -498,13 +496,13 @@ XletSettingsBase.prototype = {
      *
      * Sets the value of the setting @key to @value.
      */
-    setValue: function(key, value) {
+    setValue(key, value) {
         if (!(key in this.settingsData)) {
             key_not_found_error(key, this.uuid);
             return;
         }
         this._setValue(value, key);
-    },
+    }
 
     /**
      * getDefaultValue:
@@ -532,7 +530,7 @@ XletSettingsBase.prototype = {
      * Returns: The currently stored options of the key (or undefined if the key does
      * not support options)
      */
-    getOptions: function (key) {
+    getOptions(key) {
         if (!(key in this.settingsData)) {
             key_not_found_error(key, this.uuid);
             return null;
@@ -544,7 +542,7 @@ XletSettingsBase.prototype = {
         }
 
         return this.settingsData[key].options;
-    },
+    }
 
     /**
      * setOptions:
@@ -554,7 +552,7 @@ XletSettingsBase.prototype = {
      * Sets the available options of @key to @options. An error is given if the setting
      * does not support options.
      */
-    setOptions: function (key, options) {
+    setOptions(key, options) {
         if (!(key in this.settingsData)) {
             key_not_found_error(key, this.uuid);
             return;
@@ -569,9 +567,9 @@ XletSettingsBase.prototype = {
             this.settingsData[key].options = options;
             this._saveToFile();
         }
-    },
+    }
 
-    _checkSettings: function() {
+    _checkSettings() {
         let oldSettings = this.settingsData;
         readJSONAsync(this.file).then((json) => {
             if (this.finalized) return;
@@ -620,9 +618,9 @@ XletSettingsBase.prototype = {
                 this.emit("settings-changed");
             }
         });
-    },
+    }
 
-    _ensureSettingsFiles: function() {
+    _ensureSettingsFiles() {
         let configPath = [GLib.get_home_dir(), ".cinnamon", "configs", this.uuid].join("/");
         let configDir = Gio.file_new_for_path(configPath);
         if (!configDir.query_exists(null)) configDir.make_directory_with_parents(null);
@@ -631,14 +629,11 @@ XletSettingsBase.prototype = {
         let xletDir = Extension.getExtension(this.uuid).dir;
         let templateFile = xletDir.get_child("settings-schema.json");
 
-        if (this.async) {
-            this._ensureSettingsFilesAsync(templateFile);
-            return false;
-        }
-        else return this._ensureSettingsFilesSync(templateFile);
-    },
+        if (this.async) return this.checkSchema(templateFile);
+        return this._ensureSettingsFilesSync(templateFile);
+    }
 
-    _ensureSettingsFilesSync: function(templateFile) {
+    _ensureSettingsFilesSync(templateFile) {
         // If the settings have already been installed previously we need to check if the schema
         // has changed and if so, do an upgrade
         if (this.file.query_exists(null)) {
@@ -697,19 +692,18 @@ XletSettingsBase.prototype = {
         if (!this.monitorId) this.monitorId = this.monitor.connect("changed", Lang.bind(this, this._checkSettings));
 
         return true;
-    },
+    }
 
-    _ensureSettingsFilesAsync: function(templateFile) {
+    checkSchema(templateFile) {
         // If the settings have already been installed previously we need to check if the schema
         // has changed and if so, do an upgrade
         if (!this.file.query_exists(null)) {
             // If the settings haven't already been installed, we need to do that now
             if (!templateFile.query_exists(null)) {
-                global.logError(`Unable to load settings for ${this.uuid}: settings-schema.json could not be found`);
-                return false;
+                throw new Error(`Unable to load settings for ${this.uuid}: settings-schema.json could not be found`);
             }
 
-            readFileAsync(templateFile).then((templateData) => {
+            return readFileAsync(templateFile).then((templateData) => {
                 if (!this._doInstall(templateData)) {
                     throw new Error(`Unable to install settings for ${this.uuid}: there is a problem with settings-schema.json`);
                 }
@@ -717,10 +711,12 @@ XletSettingsBase.prototype = {
             })
             .then(() => this._ensureSettingsFilesAsync(templateFile))
             .catch((e) => global.logError(e));
-            return;
         }
+        return this._ensureSettingsFilesAsync(templateFile);
+    }
 
-        readJSONAsync(this.file).then((json) => {
+    _ensureSettingsFilesAsync(templateFile) {
+        return readJSONAsync(this.file).then((json) => {
             if (this.finalized) return;
             this.settingsData = json;
             // if this.settingsData is populated, all we need to do is check for a newer version of the schema and upgrade if we find one
@@ -729,10 +725,7 @@ XletSettingsBase.prototype = {
             if (templateFile.query_exists(null)) return readFileAsync(templateFile);
             // if settings-schema.json is missing, we can still load the settings from data, so we
             // will merely skip the upgrade test
-            else {
-                global.logWarning(`Couldn't find file settings-schema.json for ${this.uuid}: skipping upgrade`);
-                return Promise.resolve(null);
-            }
+            throw new Error(`Couldn't find file settings-schema.json for ${this.uuid}: skipping upgrade`);
         }).then((templateData) => {
             if (templateData) {
                 let checksum = global.get_md5_for_string(templateData);
@@ -742,10 +735,8 @@ XletSettingsBase.prototype = {
                 }
             }
         }).then(() => {
-            if (!this.monitorId) this.monitorId = this.monitor.connect('changed', Lang.bind(this, this._checkSettings));
-
+            if (!this.monitorId) this.monitorId = this.monitor.connect('changed', () => this._checkSettings());
             this._register();
-            this.emit('ready');
         }).catch((e) => {
             global.logError(e);
             if (this.settingsData) global.logWarning(`Upgrade failed for ${this.uuid}: falling back to previous settings`);
@@ -755,9 +746,9 @@ XletSettingsBase.prototype = {
             }
 
         });
-    },
+    }
 
-    _doInstall: function(templateData) {
+    _doInstall(templateData) {
         global.log(`Installing settings for ${this.uuid}`);
         let checksum = global.get_md5_for_string(templateData);
         this.settingsData = JSON.parse(templateData);
@@ -771,9 +762,9 @@ XletSettingsBase.prototype = {
 
         global.log(`Settings successfully installed for ${this.uuid}`);
         return true;
-    },
+    }
 
-    _doUpgrade: function(templateData, checksum) {
+    _doUpgrade(templateData, checksum) {
         global.log("Upgrading settings for " + this.uuid);
         let newSettings = JSON.parse(templateData);
         for (let key in newSettings) {
@@ -795,15 +786,14 @@ XletSettingsBase.prototype = {
 
         this.settingsData = newSettings;
         global.log("Settings successfully upgraded for " + this.uuid);
-    },
+    }
 
-    _checkSanity: function(val, setting) {
+    _checkSanity(val, setting) {
         let found;
         switch (setting["type"]) {
             case "spinbutton":
             case "scale":
                 return (val < setting["max"] && val > setting["min"]);
-                break;
             case "combobox":
             case "radiogroup":
                 found = false;
@@ -814,48 +804,51 @@ XletSettingsBase.prototype = {
                     }
                 }
                 return found;
-                break;
             default:
                 return true;
-                break;
         }
-        return true;
-    },
+    }
 
-    _loadFromFile: function() {
+    _loadFromFile() {
         let rawData = Cinnamon.get_file_contents_utf8_sync(this.file.get_path());
         let json = JSON.parse(rawData);
 
         return json;
-    },
+    }
 
-    _saveToFile: function() {
-        if (this.monitorId) this.monitor.disconnect(this.monitorId);
+    _saveToFile() {
+        if (this.monitorId) {
+            this.monitor.disconnect(this.monitorId);
+            this.monitorId = 0;
+        }
         let rawData = JSON.stringify(this.settingsData, null, 4);
         if (this.async) return this._saveToFileAsync(rawData);
         else this._saveToFileSync(rawData);
-    },
+    }
 
-    _saveToFileSync: function(rawData) {
+    _saveToFileSync(rawData) {
         let raw = this.file.replace(null, false, Gio.FileCreateFlags.NONE, null);
         let out_file = Gio.BufferedOutputStream.new_sized(raw, 4096);
         Cinnamon.write_string_to_stream(out_file, rawData);
         out_file.close(null);
         this.monitorId = this.monitor.connect("changed", Lang.bind(this, this._checkSettings));
-    },
+    }
 
-    _saveToFileAsync: function(rawData) {
-        if (this.monitorId) this.monitor.disconnect(this.monitorId);
+    _saveToFileAsync(rawData) {
+        if (this.monitorId) {
+            this.monitor.disconnect(this.monitorId);
+            this.monitorId = 0;
+        }
         return writeFileAsync(this.file, rawData, () => {
             this.monitorId = this.monitor.connect("changed", Lang.bind(this, this._checkSettings));
         });
-    },
+    }
 
     // called by cinnamonDBus.js to when the setting is changed remotely. This is to expedite the
     // update due to settings changes, as the file monitor has a significant delay.
-    remoteUpdate: function(key, payload) {
+    remoteUpdate(key, payload) {
         this._checkSettings();
-    },
+    }
 
     /**
      * finalize:
@@ -863,7 +856,7 @@ XletSettingsBase.prototype = {
      * Removes all bindings and disconnects all signals. This function should be called prior
      * to deleting the object.
      */
-    finalize: function() {
+    finalize() {
         this.finalized = true;
         Main.settingsManager.unregister(this.uuid, this.instanceId);
         for (let key in this.bindings) {
@@ -881,26 +874,20 @@ Signals.addSignalMethods(XletSettingsBase.prototype);
  *
  * Inherits: Settings.XletSettingsBase
  */
-function AppletSettings(xlet, uuid, instanceId, async) {
-    this._init(xlet, uuid, instanceId, async);
-}
-
-AppletSettings.prototype = {
-    __proto__: XletSettingsBase.prototype,
-
+var AppletSettings = class AppletSettings extends XletSettingsBase {
     /**
      * _init:
      * @xlet (Object): the object variables are binded to (usually `this`)
      * @uuid (string): uuid of the applet
      * @instanceId (int): instance id of the applet
      */
-    _init: function (xlet, uuid, instanceId, async) {
-        XletSettingsBase.prototype._init.call(this, xlet, uuid, instanceId, async);
-    },
+    constructor(xlet, uuid, instanceId, async) {
+        super(xlet, uuid, instanceId, async);
+    }
 
-    _get_is_multi_instance_xlet: function(uuid) {
+    _get_is_multi_instance_xlet(uuid) {
         return Extension.get_max_instances(uuid) != 1;
-    },
+    }
 };
 
 /**
@@ -909,24 +896,18 @@ AppletSettings.prototype = {
  *
  * Inherits: Settings.XletSettingsBase
  */
-function DeskletSettings(xlet, uuid, instanceId, async) {
-    this._init(xlet, uuid, instanceId, async);
-}
-
-DeskletSettings.prototype = {
-    __proto__: XletSettingsBase.prototype,
-
+var DeskletSettings = class DeskletSettings extends XletSettingsBase {
     /**
      * _init:
      * @xlet (Object): the object variables are binded to (usually `this`)
      * @uuid (string): uuid of the desklet
      * @instanceId (int): instance id of the desklet
      */
-    _init: function (xlet, uuid, instanceId, async) {
-        XletSettingsBase.prototype._init.call(this, xlet, uuid, instanceId, async);
-    },
+    constructor(xlet, uuid, instanceId, async) {
+        super(xlet, uuid, instanceId, async);
+    }
 
-    _get_is_multi_instance_xlet: function(uuid) {
+    _get_is_multi_instance_xlet(uuid) {
         return Extension.get_max_instances(uuid) > 1;
     }
 };
@@ -937,43 +918,33 @@ DeskletSettings.prototype = {
  *
  * Inherits: Settings.XletSettingsBase
  */
-function ExtensionSettings(xlet, uuid) {
-    this._init(xlet, uuid);
-}
-
-ExtensionSettings.prototype = {
-    __proto__: XletSettingsBase.prototype,
-
+var ExtensionSettings = class ExtensionSettings extends XletSettingsBase {
     /**
      * _init:
      * @xlet (Object): the object variables are binded to (usually `this`)
      * @uuid (string): uuid of the extension
      */
-    _init: function (xlet, uuid) {
-        XletSettingsBase.prototype._init.call(this, xlet, uuid, null);
-    },
+    constructor(xlet, uuid, async) {
+        super(xlet, uuid, null, async);
+    }
 
-    _get_is_multi_instance_xlet: function(uuid) {
+    _get_is_multi_instance_xlet(uuid) {
         return false;
     }
 };
 
-function SettingsManager() {
-    this._init();
-}
-
-SettingsManager.prototype = {
-    _init: function () {
+var SettingsManager = class SettingsManager {
+    constructor() {
         this.uuids = {};
-    },
+    }
 
-    register: function (uuid, instance_id, obj) {
+    register(uuid, instance_id, obj) {
         if (!(uuid in this.uuids))
             this.uuids[uuid] = {}
         this.uuids[uuid][instance_id] = obj;
-    },
+    }
 
-    unregister: function (uuid, instance_id) {
+    unregister(uuid, instance_id) {
         this.uuids[uuid][instance_id] = null;
     }
 };

--- a/js/ui/settings.js
+++ b/js/ui/settings.js
@@ -512,14 +512,14 @@ class XletSettingsBase {
      *
      * Returns: The default value of the setting
      */
-    getDefaultValue: function(key) {
+    getDefaultValue(key) {
         if (key in this.settingsData) {
             return this.settingsData[key].default;
         } else {
             key_not_found_error(key, this.uuid);
             return null;
         }
-    },
+    }
 
     /**
      * getOptions:

--- a/js/ui/settings.js
+++ b/js/ui/settings.js
@@ -261,18 +261,18 @@ function has_required_fields(props, key) {
  * #DeskletSettings, or #ExtensionSettings)
  */
 class XletSettingsBase {
-    constructor(bindObject, uuid, instanceId, async = false) {
+    constructor(bindObject, uuid, instanceId, asynchronous = false) {
         this.isReady = false;
         this.bindObject = bindObject;
         this.uuid = uuid;
-        this.async = async;
+        this.async = asynchronous;
         if (this._get_is_multi_instance_xlet(this.uuid)) this.instanceId = instanceId;
         else this.instanceId = this.uuid;
         this.bindings = {};
         this.settingsData = {};
         this.promise = null;
 
-        if (async) this.promise = this._ensureSettingsFiles();
+        if (asynchronous) this.promise = this._ensureSettingsFiles();
         else if (this._ensureSettingsFiles()) this._register();
     }
 
@@ -881,8 +881,8 @@ var AppletSettings = class AppletSettings extends XletSettingsBase {
      * @uuid (string): uuid of the applet
      * @instanceId (int): instance id of the applet
      */
-    constructor(xlet, uuid, instanceId, async) {
-        super(xlet, uuid, instanceId, async);
+    constructor(xlet, uuid, instanceId, asynchronous) {
+        super(xlet, uuid, instanceId, asynchronous);
     }
 
     _get_is_multi_instance_xlet(uuid) {
@@ -903,8 +903,8 @@ var DeskletSettings = class DeskletSettings extends XletSettingsBase {
      * @uuid (string): uuid of the desklet
      * @instanceId (int): instance id of the desklet
      */
-    constructor(xlet, uuid, instanceId, async) {
-        super(xlet, uuid, instanceId, async);
+    constructor(xlet, uuid, instanceId, asynchronous) {
+        super(xlet, uuid, instanceId, asynchronous);
     }
 
     _get_is_multi_instance_xlet(uuid) {
@@ -924,8 +924,8 @@ var ExtensionSettings = class ExtensionSettings extends XletSettingsBase {
      * @xlet (Object): the object variables are binded to (usually `this`)
      * @uuid (string): uuid of the extension
      */
-    constructor(xlet, uuid, async) {
-        super(xlet, uuid, null, async);
+    constructor(xlet, uuid, asynchronous) {
+        super(xlet, uuid, null, asynchronous);
     }
 
     _get_is_multi_instance_xlet(uuid) {


### PR DESCRIPTION
In order for this to be compatible with existing xlets, all of the synchronous code needs to be kept until they are all updated to initialize with a settings promise. `_checkSettings` is an exception to this because it is only responding to settings changes via the file monitor, which is async in nature already. `settings-example@cinnamon.org` is the first applet updated to work with the new async code paths.

I recommend testing this with #8201.

Todo:

- [x] Update all Cinnamon xlets