### PR TITLE
st-theme-node: fix text shadow 'none' to correctly draw no shadow

### DIFF
--- a/src/st/st-theme-node.c
+++ b/src/st/st-theme-node.c
@@ -3045,11 +3045,13 @@ parse_shadow_property (StThemeNode       *node,
                        gdouble           *yoffset,
                        gdouble           *blur,
                        gdouble           *spread,
-                       gboolean          *inset)
+                       gboolean          *inset,
+                       gboolean          *is_none)
 {
   GetFromTermResult result;
   CRTerm *term;
   int n_offsets = 0;
+  *is_none = FALSE;
 
   /* default values */
   color->red = 0x0; color->green = 0x0; color->blue = 0x0; color->alpha = 0xff;
@@ -3070,6 +3072,12 @@ parse_shadow_property (StThemeNode       *node,
    */
   for (term = decl->value; term; term = term->next)
     {
+      if (term_is_none (term))
+        {
+          *is_none = TRUE;
+          return VALUE_FOUND;
+        }
+
       if (term->type == TERM_NUMBER)
         {
           gdouble value;
@@ -3167,7 +3175,8 @@ parse_shadow_property (StThemeNode       *node,
  * See also st_theme_node_get_shadow(), which provides a simpler API.
  *
  * Return value: %TRUE if the property was found in the properties for this
- *  theme node (or in the properties of parent nodes when inheriting.)
+ * theme node (or in the properties of parent nodes when inheriting.), %FALSE
+ * if the property was not found, or was explicitly set to 'none'.
  */
 gboolean
 st_theme_node_lookup_shadow (StThemeNode  *node,
@@ -3181,6 +3190,7 @@ st_theme_node_lookup_shadow (StThemeNode  *node,
   gdouble blur = 0.;
   gdouble spread = 0.;
   gboolean inset = FALSE;
+  gboolean is_none = FALSE;
 
   int i;
 
@@ -3199,9 +3209,12 @@ st_theme_node_lookup_shadow (StThemeNode  *node,
                                                             &yoffset,
                                                             &blur,
                                                             &spread,
-                                                            &inset);
+                                                            &inset,
+                                                            &is_none);
           if (result == VALUE_FOUND)
             {
+              if (is_none)
+                return FALSE;
               *shadow = st_shadow_new (&color,
                                        xoffset, yoffset,
                                        blur, spread,


### PR DESCRIPTION
https://github.com/GNOME/gnome-shell/commit/2e1e00c3de747b9208fcd8fd6a1b713d99adc932#diff-b948bb195b709c61ce7275142a2fbdfd