### PR TITLE
runDialog: Always close on loss of key focus

### DIFF
--- a/js/ui/runDialog.js
+++ b/js/ui/runDialog.js
@@ -210,8 +210,8 @@ __proto__: ModalDialog.ModalDialog.prototype,
             if (this.asyncCommandInProgress) {
                 this.subprocess.cancellable.cancel();
                 this.subprocess = null;
-                this.close();
             }
+            this.close();
         }, 0);
     },
 


### PR DESCRIPTION
Fixes an issue with #8130. This was only closing the run dialog while an async process was still ongoing, but this would only be the case when using `pkexec`.