### PR TITLE
[Next] st-theme-node-drawing: Avoid integer overflow on unpremultiply

### DIFF
--- a/src/st/st-theme-node-drawing.c
+++ b/src/st/st-theme-node-drawing.c
@@ -224,9 +224,9 @@ unpremultiply (ClutterColor *color)
 
   if (alpha)
     {
-      color->red = (color->red * 255 + round) / alpha;
-      color->green = (color->green * 255 + round) / alpha;
-      color->blue = (color->blue * 255 + round) / alpha;
+      color->red = MIN((color->red * 255 + round) / alpha, 255);
+      color->green = MIN((color->green * 255 + round) / alpha, 255);
+      color->blue = MIN((color->blue * 255 + round) / alpha, 255);
     }
 }
 static void


### PR DESCRIPTION
https://github.com/GNOME/gnome-shell/commit/925a25da17986bf60f61bb4e06ec22e2c59fa14f#diff-b948bb195b709c61ce7275142a2fbdfd