### PR TITLE
Spices.py: fix a bug causing gwl to be removed when wl is disabled

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
@@ -774,7 +774,7 @@ class Spice_Harvester(GObject.Object):
         enabled_extensions = self.settings.get_strv(self.enabled_key)
         new_list = []
         for enabled_extension in enabled_extensions:
-            if uuid not in enabled_extension:
+            if enabled_extension.split(':')[3].strip('!') != uuid:
                 new_list.append(enabled_extension)
         self.settings.set_strv(self.enabled_key, new_list)
 


### PR DESCRIPTION
This fixes a bug in which disabling an applet with a uuid that is a sub-string of another uuid will cause both to be disabled. For example, disabling window-list@cinnamon.org will incorrectly cause any instances of grouped-window-list@cinnamon.org to also be removed.

Fixes #8282 