### PR TITLE
Add compatibility for the obscured window optimization in Muffin

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
@@ -1035,6 +1035,7 @@ class AppThumbnailHoverMenu extends PopupMenu.PopupMenu {
         } else {
             if (force || this.state.settings.onClickThumbs) this.addQueuedThumbnails();
             this.state.set({thumbnailMenuOpen: true});
+            each(this.appThumbnails, (thumb) => thumb.metaWindowActor.set_obscured(false));
             super.open(this.state.settings.animateThumbs);
         }
     }
@@ -1053,6 +1054,7 @@ class AppThumbnailHoverMenu extends PopupMenu.PopupMenu {
         }
         if (this.isOpen) {
             this.state.set({thumbnailMenuOpen: false});
+            each(this.appThumbnails, (thumb) => thumb.metaWindowActor.set_obscured(true));
             if (!this.actor.is_finalized()) super.close(this.state.settings.animateThumbs);
         }
         for (let i = 0; i < this.appThumbnails.length; i++) {

--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -145,6 +145,7 @@ class WindowPreview extends Tooltips.TooltipBase {
 
         this.thumbnailBin.set_child(this.thumbnail);
 
+        this.muffinWindow.set_obscured(false);
         this.actor.show();
         this._set_position();
 
@@ -159,6 +160,7 @@ class WindowPreview extends Tooltips.TooltipBase {
             this._sizeChangedId = null;
         }
         if (this.thumbnail) {
+            this.muffinWindow.set_obscured(true);
             this.thumbnailBin.set_child(null);
             this.thumbnail.destroy();
             this.thumbnail = null;

--- a/js/misc/windowUtils.js
+++ b/js/misc/windowUtils.js
@@ -5,69 +5,69 @@ const Clutter = imports.gi.Clutter;
 // When scaled, all clones are made to fit in width and height
 // if neither width nor height is given, windows are not scaled
 function createWindowClone(metaWindow, width, height, withTransients, withPositions) {
-  let clones = [];
-  let textures = [];
-  
-  if (!metaWindow) {
-    return clones;
-  }
-  
-  let metaWindowActor = metaWindow.get_compositor_private();
-  if (!metaWindowActor) {
-    return clones;
-  }
-  let texture = metaWindowActor.get_texture();
-  let [windowWidth, windowHeight] = metaWindowActor.get_size();
-  let [maxWidth, maxHeight] = [windowWidth, windowHeight];
-  let [x, y] = metaWindowActor.get_position();
-  let [minX, minY] = [x, y];
-  let [maxX, maxY] = [minX + windowWidth, minY + windowHeight];
-  textures.push({t: texture, x: x, y: y, w: windowWidth, h: windowHeight});
-  if (withTransients) {
-    metaWindow.foreach_transient(function(win) {
-      let metaWindowActor = win.get_compositor_private();
-      texture = metaWindowActor.get_texture();
-      [windowWidth, windowHeight] = metaWindowActor.get_size();
-      [x, y] = metaWindowActor.get_position();
-      maxWidth = Math.max(maxWidth, windowWidth);
-      maxHeight = Math.max(maxHeight, windowHeight);
-      minX = Math.min(minX, x);
-      maxX = Math.max(maxX, x + windowWidth);
-      minY = Math.min(minY, y);
-      maxY = Math.max(maxY, y + windowHeight);
-      textures.push({t: texture, x: x, y: y, w: windowWidth, h: windowHeight});
-    });
-  }
-  let scale = 1;
-  let scaleWidth = 1;
-  let scaleHeight = 1;
-  if (width) {
-    scaleWidth = Math.min(width/(maxX - minX), 1);
-  }
-  if (height) {
-    scaleHeight = Math.min(height/(maxY - minY), 1);
-  }
-  if (width || height) {
-    scale = Math.min(scaleWidth, scaleHeight);
-  }
-  
-  for (let i = 0; i < textures.length; i++) {
-    let data = textures[i];
-    let [texture, texWidth, texHeight, x, y] = [data.t, data.w, data.h, data.x, data.y];
-    if (withPositions) {
-      x -= minX;
-      y -= minY;
+    let clones = [];
+    let textures = [];
+
+    if (!metaWindow) {
+        return clones;
     }
-    let params = {};
-    params.source = texture;
-    if (scale != 1) {
-      params.width = Math.round(texWidth * scale);
-      params.height = Math.round(texHeight * scale);
-      x = Math.round(x * scale);
-      y = Math.round(y * scale);
+
+    let metaWindowActor = metaWindow.get_compositor_private();
+    if (!metaWindowActor) {
+        return clones;
     }
-    let clone = {actor: new Clutter.Clone(params), x: x, y: y};
-    clones.push(clone);
-  }
-  return clones;
+    let texture = metaWindowActor.get_texture();
+    let [windowWidth, windowHeight] = metaWindowActor.get_size();
+    let [maxWidth, maxHeight] = [windowWidth, windowHeight];
+    let [x, y] = metaWindowActor.get_position();
+    let [minX, minY] = [x, y];
+    let [maxX, maxY] = [minX + windowWidth, minY + windowHeight];
+    textures.push({t: texture, x: x, y: y, w: windowWidth, h: windowHeight});
+    if (withTransients) {
+        metaWindow.foreach_transient(function(win) {
+            let metaWindowActor = win.get_compositor_private();
+            texture = metaWindowActor.get_texture();
+            [windowWidth, windowHeight] = metaWindowActor.get_size();
+            [x, y] = metaWindowActor.get_position();
+            maxWidth = Math.max(maxWidth, windowWidth);
+            maxHeight = Math.max(maxHeight, windowHeight);
+            minX = Math.min(minX, x);
+            maxX = Math.max(maxX, x + windowWidth);
+            minY = Math.min(minY, y);
+            maxY = Math.max(maxY, y + windowHeight);
+            textures.push({t: texture, x: x, y: y, w: windowWidth, h: windowHeight});
+        });
+    }
+    let scale = 1;
+    let scaleWidth = 1;
+    let scaleHeight = 1;
+    if (width) {
+        scaleWidth = Math.min(width / (maxX - minX), 1);
+    }
+    if (height) {
+        scaleHeight = Math.min(height / (maxY - minY), 1);
+    }
+    if (width || height) {
+        scale = Math.min(scaleWidth, scaleHeight);
+    }
+
+    for (let i = 0; i < textures.length; i++) {
+        let data = textures[i];
+        let [texture, texWidth, texHeight, x, y] = [data.t, data.w, data.h, data.x, data.y];
+        if (withPositions) {
+            x -= minX;
+            y -= minY;
+        }
+        let params = {};
+        params.source = texture;
+        if (scale != 1) {
+            params.width = Math.round(texWidth * scale);
+            params.height = Math.round(texHeight * scale);
+            x = Math.round(x * scale);
+            y = Math.round(y * scale);
+        }
+        let clone = {actor: new Clutter.Clone(params), x: x, y: y};
+        clones.push(clone);
+    }
+    return clones;
 }

--- a/js/ui/appSwitcher/appSwitcher3D.js
+++ b/js/ui/appSwitcher/appSwitcher3D.js
@@ -12,6 +12,7 @@ const Mainloop = imports.mainloop;
 const AppSwitcher = imports.ui.appSwitcher.appSwitcher;
 const Main = imports.ui.main;
 const Tweener = imports.ui.tweener;
+const {each} = imports.misc.util;
 
 const INITIAL_DELAY_TIMEOUT = 150;
 const CHECK_DESTROYED_TIMEOUT = 100;
@@ -22,7 +23,7 @@ const ICON_TITLE_SPACING = 10;
 const PREVIEW_SCALE = 0.5;
 
 const TITLE_POSITION = 7/8; // percent position
-const ANIMATION_TIME = 0.25; // seconds
+var ANIMATION_TIME = 0.25; // seconds
 const SWITCH_TIME_DELAY = 100; // milliseconds
 const DIM_FACTOR = 0.4; // percent
 
@@ -67,6 +68,11 @@ AppSwitcher3D.prototype = {
 
         // hide windows and show Coverflow actors
         global.window_group.hide();
+
+        each(this._windows, function(metaWindow) {
+            metaWindow.actor.set_obscured(false);
+        });
+
         this.actor.show();
         this._background.show();
 
@@ -88,7 +94,7 @@ AppSwitcher3D.prototype = {
         
         // preview windows
         let currentWorkspace = global.screen.get_active_workspace();
-        for (let i in this._previews) {
+        for (let i = 0; i < this._previews.length; i++) {
             let preview = this._previews[i];
             let metaWin = this._windows[i];
             let compositor = this._windows[i].get_compositor_private();
@@ -162,16 +168,24 @@ AppSwitcher3D.prototype = {
         this._next();
     },
 
+    onPreviewDestroyed: function(metaWindow, metaWindowActor, preview) {
+        if (metaWindow) metaWindow.actor = undefined;
+        if (preview) preview.metaWindow = undefined;
+        if (!metaWindowActor || metaWindowActor.is_finalized()) return;
+        metaWindowActor.set_obscured(true);
+    },
+
     _createList: function() {
         let monitor = this._activeMonitor;
         let currentWorkspace = global.screen.get_active_workspace();
         
         this._previews = [];
-        
-        for (let i in this._windows) {
+
+        for (let i = 0; i < this._windows.length; i++) {
             let metaWin = this._windows[i];
             let compositor = this._windows[i].get_compositor_private();
             if (compositor) {
+                metaWin.actor = compositor;
                 let texture = compositor.get_texture();
                 let [width, height] = texture.get_size();
 
@@ -194,10 +208,10 @@ AppSwitcher3D.prototype = {
                 preview.target_width_side = preview.target_width * 2/3;
                 preview.target_height_side = preview.target_height;
 
-                
                 preview.set_child(new Clutter.Clone({ source: texture }));
                 preview.metaWindow = metaWin;
                 preview.connect('clicked', Lang.bind(this, this._cloneClicked));
+                preview.connect('destroy', () => this.onPreviewDestroyed(metaWin, compositor, preview));
 
                 this._previews.push(preview);
                 this.previewActor.add_actor(preview);


### PR DESCRIPTION
This adds compatibility for [this commit](https://github.com/linuxmint/muffin/pull/410/commits/5d3361b45a35583af6e0f50722d6aa48de8b2991) in https://github.com/linuxmint/muffin/pull/410.

The muffin patch works by skipping rendering of unminimized windows the user cannot see, so system resources are spent on the windows being interacted with. One part of this is making sure this doesn't break live thumbnail previews, which this PR addresses.