### PR TITLE
Improve property access performance

### DIFF
--- a/js/misc/util.js
+++ b/js/misc/util.js
@@ -655,7 +655,7 @@ const FastObject = function(o) {
     return new FastObject;
 }
 FastObject();
-function toFastproperties(obj) {
+function toFastProperties(obj) {
     each(obj, function(value) {
         if (value && !Array.isArray(value)) FastObject(value);
     });

--- a/js/misc/util.js
+++ b/js/misc/util.js
@@ -642,6 +642,25 @@ function unref(object, reserved = []) {
     }, 0);
 };
 
+// MIT © Petka Antonov, Benjamin Gruenbaum, John-David Dalton, Sindre Sorhus
+// https://github.com/sindresorhus/to-fast-properties
+let fastProto = null;
+const FastObject = function(o) {
+    if (fastProto !== null && typeof fastProto.property) {
+        const result = fastProto;
+        fastProto = FastObject.prototype = null;
+        return result;
+    }
+    fastProto = FastObject.prototype = o == null ? Object.create(null) : o;
+    return new FastObject;
+}
+FastObject();
+function toFastproperties(obj) {
+    each(obj, function(value) {
+        if (value && !Array.isArray(value)) FastObject(value);
+    });
+};
+
 const READWRITE = GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE;
 
 // Based on https://gist.github.com/ptomato/c4245c77d375022a43c5

--- a/js/ui/overrides.js
+++ b/js/ui/overrides.js
@@ -105,6 +105,16 @@ function overrideDumpStack() {
 }
 
 function overrideGObject() {
+    const {each, toFastproperties} = imports.misc.util;
+
+    const originalInit = GObject.Object.prototype._init;
+    GObject.Object.prototype._init = function _init() {
+        originalInit.call(this, ...arguments);
+        each(this, function(value) {
+            if (value && !Array.isArray(value)) toFastproperties(value);
+        });
+    }
+
     GObject.Object.prototype.disconnect = function(id) {
         if (this.is_finalized()) {
             return true;

--- a/js/ui/overrides.js
+++ b/js/ui/overrides.js
@@ -105,13 +105,13 @@ function overrideDumpStack() {
 }
 
 function overrideGObject() {
-    const {each, toFastproperties} = imports.misc.util;
+    const {each, toFastProperties} = imports.misc.util;
 
     const originalInit = GObject.Object.prototype._init;
     GObject.Object.prototype._init = function _init() {
         originalInit.call(this, ...arguments);
         each(this, function(value) {
-            if (value && !Array.isArray(value)) toFastproperties(value);
+            if (value && !Array.isArray(value)) toFastProperties(value);
         });
     }
 


### PR DESCRIPTION
This is an optimization intended for V8, but it [also works on Spidermonkey](http://jsben.ch/1DVog). It modifies the properties of GObject instances so the engine uses its optimized path for property access. [More info](https://stackoverflow.com/questions/24987896/how-does-bluebirds-util-tofastproperties-function-make-an-objects-properties).

I got the idea to use this when I was trying to optimize #8068 and to address a performance regression with [CJS built with mozjs60](https://github.com/linuxmint/cjs/pull/70). In any case, it has a noticeable performance improvement for me, most notably with the responsiveness of electron apps like VSCode.