### PR TITLE
Menu applet: Various improvements

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -786,14 +786,6 @@ class RecentButton extends SimpleMenuItem {
     }
 }
 
-class NoRecentDocsButton extends SimpleMenuItem {
-    constructor(label) {
-        super(false, false);
-        this.actor.set_style_class_name('menu-application-button');
-        this.addLabel(label, 'menu-application-button-label');
-    }
-}
-
 class RecentClearButton extends SimpleMenuItem {
     constructor(applet) {
         super();
@@ -2316,7 +2308,9 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                 this._recentButtons.push(recent_clear_button);
                 this.applicationsBox.add_child(recent_clear_button.actor);
             } else {
-                let no_recent_button = new NoRecentDocsButton(_("No recent documents"), null, false, null);
+                let no_recent_button = new SimpleMenuItem(false, false);
+                no_recent_button.actor.set_style_class_name('menu-application-button');
+                no_recent_button.addLabel(_("No recent documents"), 'menu-application-button-label');
                 this._recentButtons.push(no_recent_button);
                 this.applicationsBox.add_child(no_recent_button.actor);
             }

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -22,7 +22,6 @@ const DocInfo = imports.misc.docInfo;
 const GLib = imports.gi.GLib;
 const Settings = imports.ui.settings;
 const Pango = imports.gi.Pango;
-const AccountsService = imports.gi.AccountsService;
 const SearchProviderManager = imports.ui.searchProviderManager;
 const SignalManager = imports.misc.signalManager;
 const Params = imports.misc.params;
@@ -896,7 +895,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
 
         this.settings = new Settings.AppletSettings(this, "menu@cinnamon.org", instance_id);
 
-        this.settings.bind("show-places", "showPlaces", () => this._refreshBelowApps);
+        this.settings.bind("show-places", "showPlaces", this._refreshBelowApps);
 
         this._appletEnterEventId = 0;
         this._appletLeaveEventId = 0;
@@ -991,7 +990,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
     onAppSysChanged() {
         if (this.refreshing == false) {
             this.refreshing = true;
-            Mainloop.timeout_add_seconds(1, this._refreshAll.bind(this));
+            Mainloop.timeout_add_seconds(1, () => this._refreshAll());
         }
     }
 

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1154,7 +1154,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
             this.closeContextMenu(false);
 
             this._clearAllSelections(true);
-            this._scrollToButton(this.favBoxIter.getFirstVisible()._delegate, this.favoritesScrollBox);
+            this._scrollToButton(null, this.favoritesScrollBox);
             this.destroyVectorBox();
         }
     }
@@ -1442,18 +1442,18 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                         case "up":
                             this._activeContainer = this.categoriesBox;
                             item_actor = this.catBoxIter.getLastVisible();
-                            this._scrollToButton(this.appBoxIter.getFirstVisible()._delegate);
+                            this._scrollToButton();
                             break;
                         case "down":
                             this._activeContainer = this.categoriesBox;
                             item_actor = this.catBoxIter.getFirstVisible();
                             item_actor = this.catBoxIter.getNextVisible(item_actor);
-                            this._scrollToButton(this.appBoxIter.getFirstVisible()._delegate);
+                            this._scrollToButton();
                             break;
                         case "right":
                             this._activeContainer = this.applicationsBox;
                             item_actor = this.appBoxIter.getFirstVisible();
-                            this._scrollToButton(item_actor._delegate);
+                            this._scrollToButton();
                             break;
                         case "left":
                             if (this.favBoxShow) {
@@ -1462,18 +1462,18 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                             } else {
                                 this._activeContainer = this.applicationsBox;
                                 item_actor = this.appBoxIter.getFirstVisible();
-                                this._scrollToButton(item_actor._delegate);
+                                this._scrollToButton();
                             }
                             break;
                         case "top":
                             this._activeContainer = this.categoriesBox;
                             item_actor = this.catBoxIter.getFirstVisible();
-                            this._scrollToButton(this.appBoxIter.getFirstVisible()._delegate);
+                            this._scrollToButton();
                             break;
                         case "bottom":
                             this._activeContainer = this.categoriesBox;
                             item_actor = this.catBoxIter.getLastVisible();
-                            this._scrollToButton(this.appBoxIter.getFirstVisible()._delegate);
+                            this._scrollToButton();
                             break;
                     }
                     break;
@@ -1483,13 +1483,13 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                             this._previousTreeSelectedActor = this.categoriesBox.get_child_at_index(index);
                             this._previousTreeSelectedActor._delegate.isHovered = false;
                             item_actor = this.catBoxIter.getPrevVisible(this._activeActor);
-                            this._scrollToButton(this.appBoxIter.getFirstVisible()._delegate);
+                            this._scrollToButton();
                             break;
                         case "down":
                             this._previousTreeSelectedActor = this.categoriesBox.get_child_at_index(index);
                             this._previousTreeSelectedActor._delegate.isHovered = false;
                             item_actor = this.catBoxIter.getNextVisible(this._activeActor);
-                            this._scrollToButton(this.appBoxIter.getFirstVisible()._delegate);
+                            this._scrollToButton();
                             break;
                         case "right":
                             if ((this.categoriesBox.get_child_at_index(index))._delegate.categoryId === "recent" &&
@@ -1511,7 +1511,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                             if(this.favBoxShow) {
                                 this._previousSelectedActor = this.categoriesBox.get_child_at_index(index);
                                 item_actor = this.favBoxIter.getFirstVisible();
-                                this._scrollToButton(item_actor._delegate, this.favoritesScrollBox);
+                                this._scrollToButton(null, this.favoritesScrollBox);
                             } else {
                                 if ((this.categoriesBox.get_child_at_index(index))._delegate.categoryId === "recent" &&
                                     this.noRecentDocuments) {
@@ -1527,13 +1527,13 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                             this._previousTreeSelectedActor = this.categoriesBox.get_child_at_index(index);
                             this._previousTreeSelectedActor._delegate.isHovered = false;
                             item_actor = this.catBoxIter.getFirstVisible();
-                            this._scrollToButton(this.appBoxIter.getFirstVisible()._delegate);
+                            this._scrollToButton();
                             break;
                         case "bottom":
                             this._previousTreeSelectedActor = this.categoriesBox.get_child_at_index(index);
                             this._previousTreeSelectedActor._delegate.isHovered = false;
                             item_actor = this.catBoxIter.getLastVisible();
-                            this._scrollToButton(this.appBoxIter.getFirstVisible()._delegate);
+                            this._scrollToButton();
                             break;
                     }
                     break;
@@ -1645,7 +1645,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                             this._previousSelectedActor = this.systemButtonsBox.get_child_at_index(index);
                             if (this._previousSelectedActor === this.sysBoxIter.getLastVisible()) {
                                 item_actor = this.favBoxIter.getFirstVisible();
-                                this._scrollToButton(item_actor._delegate, this.favoritesScrollBox);
+                                this._scrollToButton(null, this.favoritesScrollBox);
                             } else {
                                 item_actor = this.sysBoxIter.getNextVisible(this._previousSelectedActor);
                             }
@@ -2308,15 +2308,27 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
     }
 
     _scrollToButton(button, scrollBox = null) {
-        if (!scrollBox) scrollBox = this.applicationsScrollBox;
+        if (!scrollBox)
+            scrollBox = this.applicationsScrollBox;
 
-        let current_scroll_value = scrollBox.get_vscroll_bar().get_adjustment().get_value();
-        let box_height = scrollBox.get_allocation_box().y2 - scrollBox.get_allocation_box().y1;
-        let new_scroll_value = current_scroll_value;
+        let adj = scrollBox.get_vscroll_bar().get_adjustment();
+        if (button) {
+            let box = scrollBox.get_allocation_box();
+            let boxHeight = box.y2 - box.y1;
+            let actorBox = button.actor.get_allocation_box();
+            let currentValue = adj.get_value();
+            let newValue = currentValue;
 
-        if (current_scroll_value > button.actor.get_allocation_box().y1 - 10) new_scroll_value = button.actor.get_allocation_box().y1 - 10;
-        if (box_height + current_scroll_value < button.actor.get_allocation_box().y2 + 10) new_scroll_value = button.actor.get_allocation_box().y2-box_height + 10;
-        if (new_scroll_value != current_scroll_value) scrollBox.get_vscroll_bar().get_adjustment().set_value(new_scroll_value);
+            if (currentValue > actorBox.y1 - 10)
+                newValue = actorBox.y1 - 10;
+            if (boxHeight + currentValue < actorBox.y2 + 10)
+                newValue = actorBox.y2 - boxHeight + 10;
+
+            if (newValue != currentValue)
+                adj.set_value(newValue);
+        } else {
+            adj.set_value(0);
+        }
     }
 
     _display() {

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1256,13 +1256,18 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
             menu.connect('open-state-changed', Lang.bind(this, this._contextMenuOpenStateChanged));
             this.contextMenu = menu;
             this.applicationsBox.add_actor(menu.actor);
+        } else if (this.contextMenu.isOpen &&
+                   this.contextMenu.sourceActor != button.actor) {
+            this.contextMenu.close();
         }
+
         if (!this.contextMenu.isOpen) {
             this.contextMenu.box.destroy_all_children();
             this.applicationsBox.set_child_above_sibling(this.contextMenu.actor, button.actor);
             this.contextMenu.sourceActor = button.actor;
             button.populateMenu(this.contextMenu);
         }
+
         this.contextMenu.toggle();
     }
 


### PR DESCRIPTION
This seems to work great on my end, but it may break stuff so it needs testing.

- buttons significantly faster by not using PopupBaseMenuItem
- buttons all have a 'name' and 'description' property to simplify enter/leave events
- removed some classes that just added an icon or label
- combined all enter/leave events to a single handler to consolidate all the code into one location and reduce the amount of duplicated code
- the applications box now uses only one context menu item. this is how recent buttons already worked, but there was 1 menu per application button and on my system it was about 110 menu item actors
- scrollToButton() now resets vscroll adjustment to 0 when no button is passed. avoids passing first item and having it calculate when we just want to scroll to the top.
- a lot of other random cleanups