### PR TITLE
windowManager: Cache settings, various clean up

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_effects.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_effects.py
@@ -117,7 +117,7 @@ class Module:
 
             settings = page.add_section(_("Enable Effects"))
 
-            widget = GSettingsSwitch(_("Window effects"), "org.cinnamon", "desktop-effects")
+            widget = GSettingsSwitch(_("Window effects"), "org.cinnamon.muffin", "desktop-effects")
             settings.add_row(widget)
 
             widget = GSettingsSwitch(_("Effects on dialog boxes"), "org.cinnamon", "desktop-effects-on-dialogs")

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -106,7 +106,6 @@ const NotificationDaemon = imports.ui.notificationDaemon;
 const WindowAttentionHandler = imports.ui.windowAttentionHandler;
 const Scripting = imports.ui.scripting;
 const CinnamonDBus = imports.ui.cinnamonDBus;
-const WindowManager = imports.ui.windowManager;
 const ThemeManager = imports.ui.themeManager;
 const Magnifier = imports.ui.magnifier;
 const XdndHandler = imports.ui.xdndHandler;
@@ -418,7 +417,7 @@ function start() {
 
     layoutManager._updateBoxes();
 
-    wm = new WindowManager.WindowManager();
+    wm = new imports.ui.windowManager.WindowManager();
     messageTray = new MessageTray.MessageTray();
     keyboard = new Keyboard.Keyboard();
     notificationDaemon = new NotificationDaemon.NotificationDaemon();

--- a/js/ui/overview.js
+++ b/js/ui/overview.js
@@ -289,7 +289,7 @@ Overview.prototype = {
         global.overlay_group.add_actor(this.workspacesView.actor);
         Main.panelManager.disablePanels();
 
-        let animate = global.settings.get_boolean("desktop-effects");
+        let animate = Main.wm.settingsState['desktop-effects'];
         if (animate) {
             this._group.opacity = 0;
             Tweener.addTween(this._group, {
@@ -408,7 +408,7 @@ Overview.prototype = {
 
         this.workspacesView.hide();
 
-        let animate = global.settings.get_boolean("desktop-effects");
+        let animate = Main.wm.settingsState['desktop-effects'];
         if (animate) {
             // Make other elements fade out.
             Tweener.addTween(this._group, {

--- a/js/ui/windowEffects.js
+++ b/js/ui/windowEffects.js
@@ -309,7 +309,7 @@ Unminimize.prototype = {
             this._scaleWindow(cinnamonwm, actor, 1, 1, time, transition, true);
             this._fadeWindow(cinnamonwm, actor, actor.orig_opacity, time, transition);
         } else {
-            throw "No origin found";
+            global.logWarning('windowEffects.Unminimize: No origin found.');
         }
     }
 }

--- a/js/ui/windowEffects.js
+++ b/js/ui/windowEffects.js
@@ -6,9 +6,8 @@ const Main = imports.ui.main;
 const Tweener = imports.ui.tweener;
 
 class Effect {
-    constructor(wm) {
-        //wm is the instance of windowManger.js
-        this.wm = wm;
+    constructor(endWindowEffect) {
+        this.endWindowEffect = endWindowEffect;
     }
 
     _end(actor) {
@@ -19,14 +18,12 @@ class Effect {
 
     _fadeWindow(cinnamonwm, actor, opacity, time, transition) {
         Tweener.addTween(actor, {
-            opacity: opacity,
-            time: time,
+            opacity,
+            time,
             min: 0,
             max: 255,
-            transition: transition,
-            onComplete: this.wm._endWindowEffect,
-            onCompleteScope: this.wm,
-            onCompleteParams: [cinnamonwm, this.name, actor]
+            transition,
+            onComplete: () => this.endWindowEffect(cinnamonwm, this.name, actor),
         });
     }
 
@@ -35,26 +32,22 @@ class Effect {
             actor.move_anchor_point_from_gravity(Clutter.Gravity.CENTER);
 
         Tweener.addTween(actor, {
-            scale_x: scale_x,
-            scale_y: scale_y,
-            time: time,
+            scale_x,
+            scale_y,
+            time,
             min: 0,
-            transition: transition,
-            onComplete: this.wm._endWindowEffect,
-            onCompleteScope: this.wm,
-            onCompleteParams: [cinnamonwm, this.name, actor]
+            transition,
+            onComplete: () => this.endWindowEffect(cinnamonwm, this.name, actor),
         });
     }
 
     _moveWindow(cinnamonwm, actor, x, y, time, transition) {
         Tweener.addTween(actor, {
-            x: x,
-            y: y,
-            time: time,
-            transition: transition,
-            onComplete: this.wm._endWindowEffect,
-            onCompleteScope: this.wm,
-            onCompleteParams: [cinnamonwm, this.name, actor]
+            x,
+            y,
+            time,
+            transition,
+            onComplete: () => this.endWindowEffect(cinnamonwm, this.name, actor),
         });
     }
 };

--- a/js/ui/windowEffects.js
+++ b/js/ui/windowEffects.js
@@ -1,9 +1,7 @@
-const Clutter = imports.gi.Clutter;
-const Meta = imports.gi.Meta;
-
-const AppletManager = imports.ui.appletManager;
-const Main = imports.ui.main;
-const Tweener = imports.ui.tweener;
+const {Gravity} = imports.gi.Clutter;
+const {Rectangle, WindowType} = imports.gi.Meta;
+const {layoutManager} = imports.ui.main;
+const {addTween, removeTweens} = imports.ui.tweener;
 
 class Effect {
     constructor(endWindowEffect) {
@@ -13,11 +11,11 @@ class Effect {
     _end(actor) {
         actor.set_scale(1, 1);
         actor.opacity = actor.orig_opacity || 255;
-        actor.move_anchor_point_from_gravity(Clutter.Gravity.NORTH_WEST);
+        actor.move_anchor_point_from_gravity(Gravity.NORTH_WEST);
     }
 
     _fadeWindow(cinnamonwm, actor, opacity, time, transition) {
-        Tweener.addTween(actor, {
+        addTween(actor, {
             opacity,
             time,
             min: 0,
@@ -29,9 +27,9 @@ class Effect {
 
     _scaleWindow(cinnamonwm, actor, scale_x, scale_y, time, transition, keepAnchorPoint) {
         if (!keepAnchorPoint)
-            actor.move_anchor_point_from_gravity(Clutter.Gravity.CENTER);
+            actor.move_anchor_point_from_gravity(Gravity.CENTER);
 
-        Tweener.addTween(actor, {
+        addTween(actor, {
             scale_x,
             scale_y,
             time,
@@ -42,7 +40,7 @@ class Effect {
     }
 
     _moveWindow(cinnamonwm, actor, x, y, time, transition) {
-        Tweener.addTween(actor, {
+        addTween(actor, {
             x,
             y,
             time,
@@ -96,7 +94,7 @@ var Map = class Map extends Effect {
     }
 
     flyUp(cinnamonwm, actor, time, transition) {
-        //FIXME: somehow we need this line to get the correct position, without it will return [0, 0]
+        // FIXME: somehow we need this line to get the correct position, without it will return [0, 0]
         actor.get_allocation_box().get_size();
         let [xDest, yDest] = actor.get_transformed_position();
         let ySrc = global.stage.get_height();
@@ -104,14 +102,14 @@ var Map = class Map extends Effect {
         actor.set_position(xDest, ySrc);
 
         let dist = Math.abs(ySrc - yDest);
-        time *= dist / Main.layoutManager.primaryMonitor.height * 2; // The transition time set is the time if the animation starts/ends at the middle of the screen. Scale it proportional to the actual distance so that the speed of all animations will be constant.
+        time *= dist / layoutManager.primaryMonitor.height * 2; // The transition time set is the time if the animation starts/ends at the middle of the screen. Scale it proportional to the actual distance so that the speed of all animations will be constant.
 
         this._moveWindow(cinnamonwm, actor, xDest, yDest, time, transition);
 
     }
 
     flyDown(cinnamonwm, actor, time, transition) {
-        //FIXME - see also flyUp
+        // FIXME - see also flyUp
         actor.get_allocation_box().get_size();
         let [xDest, yDest] = actor.get_transformed_position();
         let ySrc = -actor.get_allocation_box().get_height();
@@ -119,16 +117,16 @@ var Map = class Map extends Effect {
         actor.set_position(xDest, ySrc);
 
         let dist = Math.abs(ySrc - yDest);
-        time *= dist / Main.layoutManager.primaryMonitor.height * 2; // The time time set is the time if the animation starts/ends at the middle of the screen. Scale it proportional to the actual distance so that the speed of all animations will be constant.
+        time *= dist / layoutManager.primaryMonitor.height * 2; // The time time set is the time if the animation starts/ends at the middle of the screen. Scale it proportional to the actual distance so that the speed of all animations will be constant.
 
         this._moveWindow(cinnamonwm, actor, xDest, yDest, time, transition);
     }
 
     traditional(cinnamonwm, actor, time, transition) {
         switch (actor.meta_window.window_type) {
-            case Meta.WindowType.NORMAL:
-            case Meta.WindowType.MODAL_DIALOG:
-            case Meta.WindowType.DIALOG:
+            case WindowType.NORMAL:
+            case WindowType.MODAL_DIALOG:
+            case WindowType.DIALOG:
                 actor.set_pivot_point(0, 0);
                 actor.scale_x = 0.94;
                 actor.scale_y = 0.94;
@@ -136,9 +134,9 @@ var Map = class Map extends Effect {
                 this._fadeWindow(cinnamonwm, actor, actor.orig_opacity, time, transition);
                 this._scaleWindow(cinnamonwm, actor, 1, 1, time, transition);
                 break;
-            case Meta.WindowType.MENU:
-            case Meta.WindowType.DROPDOWN_MENU:
-            case Meta.WindowType.POPUP_MENU:
+            case WindowType.MENU:
+            case WindowType.DROPDOWN_MENU:
+            case WindowType.POPUP_MENU:
                 let [width, height] = actor.get_allocation_box().get_size();
                 let [destX, destY] = actor.get_transformed_position();
                 let [pointerX, pointerY] = global.get_pointer();
@@ -172,7 +170,7 @@ var Close = class Close extends Effect {
 
     _end(actor) {
         let parent = actor.get_meta_window().get_transient_for();
-        if(parent && actor._parentDestroyId) {
+        if (parent && actor._parentDestroyId) {
             parent.disconnect(actor._parentDestroyId);
             actor._parentDestroyId = 0;
         }
@@ -183,7 +181,7 @@ var Close = class Close extends Effect {
     }
 
     fade(cinnamonwm, actor, time, transition) {
-        Tweener.removeTweens(actor);
+        removeTweens(actor);
         this._fadeWindow(cinnamonwm, actor, 0, time, transition);
     }
 
@@ -204,7 +202,7 @@ var Close = class Close extends Effect {
         let yDest = -actor.get_allocation_box().get_height();
 
         let dist = Math.abs(actor.get_transformed_position()[1] - yDest);
-        time *= dist / Main.layoutManager.primaryMonitor.height * 2; // The time time set is the time if the animation starts/ends at the middle of the screen. Scale it proportional to the actual distance so that the speed of all animations will be constant.
+        time *= dist / layoutManager.primaryMonitor.height * 2; // The time time set is the time if the animation starts/ends at the middle of the screen. Scale it proportional to the actual distance so that the speed of all animations will be constant.
 
         this._moveWindow(cinnamonwm, actor, xDest, yDest, time, transition);
     }
@@ -214,16 +212,16 @@ var Close = class Close extends Effect {
         let yDest = global.stage.get_height();
 
         let dist = Math.abs(actor.get_transformed_position()[1] - yDest);
-        time *= dist / Main.layoutManager.primaryMonitor.height * 2; // The transition time set is the time if the animation starts/ends at the middle of the screen. Scale it proportional to the actual distance so that the speed of all animations will be constant.
+        time *= dist / layoutManager.primaryMonitor.height * 2; // The transition time set is the time if the animation starts/ends at the middle of the screen. Scale it proportional to the actual distance so that the speed of all animations will be constant.
 
         this._moveWindow(cinnamonwm, actor, xDest, yDest, time, transition);
     }
 
     traditional(cinnamonwm, actor, time, transition) {
         switch (actor.meta_window.window_type) {
-            case Meta.WindowType.NORMAL:
-            case Meta.WindowType.MODAL_DIALOG:
-            case Meta.WindowType.DIALOG:
+            case WindowType.NORMAL:
+            case WindowType.MODAL_DIALOG:
+            case WindowType.DIALOG:
                 actor.set_pivot_point(0, 0);
                 this._scaleWindow(cinnamonwm, actor, 0.88, 0.88, time, transition);
                 this._fadeWindow(cinnamonwm, actor, 0, time, transition);
@@ -248,7 +246,7 @@ var Minimize = class Minimize extends Close {
 
     traditional(cinnamonwm, actor, time, transition) {
         let success;
-        let geom = new Meta.Rectangle();
+        let geom = new Rectangle();
         success = actor.meta_window.get_icon_geometry(geom);
         if (success) {
             actor.set_scale(1, 1);
@@ -268,7 +266,7 @@ var Minimize = class Minimize extends Close {
 }
 
 // unminimizing is a 'map' effect but should use 'minimize' setting values
-class Unminimize extends Effect {
+var Unminimize = class Unminimize extends Effect {
     constructor() {
         super(...arguments);
 
@@ -281,7 +279,7 @@ class Unminimize extends Effect {
 
     traditional(cinnamonwm, actor, time, transition) {
         let success;
-        let geom = new Meta.Rectangle();
+        let geom = new Rectangle();
         success = actor.meta_window.get_icon_geometry(geom);
         if (success) {
             actor.set_scale(0.1, 0.1);
@@ -310,10 +308,9 @@ var Tile = class Tile extends Effect {
 
     scale(cinnamonwm, actor, time, transition, args) {
         let [targetX, targetY, targetWidth, targetHeight] = args;
-        if(targetWidth == actor.width)
-            targetWidth -= 1;
-        if(targetHeight == actor.height)
-            targetHeight -= 1;
+
+        if (targetWidth === actor.width) targetWidth -= 1;
+        if (targetHeight === actor.height) targetHeight -= 1;
 
         let scale_x = targetWidth / actor.width;
         let scale_y = targetHeight / actor.height;

--- a/js/ui/windowEffects.js
+++ b/js/ui/windowEffects.js
@@ -137,11 +137,7 @@ Map.prototype = {
     },
 
     traditional: function(cinnamonwm, actor, time, transition) {
-        if (!actor._windowType) {
-            actor._windowType = actor.meta_window.get_window_type();
-        }
-
-        switch (actor._windowType) {
+        switch (actor.meta_window.window_type) {
             case Meta.WindowType.NORMAL:
             case Meta.WindowType.MODAL_DIALOG:
             case Meta.WindowType.DIALOG:
@@ -237,11 +233,7 @@ Close.prototype = {
     },
 
     traditional: function(cinnamonwm, actor, time, transition) {
-        if (!actor._windowType) {
-            actor._windowType = actor.meta_window.get_window_type();
-        }
-
-        switch (actor._windowType) {
+        switch (actor.meta_window.window_type) {
             case Meta.WindowType.NORMAL:
             case Meta.WindowType.MODAL_DIALOG:
             case Meta.WindowType.DIALOG:
@@ -279,7 +271,7 @@ Minimize.prototype = {
             yDest = geom.y;
             xScale = geom.width / actor.width;
             yScale = geom.height / actor.height;
-            actor.get_meta_window()._cinnamonwm_has_origin = true;
+            actor.meta_window._cinnamonwm_has_origin = true;
             this._moveWindow(cinnamonwm, actor, xDest, yDest, time, transition);
             this._scaleWindow(cinnamonwm, actor, xScale, yScale, time, transition, true);
             this._fadeWindow(cinnamonwm, actor, 0, time, transition);

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -62,13 +62,8 @@ function getTopInvisibleBorder(metaWindow) {
     return outerRect.y - inputRect.y;
 }
 
-function WindowDimmer(actor) {
-    this._init(actor);
-}
-
-WindowDimmer.prototype = {
-    _init: function(actor) {
-
+class WindowDimmer {
+    constructor(actor) {
         this._desaturateEffect = new Clutter.DesaturateEffect();
         this._brightnessEffect = new Clutter.BrightnessContrastEffect();
         actor.add_effect(this._desaturateEffect);
@@ -76,18 +71,18 @@ WindowDimmer.prototype = {
 
         this.actor = actor;
         this._dimFactor = 0.0;
-    },
+    }
 
-    setEnabled: function(enabled) {
+    setEnabled(enabled) {
         this._desaturateEffect.enabled = enabled;
         this._brightnessEffect.enabled = enabled;
-    },
+    }
 
     set dimFactor(factor) {
         this._dimFactor = factor;
         this._desaturateEffect.set_factor(factor * DIM_DESATURATION);
         this._brightnessEffect.set_brightness(factor * DIM_BRIGHTNESS);
-    },
+    }
 
     get dimFactor() {
         return this._dimFactor;
@@ -101,21 +96,17 @@ function getWindowDimmer(actor) {
     return actor._windowDimmer;
 }
 
-function TilePreview() {
-    this._init();
-}
-
-TilePreview.prototype = {
-    _init: function() {
+class TilePreview {
+    constructor() {
         this.actor = new St.Bin({ style_class: 'tile-preview', important: true });
         global.window_group.add_actor(this.actor);
 
         this._snapQueued = 0;
         this._reset();
         this._showing = false;
-    },
+    }
 
-    show: function(window, tileRect, monitorIndex, snapQueued, effectsEnabled) {
+    show(window, tileRect, monitorIndex, snapQueued, effectsEnabled) {
         let windowActor = window.get_compositor_private();
         if (!windowActor)
             return;
@@ -169,9 +160,9 @@ TilePreview.prototype = {
         }
 
         Object.assign(this.actor, props);
-    },
+    }
 
-    hide: function(effectsEnabled) {
+    hide(effectsEnabled) {
         if (!this._showing)
             return;
 
@@ -188,32 +179,28 @@ TilePreview.prototype = {
         }
         this.actor.opacity = 0;
 
-    },
+    }
 
-    _reset: function() {
+    _reset() {
         this.actor.hide();
         this._rect = null;
         this._monitorIndex = -1;
-    },
+    }
 
-    _updateStyle: function() {
+    _updateStyle() {
         if (this.actor.has_style_class_name('snap'))
             this.actor.remove_style_class_name('snap');
         else
             this.actor.add_style_class_name('snap');
-    },
+    }
 
-    destroy: function() {
+    destroy() {
         this.actor.destroy();
     }
 };
 
-function HudPreview() {
-    this._init();
-}
-
-HudPreview.prototype = {
-    _init: function() {
+class HudPreview {
+    constructor() {
         this.actor = new St.Bin({ style_class: 'tile-hud', important: true });
         global.window_group.add_actor(this.actor);
 
@@ -225,9 +212,9 @@ HudPreview.prototype = {
 
         this._reset();
         this._showing = false;
-    },
+    }
 
-    show: function(currentProximityZone, workArea, snapQueued, effectsEnabled) {
+    show(currentProximityZone, workArea, snapQueued, effectsEnabled) {
         let changeZone = (this._zone != currentProximityZone);
 
         if (this._snapQueued != snapQueued) {
@@ -379,9 +366,9 @@ HudPreview.prototype = {
 
             Object.assign(this.actor, props);
         }
-    },
+    }
 
-    hide: function(effectsEnabled) {
+    hide(effectsEnabled) {
         if (!this._showing)
             return;
         this._showing = false;
@@ -404,46 +391,42 @@ HudPreview.prototype = {
         }
 
         Object.assign(this.actor, props);
-    },
+    }
 
-    _reset: function () {
+    _reset() {
         this.actor.hide();
         this._zone = -1;
-    },
+    }
 
-    _onTileHudSettingsChanged: function() {
+    _onTileHudSettingsChanged() {
         let scaleFactor = St.ThemeContext.get_for_stage(global.stage).scale_factor;
         this._hudSize = this._tileHudSettings.get_int("tile-hud-threshold") * scaleFactor;
 
-    },
+    }
 
-    _updateStyle: function(pseudoClass) {
+    _updateStyle(pseudoClass) {
         let currentStyle = this.actor.get_style_pseudo_class();
         if (currentStyle)
             this.actor.remove_style_pseudo_class(currentStyle);
         if (pseudoClass) {
             this.actor.set_style_pseudo_class(pseudoClass);
         }
-    },
+    }
 
-    _updateSnapStyle: function() {
+    _updateSnapStyle() {
         if (this.actor.has_style_class_name('snap'))
             this.actor.remove_style_class_name('snap');
         else
             this.actor.add_style_class_name('snap');
-    },
+    }
 
-    destroy: function() {
+    destroy() {
         this.actor.destroy();
     }
 }
 
-function WindowManager() {
-    this._init();
-}
-
-WindowManager.prototype = {
-    _init : function() {
+var WindowManager = class WindowManager {
+    constructor() {
         this._minimizing = [];
         this._maximizing = [];
         this._unmaximizing = [];
@@ -564,9 +547,9 @@ WindowManager.prototype = {
         global.screen.connect ("show-snap-osd", Lang.bind (this, this._showSnapOSD));
         global.screen.connect ("hide-snap-osd", Lang.bind (this, this._hideSnapOSD));
         global.screen.connect ("show-workspace-osd", Lang.bind (this, this.showWorkspaceOSD));
-    },
+    }
 
-    onSettingsChanged: function(settings, key, type) {
+    onSettingsChanged(settings, key, type) {
         switch (settings.schema) {
             case 'org.cinnamon':
                 this.settingsState[key] = global.settings[type](key);
@@ -575,17 +558,17 @@ WindowManager.prototype = {
                 this.settingsState[key] = this.settings[type](key);
                 break;
         }
-    },
+    }
 
-    blockAnimations: function() {
+    blockAnimations() {
         this._animationBlockCount++;
-    },
+    }
 
-    unblockAnimations: function() {
+    unblockAnimations() {
         this._animationBlockCount = Math.max(0, this._animationBlockCount - 1);
-    },
+    }
 
-    _shouldAnimate: function(actor) {
+    _shouldAnimate(actor) {
         // Check if system is in modal state or in software rendering
         if (Main.modalCount || Main.software_rendering) {
             return false;
@@ -611,9 +594,9 @@ WindowManager.prototype = {
             default:
                 return false;
         }
-    },
+    }
 
-    _startWindowEffect: function(cinnamonwm, name, actor, args, overwriteKey){
+    _startWindowEffect(cinnamonwm, name, actor, args, overwriteKey){
         let effect = this.effects[name];
         if(!this._shouldAnimate(actor)){
             cinnamonwm[effect.wmCompleteName](actor);
@@ -639,9 +622,9 @@ WindowManager.prototype = {
             effect[type](cinnamonwm, actor, time, transition, args);
         } else if(!overwriteKey) //when not unminimizing, but the effect was not found, end it
             this._endWindowEffect(cinnamonwm, name, actor);
-    },
+    }
 
-    _endWindowEffect: function(cinnamonwm, name, actor){
+    _endWindowEffect(cinnamonwm, name, actor){
         let effect = this.effects[name];
         //effect will be an instance of WindowEffects.Effect
         let idx = this[effect.arrayName].indexOf(actor);
@@ -653,41 +636,41 @@ WindowManager.prototype = {
             cinnamonwm[effect.wmCompleteName](actor);
             Main.panelManager.updatePanelsVisibility();
         }
-    },
+    }
 
-    _killWindowEffects: function (cinnamonwm, actor) {
+    _killWindowEffects(cinnamonwm, actor) {
         for(let i in this.effects){
             this._endWindowEffect(cinnamonwm, i, actor);
         }
-    },
+    }
 
-    _minimizeWindow : function(cinnamonwm, actor) {
+    _minimizeWindow(cinnamonwm, actor) {
         Main.soundManager.play('minimize');
 
         // reset all cached values in case "traditional" is no longer in effect
         actor.meta_window._cinnamonwm_has_origin = false;
         this._startWindowEffect(cinnamonwm, "minimize", actor);
-    },
+    }
 
-    _tileWindow : function (cinnamonwm, actor, targetX, targetY, targetWidth, targetHeight) {
+    _tileWindow(cinnamonwm, actor, targetX, targetY, targetWidth, targetHeight) {
         Main.soundManager.play('tile');
 
         this._startWindowEffect(cinnamonwm, "tile", actor, [targetX, targetY, targetWidth, targetHeight]);
-    },
+    }
 
-    _maximizeWindow : function(cinnamonwm, actor, targetX, targetY, targetWidth, targetHeight) {
+    _maximizeWindow(cinnamonwm, actor, targetX, targetY, targetWidth, targetHeight) {
         Main.soundManager.play('maximize');
 
         this._startWindowEffect(cinnamonwm, "maximize", actor, [targetX, targetY, targetWidth, targetHeight]);
-    },
+    }
 
-    _unmaximizeWindow : function(cinnamonwm, actor, targetX, targetY, targetWidth, targetHeight) {
+    _unmaximizeWindow(cinnamonwm, actor, targetX, targetY, targetWidth, targetHeight) {
         Main.soundManager.play('unmaximize');
 
         this._startWindowEffect(cinnamonwm, "unmaximize", actor, [targetX, targetY, targetWidth, targetHeight]);
-    },
+    }
 
-    _hasAttachedDialogs: function(window, ignoreWindow) {
+    _hasAttachedDialogs(window, ignoreWindow) {
         var count = 0;
         window.foreach_transient(function(win) {
             if (win != ignoreWindow && win.is_attached_dialog())
@@ -695,9 +678,9 @@ WindowManager.prototype = {
             return false;
         });
         return count != 0;
-    },
+    }
 
-    _checkDimming: function(window, ignoreWindow) {
+    _checkDimming(window, ignoreWindow) {
         let shouldDim = this._hasAttachedDialogs(window, ignoreWindow);
 
         if (shouldDim && !window._dimmed) {
@@ -713,9 +696,9 @@ WindowManager.prototype = {
             if (!Main.overview.visible)
                 this._undimWindow(window, true);
         }
-    },
+    }
 
-    _dimWindow: function(window, animate) {
+    _dimWindow(window, animate) {
         let actor = window.get_compositor_private();
         if (!actor)
             return;
@@ -735,9 +718,9 @@ WindowManager.prototype = {
         } else {
             getWindowDimmer(actor).dimFactor = 1.0;
         }
-    },
+    }
 
-    _undimWindow: function(window, animate) {
+    _undimWindow(window, animate) {
         let actor = window.get_compositor_private();
         if (!actor)
             return;
@@ -757,9 +740,9 @@ WindowManager.prototype = {
         } else {
             getWindowDimmer(actor).dimFactor = 0.0;
         }
-    },
+    }
 
-    _mapWindow: function(cinnamonwm, actor) {
+    _mapWindow(cinnamonwm, actor) {
         let {meta_window} = actor;
         if (meta_window.is_attached_dialog()) {
             this._checkDimming(meta_window.get_transient_for());
@@ -773,9 +756,9 @@ WindowManager.prototype = {
             Main.soundManager.play('map');
         }
         this._startWindowEffect(cinnamonwm, "map", actor);
-    },
+    }
 
-    _destroyWindow: function(cinnamonwm, actor) {
+    _destroyWindow(cinnamonwm, actor) {
         let {meta_window} = actor;
 
         if (actor.meta_window.window_type === WindowType.NORMAL) {
@@ -806,9 +789,9 @@ WindowManager.prototype = {
         }
 
         this._startWindowEffect(cinnamonwm, "close", actor);
-    },
+    }
 
-    _switchWorkspace : function(cinnamonwm, from, to, direction) {
+    _switchWorkspace(cinnamonwm, from, to, direction) {
         if (!this._shouldAnimate()) {
             this.showWorkspaceOSD();
             cinnamonwm.completed_switch_workspace();
@@ -905,39 +888,39 @@ WindowManager.prototype = {
         Tweener.addTween(this, {time: WINDOW_ANIMATION_TIME, onComplete: function() {
             cinnamonwm.completed_switch_workspace();
         }});
-    },
+    }
 
-    _showTilePreview: function(cinnamonwm, window, tileRect, monitorIndex, snapQueued) {
+    _showTilePreview(cinnamonwm, window, tileRect, monitorIndex, snapQueued) {
         if (!this._tilePreview)
             this._tilePreview = new TilePreview();
         this._tilePreview.show(window, tileRect, monitorIndex, snapQueued, this.settingsState['desktop-effects']);
-    },
+    }
 
-    _hideTilePreview: function(cinnamonwm) {
+    _hideTilePreview(cinnamonwm) {
         if (!this._tilePreview)
             return;
         this._tilePreview.hide(this.settingsState['desktop-effects']);
         this._tilePreview.destroy();
         this._tilePreview = null;
-    },
+    }
 
-    _showHudPreview: function(cinnamonwm, currentProximityZone, workArea, snapQueued) {
+    _showHudPreview(cinnamonwm, currentProximityZone, workArea, snapQueued) {
         if (this.settingsState['show-tile-hud']) {
             if (!this._hudPreview)
                 this._hudPreview = new HudPreview();
             this._hudPreview.show(currentProximityZone, workArea, snapQueued, this.settingsState['desktop-effects']);
         }
-    },
+    }
 
-    _hideHudPreview: function(cinnamonwm) {
+    _hideHudPreview(cinnamonwm) {
         if (!this._hudPreview)
             return;
         this._hudPreview.hide(this.settingsState['desktop-effects']);
         this._hudPreview.destroy();
         this._hudPreview = null;
-    },
+    }
 
-    showWorkspaceOSD : function() {
+    showWorkspaceOSD() {
         this._hideSnapOSD();
         this._hideWorkspaceOSD();
         if (this.settingsState['workspace-osd-visible']) {
@@ -955,9 +938,9 @@ WindowManager.prototype = {
                 }
             }
         }
-    },
+    }
 
-    _showWorkspaceOSDOnMonitor : function(monitor, osd_x, osd_y, duration, current_workspace_index) {
+    _showWorkspaceOSDOnMonitor(monitor, osd_x, osd_y, duration, current_workspace_index) {
         let osd = new St.Label({style_class:'workspace-osd', important: true});
         let effectsEnabled = this.settingsState['desktop-effects'];
         this._workspace_osd_array.push(osd);
@@ -989,9 +972,9 @@ WindowManager.prototype = {
             return;
         }
         setTimeout(() => this._hideWorkspaceOSD(), duration * 1000);
-    },
+    }
 
-    _hideWorkspaceOSD : function() {
+    _hideWorkspaceOSD() {
         for (let i = 0; i < this._workspace_osd_array.length; i++) {
             let osd = this._workspace_osd_array[i];
             if (osd != null) {
@@ -1001,9 +984,9 @@ WindowManager.prototype = {
             }
         }
         this._workspace_osd_array = []
-    },
+    }
 
-    _showSnapOSD : function(metaScreen, monitorIndex) {
+    _showSnapOSD(metaScreen, monitorIndex) {
         if (this.settingsState['show-snap-osd']) {
             if (this._snapOsd == null) {
                 this._snapOsd = new ModalDialog.InfoOSD();
@@ -1021,15 +1004,15 @@ WindowManager.prototype = {
             }
             this._snapOsd.show(monitorIndex);
         }
-    },
+    }
 
-    _hideSnapOSD : function() {
+    _hideSnapOSD() {
         if (this._snapOsd != null) {
             this._snapOsd.hide();
         }
-    },
+    }
 
-    _createAppSwitcher : function(binding) {
+    _createAppSwitcher(binding) {
         if (AppSwitcher.getWindowsForBinding(binding).length == 0)
             return;
         let style = this.settingsState['alttab-switcher-style'];
@@ -1039,13 +1022,13 @@ WindowManager.prototype = {
             new TimelineSwitcher.TimelineSwitcher(binding);
         else
             new ClassicSwitcher.ClassicSwitcher(binding);
-    },
+    }
 
-    _startAppSwitcher : function(display, screen, window, binding) {
+    _startAppSwitcher(display, screen, window, binding) {
         this._createAppSwitcher(binding);
-    },
+    }
 
-    _shiftWindowToWorkspace : function(window, direction) {
+    _shiftWindowToWorkspace(window, direction) {
         if (window.window_type === WindowType.DESKTOP) {
             return;
         }
@@ -1055,17 +1038,17 @@ WindowManager.prototype = {
             window.change_workspace(workspace);
             workspace.activate_with_focus(window, global.get_current_time());
         }
-    },
+    }
 
-    _moveWindowToWorkspaceLeft : function(display, screen, window, binding) {
+    _moveWindowToWorkspaceLeft(display, screen, window, binding) {
         this._shiftWindowToWorkspace(window, MotionDirection.LEFT);
-    },
+    }
 
-    _moveWindowToWorkspaceRight : function(display, screen, window, binding) {
+    _moveWindowToWorkspaceRight(display, screen, window, binding) {
         this._shiftWindowToWorkspace(window, MotionDirection.RIGHT);
-    },
+    }
 
-    moveToWorkspace: function(workspace, direction_hint) {
+    moveToWorkspace(workspace, direction_hint) {
         let active = global.screen.get_active_workspace();
         if (workspace != active) {
             if (direction_hint)
@@ -1073,9 +1056,9 @@ WindowManager.prototype = {
             else
                 workspace.activate(global.get_current_time());
         }
-    },
+    }
 
-    _showWorkspaceSwitcher : function(display, screen, window, binding) {
+    _showWorkspaceSwitcher(display, screen, window, binding) {
         let bindingName = binding.get_name();
         if (bindingName === 'switch-to-workspace-up') {
             Main.expo.toggle();
@@ -1094,33 +1077,33 @@ WindowManager.prototype = {
         } else if (bindingName === 'switch-to-workspace-right') {
             this.actionMoveWorkspaceRight();
         }
-    },
+    }
 
-    actionMoveWorkspaceLeft: function() {
+    actionMoveWorkspaceLeft() {
         let active = global.screen.get_active_workspace();
         let neighbor = active.get_neighbor(MotionDirection.LEFT)
         if (active != neighbor) {
             this.moveToWorkspace(neighbor, MotionDirection.LEFT);
         }
-    },
+    }
 
-    actionMoveWorkspaceRight: function() {
+    actionMoveWorkspaceRight() {
         let active = global.screen.get_active_workspace();
         let neighbor = active.get_neighbor(MotionDirection.RIGHT)
         if (active != neighbor) {
             this.moveToWorkspace(neighbor, MotionDirection.RIGHT);
         }
-    },
+    }
 
-    actionMoveWorkspaceUp: function() {
+    actionMoveWorkspaceUp() {
         global.screen.get_active_workspace().get_neighbor(MotionDirection.UP).activate(global.get_current_time());
-    },
+    }
 
-    actionMoveWorkspaceDown: function() {
+    actionMoveWorkspaceDown() {
         global.screen.get_active_workspace().get_neighbor(MotionDirection.DOWN).activate(global.get_current_time());
-    },
+    }
 
-    actionFlipWorkspaceLeft: function() {
+    actionFlipWorkspaceLeft() {
         var active = global.screen.get_active_workspace();
         var neighbor = active.get_neighbor(MotionDirection.LEFT);
         if (active != neighbor) {
@@ -1128,9 +1111,9 @@ WindowManager.prototype = {
             let [x, y, mods] = global.get_pointer();
             global.set_pointer(global.screen_width - 10, y);
         }
-    },
+    }
 
-    actionFlipWorkspaceRight: function() {
+    actionFlipWorkspaceRight() {
         var active = global.screen.get_active_workspace();
         var neighbor = active.get_neighbor(MotionDirection.RIGHT);
         if (active != neighbor) {

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -90,7 +90,7 @@ WindowDimmer.prototype = {
     },
 
     get dimFactor() {
-       return this._dimFactor;
+        return this._dimFactor;
     }
 };
 
@@ -492,6 +492,7 @@ WindowManager.prototype = {
         this.settings.connect('changed::snap-modifier', (s, k) => this.onSettingsChanged(s, k, 'get_string'));
 
         each(this.effects, (value, key) => {
+            if (key === 'unmaximize' || key === 'unminimize') return;
             each(SETTINGS_EFFECTS_TYPES, (item) => {
                 let [name, type] = item;
                 let property = `desktop-effects-${key}-${name}`;

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -686,7 +686,7 @@ var WindowManager = class WindowManager {
     }
 
     _hasAttachedDialogs(window, ignoreWindow) {
-        var count = 0;
+        let count = 0;
         window.foreach_transient(function(win) {
             if (win != ignoreWindow && win.is_attached_dialog())
                 count++;
@@ -1122,8 +1122,8 @@ var WindowManager = class WindowManager {
     }
 
     actionFlipWorkspaceLeft() {
-        var active = global.screen.get_active_workspace();
-        var neighbor = active.get_neighbor(MotionDirection.LEFT);
+        let active = global.screen.get_active_workspace();
+        let neighbor = active.get_neighbor(MotionDirection.LEFT);
         if (active != neighbor) {
             neighbor.activate(global.get_current_time());
             let [x, y, mods] = global.get_pointer();
@@ -1132,8 +1132,8 @@ var WindowManager = class WindowManager {
     }
 
     actionFlipWorkspaceRight() {
-        var active = global.screen.get_active_workspace();
-        var neighbor = active.get_neighbor(MotionDirection.RIGHT);
+        let active = global.screen.get_active_workspace();
+        let neighbor = active.get_neighbor(MotionDirection.RIGHT);
         if (active != neighbor) {
             neighbor.activate(global.get_current_time());
             let [x, y, mods] = global.get_pointer();

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -139,7 +139,7 @@ class TilePreview {
         if (this._rect && this._rect.equal(tileRect))
             return;
 
-        let changeMonitor = (this._monitorIndex == -1 ||
+        let changeMonitor = (this._monitorIndex === -1 ||
                              this._monitorIndex != monitorIndex);
 
         this._monitorIndex = monitorIndex;
@@ -469,7 +469,6 @@ var WindowManager = class WindowManager {
         this.settings = new Settings({schema_id: 'org.cinnamon.muffin'});
 
         const settingsState = {
-            'desktop-effects': global.settings.get_boolean('desktop-effects'),
             'desktop-effects-on-dialogs': global.settings.get_boolean('desktop-effects-on-dialogs'),
             'desktop-effects-on-menus': global.settings.get_boolean('desktop-effects-on-menus'),
             'show-snap-osd': global.settings.get_boolean('show-snap-osd'),
@@ -479,11 +478,11 @@ var WindowManager = class WindowManager {
             'workspace-osd-y': global.settings.get_int('workspace-osd-y'),
             'workspace-osd-duration': global.settings.get_int('workspace-osd-duration'),
             'alttab-switcher-style': global.settings.get_string('alttab-switcher-style'),
+            'desktop-effects': this.settings.get_boolean('desktop-effects'),
             'workspaces-only-on-primary': this.settings.get_boolean('workspaces-only-on-primary'),
             'snap-modifier': this.settings.get_string('snap-modifier'),
         };
 
-        global.settings.connect('changed::desktop-effects', (s, k) => this.onSettingsChanged(s, k, 'get_boolean'));
         global.settings.connect('changed::desktop-effects-on-dialogs', (s, k) => this.onSettingsChanged(s, k, 'get_boolean'));
         global.settings.connect('changed::desktop-effects-on-menus', (s, k) => this.onSettingsChanged(s, k, 'get_boolean'));
         global.settings.connect('changed::show-snap-osd', (s, k) => this.onSettingsChanged(s, k, 'get_boolean'));
@@ -493,6 +492,7 @@ var WindowManager = class WindowManager {
         global.settings.connect('changed::workspace-osd-y', (s, k) => this.onSettingsChanged(s, k, 'get_int'));
         global.settings.connect('changed::workspace-osd-duration', (s, k) => this.onSettingsChanged(s, k, 'get_int'));
         global.settings.connect('changed::alttab-switcher-style', (s, k) => this.onSettingsChanged(s, k, 'get_string'));
+        this.settings.connect('changed::desktop-effects', (s, k) => this.onSettingsChanged(s, k, 'get_boolean'));
         this.settings.connect('changed::workspaces-only-on-primary', (s, k) => this.onSettingsChanged(s, k, 'get_boolean'));
         this.settings.connect('changed::snap-modifier', (s, k) => this.onSettingsChanged(s, k, 'get_string'));
 
@@ -765,7 +765,7 @@ var WindowManager = class WindowManager {
 
         if (meta_window._cinnamonwm_has_origin && meta_window._cinnamonwm_has_origin === true) {
             soundManager.play('minimize');
-            tryFn(() => this._startWindowEffect(cinnamonwm, 'unminimize', actor, null, 'minimize'));
+            this._startWindowEffect(cinnamonwm, 'unminimize', actor, null, 'minimize');
             return;
         } else if (meta_window.window_type === WindowType.NORMAL) {
             soundManager.play('map');
@@ -828,22 +828,22 @@ var WindowManager = class WindowManager {
         let grabOp = display.get_grab_op();
 
 
-        if (direction == MotionDirection.UP ||
-            direction == MotionDirection.UP_LEFT ||
-            direction == MotionDirection.UP_RIGHT)
+        if (direction === MotionDirection.UP ||
+            direction === MotionDirection.UP_LEFT ||
+            direction === MotionDirection.UP_RIGHT)
             yDest = screen_height;
-        else if (direction == MotionDirection.DOWN ||
-            direction == MotionDirection.DOWN_LEFT ||
-            direction == MotionDirection.DOWN_RIGHT)
+        else if (direction === MotionDirection.DOWN ||
+            direction === MotionDirection.DOWN_LEFT ||
+            direction === MotionDirection.DOWN_RIGHT)
             yDest = -screen_height;
 
-        if (direction == MotionDirection.LEFT ||
-            direction == MotionDirection.UP_LEFT ||
-            direction == MotionDirection.DOWN_LEFT)
+        if (direction === MotionDirection.LEFT ||
+            direction === MotionDirection.UP_LEFT ||
+            direction === MotionDirection.DOWN_LEFT)
             xDest = screen_width;
-        else if (direction == MotionDirection.RIGHT ||
-                 direction == MotionDirection.UP_RIGHT ||
-                 direction == MotionDirection.DOWN_RIGHT)
+        else if (direction === MotionDirection.RIGHT ||
+                 direction === MotionDirection.UP_RIGHT ||
+                 direction === MotionDirection.DOWN_RIGHT)
             xDest = -screen_width;
 
         for (let i = 0; i < windows.length; i++) {
@@ -1007,13 +1007,13 @@ var WindowManager = class WindowManager {
                 this._snapOsd = new InfoOSD();
 
                 let mod = this.settingsState['snap-modifier'];
-                if (mod == "Super")
+                if (mod === 'Super')
                     this._snapOsd.addText(_("Hold <Super> to enter snap mode"));
-                else if (mod == "Alt")
+                else if (mod === 'Alt')
                     this._snapOsd.addText(_("Hold <Alt> to enter snap mode"));
-                else if (mod == "Control")
+                else if (mod === 'Control')
                     this._snapOsd.addText(_("Hold <Ctrl> to enter snap mode"));
-                else if (mod == "Shift")
+                else if (mod === 'Shift')
                     this._snapOsd.addText(_("Hold <Shift> to enter snap mode"));
                 this._snapOsd.addText(_("Use the arrow or numeric keys to switch workspaces while dragging"));
             }
@@ -1087,7 +1087,7 @@ var WindowManager = class WindowManager {
             return;
         }
 
-        if (screen.n_workspaces == 1)
+        if (screen.n_workspaces === 1)
             return;
 
         if (bindingName === 'switch-to-workspace-left') {

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -589,23 +589,16 @@ var WindowManager = class WindowManager {
             return false;
         }
 
-        const desktopEffects = this.settingsState['desktop-effects'];
-
-        if (!actor) return desktopEffects;
-
-        const desktopEffectsOnDialogs = this.settingsState['desktop-effects-on-dialogs'];
-        const desktopEffectsOnMenus = this.settingsState['desktop-effects-on-menus'];
-
         switch (actor.meta_window.window_type) {
             case WindowType.NORMAL:
-                return desktopEffects;
+                return true;
             case WindowType.DIALOG:
             case WindowType.MODAL_DIALOG:
-                return desktopEffects && desktopEffectsOnDialogs;
+                return this.settingsState['desktop-effects-on-dialogs'];
             case WindowType.MENU:
             case WindowType.DROPDOWN_MENU:
             case WindowType.POPUP_MENU:
-                return desktopEffects && desktopEffectsOnMenus;
+                return this.settingsState['desktop-effects-on-menus'];
             default:
                 return false;
         }
@@ -613,7 +606,7 @@ var WindowManager = class WindowManager {
 
     _startWindowEffect(cinnamonwm, name, actor, args, overwriteKey) {
         let effect = this.effects[name];
-        if (!this._shouldAnimate(actor)) {
+        if (!this.settingsState['desktop-effects'] || !this._shouldAnimate(actor)) {
             cinnamonwm[effect.wmCompleteName](actor);
             return;
         }
@@ -815,7 +808,7 @@ var WindowManager = class WindowManager {
     }
 
     _switchWorkspace(cinnamonwm, from, to, direction) {
-        if (!this._shouldAnimate()) {
+        if (!this.settingsState['desktop-effects'] || Main.modalCount || Main.software_rendering) {
             this.showWorkspaceOSD();
             cinnamonwm.completed_switch_workspace();
             return;

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -619,6 +619,14 @@ var WindowManager = class WindowManager {
         }
 
         let key = "desktop-effects-" + (overwriteKey || effect.name);
+        let time = this.settingsState[`${key}-time`];
+
+        // Transition time is 0ms, bail
+        if (!time) {
+            cinnamonwm[effect.wmCompleteName](actor);
+            return;
+        }
+
         let type = this.settingsState[`${key}-effect`];
 
         // make sure to end a running effect
@@ -631,7 +639,7 @@ var WindowManager = class WindowManager {
         actor.show();
 
         if (effect[type]) {
-            let time = this.settingsState[`${key}-time`] / 1000;
+            time = time / 1000;
             let transition = this.settingsState[`${key}-transition`];
 
             effect[type](cinnamonwm, actor, time, transition, args);

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -454,14 +454,16 @@ var WindowManager = class WindowManager {
         this._mapping = [];
         this._destroying = [];
 
+        const _endWindowEffect = (c, n, a) => this._endWindowEffect(c, n, a);
+
         this.effects = {
-            map: new Map(this),
-            close: new Close(this),
-            minimize: new Minimize(this),
-            unminimize: new Unminimize(this),
-            tile: new Tile(this),
-            maximize: new Maximize(this),
-            unmaximize: new Unmaximize(this)
+            map: new Map(_endWindowEffect),
+            close: new Close(_endWindowEffect),
+            minimize: new Minimize(_endWindowEffect),
+            unminimize: new Unminimize(_endWindowEffect),
+            tile: new Tile(_endWindowEffect),
+            maximize: new Maximize(_endWindowEffect),
+            unmaximize: new Unmaximize(_endWindowEffect)
         };
 
         this.settings = new Settings({schema_id: 'org.cinnamon.muffin'});

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -609,9 +609,9 @@ var WindowManager = class WindowManager {
         }
     }
 
-    _startWindowEffect(cinnamonwm, name, actor, args, overwriteKey){
+    _startWindowEffect(cinnamonwm, name, actor, args, overwriteKey) {
         let effect = this.effects[name];
-        if(!this._shouldAnimate(actor)){
+        if (!this._shouldAnimate(actor)) {
             cinnamonwm[effect.wmCompleteName](actor);
             return;
         }
@@ -619,8 +619,8 @@ var WindowManager = class WindowManager {
         let key = "desktop-effects-" + (overwriteKey || effect.name);
         let type = this.settingsState[`${key}-effect`];
 
-        //make sure to end a running effect
-        if(actor.current_effect_name){
+        // make sure to end a running effect
+        if (actor.current_effect_name) {
             this._endWindowEffect(cinnamonwm, actor.current_effect_name, actor);
         }
         this[effect.arrayName].push(actor);
@@ -628,20 +628,20 @@ var WindowManager = class WindowManager {
         actor.orig_opacity = actor.opacity;
         actor.show();
 
-        if(effect[type]){
+        if (effect[type]) {
             let time = this.settingsState[`${key}-time`] / 1000;
             let transition = this.settingsState[`${key}-transition`];
 
             effect[type](cinnamonwm, actor, time, transition, args);
-        } else if(!overwriteKey) //when not unminimizing, but the effect was not found, end it
+        } else if (!overwriteKey) // when not unminimizing, but the effect was not found, end it
             this._endWindowEffect(cinnamonwm, name, actor);
     }
 
-    _endWindowEffect(cinnamonwm, name, actor){
+    _endWindowEffect(cinnamonwm, name, actor) {
         let effect = this.effects[name];
-        //effect will be an instance of Effect
+        // effect will be an instance of Effect
         let idx = this[effect.arrayName].indexOf(actor);
-        if(idx !== -1){
+        if (idx !== -1) {
             this[effect.arrayName].splice(idx, 1);
             removeTweens(actor);
             delete actor.current_effect_name;
@@ -652,7 +652,7 @@ var WindowManager = class WindowManager {
     }
 
     _killWindowEffects(cinnamonwm, actor) {
-        for(let i in this.effects){
+        for (let i in this.effects) {
             this._endWindowEffect(cinnamonwm, i, actor);
         }
     }

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -149,7 +149,7 @@ TilePreview.prototype = {
 
         this._showing = true;
         this.actor.show();
-        windowActor.raise_top();
+        windowActor.get_parent().set_child_above_sibling(windowActor, null);
 
         let props = {
             x,
@@ -357,7 +357,7 @@ HudPreview.prototype = {
 
             this._showing = true;
             this.actor.show();
-            this.actor.raise_top();
+            this.actor.get_parent().set_child_above_sibling(this.actor, null);
             this.actor.opacity = 0;
 
             let props = {

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -1075,11 +1075,12 @@ WindowManager.prototype = {
     },
 
     _showWorkspaceSwitcher : function(display, screen, window, binding) {
-        if (binding.get_name() == 'switch-to-workspace-up') {
+        let bindingName = binding.get_name();
+        if (bindingName === 'switch-to-workspace-up') {
             Main.expo.toggle();
             return;
         }
-        if (binding.get_name() == 'switch-to-workspace-down') {
+        if (bindingName === 'switch-to-workspace-down') {
             Main.overview.toggle();
             return;
         }
@@ -1087,10 +1088,10 @@ WindowManager.prototype = {
         if (screen.n_workspaces == 1)
             return;
 
-        if (binding.get_name() == 'switch-to-workspace-left') {
-           this.actionMoveWorkspaceLeft();
-        } else if (binding.get_name() == 'switch-to-workspace-right') {
-           this.actionMoveWorkspaceRight();
+        if (bindingName === 'switch-to-workspace-left') {
+            this.actionMoveWorkspaceLeft();
+        } else if (bindingName === 'switch-to-workspace-right') {
+            this.actionMoveWorkspaceRight();
         }
     },
 

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -56,12 +56,6 @@ const ZONE_BL = 7;
 
 const SETTINGS_EFFECTS_TYPES = [['effect', 'get_string'], ['time', 'get_int'], ['transition', 'get_string']];
 
-function getTopInvisibleBorder(metaWindow) {
-    let outerRect = metaWindow.get_outer_rect();
-    let inputRect = metaWindow.get_input_rect();
-    return outerRect.y - inputRect.y;
-}
-
 class WindowDimmer {
     constructor(actor) {
         this._desaturateEffect = new Clutter.DesaturateEffect();

--- a/js/ui/workspace.js
+++ b/js/ui/workspace.js
@@ -889,7 +889,7 @@ WorkspaceMonitor.prototype = {
             else
                 this._updateEmptyPlaceholder();
         } else {
-            let animate = global.settings.get_boolean("desktop-effects");
+            let animate = Main.wm.settingsState['desktop-effects'];
             this.positionWindows(animate ? WindowPositionFlags.ANIMATE : 0);
         }
 
@@ -928,7 +928,7 @@ WorkspaceMonitor.prototype = {
 
         if (this.actor.get_stage()) {
             clone._is_new_window = true;
-            let animate = global.settings.get_boolean("desktop-effects");
+            let animate = Main.wm.settingsState['desktop-effects'];
             this.positionWindows(animate ? WindowPositionFlags.ANIMATE : 0);
         }
     },
@@ -967,7 +967,7 @@ WorkspaceMonitor.prototype = {
 
     // Animate the full-screen to Overview transition.
     zoomToOverview : function() {
-        let animate = global.settings.get_boolean("desktop-effects");
+        let animate = Main.wm.settingsState['desktop-effects'];
         // Position and scale the windows.
         if (Main.overview.animationInProgress && animate)
             this.positionWindows(WindowPositionFlags.ANIMATE | WindowPositionFlags.INITIAL);
@@ -991,7 +991,7 @@ WorkspaceMonitor.prototype = {
         if (this.metaWorkspace != null && this.metaWorkspace != currentWorkspace)
             return;
 
-        let animate = global.settings.get_boolean("desktop-effects");
+        let animate = Main.wm.settingsState['desktop-effects'];
         if (!animate)
             return;
 


### PR DESCRIPTION
- Caches settings so we are not invoking Gio.Settings calls on every window action.
- Removes assignment of window_type via a signal.
- Reduces function invocation.
- Switches WindowManager and the effects classes to ES2015 class syntax.
- Removes circular references to WindowManager on the effects instances.
- Uses object destructuring assignment for imports so we are not accessing properties on large objects as much.
- Makes OSD elements not animate when animations are disabled. This could be turned into its own effects option if needed, though not sure it's necessary.
- Moves the main desktop effects setting to Muffin, so we can disable some unnecessary code paths from Muffin when effects are disabled.

Depends on https://github.com/linuxmint/muffin/pull/428

This area of Cinnamon controls animations, and can bottleneck the compositor. It's important that it's optimized as much as it can be without compromising functionality and readability.

Closes #8322 