### PR TITLE
[WIP] main: Disable unnecessary Clutter events while dragging windows

### DIFF
--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -541,6 +541,7 @@ function start() {
         });
         global.display.connect('grab-op-end', function() {
             Util.each(reactive, function(actor) {
+                if (actor.is_finalized()) return;
                 actor.reactive = true;
             });
             reactive = [];


### PR DESCRIPTION
This uses `MetaDisplay`'s grab-op signals to disable most actors' reactivity during dragging. The overlay actors remain reactive so the tiling/snapping OSD continues to work. The `position-changed` signal is unaffected - the workspace switcher's window graph and panel auto-hiding modes are tested and working correctly.

`disableReactivityRecursive` was intentionally left in the `start` function's scope so it remains private. 