### PR TITLE
st-private: Don't try to create shadow for empty texture

### DIFF
--- a/src/st/st-private.c
+++ b/src/st/st-private.c
@@ -472,7 +472,8 @@ _st_create_shadow_pipeline_from_actor (StShadow     *shadow_spec,
       CoglTexture *texture;
 
       texture = clutter_texture_get_cogl_texture (CLUTTER_TEXTURE (actor));
-      shadow_pipeline = _st_create_shadow_pipeline (shadow_spec, texture);
+      if (texture)
+        shadow_pipeline = _st_create_shadow_pipeline (shadow_spec, texture);
     }
   else
     {


### PR DESCRIPTION
https://github.com/GNOME/gnome-shell/commit/d1c71fd00d82b517da439a36ce86ca403c645fa2#diff-b948bb195b709c61ce7275142a2fbdfd
This stops an error warning I see frequently