### PR TITLE
st-icon: remove unused size values

### DIFF
--- a/src/st/st-icon.c
+++ b/src/st/st-icon.c
@@ -186,10 +186,8 @@ st_icon_paint (ClutterActor *actor)
       if (priv->shadow_pipeline)
         {
           ClutterActorBox allocation;
-          float width, height;
 
           clutter_actor_get_allocation_box (priv->icon_texture, &allocation);
-          clutter_actor_box_get_size (&allocation, &width, &height);
 
           _st_paint_shadow_with_opacity (priv->shadow_spec,
                                          priv->shadow_pipeline,


### PR DESCRIPTION
https://github.com/GNOME/gnome-shell/commit/2ba26407f18e2520a87bbae58b29cf72fe9c6a26#diff-b948bb195b709c61ce7275142a2fbdfd