### PR TITLE
Menu applet settings: move the favbox height setting

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/settings-schema.json
@@ -25,7 +25,7 @@
         "menu-layout" : {
             "type" : "section",
             "title" : "Layout and content",
-            "keys" : ["favbox-min-height", "show-category-icons", "show-application-icons", "favbox-show", "show-places", "menu-editor-button"]
+            "keys" : ["show-category-icons", "show-application-icons", "favbox-show", "favbox-min-height", "show-places", "menu-editor-button"]
         },
         "menu-behave" : {
             "type" : "section",
@@ -67,6 +67,7 @@
     "max" : 1000,
     "step" : 10,
     "units" : "px",
+    "dependency" : "favbox-show",
     "description" : "Minimum height of the favorites section",
     "tooltip" : "The minimum size allocated for the favorites section (this has an impact on the overall height of the menu)."
  },


### PR DESCRIPTION
This pull request moves the setting "Minimum height of the favorites section (px)" so that it's now below the setting "Show favorites and session buttons". It also makes the favbox height setting dependent on the show favs setting since the former only makes sense when the latter is enabled.