### PR TITLE
Menu applet: Disable button reactivity while scrolling through app list to improve performance

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1137,6 +1137,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         this._recentButtons = [];
         this._categoryButtons = [];
         this._searchProviderButtons = [];
+        this._appButtonsEnabled = true;
         this._selectedItemIndex = null;
         this._previousSelectedActor = null;
         this._previousVisibleIndex = null;
@@ -2806,6 +2807,24 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         if (box_height + current_scroll_value < button.actor.get_allocation_box().y2 + 10) new_scroll_value = button.actor.get_allocation_box().y2-box_height + 10;
         if (new_scroll_value != current_scroll_value) scrollBox.get_vscroll_bar().get_adjustment().set_value(new_scroll_value);
     }
+    
+    _enableAppButtons() {
+        if (!this._appButtonsEnabled) {
+            for (let i in this._applicationsButtons) {
+                this._applicationsButtons[i].actor.reactive = true;
+            }
+        }
+        this._appButtonsEnabled = true;
+    }
+
+    _disableAppButtons() {
+        if (this._appButtonsEnabled) {
+            for (let i in this._applicationsButtons) {
+                this._applicationsButtons[i].actor.reactive = false;
+            }
+            this._appButtonsEnabled = false;
+        }
+    }
 
     _display() {
         this._activeContainer = null;
@@ -2880,6 +2899,14 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                         Lang.bind(this, function() {
                             this.menu.passEvents = false;
                         }));
+        
+        // Disable app buttons while scrolling with mouse                
+        this.applicationsScrollBox.connect('scroll-event',
+            Lang.bind(this, this._disableAppButtons));
+        this.applicationsScrollBox.connect('motion-event',
+            Lang.bind(this, this._enableAppButtons));
+        this.applicationsScrollBox.connect('button-press-event',
+            Lang.bind(this, this._enableAppButtons));
 
         this.applicationsBox = new St.BoxLayout({ style_class: 'menu-applications-inner-box', vertical:true });
         this.applicationsBox.add_style_class_name('menu-applications-box'); //this is to support old themes


### PR DESCRIPTION
I'm attempting to solve #7191 by disabling the 'reactive' property of app list buttons when the mouse is scrolled, and re-enabling it when the pointer is moved or a button is clicked. This prevents the large number of enter and leave events from being triggered, which seems to be the primary cause of lag.

On my laptop this improves scrolling performance significantly, but buttons are no longer highlighted during scrolling. I feel like this is a hack around a different root cause, but I'm not familiar enough with Clutter or Cinnamon applets to figure out what that is. Even just moving the pointer around on the app list causes high CPU loads.
