### PR TITLE
sound chooser widget: add all mimetypes option and improve default

### DIFF
--- a/docs/reference/cinnamon-tutorials/xlet-settings-ref.xml
+++ b/docs/reference/cinnamon-tutorials/xlet-settings-ref.xml
@@ -105,6 +105,7 @@
         <listitem><code>type</code>: should be <code>soundfilechooser</code></listitem>
         <listitem><code>description</code>: String describing the setting</listitem>
         <listitem><code>default</code>: default icon path or icon name to use</listitem>
+        <listitem><code>event-sounds</code>: (optional) true or false, or leave off entirely. Unless this property is set to false, the file chooser will only allow wav and ogg/oga type files as these are the only types currently supported by cinnamon sound events. (New in Cinnamon 4.2)</listitem>
       </itemizedlist>
 
       <para>Provides a button which shows the currently selected file name and opens a file dialog when clicked. A preview button is also provided to allow the user to test the selected sound. Stores as a <code>string</code>.</para>

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py
@@ -21,7 +21,8 @@ JSON_SETTINGS_PROPERTIES_MAP = {
     "tooltip"       : "tooltip",
     "possible"      : "possible",
     "expand-width"  : "expand_width",
-    "columns"       : "columns"
+    "columns"       : "columns",
+    "event-sounds"  : "event_sounds"
 }
 
 OPERATIONS = ['<=', '>=', '<', '>', '!=', '=']

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
@@ -850,8 +850,10 @@ class FileChooser(SettingsWidget):
 class SoundFileChooser(SettingsWidget):
     bind_dir = None
 
-    def __init__(self, label, size_group=None, dep_key=None, tooltip=""):
+    def __init__(self, label, event_sounds=True, size_group=None, dep_key=None, tooltip=""):
         super(SoundFileChooser, self).__init__(dep_key=dep_key)
+
+        self.event_sounds = event_sounds
 
         self.label = SettingsLabel(label)
         self.content_widget = Gtk.Box()
@@ -910,11 +912,17 @@ class SoundFileChooser(SettingsWidget):
                                        buttons=(_("_Cancel"), Gtk.ResponseType.CANCEL,
                                                 _("_Open"), Gtk.ResponseType.ACCEPT))
 
-        dialog.set_filename(self.get_value())
+        if os.path.exists(self.get_value()):
+            dialog.set_filename(self.get_value())
+        else:
+            dialog.set_current_folder('/usr/share/sounds')
 
         sound_filter = Gtk.FileFilter()
-        sound_filter.add_mime_type("audio/x-wav")
-        sound_filter.add_mime_type("audio/x-vorbis+ogg")
+        if self.event_sounds:
+            sound_filter.add_mime_type("audio/x-wav")
+            sound_filter.add_mime_type("audio/x-vorbis+ogg")
+        else:
+            sound_filter.add_mime_type("audio/*")
         sound_filter.set_name(_("Sound files"))
         dialog.add_filter(sound_filter)
 


### PR DESCRIPTION
This adds an option to the sound chooser widget to use any sound file type - not just ogg/oga and wav (which are the ones supported by the cinnamon sound system). The settings reference tutorial is also updated to reflect the new option.

The default path for the file chooser dialog in this widget was also set to /usr/share/sounds for cases where the file is not set or doesn't exist as this is a much better default than ~/.

Fixes #8267 