### PR TITLE
PopupSubMenu: Set sourceActor active before closing menu

### DIFF
--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -2756,14 +2756,12 @@ var PopupSubMenu = class PopupSubMenu extends PopupMenuBase {
                                        this._arrow.rotation_angle_z = this.actor._arrowRotation;
                                }
                              });
-            } else {
-                if (this._arrow)
-                    this._arrow.rotation_angle_z = 0;
-                this.actor.hide();
-
-                this.isOpen = false;
-                this.emit('open-state-changed', false);
-            }
+        } else {
+            if (this._arrow) this._arrow.rotation_angle_z = 0;
+            this.actor.hide();
+            this.isOpen = false;
+            this.emit('open-state-changed', false);
+        }
     }
 
     //Closes the submenu after it has been unmapped. Used to prevent size changes
@@ -2786,8 +2784,9 @@ var PopupSubMenu = class PopupSubMenu extends PopupMenuBase {
         // Move focus back to parent menu if the user types Left.
 
         if (this.isOpen && event.get_key_symbol() == Clutter.KEY_Left) {
-            this.close(true);
+
             this.sourceActor._delegate.setActive(true);
+            this.close(true);
             return true;
         }
 

--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -2784,7 +2784,6 @@ var PopupSubMenu = class PopupSubMenu extends PopupMenuBase {
         // Move focus back to parent menu if the user types Left.
 
         if (this.isOpen && event.get_key_symbol() == Clutter.KEY_Left) {
-
             this.sourceActor._delegate.setActive(true);
             this.close(true);
             return true;


### PR DESCRIPTION
Prevents a segfault occurring in Clutter when pressing left on a sub-menu item.

C/O @Cobinja 