### PR TITLE
st-icon: avoid a redraw if no shadow

### DIFF
--- a/src/st/st-icon.c
+++ b/src/st/st-icon.c
@@ -337,8 +337,13 @@ static void
 on_pixbuf_changed (ClutterTexture *texture,
                    StIcon         *icon)
 {
-  st_icon_clear_shadow_pipeline (icon);
-  clutter_actor_queue_redraw (CLUTTER_ACTOR (icon));
+  StIconPrivate *priv = icon->priv;
+
+  if (priv->shadow_pipeline)
+    {
+      st_icon_clear_shadow_pipeline (icon);
+      clutter_actor_queue_redraw (CLUTTER_ACTOR (icon));
+    }
 }
 
 static void


### PR DESCRIPTION
A previous commit (from upstream) introduced a redraw.  But the only reason for this was when icon shadow was there, so if there's no shadow then we don't need to clear it and we don't need the redraw