### PR TITLE
Replace allocation signals with callbacks

### DIFF
--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/calendar.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/calendar.js
@@ -214,7 +214,7 @@ class Calendar {
                        {row: 0, col: 0, col_span: offsetCols + 3});
         }
 
-        this.actor.connect('style-changed', Lang.bind(this, this._onStyleChange));
+        this.actor.set_style_changed_callback(() => this._onStyleChange());
 
         let back = new St.Button({ style_class: 'calendar-change-month-back' });
         this._topBoxMonth.add(back);

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -95,6 +95,10 @@ class AppGroup {
             can_focus: true,
             track_hover: true
         });
+        this.actor.set_allocation_callback((b, f) => this.allocate(b, f))
+        this.actor.set_preferred_width_callback((w) => this.getPreferredWidth(w))
+        this.actor.set_preferred_height_callback((h) => this.getPreferredHeight(h));
+
         this.actor._delegate = this;
 
         this.progressOverlay = new St.Widget({
@@ -149,9 +153,6 @@ class AppGroup {
 
         this._draggable = new DND._Draggable(this.actor);
 
-        this.signals.connect(this.actor, 'get-preferred-width', (...args) => this.getPreferredWidth(...args));
-        this.signals.connect(this.actor, 'get-preferred-height', (...args) => this.getPreferredHeight(...args));
-        this.signals.connect(this.actor, 'allocate', (...args) => this.allocate(...args));
         this.signals.connect(this.actor, 'enter-event', (...args) => this.onEnter(...args));
         this.signals.connect(this.actor, 'leave-event', (...args) => this.onLeave(...args));
         this.signals.connect(this.actor, 'button-release-event', (...args) => this.onAppButtonRelease(...args));
@@ -338,9 +339,10 @@ class AppGroup {
         }
     }
 
-    getPreferredWidth(actor, forHeight, alloc) {
-        let [iconMinSize, iconNaturalSize] = this.iconBox.get_preferred_width(forHeight);
-        let [labelMinSize, labelNaturalSize] = this.label.get_preferred_width(forHeight);
+    getPreferredWidth(alloc) {
+        let {for_size} = alloc;
+        let [iconMinSize, iconNaturalSize] = this.iconBox.get_preferred_width(for_size);
+        let [labelMinSize, labelNaturalSize] = this.label.get_preferred_width(for_size);
         let {iconSpacing} = this.state.settings;
         // The label text starts in the center of the icon, so we should allocate the space
         // needed for the icon plus the space needed for(label - icon/2)
@@ -354,14 +356,15 @@ class AppGroup {
         }
     }
 
-    getPreferredHeight(actor, forWidth, alloc) {
-        let [iconMinSize, iconNaturalSize] = this.iconBox.get_preferred_height(forWidth);
-        let [labelMinSize, labelNaturalSize] = this.label.get_preferred_height(forWidth);
+    getPreferredHeight(alloc) {
+        let {for_size} = alloc;
+        let [iconMinSize, iconNaturalSize] = this.iconBox.get_preferred_height(for_size);
+        let [labelMinSize, labelNaturalSize] = this.label.get_preferred_height(for_size);
         alloc.min_size = Math.min(iconMinSize, labelMinSize);
         alloc.natural_size = Math.max(iconNaturalSize, labelNaturalSize);
     }
 
-    allocate(actor, box, flags) {
+    allocate(box, flags) {
         let allocWidth = box.x2 - box.x1;
         let allocHeight = box.y2 - box.y1;
         let childBox = new Clutter.ActorBox();

--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -242,7 +242,7 @@ class AppMenuButton {
         });
         this.actor.set_allocation_callback((b, f) => this._allocate(b, f))
         this.actor.set_preferred_width_callback((a) => this._getPreferredWidth(a))
-        this.actor.set_preferred_height_callback((a) => this._getPreferredWidth(a));
+        this.actor.set_preferred_height_callback((a) => this._getPreferredHeight(a));
 
         this._applet = applet;
         this.metaWindow = metaWindow;

--- a/js/ui/appSwitcher/classicSwitcher.js
+++ b/js/ui/appSwitcher/classicSwitcher.js
@@ -52,7 +52,7 @@ ClassicSwitcher.prototype = {
         });
         this.actor.set_allocation_callback((b, f) => this._allocate(b, f))
         this.actor.set_preferred_width_callback((a) => this._getPreferredWidth(a))
-        this.actor.set_preferred_height_callback((a) => this._getPreferredWidth(a));
+        this.actor.set_preferred_height_callback((a) => this._getPreferredHeight(a));
 
         this._thumbnailTimeoutId = 0;
         this.thumbnailsVisible = false;
@@ -459,7 +459,7 @@ SwitcherList.prototype = {
         this.actor = new Cinnamon.GenericContainer({ style_class: 'switcher-list' });
         this.actor.set_allocation_callback((b, f) => this._allocateTop(b, f))
         this.actor.set_preferred_width_callback((a) => this._getPreferredWidth(a))
-        this.actor.set_preferred_height_callback((a) => this._getPreferredWidth(a));
+        this.actor.set_preferred_height_callback((a) => this._getPreferredHeight(a));
 
         // Here we use a GenericContainer so that we can force all the
         // children except the separator to have the same width.
@@ -471,7 +471,7 @@ SwitcherList.prototype = {
 
         this._list.set_allocation_callback((b, f) => this._allocate(b, f))
         this._list.set_preferred_width_callback((a) => this._getPreferredWidth(a))
-        this._list.set_preferred_height_callback((a) => this._getPreferredWidth(a));
+        this._list.set_preferred_height_callback((a) => this._getPreferredHeight(a));
 
         this._clipBin = new St.Bin({style_class: 'cbin'});
         this._clipBin.child = this._list;

--- a/js/ui/boxpointer.js
+++ b/js/ui/boxpointer.js
@@ -43,7 +43,7 @@ BoxPointer.prototype = {
         this.actor.set_child(this._container);
         this.actor.set_allocation_callback((b, f) => this._allocate(b, f))
         this.actor.set_preferred_width_callback((a) => this._getPreferredWidth(a))
-        this.actor.set_preferred_height_callback((a) => this._getPreferredWidth(a));
+        this.actor.set_preferred_height_callback((a) => this._getPreferredHeight(a));
         this.bin = new St.Bin(binProperties);
         this._container.add_actor(this.bin);
         this._border = new St.DrawingArea();

--- a/js/ui/boxpointer.js
+++ b/js/ui/boxpointer.js
@@ -41,9 +41,9 @@ BoxPointer.prototype = {
                                   y_fill: true });
         this._container = new Cinnamon.GenericContainer();
         this.actor.set_child(this._container);
-        this._container.connect('get-preferred-width', Lang.bind(this, this._getPreferredWidth));
-        this._container.connect('get-preferred-height', Lang.bind(this, this._getPreferredHeight));
-        this._container.connect('allocate', Lang.bind(this, this._allocate));
+        this.actor.set_allocation_callback((b, f) => this._allocate(b, f))
+        this.actor.set_preferred_width_callback((a) => this._getPreferredWidth(a))
+        this.actor.set_preferred_height_callback((a) => this._getPreferredWidth(a));
         this.bin = new St.Bin(binProperties);
         this._container.add_actor(this.bin);
         this._border = new St.DrawingArea();
@@ -136,9 +136,9 @@ BoxPointer.prototype = {
     /**
      * setArrowSide:
      * @side (St.Side): The new side of the menu
-     * 
+     *
      * Sets the arrow side of the menu. Note that the side is the side
-     * of the source actor, not the menu, e.g. If St.Side.TOP is set, 
+     * of the source actor, not the menu, e.g. If St.Side.TOP is set,
      * then the menu will appear below the source actor (the source
      * actor will be on top of the menu)
      */
@@ -162,21 +162,23 @@ BoxPointer.prototype = {
         }
     },
 
-    _getPreferredWidth: function(actor, forHeight, alloc) {
-        let [minInternalSize, natInternalSize] = this.bin.get_preferred_width(forHeight);
+    _getPreferredWidth: function(alloc) {
+        let {for_size} = alloc;
+        let [minInternalSize, natInternalSize] = this.bin.get_preferred_width(for_size);
         alloc.min_size = minInternalSize;
         alloc.natural_size = natInternalSize;
         this._adjustAllocationForArrow(true, alloc);
     },
 
-    _getPreferredHeight: function(actor, forWidth, alloc) {
-        let [minSize, naturalSize] = this.bin.get_preferred_height(forWidth);
+    _getPreferredHeight: function(alloc) {
+        let {for_size} = alloc;
+        let [minSize, naturalSize] = this.bin.get_preferred_height(for_size);
         alloc.min_size = minSize;
         alloc.natural_size = naturalSize;
         this._adjustAllocationForArrow(false, alloc);
     },
 
-    _allocate: function(actor, box, flags) {
+    _allocate: function(box, flags) {
         let themeNode = this.actor.get_theme_node();
         let borderWidth = themeNode.get_length('-arrow-border-width');
         let rise = themeNode.get_length('-arrow-rise');

--- a/js/ui/boxpointer.js
+++ b/js/ui/boxpointer.js
@@ -41,9 +41,9 @@ BoxPointer.prototype = {
                                   y_fill: true });
         this._container = new Cinnamon.GenericContainer();
         this.actor.set_child(this._container);
-        this.actor.set_allocation_callback((b, f) => this._allocate(b, f))
-        this.actor.set_preferred_width_callback((a) => this._getPreferredWidth(a))
-        this.actor.set_preferred_height_callback((a) => this._getPreferredHeight(a));
+        this._container.set_allocation_callback((b, f) => this._allocate(b, f))
+        this._container.set_preferred_width_callback((a) => this._getPreferredWidth(a))
+        this._container.set_preferred_height_callback((a) => this._getPreferredHeight(a));
         this.bin = new St.Bin(binProperties);
         this._container.add_actor(this.bin);
         this._border = new St.DrawingArea();

--- a/js/ui/checkBox.js
+++ b/js/ui/checkBox.js
@@ -15,7 +15,7 @@ CheckBoxContainer.prototype = {
         this.actor = new Cinnamon.GenericContainer({ y_align: St.Align.MIDDLE });
         this.actor.set_allocation_callback((b, f) => this._allocate(b, f))
         this.actor.set_preferred_width_callback((a) => this._getPreferredWidth(a))
-        this.actor.set_preferred_height_callback((a) => this._getPreferredWidth(a));
+        this.actor.set_preferred_height_callback((a) => this._getPreferredHeight(a));
         this.actor.connect('style-changed', Lang.bind(this,
             function() {
                 let node = this.actor.get_theme_node();

--- a/js/ui/checkBox.js
+++ b/js/ui/checkBox.js
@@ -13,12 +13,9 @@ function CheckBoxContainer() {
 CheckBoxContainer.prototype = {
     _init: function() {
         this.actor = new Cinnamon.GenericContainer({ y_align: St.Align.MIDDLE });
-        this.actor.connect('get-preferred-width',
-                           Lang.bind(this, this._getPreferredWidth));
-        this.actor.connect('get-preferred-height',
-                           Lang.bind(this, this._getPreferredHeight));
-        this.actor.connect('allocate',
-                           Lang.bind(this, this._allocate));
+        this.actor.set_allocation_callback((b, f) => this._allocate(b, f))
+        this.actor.set_preferred_width_callback((a) => this._getPreferredWidth(a))
+        this.actor.set_preferred_height_callback((a) => this._getPreferredWidth(a));
         this.actor.connect('style-changed', Lang.bind(this,
             function() {
                 let node = this.actor.get_theme_node();
@@ -37,15 +34,16 @@ CheckBoxContainer.prototype = {
         this._spacing = 0;
     },
 
-    _getPreferredWidth: function(actor, forHeight, alloc) {
+    _getPreferredWidth: function(alloc) {
+        let {for_size} = alloc;
         let node = this.actor.get_theme_node();
-        forHeight = node.adjust_for_height(forHeight);
+        for_size = node.adjust_for_height(for_size);
 
-        let [minBoxWidth, natBoxWidth] = this._box.get_preferred_width(forHeight);
+        let [minBoxWidth, natBoxWidth] = this._box.get_preferred_width(for_size);
         let boxNode = this._box.get_theme_node();
         [minBoxWidth, natBoxWidth] = boxNode.adjust_preferred_width(minBoxWidth, natBoxWidth);
 
-        let [minLabelWidth, natLabelWidth] = this.label.get_preferred_width(forHeight);
+        let [minLabelWidth, natLabelWidth] = this.label.get_preferred_width(for_size);
         let labelNode = this.label.get_theme_node();
         [minLabelWidth, natLabelWidth] = labelNode.adjust_preferred_width(minLabelWidth, natLabelWidth);
 
@@ -57,7 +55,7 @@ CheckBoxContainer.prototype = {
         alloc.natural_size = nat;
     },
 
-    _getPreferredHeight: function(actor, forWidth, alloc) {
+    _getPreferredHeight: function(alloc) {
         let [minBoxHeight, natBoxHeight] =
             this._box.get_preferred_height(-1);
         let [minLabelHeight, natLabelHeight] =
@@ -67,7 +65,7 @@ CheckBoxContainer.prototype = {
         alloc.natural_size = Math.max(natBoxHeight, natLabelHeight);
     },
 
-    _allocate: function(actor, box, flags) {
+    _allocate: function(box, flags) {
         let availWidth = box.x2 - box.x1;
         let availHeight = box.y2 - box.y1;
 

--- a/js/ui/dnd.js
+++ b/js/ui/dnd.js
@@ -685,12 +685,9 @@ function GenericDragItemContainer() {
 GenericDragItemContainer.prototype = {
     _init: function() {
         this.actor = new Cinnamon.GenericContainer({ style_class: 'drag-item-container' });
-        this.actor.connect('get-preferred-width',
-                           Lang.bind(this, this._getPreferredWidth));
-        this.actor.connect('get-preferred-height',
-                           Lang.bind(this, this._getPreferredHeight));
-        this.actor.connect('allocate',
-                           Lang.bind(this, this._allocate));
+        this.actor.set_allocation_callback((b, f) => this._allocate(b, f))
+        this.actor.set_preferred_width_callback((a) => this._getPreferredWidth(a))
+        this.actor.set_preferred_height_callback((a) => this._getPreferredWidth(a));
         this.actor._delegate = this;
 
         this.child = null;
@@ -699,7 +696,7 @@ GenericDragItemContainer.prototype = {
         this.animatingOut = false;
     },
 
-    _allocate: function(actor, box, flags) {
+    _allocate: function(box, flags) {
         if (this.child == null)
             return;
 
@@ -721,26 +718,28 @@ GenericDragItemContainer.prototype = {
         this.child.allocate(childBox, flags);
     },
 
-    _getPreferredHeight: function(actor, forWidth, alloc) {
+    _getPreferredHeight: function(alloc) {
+        let {for_size} = alloc;
         alloc.min_size = 0;
         alloc.natural_size = 0;
 
         if (this.child == null)
             return;
 
-        let [minHeight, natHeight] = this.child.get_preferred_height(forWidth);
+        let [minHeight, natHeight] = this.child.get_preferred_height(for_size);
         alloc.min_size += minHeight * this.child.scale_y;
         alloc.natural_size += natHeight * this.child.scale_y;
     },
 
-    _getPreferredWidth: function(actor, forHeight, alloc) {
+    _getPreferredWidth: function(alloc) {
+        let {for_size} = alloc;
         alloc.min_size = 0;
         alloc.natural_size = 0;
 
         if (this.child == null)
             return;
 
-        let [minWidth, natWidth] = this.child.get_preferred_width(forHeight);
+        let [minWidth, natWidth] = this.child.get_preferred_width(for_size);
         alloc.min_size = minWidth * this.child.scale_y;
         alloc.natural_size = natWidth * this.child.scale_y;
     },

--- a/js/ui/dnd.js
+++ b/js/ui/dnd.js
@@ -687,7 +687,7 @@ GenericDragItemContainer.prototype = {
         this.actor = new Cinnamon.GenericContainer({ style_class: 'drag-item-container' });
         this.actor.set_allocation_callback((b, f) => this._allocate(b, f))
         this.actor.set_preferred_width_callback((a) => this._getPreferredWidth(a))
-        this.actor.set_preferred_height_callback((a) => this._getPreferredWidth(a));
+        this.actor.set_preferred_height_callback((a) => this._getPreferredHeight(a));
         this.actor._delegate = this;
 
         this.child = null;

--- a/js/ui/lookingGlass.js
+++ b/js/ui/lookingGlass.js
@@ -241,7 +241,7 @@ Inspector.prototype = {
     _init: function() {
         let container = new Cinnamon.GenericContainer({ width: 0,
                                                      height: 0 });
-        container.connect('allocate', Lang.bind(this, this._allocate));
+        container.set_allocation_callback((b, f) => this._allocate(b, f));
         Main.uiGroup.add_actor(container);
 
         let eventHandler = new St.BoxLayout({ name: 'LookingGlassDialog',
@@ -304,7 +304,7 @@ Inspector.prototype = {
         }
     },
 
-    _allocate: function(actor, box, flags) {
+    _allocate: function(box, flags) {
         if (!this._eventHandler)
             return;
 

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -350,22 +350,19 @@ function start() {
 
     // Set up stage hierarchy to group all UI actors under one container.
     uiGroup = new Cinnamon.GenericContainer({ name: 'uiGroup' });
-    uiGroup.connect('allocate',
-                    function (actor, box, flags) {
-                        let children = uiGroup.get_children();
-                        for (let i = 0; i < children.length; i++)
-                            children[i].allocate_preferred_size(flags);
-                    });
-    uiGroup.connect('get-preferred-width',
-                    function(actor, forHeight, alloc) {
-                        let width = global.stage.width;
-                        [alloc.min_size, alloc.natural_size] = [width, width];
-                    });
-    uiGroup.connect('get-preferred-height',
-                    function(actor, forWidth, alloc) {
-                        let height = global.stage.height;
-                        [alloc.min_size, alloc.natural_size] = [height, height];
-                    });
+    uiGroup.set_allocation_callback(function (box, flags) {
+        let children = uiGroup.get_children();
+        for (let i = 0; i < children.length; i++)
+            children[i].allocate_preferred_size(flags);
+    });
+    uiGroup.set_preferred_width_callback(function(alloc) {
+        let width = global.stage.width;
+        [alloc.min_size, alloc.natural_size] = [width, width];
+    });
+    uiGroup.set_preferred_height_callback(function(alloc) {
+        let height = global.stage.height;
+        [alloc.min_size, alloc.natural_size] = [height, height];
+    });
 
     global.reparentActor(global.background_actor, uiGroup);
     global.background_actor.hide();

--- a/js/ui/messageTray.js
+++ b/js/ui/messageTray.js
@@ -1048,7 +1048,7 @@ Source.prototype = {
         this.actor = new Cinnamon.GenericContainer();
         this.actor.set_allocation_callback((b, f) => this._allocate(b, f))
         this.actor.set_preferred_width_callback((a) => this._getPreferredWidth(a))
-        this.actor.set_preferred_height_callback((a) => this._getPreferredWidth(a));
+        this.actor.set_preferred_height_callback((a) => this._getPreferredHeight(a));
         this.actor.connect('destroy', Lang.bind(this,
             function() {
                 this._actorDestroyed = true;

--- a/js/ui/messageTray.js
+++ b/js/ui/messageTray.js
@@ -469,9 +469,9 @@ Notification.prototype = {
         // show banner at all if title needs to be ellipsized), so we
         // use Cinnamon.GenericContainer.
         this._bannerBox = new Cinnamon.GenericContainer();
-        this._bannerBox.connect('get-preferred-width', Lang.bind(this, this._bannerBoxGetPreferredWidth));
-        this._bannerBox.connect('get-preferred-height', Lang.bind(this, this._bannerBoxGetPreferredHeight));
-        this._bannerBox.connect('allocate', Lang.bind(this, this._bannerBoxAllocate));
+        this._bannerBox.set_allocation_callback((b, f) => this._bannerBoxAllocate(b, f))
+        this._bannerBox.set_preferred_width_callback((w) => this._bannerBoxGetPreferredWidth(w))
+        this._bannerBox.set_preferred_height_callback((h) => this._bannerBoxGetPreferredHeight(h));
         this._table.add(this._bannerBox, { row: 0,
                                            col: 1,
                                            col_span: 2,
@@ -825,10 +825,11 @@ Notification.prototype = {
         this._spacing = this._table.get_theme_node().get_length('spacing-columns');
     },
 
-    _bannerBoxGetPreferredWidth: function(actor, forHeight, alloc) {
-        let [titleMin, titleNat] = this._titleLabel.get_preferred_width(forHeight);
-        let [bannerMin, bannerNat] = this._bannerLabel.get_preferred_width(forHeight);
-        let [timeMin, timeNat] = this._timeLabel.get_preferred_width(forHeight);
+    _bannerBoxGetPreferredWidth: function(alloc) {
+        let {for_size} = alloc;
+        let [titleMin, titleNat] = this._titleLabel.get_preferred_width(for_size);
+        let [bannerMin, bannerNat] = this._bannerLabel.get_preferred_width(for_size);
+        let [timeMin, timeNat] = this._timeLabel.get_preferred_width(for_size);
         if (this._inNotificationBin) {
             alloc.min_size = Math.max(titleMin, timeMin);
             alloc.natural_size = Math.max(titleNat, timeNat) + this._spacing + bannerNat;
@@ -838,19 +839,19 @@ Notification.prototype = {
         }
     },
 
-    _bannerBoxGetPreferredHeight: function(actor, forWidth, alloc) {
+    _bannerBoxGetPreferredHeight: function(alloc) {
+        let {for_size} = alloc;
         if (this._inNotificationBin) {
-            let [titleMin, titleNat] = this._titleLabel.get_preferred_height(forWidth);
-            let [timeMin, timeNat] = this._timeLabel.get_preferred_height(forWidth);
+            let [titleMin, titleNat] = this._titleLabel.get_preferred_height(for_size);
+            let [timeMin, timeNat] = this._timeLabel.get_preferred_height(for_size);
             alloc.min_size = titleMin + timeMin;
             alloc.natural_size = titleNat + timeNat;
         } else {
-            [alloc.min_size, alloc.natural_size] =
-                this._titleLabel.get_preferred_height(forWidth);
+            [alloc.min_size, alloc.natural_size] = this._titleLabel.get_preferred_height(for_size);
         }
     },
 
-    _bannerBoxAllocate: function(actor, box, flags) {
+    _bannerBoxAllocate: function(box, flags) {
         let availWidth = box.x2 - box.x1;
 
         let [titleMinW, titleNatW] = this._titleLabel.get_preferred_width(-1);
@@ -1045,9 +1046,9 @@ Source.prototype = {
         this.title = title;
 
         this.actor = new Cinnamon.GenericContainer();
-        this.actor.connect('get-preferred-width', Lang.bind(this, this._getPreferredWidth));
-        this.actor.connect('get-preferred-height', Lang.bind(this, this._getPreferredHeight));
-        this.actor.connect('allocate', Lang.bind(this, this._allocate));
+        this.actor.set_allocation_callback((b, f) => this._allocate(b, f))
+        this.actor.set_preferred_width_callback((a) => this._getPreferredWidth(a))
+        this.actor.set_preferred_height_callback((a) => this._getPreferredWidth(a));
         this.actor.connect('destroy', Lang.bind(this,
             function() {
                 this._actorDestroyed = true;
@@ -1071,17 +1072,19 @@ Source.prototype = {
         this.notifications = [];
     },
 
-    _getPreferredWidth: function (actor, forHeight, alloc) {
-        let [min, nat] = this._iconBin.get_preferred_width(forHeight);
+    _getPreferredWidth: function (alloc) {
+        let {for_size} = alloc;
+        let [min, nat] = this._iconBin.get_preferred_width(for_size);
         alloc.min_size = min; alloc.nat_size = nat;
     },
 
-    _getPreferredHeight: function (actor, forWidth, alloc) {
-        let [min, nat] = this._iconBin.get_preferred_height(forWidth);
+    _getPreferredHeight: function (alloc) {
+        let {for_size} = alloc;
+        let [min, nat] = this._iconBin.get_preferred_height(for_size);
         alloc.min_size = min; alloc.nat_size = nat;
     },
 
-    _allocate: function(actor, box, flags) {
+    _allocate: function(box, flags) {
         // the iconBin should fill our entire box
         this._iconBin.allocate(box, flags);
 

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -1899,7 +1899,7 @@ Panel.prototype = {
         this._processPanelAutoHide();
 
         this.actor.connect('button-press-event', Lang.bind(this, this._onButtonPressEvent));
-        this.actor.set_style_changed_callback((n) => this._moveResizePanel(n));
+        this.actor.set_style_changed_callback((n) => this._moveResizePanel(null, null, n));
         this.actor.connect('leave-event', Lang.bind(this, this._leavePanel));
         this.actor.connect('enter-event', Lang.bind(this, this._enterPanel));
         this.actor.connect('queue-relayout', () => this._setPanelHeight());
@@ -2553,7 +2553,7 @@ Panel.prototype = {
      * Function to update the panel position, size, and clip region according to settings
      * values.  Note that this is also called when the style changes.
      */
-    _moveResizePanel: function(themeNode) {
+    _moveResizePanel: function(settings, key, themeNode) {
         if (this._destroyed)
             return false;
 

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -1273,7 +1273,7 @@ PanelCorner.prototype = {
 
         this.actor = new St.DrawingArea({ style_class: 'panel-corner' });
 
-        this.actor.connect('style-changed', Lang.bind(this, this._styleChanged));
+        this.actor.set_style_changed_callback((n) => this._styleChanged(n));
         this.actor.connect('repaint', Lang.bind(this, this._repaint));
     },
 
@@ -1416,11 +1416,8 @@ PanelCorner.prototype = {
         }
     },
 
-    _styleChanged: function() {
-        let node = this.actor.get_theme_node();
-
+    _styleChanged: function(node) {
         let cornerRadius = node.get_length("-panel-corner-radius");
-        let innerBorderWidth = node.get_length('-panel-corner-inner-border-width');
 
         this.actor.set_size(cornerRadius, cornerRadius);
         this.actor.set_anchor_point(0, 0);
@@ -1902,7 +1899,7 @@ Panel.prototype = {
         this._processPanelAutoHide();
 
         this.actor.connect('button-press-event', Lang.bind(this, this._onButtonPressEvent));
-        this.actor.connect('style-changed', Lang.bind(this, this._moveResizePanel));
+        this.actor.set_style_changed_callback((n) => this._moveResizePanel(n));
         this.actor.connect('leave-event', Lang.bind(this, this._leavePanel));
         this.actor.connect('enter-event', Lang.bind(this, this._enterPanel));
         this.actor.connect('queue-relayout', () => this._setPanelHeight());
@@ -2556,7 +2553,7 @@ Panel.prototype = {
      * Function to update the panel position, size, and clip region according to settings
      * values.  Note that this is also called when the style changes.
      */
-    _moveResizePanel: function() {
+    _moveResizePanel: function(themeNode) {
         if (this._destroyed)
             return false;
 
@@ -2579,7 +2576,7 @@ Panel.prototype = {
         if (Main.panelManager && !horizontal_panel)
             [this.toppanelHeight, this.bottompanelHeight] = heightsUsedMonitor(this.monitorIndex, Main.panelManager.panels);
         // get shadow and margins
-        let themeNode = this.actor.get_theme_node();
+        if (!themeNode) themeNode = this.actor.get_theme_node();
 
         // FIXME: inset shadows will probably break clipping.
         // I haven't seen a theme with inset panel shadows, but if there

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -1244,89 +1244,6 @@ AnimatedIcon.prototype = {
             Mainloop.source_remove(this._timeoutId);
     }
 };
-/* FIXME:  Find out if this TextShadower functionality below is actually used */
-
-function TextShadower() {
-    this._init();
-}
-
-TextShadower.prototype = {
-    _init: function() {
-
-        this.actor = new Cinnamon.GenericContainer();
-
-        this.actor.connect('get-preferred-width', Lang.bind(this, this._getPreferredWidth));
-        this.actor.connect('get-preferred-height', Lang.bind(this, this._getPreferredHeight));
-        this.actor.connect('allocate', Lang.bind(this, this._allocate));
-
-        this._label = new St.Label();
-        this.actor.add_actor(this._label);
-        for (let i = 0; i < 4; i++) {
-            let actor = new St.Label({ style_class: 'label-shadow' });
-            actor.clutter_text.ellipsize = Pango.EllipsizeMode.END;
-            this.actor.add_actor(actor);
-        }
-        this._label.raise_top();
-    },
-
-    _getPreferredWidth: function(actor, forHeight, alloc) {
-        let [minWidth, natWidth] = this._label.get_preferred_width(forHeight);
-        alloc.min_size = minWidth + 2;
-        alloc.natural_size = natWidth + 2;
-    },
-
-    _getPreferredHeight: function(actor, forWidth, alloc) {
-        let [minHeight, natHeight] = this._label.get_preferred_height(forWidth);
-        alloc.min_size = minHeight + 2;
-        alloc.natural_size = natHeight + 2;
-    },
-
-    _allocate: function(actor, box, flags) {
-        let children = this.actor.get_children();
-
-        let availWidth = box.x2 - box.x1;
-        let availHeight = box.y2 - box.y1;
-
-        let [minChildWidth, minChildHeight, natChildWidth, natChildHeight] =
-            this._label.get_preferred_size();
-
-        let childWidth = Math.min(natChildWidth, availWidth - 2);
-        let childHeight = Math.min(natChildHeight, availHeight - 2);
-
-        for (let i = 0; i < children.length; i++) {
-            let child = children[i];
-            let childBox = new Clutter.ActorBox();
-            // The order of the labels here is arbitrary, except
-            // we know the "real" label is at the end because Clutter.Group
-            // sorts by Z order
-            switch (i) {
-                case 0: // top
-                    childBox.x1 = 1;
-                    childBox.y1 = 0;
-                    break;
-                case 1: // right
-                    childBox.x1 = 2;
-                    childBox.y1 = 1;
-                    break;
-                case 2: // bottom
-                    childBox.x1 = 1;
-                    childBox.y1 = 2;
-                    break;
-                case 3: // left
-                    childBox.x1 = 0;
-                    childBox.y1 = 1;
-                    break;
-                case 4: // center
-                    childBox.x1 = 1;
-                    childBox.y1 = 1;
-                    break;
-            }
-            childBox.x2 = childBox.x1 + childWidth;
-            childBox.y2 = childBox.y1 + childHeight;
-            child.allocate(childBox, flags);
-        }
-    }
-};
     /**
      * PanelCorner:
      * @box: the box in a panel the corner is associated with
@@ -1948,6 +1865,9 @@ Panel.prototype = {
         this.themeSettings = new Gio.Settings({ schema_id: 'org.cinnamon.theme' });
 
         this.actor = new Cinnamon.GenericContainer({ name: 'panel', reactive: true });
+        this.actor.set_allocation_callback((b, f) => this._allocate(b, f));
+        this.actor.set_preferred_width_callback((a) => this._getPreferredWidth(a));
+        this.actor.set_preferred_height_callback((a) => this._getPreferredHeight(a));
         this.addPanelStyleClass(this.panelPosition);
 
         this.actor._delegate = this;
@@ -1985,9 +1905,6 @@ Panel.prototype = {
         this.actor.connect('style-changed', Lang.bind(this, this._moveResizePanel));
         this.actor.connect('leave-event', Lang.bind(this, this._leavePanel));
         this.actor.connect('enter-event', Lang.bind(this, this._enterPanel));
-        this.actor.connect('get-preferred-width', Lang.bind(this, this._getPreferredWidth));
-        this.actor.connect('get-preferred-height', Lang.bind(this, this._getPreferredHeight));
-        this.actor.connect('allocate', Lang.bind(this, this._allocate));
         this.actor.connect('queue-relayout', () => this._setPanelHeight());
 
         this._signalManager.connect(global.settings, "changed::" + PANEL_AUTOHIDE_KEY, this._processPanelAutoHide, this);
@@ -2989,25 +2906,14 @@ Panel.prototype = {
         global.log(`[Panel ${this.panelId}] Removing zone configuration`);
     },
 
-    _getPreferredWidth: function(actor, forHeight, alloc) {
-
+    _getPreferredWidth: function(alloc) {
         alloc.min_size = -1;
         alloc.natural_size = -1;
-
- /*       if (this.panelPosition == PanelLoc.top || this.panelPosition == PanelLoc.bottom) {
-            alloc.natural_size = Main.layoutManager.primaryMonitor.width;
-        } */
     },
 
-    _getPreferredHeight: function(actor, forWidth, alloc) {
-
+    _getPreferredHeight: function(alloc) {
         alloc.min_size = -1;
         alloc.natural_size = -1;
-
-/*        if (this.panelPosition == PanelLoc.left || this.panelPosition == PanelLoc.right) {
-            alloc.natural_size = Main.layoutManager.primaryMonitor.height;
-            alloc.natural_size = alloc.natural_size - this.toppanelHeight - this.bottompanelHeight - this.margin_top - this.margin_bottom;
-        } */
     },
 
     /**
@@ -3215,7 +3121,7 @@ Panel.prototype = {
         return;
     },
 
-    _allocate: function(actor, box, flags) {
+    _allocate: function(box, flags) {
 
         let cornerMinWidth = 0;
         let cornerWidth = 0;

--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -114,7 +114,7 @@ var PopupBaseMenuItem = class PopupBaseMenuItem {
                                                   accessible_role: Atk.Role.MENU_ITEM });
         this.actor.set_allocation_callback((b, f) => this._allocate(b, f))
         this.actor.set_preferred_width_callback((a) => this._getPreferredWidth(a))
-        this.actor.set_preferred_height_callback((a) => this._getPreferredWidth(a));
+        this.actor.set_preferred_height_callback((a) => this._getPreferredHeight(a));
         this._signals.connect(this.actor, 'style-changed', Lang.bind(this, this._onStyleChanged));
         this.actor._delegate = this;
 

--- a/js/ui/radioButton.js
+++ b/js/ui/radioButton.js
@@ -12,12 +12,9 @@ function RadioButtonContainer() {
 RadioButtonContainer.prototype = {
     _init: function() {
         this.actor = new Cinnamon.GenericContainer({ y_align: St.Align.MIDDLE });
-        this.actor.connect('get-preferred-width',
-                           Lang.bind(this, this._getPreferredWidth));
-        this.actor.connect('get-preferred-height',
-                           Lang.bind(this, this._getPreferredHeight));
-        this.actor.connect('allocate',
-                           Lang.bind(this, this._allocate));
+        this.actor.set_allocation_callback((b, f) => this._allocate(b, f));
+        this.actor.set_preferred_width_callback((a) => this._getPreferredWidth(a));
+        this.actor.set_preferred_height_callback((a) => this._getPreferredHeight(a));
         this.actor.connect('style-changed', Lang.bind(this,
             function() {
                 let node = this.actor.get_theme_node();
@@ -36,14 +33,15 @@ RadioButtonContainer.prototype = {
         this._spacing = 0;
     },
 
-    _getPreferredWidth: function(actor, forHeight, alloc) {
-        let [minWidth, natWidth] = this._box.get_preferred_width(forHeight);
+    _getPreferredWidth: function(alloc) {
+        let {for_size} = alloc;
+        let [minWidth, natWidth] = this._box.get_preferred_width(for_size);
 
         alloc.min_size = minWidth + this._spacing;
         alloc.natural_size = natWidth + this._spacing;
     },
 
-    _getPreferredHeight: function(actor, forWidth, alloc) {
+    _getPreferredHeight: function(alloc) {
         let [minBoxHeight, natBoxHeight] =
             this._box.get_preferred_height(-1);
         let [minLabelHeight, natLabelHeight] =
@@ -53,9 +51,8 @@ RadioButtonContainer.prototype = {
         alloc.natural_size = Math.max(natBoxHeight, 2 * natLabelHeight);
     },
 
-    _allocate: function(actor, box, flags) {
+    _allocate: function(box, flags) {
         let availWidth = box.x2 - box.x1;
-        let availHeight = box.y2 - box.y1;
 
         let childBox = new Clutter.ActorBox();
         let [minBoxWidth, natBoxWidth] =
@@ -151,9 +148,9 @@ RadioButtonGroup.prototype = {
 
    addButton: function(buttonId, label) {
       this.radioButton = new RadioButton(label);
-      this.radioButton.actor.connect("clicked", 
+      this.radioButton.actor.connect("clicked",
          Lang.bind(this, function(actor) {
-            this.buttonClicked(actor, buttonId); 
+            this.buttonClicked(actor, buttonId);
          }));
 
       this._buttons.push({ id: buttonId, button: this.radioButton });
@@ -173,7 +170,7 @@ RadioButtonGroup.prototype = {
                 button['button'].actor.checked = true;
             }
         }
-      
+
         // Only trigger real changes to radio selection.
         if (buttonId !== this._activeId) {
             this._activeId = buttonId;

--- a/src/cinnamon-generic-container.h
+++ b/src/cinnamon-generic-container.h
@@ -12,6 +12,7 @@
 #define CINNAMON_GENERIC_CONTAINER_GET_CLASS(obj)       (G_TYPE_INSTANCE_GET_CLASS ((obj), CINNAMON_TYPE_GENERIC_CONTAINER, CinnamonGenericContainerClass))
 
 typedef struct {
+  float for_size;
   float min_size;
   float natural_size;
 
@@ -39,6 +40,24 @@ struct _CinnamonGenericContainerClass
     StWidgetClass parent_class;
 };
 
+/**
+ * CinnamonGenericContainerAllocationCallback:
+ * @content_box: (closure): Data passed to allocation functions
+ * @flags: (closure): Allocation flags
+ *
+ * Callback type for CinnamonGenericContainer
+ */
+typedef void (* CinnamonGenericContainerAllocationCallback) (ClutterActorBox       *content_box,
+                                                             ClutterAllocationFlags flags);
+
+/**
+ * CinnamonGenericContainerPreferredSizeCallback:
+ * @alloc: (closure): allocation object
+ *
+ * Callback type for CinnamonGenericContainer
+ */
+typedef void (* CinnamonGenericContainerPreferredSizeCallback) (CinnamonGenericContainerAllocation *alloc);
+
 GType    cinnamon_generic_container_get_type         (void) G_GNUC_CONST;
 
 guint    cinnamon_generic_container_get_n_skip_paint (CinnamonGenericContainer *self);
@@ -48,5 +67,18 @@ gboolean cinnamon_generic_container_get_skip_paint   (CinnamonGenericContainer *
 void     cinnamon_generic_container_set_skip_paint   (CinnamonGenericContainer *self,
                                                    ClutterActor          *child,
                                                    gboolean               skip);
+
+void cinnamon_generic_container_set_allocation_callback (CinnamonGenericContainer                  *self,
+                                                         CinnamonGenericContainerAllocationCallback allocation_callback,
+                                                         gpointer                                   user_data,
+                                                         GDestroyNotify                             data_destroy);
+void cinnamon_generic_container_set_preferred_width_callback (CinnamonGenericContainer                     *self,
+                                                              CinnamonGenericContainerPreferredSizeCallback preferred_width_callback,
+                                                              gpointer                                      user_data,
+                                                              GDestroyNotify                                data_destroy);
+void cinnamon_generic_container_set_preferred_height_callback (CinnamonGenericContainer                     *self,
+                                                               CinnamonGenericContainerPreferredSizeCallback preferred_height_callback,
+                                                               gpointer                                      user_data,
+                                                               GDestroyNotify                                data_destroy);
 
 #endif /* __CINNAMON_GENERIC_CONTAINER_H__ */

--- a/src/st/st-private.h
+++ b/src/st/st-private.h
@@ -115,6 +115,8 @@ struct _StWidgetPrivate
    * that we can remove the pseudo classes on them. */
   StWidget *prev_last_child;
   StWidget *prev_first_child;
+
+  StWidgetCallback style_changed_callback;
 };
 
 #endif /* __ST_PRIVATE_H__ */

--- a/src/st/st-widget.c
+++ b/src/st/st-widget.c
@@ -1507,13 +1507,14 @@ static void
 st_widget_recompute_style (StWidget    *widget,
                            StThemeNode *old_theme_node)
 {
+  StWidgetPrivate *priv = widget->priv;
   StThemeNode *new_theme_node = st_widget_get_theme_node (widget);
   int transition_duration;
   gboolean paint_equal;
 
   if (new_theme_node == old_theme_node)
     {
-      widget->priv->is_style_dirty = FALSE;
+      priv->is_style_dirty = FALSE;
       return;
     }
 
@@ -1532,9 +1533,9 @@ st_widget_recompute_style (StWidget    *widget,
 
   if (transition_duration > 0)
     {
-      if (widget->priv->transition_animation != NULL)
+      if (priv->transition_animation != NULL)
         {
-          st_theme_node_transition_update (widget->priv->transition_animation,
+          st_theme_node_transition_update (priv->transition_animation,
                                            new_theme_node);
         }
       else if (old_theme_node && !paint_equal)
@@ -1545,28 +1546,33 @@ st_widget_recompute_style (StWidget    *widget,
            * we can't animate that anyways.
            */
 
-          widget->priv->transition_animation =
+          priv->transition_animation =
             st_theme_node_transition_new (old_theme_node,
                                           new_theme_node,
                                           transition_duration);
 
-          g_signal_connect (widget->priv->transition_animation, "completed",
+          g_signal_connect (priv->transition_animation, "completed",
                             G_CALLBACK (on_transition_completed), widget);
-          g_signal_connect_swapped (widget->priv->transition_animation,
+          g_signal_connect_swapped (priv->transition_animation,
                                     "new-frame",
                                     G_CALLBACK (clutter_actor_queue_redraw),
                                     widget);
         }
     }
-  else if (widget->priv->transition_animation)
+  else if (priv->transition_animation)
     {
       st_widget_remove_transition (widget);
     }
 
   if (!paint_equal)
-    g_signal_emit (widget, signals[STYLE_CHANGED], 0);
+    {
+      if (priv->style_changed_callback != NULL)
+        (priv->style_changed_callback) (new_theme_node);
+      else
+        g_signal_emit (widget, signals[STYLE_CHANGED], 0);
+    }
 
-  widget->priv->is_style_dirty = FALSE;
+  priv->is_style_dirty = FALSE;
 }
 
 /**
@@ -2952,4 +2958,24 @@ st_widget_move_before (StWidget     *widget,
 {
   clutter_actor_set_child_below_sibling (CLUTTER_ACTOR (widget),
                                          actor, sibling);
+}
+
+/**
+ * st_widget_set_style_changed_callback:
+ * @widget: an #StWidget
+ * @callback (scope notified): callback
+ * @user_data (closure): user data
+ * @data_destroy: a #GDestroyNotify
+ *
+ * Sets the callback which will be invoked on style change. When a callback
+ * is set, it replaces signal emission for the instance.
+ */
+void
+st_widget_set_style_changed_callback (StWidget        *widget,
+                                      StWidgetCallback callback,
+                                      gpointer         user_data,
+                                      GDestroyNotify   data_destroy)
+{
+  StWidgetPrivate *priv = ST_WIDGET (widget)->priv;
+  priv->style_changed_callback = callback;
 }

--- a/src/st/st-widget.c
+++ b/src/st/st-widget.c
@@ -1563,7 +1563,9 @@ st_widget_recompute_style (StWidget    *widget,
       st_widget_remove_transition (widget);
     }
 
-  g_signal_emit (widget, signals[STYLE_CHANGED], 0);
+  if (!paint_equal)
+    g_signal_emit (widget, signals[STYLE_CHANGED], 0);
+
   widget->priv->is_style_dirty = FALSE;
 }
 

--- a/src/st/st-widget.h
+++ b/src/st/st-widget.h
@@ -97,6 +97,14 @@ struct _StWidgetClass
   GList *  (* get_focus_chain)     (StWidget         *widget);
 };
 
+/**
+ * StWidgetCallback:
+ * @theme_node: (closure): an #StThemeNode
+ *
+ * Callback type for StWidget
+ */
+typedef void (* StWidgetCallback) (StThemeNode *theme_node);
+
 GType st_widget_get_type (void) G_GNUC_CONST;
 
 void                  st_widget_set_style_pseudo_class    (StWidget        *actor,
@@ -200,6 +208,11 @@ const gchar *         st_widget_get_accessible_name       (StWidget *widget);
 
 void                  st_widget_set_accessible           (StWidget    *widget,
                                                           AtkObject   *accessible);
+
+void st_widget_set_style_changed_callback (StWidget        *widget,
+                                           StWidgetCallback callback,
+                                           gpointer         user_data,
+                                           GDestroyNotify   data_destroy);
 
 G_END_DECLS
 


### PR DESCRIPTION
This replaces #8068. This is loosely based on the idea of this [upstream MR](https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/153). 

>  Signals are not specially performant. One of the reasons is that they acquire a global lock for signal handlers lookup.

After attempting to expose vfunc callbacks in #8068, the main issues I discovered had to do with CJS/GJS handling of vfuncs. On the mozjs60 branch random crashing occurred that didn't exist on cjs master, and there's a [long-standing bug](https://gitlab.gnome.org/GNOME/gjs/issues/89) that causes inherited classes' replaced vfuncs to replace the base prototype's. Another issue is doing this effectively moves the performance sensitive base allocation logic from C to the JS context where it can't perform as well, and as a result there is worse performance.

Instead of exposing GObject classes in JS, what this does is keeps everything where it is, but adds callback support to CinnamonGenericContainer in C. When a callback is set for an allocation signal, it replaces the signal's emission. I've found this solution to perform better so far in my casual testing.