### PR TITLE
Simplify DocSystem/DocInfo

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -18,12 +18,12 @@ const FileUtils = imports.misc.fileUtils;
 const Util = imports.misc.util;
 const DND = imports.ui.dnd;
 const Meta = imports.gi.Meta;
+const DocInfo = imports.misc.docInfo;
 const GLib = imports.gi.GLib;
 const Settings = imports.ui.settings;
 const Pango = imports.gi.Pango;
 const AccountsService = imports.gi.AccountsService;
 const SearchProviderManager = imports.ui.searchProviderManager;
-const DocInfo = imports.misc.docInfo;
 
 const MAX_FAV_ICON_SIZE = 32;
 const CATEGORY_ICON_SIZE = 22;

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -553,13 +553,13 @@ class RecentContextMenuItem extends PopupMenu.PopupBaseMenuItem {
 }
 
 class RecentButton extends PopupMenu.PopupBaseMenuItem {
-    constructor(appsMenuButton, file, showIcon) {
+    constructor(appsMenuButton, recent, showIcon) {
         super({hover: false});
-        this.mimeType = file.mimeType;
-        this.uri = file.uri;
-        this.uriDecoded = file.uriDecoded;
+        this.mimeType = recent.mimeType;
+        this.uri = recent.uri;
+        this.uriDecoded = recent.uriDecoded;
         this.appsMenuButton = appsMenuButton;
-        this.button_name = file.name;
+        this.button_name = recent.name;
 
         this.menu = null;
 
@@ -569,7 +569,7 @@ class RecentButton extends PopupMenu.PopupBaseMenuItem {
         this.label.clutter_text.ellipsize = Pango.EllipsizeMode.END;
         this.label.set_style(MAX_BUTTON_WIDTH);
         if (showIcon) {
-            this.icon = file.createIcon(APPLICATION_ICON_SIZE);
+            this.icon = recent.createIcon(APPLICATION_ICON_SIZE);
             this.addActor(this.icon);
         }
         this.addActor(this.label);

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1149,7 +1149,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         this._appsWereRefreshed = false;
         this._canUninstallApps = GLib.file_test("/usr/bin/cinnamon-remove-application", GLib.FileTest.EXISTS);
         this._isBumblebeeInstalled = GLib.file_test("/usr/bin/optirun", GLib.FileTest.EXISTS);
-        this.RecentManager = new DocInfo.DocManager();
+        this.RecentManager = new DocInfo.getDocManager();
         this.privacy_settings = new Gio.Settings( {schema_id: PRIVACY_SCHEMA} );
         this.noRecentDocuments = true;
         this._activeContextMenuParent = null;

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -23,6 +23,7 @@ const Settings = imports.ui.settings;
 const Pango = imports.gi.Pango;
 const AccountsService = imports.gi.AccountsService;
 const SearchProviderManager = imports.ui.searchProviderManager;
+const DocInfo = imports.misc.docInfo;
 
 const MAX_FAV_ICON_SIZE = 32;
 const CATEGORY_ICON_SIZE = 22;
@@ -1148,7 +1149,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         this._appsWereRefreshed = false;
         this._canUninstallApps = GLib.file_test("/usr/bin/cinnamon-remove-application", GLib.FileTest.EXISTS);
         this._isBumblebeeInstalled = GLib.file_test("/usr/bin/optirun", GLib.FileTest.EXISTS);
-        this.RecentManager = Main.recentManager;
+        this.RecentManager = DocInfo.getDocManager();
         this.privacy_settings = new Gio.Settings( {schema_id: PRIVACY_SCHEMA} );
         this.noRecentDocuments = true;
         this._activeContextMenuParent = null;

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -18,7 +18,6 @@ const FileUtils = imports.misc.fileUtils;
 const Util = imports.misc.util;
 const DND = imports.ui.dnd;
 const Meta = imports.gi.Meta;
-const DocInfo = imports.misc.docInfo;
 const GLib = imports.gi.GLib;
 const Settings = imports.ui.settings;
 const Pango = imports.gi.Pango;
@@ -1149,7 +1148,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         this._appsWereRefreshed = false;
         this._canUninstallApps = GLib.file_test("/usr/bin/cinnamon-remove-application", GLib.FileTest.EXISTS);
         this._isBumblebeeInstalled = GLib.file_test("/usr/bin/optirun", GLib.FileTest.EXISTS);
-        this.RecentManager = new DocInfo.getDocManager();
+        this.RecentManager = Main.recentManager;
         this.privacy_settings = new Gio.Settings( {schema_id: PRIVACY_SCHEMA} );
         this.noRecentDocuments = true;
         this._activeContextMenuParent = null;

--- a/files/usr/share/cinnamon/applets/recent@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/recent@cinnamon.org/applet.js
@@ -108,7 +108,6 @@ class CinnamonRecentApplet extends Applet.IconApplet {
                 while (id < this.RecentManager._infosByTimestamp.length) {
                     let recent = this.RecentManager._infosByTimestamp[id];
                     let button = new MyPopupMenuItem(recent.createIcon(22), recent.name, recent.uri, {});
-                    this.menu.addMenuItem(button);
                     button.connect('activate', Lang.bind(this, this._launchFile, recent.uri));
                     this._recentButtons.push(button);
                     this.recentsBox.add_child(button.actor);
@@ -116,18 +115,15 @@ class CinnamonRecentApplet extends Applet.IconApplet {
                 }
                 let separator = new PopupMenu.PopupSeparatorMenuItem();
                 this._recentButtons.push(separator);
-                this.menu.addMenuItem(separator);
                 this.recentsBox.add_child(separator.actor);
                 let icon = new St.Icon({ icon_name: 'edit-clear', icon_type: St.IconType.SYMBOLIC, icon_size: 22 });
                 let clear_button = new MyPopupMenuItem(icon, _("Clear list"), "clear", {});
                 clear_button.connect('activate', Lang.bind(this, this._clearAll));
                 this._recentButtons.push(clear_button);
-                this.menu.addMenuItem(clear_button);
                 this.recentsBox.add_child(clear_button.actor);
             } else {
                 let no_recents_button = new MyPopupMenuItem(null, _("No recent documents"), "no-recents", {});
                 this._recentButtons.push(no_recents_button);
-                this.menu.addMenuItem(no_recents_button);
                 this.recentsBox.add_child(no_recents_button.actor);
             }
             this.actor.show();

--- a/files/usr/share/cinnamon/applets/recent@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/recent@cinnamon.org/applet.js
@@ -1,11 +1,10 @@
-const Main = imports.ui.main;
+const DocInfo = imports.misc.docInfo;
 const Gtk = imports.gi.Gtk;
 const Gio = imports.gi.Gio;
 const St = imports.gi.St;
 const PopupMenu = imports.ui.popupMenu;
 const Lang = imports.lang;
 const Applet = imports.ui.applet;
-const DocInfo = imports.misc.docInfo;
 
 const PRIVACY_SCHEMA = "org.cinnamon.desktop.privacy";
 const REMEMBER_RECENT_KEY = "remember-recent-files";

--- a/files/usr/share/cinnamon/applets/recent@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/recent@cinnamon.org/applet.js
@@ -49,7 +49,7 @@ class CinnamonRecentApplet extends Applet.IconApplet {
         this.recentsScrollBox.add_actor(this.recentsBox);
         this.recentsScrollBox.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC);
 
-        this.RecentManager = new DocInfo.DocManager();
+        this.RecentManager = new DocInfo.getDocManager();
         this.privacy_settings = new Gio.Settings( {schema_id: PRIVACY_SCHEMA} );
 
         this._recentButtons = [];

--- a/files/usr/share/cinnamon/applets/recent@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/recent@cinnamon.org/applet.js
@@ -5,6 +5,7 @@ const St = imports.gi.St;
 const PopupMenu = imports.ui.popupMenu;
 const Lang = imports.lang;
 const Applet = imports.ui.applet;
+const DocInfo = imports.misc.docInfo;
 
 const PRIVACY_SCHEMA = "org.cinnamon.desktop.privacy";
 const REMEMBER_RECENT_KEY = "remember-recent-files";
@@ -49,7 +50,7 @@ class CinnamonRecentApplet extends Applet.IconApplet {
         this.recentsScrollBox.add_actor(this.recentsBox);
         this.recentsScrollBox.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC);
 
-        this.RecentManager = Main.recentManager;
+        this.RecentManager = DocInfo.getDocManager();
         this.privacy_settings = new Gio.Settings( {schema_id: PRIVACY_SCHEMA} );
 
         this._recentButtons = [];

--- a/files/usr/share/cinnamon/applets/recent@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/recent@cinnamon.org/applet.js
@@ -53,7 +53,7 @@ class CinnamonRecentApplet extends Applet.IconApplet {
         this.privacy_settings = new Gio.Settings( {schema_id: PRIVACY_SCHEMA} );
 
         this._recentButtons = [];
-        this._display();
+        this._refreshRecents();
 
         this.recent_id = this.RecentManager.connect('changed', Lang.bind(this, this._refreshRecents));
         this.settings_id = this.privacy_settings.connect("changed::" + REMEMBER_RECENT_KEY, Lang.bind(this, this._refreshRecents));
@@ -77,12 +77,8 @@ class CinnamonRecentApplet extends Applet.IconApplet {
         this.menu.toggle();
     }
 
-    _display() {
-        this._refreshRecents();
-    }
-
-    _launchFile(a, b, c, docinfo) {
-        docinfo.launch();
+    _launchFile(a, b, c, uri) {
+        Gio.app_info_launch_default_for_uri(uri, global.create_app_launch_context());
     }
 
     _clearAll() {
@@ -100,114 +96,42 @@ class CinnamonRecentApplet extends Applet.IconApplet {
     }
 
     _refreshRecents() {
-        if (this.privacy_settings.get_boolean(REMEMBER_RECENT_KEY)) {
-            let new_recents = [];
-            let have_recents = false;
+        // Clean content
+        for (let i = 0; i < this._recentButtons.length; i ++) {
+            this._recentButtons[i].destroy();
+        }
+        this._recentButtons = [];
 
+        if (this.privacy_settings.get_boolean(REMEMBER_RECENT_KEY)) {
             if (this.RecentManager._infosByTimestamp.length > 0) {
                 let id = 0;
                 while (id < this.RecentManager._infosByTimestamp.length) {
-                    let uri = this.RecentManager._infosByTimestamp[id].uri;
-
-                    let new_button = null;
-
-                    new_button = this._recentButtons.find(button => ((button.uri) && (button.uri == uri)));
-
-                    if (new_button == undefined) {
-                        let icon = this.RecentManager._infosByTimestamp[id].createIcon(22);
-                        let menuItem = new MyPopupMenuItem(icon, this.RecentManager._infosByTimestamp[id].name, uri, {});
-                        this.menu.addMenuItem(menuItem);
-                        menuItem.connect('activate', Lang.bind(this, this._launchFile, this.RecentManager._infosByTimestamp[id]));
-                        new_button = menuItem;
-                    }
-
-                    new_recents.push(new_button);
-
+                    let recent = this.RecentManager._infosByTimestamp[id];
+                    let button = new MyPopupMenuItem(recent.createIcon(22), recent.name, recent.uri, {});
+                    this.menu.addMenuItem(button);
+                    button.connect('activate', Lang.bind(this, this._launchFile, recent.uri));
+                    this._recentButtons.push(button);
+                    this.recentsBox.add_child(button.actor);
                     id++;
                 }
-
-                let recent_clear_button = null;
-
-                recent_clear_button = this._recentButtons.find(button => ((button.uri) && (button.uri == "clear")));
-
-                if (recent_clear_button == undefined) {
-                    let icon = new St.Icon({ icon_name: 'edit-clear', icon_type: St.IconType.SYMBOLIC, icon_size: 22 });
-                    let menuItem = new MyPopupMenuItem(icon, _("Clear list"), "clear", {});
-                    menuItem.connect('activate', Lang.bind(this, this._clearAll));
-
-                    recent_clear_button = menuItem;
-                }
-
-                have_recents = true;
-                new_recents.push(recent_clear_button);
+                let separator = new PopupMenu.PopupSeparatorMenuItem();
+                this._recentButtons.push(separator);
+                this.menu.addMenuItem(separator);
+                this.recentsBox.add_child(separator.actor);
+                let icon = new St.Icon({ icon_name: 'edit-clear', icon_type: St.IconType.SYMBOLIC, icon_size: 22 });
+                let clear_button = new MyPopupMenuItem(icon, _("Clear list"), "clear", {});
+                clear_button.connect('activate', Lang.bind(this, this._clearAll));
+                this._recentButtons.push(clear_button);
+                this.menu.addMenuItem(clear_button);
+                this.recentsBox.add_child(clear_button.actor);
             } else {
-                let no_recents_button = null;
-
-                no_recents_button = this._recentButtons.find(button => ((button.uri) && (button.uri == "no-recents")));
-
-                if (no_recents_button == undefined) {
-                    let menuItem = new MyPopupMenuItem(null, _("No recent documents"), "no-recents", {});
-
-                    no_recents_button = menuItem;
-                }
-
-                new_recents.push(no_recents_button);
+                let no_recents_button = new MyPopupMenuItem(null, _("No recent documents"), "no-recents", {});
+                this._recentButtons.push(no_recents_button);
+                this.menu.addMenuItem(no_recents_button);
+                this.recentsBox.add_child(no_recents_button.actor);
             }
-
-            let to_remove = [];
-
-            /* Remove no-longer-valid items */
-            for (let i = 0; i < this._recentButtons.length; i++) {
-                let button = this._recentButtons[i];
-
-                if (button.uri == "no-recents" && have_recents) {
-                    to_remove.push(button);
-                } else {
-                    if (new_recents.indexOf(button) == -1) {
-                        to_remove.push(button);
-                    }
-                }
-            }
-
-            if (to_remove.length > 0) {
-                for (let i in to_remove) {
-                    to_remove[i].destroy();
-                    this._recentButtons.splice(this._recentButtons.indexOf(to_remove[i]), 1);
-                }
-            }
-
-            to_remove = [];
-
-            /* Now, add new actors, shuffle existing actors */
-
-            let placeholder = this.recentsBox.get_first_child();
-
-            for (let i = 0; i < new_recents.length; i++) {
-                let actor = new_recents[i].actor;
-
-                let parent = actor.get_parent();
-                if (parent != null) {
-                    parent.remove_child(actor);
-                }
-
-                if (actor != placeholder) {
-                    this.recentsBox.insert_child_above(actor, placeholder);
-                } else {
-                    this.recentsBox.add_child(actor);
-                }
-
-                placeholder = actor;
-            }
-
-            this._recentButtons = new_recents;
-
             this.actor.show();
         } else {
-            for (let i = 0; i < this._recentButtons.length; i ++) {
-                this._recentButtons[i].destroy();
-            }
-
-            this._recentButtons = [];
             this.actor.hide();
         }
         this._on_panel_edit_mode_changed();

--- a/files/usr/share/cinnamon/applets/recent@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/recent@cinnamon.org/applet.js
@@ -1,4 +1,4 @@
-const DocInfo = imports.misc.docInfo;
+const Main = imports.ui.main;
 const Gtk = imports.gi.Gtk;
 const Gio = imports.gi.Gio;
 const St = imports.gi.St;
@@ -49,7 +49,7 @@ class CinnamonRecentApplet extends Applet.IconApplet {
         this.recentsScrollBox.add_actor(this.recentsBox);
         this.recentsScrollBox.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC);
 
-        this.RecentManager = new DocInfo.getDocManager();
+        this.RecentManager = Main.recentManager;
         this.privacy_settings = new Gio.Settings( {schema_id: PRIVACY_SCHEMA} );
 
         this._recentButtons = [];
@@ -78,6 +78,7 @@ class CinnamonRecentApplet extends Applet.IconApplet {
     }
 
     _launchFile(a, b, c, uri) {
+        this.menu.toggle();
         Gio.app_info_launch_default_for_uri(uri, global.create_app_launch_context());
     }
 

--- a/js/misc/docInfo.js
+++ b/js/misc/docInfo.js
@@ -10,8 +10,6 @@ const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 const Main = imports.ui.main;
 
-const MAX_RECENT_FILES = 20;
-
 function DocInfo(recentInfo) {
     this._init(recentInfo);
 }
@@ -73,7 +71,7 @@ DocManager.prototype = {
         let docs = this._docSystem.get_all();
         this._infosByTimestamp = [];
         let i = 0;
-        while (i < docs.length && i < MAX_RECENT_FILES) {
+        while (i < docs.length) {
             let recentInfo = docs[i];
             let docInfo = new DocInfo(recentInfo);
             this._infosByTimestamp.push(docInfo);

--- a/js/misc/docInfo.js
+++ b/js/misc/docInfo.js
@@ -15,14 +15,10 @@
 */
 
 const St = imports.gi.St;
-const Mainloop = imports.mainloop;
 const Cinnamon = imports.gi.Cinnamon;
 const Lang = imports.lang;
 const Signals = imports.signals;
-const Search = imports.ui.search;
 const Gio = imports.gi.Gio;
-const GLib = imports.gi.GLib;
-const Main = imports.ui.main;
 
 function DocInfo(recentInfo) {
     this._init(recentInfo);
@@ -31,12 +27,7 @@ function DocInfo(recentInfo) {
 DocInfo.prototype = {
     _init : function(recentInfo) {
         this.gicon = recentInfo.get_gicon();
-        // We actually used get_modified() instead of get_visited()
-        // here, as GtkRecentInfo doesn't updated get_visited()
-        // correctly. See http://bugzilla.gnome.org/show_bug.cgi?id=567094
-        this.timestamp = recentInfo.get_modified();
         this.name = recentInfo.get_display_name();
-        this._lowerName = this.name.toLowerCase();
         this.uri = recentInfo.get_uri();
         try {
             this.uriDecoded = decodeURIComponent(this.uri);
@@ -50,12 +41,7 @@ DocInfo.prototype = {
 
     createIcon : function(size) {
         return new St.Icon({ gicon: this.gicon, icon_size: size });
-    },
-
-    launch : function() {
-        Gio.app_info_launch_default_for_uri(this.uri, global.create_app_launch_context());
     }
-
 };
 
 var docManagerInstance = null;

--- a/js/misc/docInfo.js
+++ b/js/misc/docInfo.js
@@ -1,5 +1,19 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
+/**
+* DOCINFO
+*
+* DocInfo is a JS layer on top of Cinnamon's DocSystem (which is written in C).
+*
+* The advantages of using DocInfo (rather than Gtk.RecentManager) are:
+*
+*  - Results are limited to 20 (with RecentManager you can get a huge number of results)
+*  - Results are sorted by timestamp (they're not sorted by RecentManager)
+*  - Sorting and clamping of the results is done in C and only the 20 most recent results are stored in memory
+*  - The "changed" signal sent by DocSystem is delayed via idle_timeout, so your applet doesn't rebuild immediately when Gtk.RecentManager sends its signal (which could potentially reduce the speed at which apps are launched)
+*  - DocInfo provides decoded URIs and the ability to quickly create the icon so your applet doesn't need to do that itself.
+*/
+
 const St = imports.gi.St;
 const Mainloop = imports.mainloop;
 const Cinnamon = imports.gi.Cinnamon;

--- a/js/misc/docInfo.js
+++ b/js/misc/docInfo.js
@@ -10,7 +10,6 @@ const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 const Main = imports.ui.main;
 
-const THUMBNAIL_ICON_MARGIN = 2;
 const MAX_RECENT_FILES = 20;
 
 function DocInfo(recentInfo) {
@@ -35,79 +34,16 @@ DocInfo.prototype = {
             global.logError("Error while decoding URI: " + this.uri);
         }
         this.mimeType = recentInfo.get_mime_type();
-        //this.mtime = this._fetch_mtime(); // Expensive
     },
-
-    // _fetch_mtime : function() {
-    //     let ret = -1;
-    //     if (GLib.str_has_prefix(this.uri, "file://")) {
-    //         let file = Gio.file_new_for_uri(this.uri);
-    //         let file_info;
-    //         try {
-    //             file_info = file.query_info(Gio.FILE_ATTRIBUTE_TIME_MODIFIED, Gio.FileQueryInfoFlags.NONE, null);
-    //             if (file_info) {
-    //                 ret = file_info.get_attribute_uint64(Gio.FILE_ATTRIBUTE_TIME_MODIFIED);
-    //             }
-    //         } catch (e) {}
-    //     }
-
-    //     return ret;
-    // },
 
     createIcon : function(size) {
         return new St.Icon({ gicon: this.gicon, icon_size: size });
     },
 
-    _realLaunch : function() {
-        Gio.app_info_launch_default_for_uri(this.uri, global.create_app_launch_context());
-    },
-
-    // _onMountCallback: function (file, result, data) {
-    //     try {
-    //         this._realLaunch();
-    //     } catch (e) {
-    //         let q = GLib.quark_from_static_string("g-vfs-error-quark");
-    //         if (e.domain == q) {/* gvfs cache invalid - not sure why... retry succeeds */
-    //             this._realLaunch();
-    //         } else {
-    //             Main.notify(_("Problem opening file"),
-    //                         _("There was a problem opening the selected file.") +
-    //                         _("  Please check to see if you have the proper permissions to access this resource,") +
-    //                         _(" or try manually mounting the file's enclosing volume.\n\n") +
-    //                         _("The file uri is: " + file.get_uri()));
-    //             global.logError("docInfo.js: Failed to mount:  " + file.get_uri());
-    //             global.logError("............Error domain is:  " + GLib.quark_to_string(e.domain));
-    //             global.logError("............Error code is:    " + e.code);
-    //             global.logError("............Error Message is: " + e.message);
-    //         }
-    //     }
-    // },
-
     launch : function() {
-        // if (this.mtime == -1) {
-        //     let file = Gio.File.new_for_uri(this.uri);
-        //     file.mount_enclosing_volume(0, null, null, Lang.bind(this, this._onMountCallback), null);
-        // } else {
-            this._realLaunch();
-        // }
-    },
-
-    matchTerms: function(terms) {
-        let mtype = Search.MatchType.NONE;
-        for (let i = 0; i < terms.length; i++) {
-            let term = terms[i];
-            let idx = this._lowerName.indexOf(term);
-            if (idx == 0) {
-                mtype = Search.MatchType.PREFIX;
-            } else if (idx > 0) {
-                if (mtype == Search.MatchType.NONE)
-                    mtype = Search.MatchType.SUBSTRING;
-            } else {
-                return Search.MatchType.NONE;
-            }
-        }
-        return mtype;
+        Gio.app_info_launch_default_for_uri(this.uri, global.create_app_launch_context());
     }
+
 };
 
 var docManagerInstance = null;
@@ -129,7 +65,6 @@ DocManager.prototype = {
     _init: function() {
         this._docSystem = Cinnamon.DocSystem.get_default();
         this._infosByTimestamp = [];
-        this._infosByUri = {};
         this._load();
         this._docSystem.connect('changed', Lang.bind(this, this._reload));
     },
@@ -137,17 +72,11 @@ DocManager.prototype = {
     _load: function() {
         let docs = this._docSystem.get_all();
         this._infosByTimestamp = [];
-        this._infosByUri = {};
-
-        let valid_count = 0;
-        let i = 0; 
-
-        while (i < docs.length && valid_count < MAX_RECENT_FILES) {
+        let i = 0;
+        while (i < docs.length && i < MAX_RECENT_FILES) {
             let recentInfo = docs[i];
             let docInfo = new DocInfo(recentInfo);
             this._infosByTimestamp.push(docInfo);
-            this._infosByUri[docInfo.uri] = docInfo;
-            valid_count++;
             i++;
         }
     },
@@ -155,53 +84,6 @@ DocManager.prototype = {
     _reload: function() {
         this._load();
         this.emit('changed');
-    },
-
-    getTimestampOrderedInfos: function() {
-        return this._infosByTimestamp;
-    },
-
-    getInfosByUri: function() {
-        return this._infosByUri;
-    },
-
-    lookupByUri: function(uri) {
-        return this._infosByUri[uri];
-    },
-
-    queueExistenceCheck: function(count) {
-        return this._docSystem.queue_existence_check(count);
-    },
-
-    _searchDocs: function(items, terms) {
-        let multiplePrefixMatches = [];
-        let prefixMatches = [];
-        let multipleSubtringMatches = [];
-        let substringMatches = [];
-        for (let i = 0; i < items.length; i++) {
-            let item = items[i];
-            let mtype = item.matchTerms(terms);
-            if (mtype == Search.MatchType.MULTIPLE_PREFIX)
-                multiplePrefixMatches.push(item.uri);
-            else if (mtype == Search.MatchType.PREFIX)
-                prefixMatches.push(item.uri);
-            else if (mtype == Search.MatchType.MULTIPLE_SUBSTRING)
-                multipleSubtringMatches.push(item.uri);
-            else if (mtype == Search.MatchType.SUBSTRING)
-                substringMatches.push(item.uri);
-         }
-        return multiplePrefixMatches.concat(prefixMatches.concat(multipleSubtringMatches.concat(substringMatches)));
-    },
-
-    initialSearch: function(terms) {
-        return this._searchDocs(this._infosByTimestamp, terms);
-    },
-
-    subsearch: function(previousResults, terms) {
-        return this._searchDocs(previousResults.map(Lang.bind(this,
-            function(url) {
-                return this._infosByUri[url];
-            })), terms);
     }
 };
 

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -83,6 +83,7 @@ const St = imports.gi.St;
 const GObject = imports.gi.GObject;
 const PointerTracker = imports.misc.pointerTracker;
 const Lang = imports.lang;
+
 const SoundManager = imports.ui.soundManager;
 const BackgroundManager = imports.ui.backgroundManager;
 const SlideshowManager = imports.ui.slideshowManager;
@@ -125,7 +126,6 @@ var LAYOUT_CLASSIC = "classic";
 var DEFAULT_BACKGROUND_COLOR = Clutter.Color.from_pixel(0x000000ff);
 
 var panel = null;
-var recentManager = null;
 var soundManager = null;
 var backgroundManager = null;
 var slideshowManager = null;

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -83,8 +83,6 @@ const St = imports.gi.St;
 const GObject = imports.gi.GObject;
 const PointerTracker = imports.misc.pointerTracker;
 const Lang = imports.lang;
-const DocInfo = imports.misc.docInfo;
-
 const SoundManager = imports.ui.soundManager;
 const BackgroundManager = imports.ui.backgroundManager;
 const SlideshowManager = imports.ui.slideshowManager;
@@ -323,11 +321,6 @@ function start() {
     let startTime = new Date().getTime();
     Cinnamon.AppSystem.get_default();
     global.log('Cinnamon.AppSystem.get_default() started in %d ms'.format(new Date().getTime() - startTime));
-
-    // Initiate docinfo
-    startTime = new Date().getTime();
-    recentManager = DocInfo.getDocManager();
-    global.log('DocInfo.getDocManager() started in %d ms'.format(new Date().getTime() - startTime));
 
     // The stage is always covered so Clutter doesn't need to clear it; however
     // the color is used as the default contents for the Muffin root background

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -83,6 +83,7 @@ const St = imports.gi.St;
 const GObject = imports.gi.GObject;
 const PointerTracker = imports.misc.pointerTracker;
 const Lang = imports.lang;
+const DocInfo = imports.misc.docInfo;
 
 const SoundManager = imports.ui.soundManager;
 const BackgroundManager = imports.ui.backgroundManager;
@@ -126,6 +127,7 @@ var LAYOUT_CLASSIC = "classic";
 var DEFAULT_BACKGROUND_COLOR = Clutter.Color.from_pixel(0x000000ff);
 
 var panel = null;
+var recentManager = null;
 var soundManager = null;
 var backgroundManager = null;
 var slideshowManager = null;
@@ -321,6 +323,11 @@ function start() {
     let startTime = new Date().getTime();
     Cinnamon.AppSystem.get_default();
     global.log('Cinnamon.AppSystem.get_default() started in %d ms'.format(new Date().getTime() - startTime));
+
+    // Initiate docinfo
+    startTime = new Date().getTime();
+    recentManager = DocInfo.getDocManager();
+    global.log('DocInfo.getDocManager() started in %d ms'.format(new Date().getTime() - startTime));
 
     // The stage is always covered so Clutter doesn't need to clear it; however
     // the color is used as the default contents for the Muffin root background

--- a/src/cinnamon-doc-system.c
+++ b/src/cinnamon-doc-system.c
@@ -16,7 +16,6 @@
  */
 enum {
   CHANGED,
-  DELETED,
   LAST_SIGNAL
 };
 
@@ -24,16 +23,17 @@ static guint signals[LAST_SIGNAL] = { 0 };
 
 struct _CinnamonDocSystemPrivate {
   GtkRecentManager *manager;
-  GHashTable *infos_by_uri;
   GSList *infos_by_timestamp;
 
   guint idle_recent_changed_id;
-
-  GHashTable *deleted_infos;
-  guint idle_emit_deleted_id;
 };
 
 G_DEFINE_TYPE(CinnamonDocSystem, cinnamon_doc_system, G_TYPE_OBJECT);
+
+// Showing all recent items isn't viable, GTK.RecentManager can contain
+// thousands of items and this can significantly affect performance
+// in the JS layer.
+static const MAX_RECENT_ITEMS = 20;
 
 /**
  * cinnamon_doc_system_get_all:
@@ -51,122 +51,10 @@ cinnamon_doc_system_get_all (CinnamonDocSystem    *self)
   return self->priv->infos_by_timestamp;
 }
 
-/**
- * cinnamon_doc_system_lookup_by_uri:
- * @system: A #CinnamonDocSystem
- * @uri: Url
- *
- * Returns: (transfer none): Recent file info corresponding to given @uri
- */
-GtkRecentInfo *
-cinnamon_doc_system_lookup_by_uri (CinnamonDocSystem  *self,
-                                const char      *uri)
-{
-  return g_hash_table_lookup (self->priv->infos_by_uri, uri);
-}
-
-static gboolean
-cinnamon_doc_system_idle_emit_deleted (gpointer data)
-{
-  CinnamonDocSystem *self = CINNAMON_DOC_SYSTEM (data);
-  GHashTableIter iter;
-  gpointer key, value;
-
-  self->priv->idle_emit_deleted_id = 0;
-
-  g_hash_table_iter_init (&iter, self->priv->deleted_infos);
-
-  while (g_hash_table_iter_next (&iter, &key, &value))
-    {
-      GtkRecentInfo *info = key;
-      g_signal_emit (self, signals[DELETED], 0, info);
-    }
-
-  g_signal_emit (self, signals[CHANGED], 0);
-
-  return FALSE;
-}
-
 typedef struct {
   CinnamonDocSystem *self;
   GtkRecentInfo *info;
 } CinnamonDocSystemRecentQueryData;
-
-static void
-on_recent_file_query_result (GObject       *source,
-                             GAsyncResult  *result,
-                             gpointer       user_data)
-{
-  CinnamonDocSystemRecentQueryData *data = user_data;
-  CinnamonDocSystem *self = data->self;
-  GError *error = NULL;
-  GFileInfo *fileinfo;
-
-  fileinfo = g_file_query_info_finish (G_FILE (source), result, &error);
-  if (fileinfo)
-    g_object_unref (fileinfo);
-  /* This is a strict error check; we don't want to cause recent files to
-   * vanish for anything potentially transient.
-   */
-  if (error != NULL && error->domain == G_IO_ERROR && error->code == G_IO_ERROR_NOT_FOUND)
-    {
-      self->priv->infos_by_timestamp = g_slist_remove (self->priv->infos_by_timestamp, data->info);
-      g_hash_table_remove (self->priv->infos_by_uri, gtk_recent_info_get_uri (data->info));
-
-      g_hash_table_insert (self->priv->deleted_infos, gtk_recent_info_ref (data->info), NULL);
-
-      if (self->priv->idle_emit_deleted_id == 0)
-        self->priv->idle_emit_deleted_id = g_timeout_add (0, cinnamon_doc_system_idle_emit_deleted, self);
-    }
-  g_clear_error (&error);
-
-  gtk_recent_info_unref (data->info);
-  g_free (data);
-}
-
-/**
- * cinnamon_doc_system_queue_existence_check:
- * @system: A #CinnamonDocSystem
- * @n_items: Count of items to check for existence, starting from most recent
- *
- * Asynchronously start a check of a number of recent file for existence;
- * any deleted files will be emitted from the #CinnamonDocSystem::deleted
- * signal.  Note that this function ignores non-local files; they
- * will simply always appear to exist (until they are removed from
- * the recent file list manually).
- *
- * The intent of this function is to be called after a #CinnamonDocSystem::changed
- * signal has been emitted, and a display has shown a subset of those files.
- */
-void
-cinnamon_doc_system_queue_existence_check (CinnamonDocSystem   *self,
-                                        guint             n_items)
-{
-  GSList *iter;
-  guint i;
-
-  for (i = 0, iter = self->priv->infos_by_timestamp; i < n_items && iter; i++, iter = iter->next)
-    {
-      GtkRecentInfo *info = iter->data;
-      const char *uri;
-      GFile *file;
-      CinnamonDocSystemRecentQueryData *data;
-
-      if (!gtk_recent_info_is_local (info))
-        continue;
-
-      data = g_new0 (CinnamonDocSystemRecentQueryData, 1);
-      data->self = self;
-      data->info = gtk_recent_info_ref (info);
-
-      uri = gtk_recent_info_get_uri (info);
-      file = g_file_new_for_uri (uri);
-
-      g_file_query_info_async (file, "standard::type", G_FILE_QUERY_INFO_NONE,
-                               G_PRIORITY_DEFAULT, NULL, on_recent_file_query_result, data);
-      g_object_unref (file);
-    }
-}
 
 static int
 sort_infos_by_timestamp_descending (gconstpointer a,
@@ -182,34 +70,34 @@ sort_infos_by_timestamp_descending (gconstpointer a,
   return modified_b - modified_a;
 }
 
+static void load_items (CinnamonDocSystem *self)
+{
+  GList *items, *iter;
+  self->priv->infos_by_timestamp = NULL;
+  items = gtk_recent_manager_get_items (self->priv->manager);
+  items = g_slist_sort (items, sort_infos_by_timestamp_descending);
+  int i = 0;
+  for (iter = items; iter; iter = iter->next)
+    {
+      GtkRecentInfo *info = iter->data;
+      if (i < MAX_RECENT_ITEMS) {
+        self->priv->infos_by_timestamp = g_slist_append (self->priv->infos_by_timestamp, info);
+      }
+      else {
+        gtk_recent_info_unref (info);
+      }
+      i++;
+    }
+  g_list_free (items);
+}
+
 static gboolean
 idle_handle_recent_changed (gpointer data)
 {
   CinnamonDocSystem *self = CINNAMON_DOC_SYSTEM (data);
-  GList *items, *iter;
-
   self->priv->idle_recent_changed_id = 0;
-
-  g_hash_table_remove_all (self->priv->deleted_infos);
-  g_hash_table_remove_all (self->priv->infos_by_uri);
-  g_slist_free (self->priv->infos_by_timestamp);
-  self->priv->infos_by_timestamp = NULL;
-
-  items = gtk_recent_manager_get_items (self->priv->manager);
-  for (iter = items; iter; iter = iter->next)
-    {
-      GtkRecentInfo *info = iter->data;
-      const char *uri = gtk_recent_info_get_uri (info);
-
-      /* uri is owned by the info */
-      g_hash_table_insert (self->priv->infos_by_uri, (char*) uri, info);
-
-      self->priv->infos_by_timestamp = g_slist_prepend (self->priv->infos_by_timestamp, info);
-    }
-  g_list_free (items);
-
-  self->priv->infos_by_timestamp = g_slist_sort (self->priv->infos_by_timestamp, sort_infos_by_timestamp_descending);
-
+  g_slist_free_full (self->priv->infos_by_timestamp, gtk_recent_info_unref);
+  load_items(self);
   g_signal_emit (self, signals[CHANGED], 0);
 
   return FALSE;
@@ -222,92 +110,6 @@ cinnamon_doc_system_on_recent_changed (GtkRecentManager  *manager,
   if (self->priv->idle_recent_changed_id != 0)
     return;
   self->priv->idle_recent_changed_id = g_timeout_add (0, idle_handle_recent_changed, self);
-}
-
-/**
- * cinnamon_doc_system_open:
- * @system: A #CinnamonDocSystem
- * @info: A #GtkRecentInfo
- * @workspace: Open on this workspace, or -1 for default
- *
- * Launch the default application associated with the mime type of
- * @info, using its uri.
- */
-void
-cinnamon_doc_system_open (CinnamonDocSystem *system,
-                       GtkRecentInfo  *info,
-                       int             workspace)
-{
-  GFile *file;
-  GAppInfo *app_info;
-  gboolean needs_uri;
-  GAppLaunchContext *context;
-
-  context = cinnamon_global_create_app_launch_context (cinnamon_global_get ());
-  if (workspace != -1)
-    gdk_app_launch_context_set_desktop ((GdkAppLaunchContext *)context, workspace);
-
-  file = g_file_new_for_uri (gtk_recent_info_get_uri (info));
-  needs_uri = g_file_get_path (file) == NULL;
-  g_object_unref (file);
-
-  app_info = g_app_info_get_default_for_type (gtk_recent_info_get_mime_type (info), needs_uri);
-  if (app_info != NULL)
-    {
-      GList *uris;
-      uris = g_list_prepend (NULL, (gpointer)gtk_recent_info_get_uri (info));
-      g_app_info_launch_uris (app_info, uris, context, NULL);
-      g_list_free (uris);
-    }
-  else
-    {
-      char *app_name;
-      const char *app_exec;
-      char *app_exec_quoted;
-      guint count;
-      time_t time;
-
-      app_name = gtk_recent_info_last_application (info);
-      if (gtk_recent_info_get_application_info (info, app_name, &app_exec, &count, &time))
-        {
-          GRegex *regex;
-
-          /* TODO: Change this once better support for creating
-             GAppInfo is added to GtkRecentInfo, as right now
-             this relies on the fact that the file uri is
-             already a part of appExec, so we don't supply any
-             files to app_info.launch().
-
-             The 'command line' passed to
-             create_from_command_line is allowed to contain
-             '%<something>' macros that are expanded to file
-             name / icon name, etc, so we need to escape % as %%
-           */
-
-          regex = g_regex_new ("%", 0, 0, NULL);
-          app_exec_quoted = g_regex_replace (regex, app_exec, -1, 0, "%%", 0, NULL);
-          g_regex_unref (regex);
-
-          app_info = g_app_info_create_from_commandline (app_exec_quoted, NULL, 0, NULL);
-          g_free (app_exec_quoted);
-
-          /* The point of passing an app launch context to
-             launch() is mostly to get startup notification and
-             associated benefits like the app appearing on the
-             right desktop; but it doesn't really work for now
-             because with the way we create the appInfo we
-             aren't reading the application's desktop file, and
-             thus don't find the StartupNotify=true in it. So,
-             despite passing the app launch context, no startup
-             notification occurs.
-           */
-          g_app_info_launch (app_info, NULL, context, NULL);
-        }
-
-      g_free (app_name);
-    }
-
-  g_object_unref (context);
 }
 
 static void
@@ -323,14 +125,6 @@ cinnamon_doc_system_class_init(CinnamonDocSystemClass *klass)
                  NULL, NULL, NULL,
 		  G_TYPE_NONE, 0);
 
-  signals[DELETED] =
-    g_signal_new ("deleted",
-		  CINNAMON_TYPE_DOC_SYSTEM,
-		  G_SIGNAL_RUN_LAST,
-		  0,
-                 NULL, NULL, NULL,
-		  G_TYPE_NONE, 1, GTK_TYPE_RECENT_INFO);
-
   g_type_class_add_private (gobject_class, sizeof (CinnamonDocSystemPrivate));
 }
 
@@ -338,30 +132,12 @@ static void
 cinnamon_doc_system_init (CinnamonDocSystem *self)
 {
   CinnamonDocSystemPrivate *priv;
-  GList *items, *iter;
-
   self->priv = priv = G_TYPE_INSTANCE_GET_PRIVATE (self,
                                                    CINNAMON_TYPE_DOC_SYSTEM,
                                                    CinnamonDocSystemPrivate);
+
   self->priv->manager = gtk_recent_manager_get_default ();
-
-  self->priv->deleted_infos = g_hash_table_new_full (NULL, NULL, (GDestroyNotify)gtk_recent_info_unref, NULL);
-  self->priv->infos_by_uri = g_hash_table_new_full (g_str_hash, g_str_equal, NULL, (GDestroyNotify)gtk_recent_info_unref);
-
-  self->priv->infos_by_timestamp = NULL;
-  items = gtk_recent_manager_get_items (self->priv->manager);
-  for (iter = items; iter; iter = iter->next)
-    {
-      GtkRecentInfo *info = iter->data;
-      const char *uri = gtk_recent_info_get_uri (info);
-      /* uri is owned by the info */
-      g_hash_table_insert (self->priv->infos_by_uri, (char*) uri, info);
-      self->priv->infos_by_timestamp = g_slist_prepend (self->priv->infos_by_timestamp, info);
-    }
-  g_list_free (items);
-
-  self->priv->infos_by_timestamp = g_slist_sort (self->priv->infos_by_timestamp, sort_infos_by_timestamp_descending);
-
+  load_items(self);
   g_signal_connect (self->priv->manager, "changed", G_CALLBACK(cinnamon_doc_system_on_recent_changed), self);
 }
 

--- a/src/cinnamon-doc-system.c
+++ b/src/cinnamon-doc-system.c
@@ -31,7 +31,7 @@ struct _CinnamonDocSystemPrivate {
 G_DEFINE_TYPE(CinnamonDocSystem, cinnamon_doc_system, G_TYPE_OBJECT);
 
 // Showing all recent items isn't viable, GTK.RecentManager can contain
-// thousands of items and this can significantly affect performance
+// up to 1000 items and this can significantly affect performance
 // in the JS layer.
 static const MAX_RECENT_ITEMS = 20;
 

--- a/src/cinnamon-doc-system.h
+++ b/src/cinnamon-doc-system.h
@@ -34,14 +34,4 @@ CinnamonDocSystem* cinnamon_doc_system_get_default (void);
 
 GSList *cinnamon_doc_system_get_all (CinnamonDocSystem    *system);
 
-GtkRecentInfo *cinnamon_doc_system_lookup_by_uri (CinnamonDocSystem  *system,
-                                               const char     *uri);
-
-void cinnamon_doc_system_queue_existence_check (CinnamonDocSystem   *system,
-                                             guint             n_items);
-
-void cinnamon_doc_system_open (CinnamonDocSystem *system,
-                            GtkRecentInfo  *info,
-                            int             workspace);
-
 #endif /* __CINNAMON_DOC_SYSTEM_H__ */


### PR DESCRIPTION
This PR simplifies DocSystem/DocInfo (which role is to handle the list of recent documents in Cinnamon), to optimize performance, memory usage and prevent memory leaks (by removing complicated code).

It:

- Removes a lot of unused code.
- Simplifies the listing of recent docs in the menu@cinnamon.org and recent@cinnamon.org applets.
- Makes everybody use the same unique instance of DocInfo.
- Frees recent objects which aren't used.
- Moves the limit of 20 recent items from JS to C (Gtk.RecentManager can't sort or clamp result, this is done in C in DocSystem.. it used to be sorted in C but clamped in JS before this PR).
- Remove the number of objects in memory (for instance recent applet no longer keeps a handle on recent objects, only their URI)
