### PR TITLE
xlet settings list widget: some fixes and improvements to the tree

### DIFF
--- a/docs/reference/cinnamon-tutorials/xlet-settings-ref.xml
+++ b/docs/reference/cinnamon-tutorials/xlet-settings-ref.xml
@@ -315,6 +315,7 @@
           <listitem><code>type</code>: the data type for the column</listitem>
           <listitem><code>default</code>: (optional) a default value for the column when a new row is being created. This will only be used to auto-populate the corresponding widget when it is first generated in the add row dialog. If this property is omitted, the default will be determined by the widget.</listitem>
           <listitem><code>options</code>: (optional) A list of acceptable values for that column. Either an array or an object with key value pairs may be used. If an object is given, the key is displayed as the text of the widget, and must be a string; the value must match the data type of the column (ie. string, integer, boolean, etc).</listitem>
+          <listitem><code>align</code>: (optional) A number between 0 and 1 indicating how the value should be aligned with respect to the column in which it is displayed. 0 aligns to the left of the cell, 1 to the right, and 0.5 in the center. (New in Cinnamon 4.2)</listitem>
         </itemizedlist>
       </para>
       <para>

--- a/files/usr/share/cinnamon/applets/settings-example@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/settings-example@cinnamon.org/settings-schema.json
@@ -214,7 +214,7 @@
             {"id": "name", "title": "Name", "type": "string"},
             {"id": "resident", "title": "Resident", "type": "boolean"},
             {"id": "address", "title": "Address", "type": "string", "default": "none"},
-            {"id": "number", "title": "Id number", "type": "integer", "min": 0, "max": 100},
+            {"id": "number", "title": "Id number", "type": "integer", "align": 0.5, "min": 0, "max": 100},
             {"id": "icon", "title": "Icon", "type": "icon"},
             {"id": "key", "title": "Shortcut key", "type": "keybinding"},
             {"id": "file", "title": "File Path", "type": "file", "select-dir": false},

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/TreeListWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/TreeListWidgets.py
@@ -131,6 +131,12 @@ class List(SettingsWidget):
 
             if render_type == 'boolean':
                 renderer = Gtk.CellRendererToggle()
+
+                def toggle_checkbox(renderer, path, column):
+                    self.model[path][column] = not self.model[path][column]
+                    self.list_changed()
+
+                renderer.connect('toggled', toggle_checkbox, i)
                 prop_name = 'active'
             elif render_type == 'icon':
                 renderer = Gtk.CellRendererPixbuf()

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/TreeListWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/TreeListWidgets.py
@@ -123,9 +123,38 @@ class List(SettingsWidget):
         types = []
         tv_columns = []
         for i in range(len(columns)):
-            types.append(VARIABLE_TYPE_MAP[columns[i]["type"]])
-            renderer = Gtk.CellRendererText()
-            column = Gtk.TreeViewColumn(columns[i]["title"], renderer, text=i)
+            column_def = columns[i]
+            types.append(VARIABLE_TYPE_MAP[column_def['type']])
+
+            has_option_map = 'options' in column_def and isinstance(column_def['options'], dict)
+            render_type = 'string' if has_option_map else column_def['type']
+
+            if render_type == 'boolean':
+                renderer = Gtk.CellRendererToggle()
+                prop_name = 'active'
+            elif render_type == 'icon':
+                renderer = Gtk.CellRendererPixbuf()
+                prop_name = 'icon_name'
+            else:
+                renderer = Gtk.CellRendererText()
+                prop_name = 'text'
+
+            column = Gtk.TreeViewColumn(column_def['title'], renderer)
+
+            if has_option_map:
+                def map_func(col, rend, model, row_iter, options):
+                    value = model[row_iter][i]
+                    for key, val in options.items():
+                        if val == value:
+                            rend.set_property('text', key)
+
+                column.set_cell_data_func(renderer, map_func, column_def['options'])
+            else:
+                column.add_attribute(renderer, prop_name, i)
+
+            if 'align' in column_def:
+                renderer.set_alignment(column_def['align'], 0.5)
+
             column.set_resizable(True)
             self.content_widget.append_column(column)
         self.model = Gtk.ListStore(*types)


### PR DESCRIPTION
This improves how data is displayed in the tree of an xlet settings list widget in several ways:

1.) Boolean values are now displayed as a checkbox rather than the values TRUE and FALSE.
2.) Icon type values are now displayed as an icon rather than text.
3.) Columns with a key-value options list now display the key rather than the value. In most cases this makes more sense and it brings it more in line with the combo box widget which is used in the add/edit dialog.
4.) A new property 'align' was added to allow the alignment of the content to be controlled. The settings example applet and the docs were updated to reflect this change.

Fixes #8009