### PR TITLE
JsonSettingsWidgets: Fix TypeError

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py
@@ -116,7 +116,7 @@ class JSONSettingsHandler(object):
         with info["obj"].freeze_notify():
             if "map_get" in info and info["map_get"] != None:
                 value = info["map_get"](value)
-            if value != info["obj"].get_property(info["prop"]) and isinstance(value, int):
+            if value != info["obj"].get_property(info["prop"]) and value is not None:
                 info["obj"].set_property(info["prop"], value)
 
     def check_settings(self, *args):

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py
@@ -116,7 +116,7 @@ class JSONSettingsHandler(object):
         with info["obj"].freeze_notify():
             if "map_get" in info and info["map_get"] != None:
                 value = info["map_get"](value)
-            if value != info["obj"].get_property(info["prop"]):
+            if value != info["obj"].get_property(info["prop"]) and isinstance(value, int):
                 info["obj"].set_property(info["prop"], value)
 
     def check_settings(self, *args):


### PR DESCRIPTION
```
Traceback (most recent call last):
  File '/usr/share/cinnamon/cinnamon-settings/xlet-settings.py', line 500, in <module>
    window = MainWindow(xlet_type, *sys.argv[2:])
  File '/usr/share/cinnamon/cinnamon-settings/xlet-settings.py', line 96, in __init__
    self.load_instances()
  File '/usr/share/cinnamon/cinnamon-settings/xlet-settings.py', line 280, in load_instances
    self.build_from_order(settings_map, info, instance_box, first_key)
  File '/usr/share/cinnamon/cinnamon-settings/xlet-settings.py', line 378, in build_from_order
    widget = globals()[XLET_SETTINGS_WIDGETS[settings_type]](key, info['settings'], item)
  File '/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py', line 310, in __init__
    self.attach()
  File '/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py', line 271, in attach
    self.map_set if hasattr(self, 'map_set') else None)
  File '/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py', line 59, in bind
    self.set_object_value(binding_info, self.get_value(key))
  File '/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py', line 120, in set_object_value
    info['obj'].set_property(info['prop'], value)
TypeError: Must be number, not NoneType
```