### PR TITLE
Fixing gradient revealer not showing up on .png images

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_backgrounds.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_backgrounds.py
@@ -521,7 +521,7 @@ class Module:
         if settings.get_string("picture-uri").endswith(".png"):
             #the picture is a .png file
             show = True
-        if settings.get_string("picture-options") in PICTURE_OPTIONS_NEEDS_COLOR:
+        elif settings.get_string("picture-options") in PICTURE_OPTIONS_NEEDS_COLOR:
             #the picture is taking all the width
             if settings.get_string("color-shading-type") != "solid":
                 #it is using a gradient, so need to show

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_backgrounds.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_backgrounds.py
@@ -518,6 +518,9 @@ class Module:
     def update_secondary_revealer(self, settings, key):
         show = False
 
+        if settings.get_string("picture-uri").endswith(".png"):
+            #the picture is a .png file
+            show = True
         if settings.get_string("picture-options") in PICTURE_OPTIONS_NEEDS_COLOR:
             #the picture is taking all the width
             if settings.get_string("color-shading-type") != "solid":


### PR DESCRIPTION
There's a unwanted behaviour on gradient color revealers when changing the picture aspect of a .png image file

When we choose a .png file for the background image, we want to be able to select the gradient colors for any picture aspect chosen, because .png files also have a transparency channel to show gradients

What happens: If the picture aspect make the image fill the whole screen, the gradient options are hidden, even if the image is a _.png_ file and is actually showing the background gradient through it's transparency

Picture aspects that fill the whole image and reproduce the error when using a .png file with transparency: **Mosaic**, **Stretched** and **Zoom**

I tried to fix it, but my additions to the code only fix the gradient end color (_secondary_revealer_), and i couldn't find the fix for the gradient start color

I also noted that this partial fix only works when the user change the Picture Aspect on the settings section, ideally, the revealers should also reload when the user change from a non-.png file, to a .png file, and vice-versa 