### PR TITLE
settings.js: Add a method to get the default value from settings-schema

### DIFF
--- a/js/ui/settings.js
+++ b/js/ui/settings.js
@@ -501,6 +501,23 @@ XletSettingsBase.prototype = {
     },
 
     /**
+     * getDefaultValue:
+     * @key (string): the name of the settings key
+     *
+     * Gets the default value of the setting @key.
+     *
+     * Returns: The default value of the setting
+     */
+    getDefaultValue: function(key) {
+        if (key in this.settingsData) {
+            return this.settingsData[key].default;
+        } else {
+            key_not_found_error(key, this.uuid);
+            return null;
+        }
+    },
+
+    /**
      * getOptions:
      * @key (String): the name of the settings key
      *


### PR DESCRIPTION
This is useful for settings with dependencies like "Use default X", where the xlet has to use a default value for another setting. Get it directly from the schema instead of hardcoding/duplicating it in code files.