### PR TITLE
Overview: don't close on key release just after opening from keyboard

### DIFF
--- a/js/ui/workspacesView.js
+++ b/js/ui/workspacesView.js
@@ -58,7 +58,7 @@ WorkspacesView.prototype = {
         this._scrolling = false; // swipe-scrolling
         this._animatingScroll = false; // programatically updating the adjustment
 
-        this._keyIsHandled = false;
+        this._keyIsHandled = true;
 
         let activeWorkspaceIndex = global.screen.get_active_workspace_index();
         this._workspaces = [];


### PR DESCRIPTION
The flag used to indicate if the key was already handled shouldn't be initialized to false until a key is pressed, so that initial key release events don't think they have not been handled in case the overview is
opened via a keyboard shortcut. This flag will be initialized to true/false on key press anyways.

Fixes #8037