### PR TITLE
st-texture-cache: Use right event to detect file changes

### DIFF
--- a/src/st/st-texture-cache.c
+++ b/src/st/st-texture-cache.c
@@ -994,7 +994,7 @@ file_changed_cb (GFileMonitor      *monitor,
   StTextureCache *cache = user_data;
   char *uri, *key;
 
-  if (event_type != G_FILE_MONITOR_EVENT_CHANGED)
+  if (event_type != G_FILE_MONITOR_EVENT_CHANGES_DONE_HINT)
     return;
 
   uri = g_file_get_uri (file);


### PR DESCRIPTION
https://github.com/GNOME/gnome-shell/commit/ca3f4cfb41851fec84a68fc334bef2e3e9a552bc#diff-b948bb195b709c61ce7275142a2fbdfd