### PR TITLE
st-cogl-wrapper: Get context from Clutter once

### DIFF
--- a/src/st/st-cogl-wrapper.c
+++ b/src/st/st-cogl-wrapper.c
@@ -26,9 +26,9 @@ hardware_supports_npot_sizes (void)
 CoglContext *
 st_get_cogl_context (void)
 {
-    if (cogl_context == NULL)
-      cogl_context = clutter_backend_get_cogl_context (clutter_get_default_backend ());
-    return cogl_context;
+  if (G_UNLIKELY (cogl_context == NULL))
+    cogl_context = clutter_backend_get_cogl_context (clutter_get_default_backend ());
+  return cogl_context;
 }
 
 /**

--- a/src/st/st-cogl-wrapper.c
+++ b/src/st/st-cogl-wrapper.c
@@ -26,7 +26,9 @@ hardware_supports_npot_sizes (void)
 CoglContext *
 st_get_cogl_context (void)
 {
-    return clutter_backend_get_cogl_context (clutter_get_default_backend ());
+    if (cogl_context == NULL)
+      cogl_context = clutter_backend_get_cogl_context (clutter_get_default_backend ());
+    return cogl_context;
 }
 
 /**

--- a/src/st/st-theme-node-drawing.c
+++ b/src/st/st-theme-node-drawing.c
@@ -1550,10 +1550,7 @@ st_theme_node_ensure_color_pipeline (StThemeNode *node)
 
   if (G_UNLIKELY (color_pipeline_template == NULL))
     {
-      CoglContext *ctx =
-        clutter_backend_get_cogl_context (clutter_get_default_backend ());
-
-      color_pipeline_template = cogl_pipeline_new (ctx);
+      color_pipeline_template = cogl_pipeline_new (st_get_cogl_context ());
     }
 
   node->color_pipeline = cogl_pipeline_copy (color_pipeline_template);

--- a/src/st/st-theme-node-transition.c
+++ b/src/st/st-theme-node-transition.c
@@ -277,9 +277,7 @@ setup_framebuffers (StThemeNodeTransition *transition,
     {
       if (G_UNLIKELY (material_template == COGL_INVALID_HANDLE))
         {
-          CoglContext *ctx =
-            clutter_backend_get_cogl_context (clutter_get_default_backend ());
-          material_template = cogl_pipeline_new (ctx);
+          material_template = cogl_pipeline_new (st_get_cogl_context ());
 
           cogl_pipeline_set_layer_combine (material_template, 0,
                                            "RGBA = REPLACE (TEXTURE)",

--- a/src/st/st-theme-node.c
+++ b/src/st/st-theme-node.c
@@ -38,6 +38,8 @@ static const ClutterColor DEFAULT_SUCCESS_COLOR = { 0x4e, 0x9a, 0x06, 0xff };
 static const ClutterColor DEFAULT_WARNING_COLOR = { 0xf5, 0x79, 0x3e, 0xff };
 static const ClutterColor DEFAULT_ERROR_COLOR = { 0xcc, 0x00, 0x00, 0xff };
 
+static double resolution = -1.0;
+
 extern gfloat st_slow_down_factor;
 
 G_DEFINE_TYPE (StThemeNode, st_theme_node, G_TYPE_OBJECT)
@@ -859,7 +861,6 @@ get_length_from_term (StThemeNode *node,
 
   double multiplier = 1.0;
   int scale_factor;
-  double resolution;
 
   g_object_get (node->context, "scale-factor", &scale_factor, NULL);
 
@@ -966,7 +967,6 @@ get_length_from_term (StThemeNode *node,
       *length = num->val * multiplier;
       break;
     case POINTS:
-      resolution = clutter_backend_get_resolution (clutter_get_default_backend ());
       *length = num->val * multiplier * (resolution / 72.);
       break;
     case FONT_RELATIVE:
@@ -987,7 +987,6 @@ get_length_from_term (StThemeNode *node,
           }
         else
           {
-            resolution = clutter_backend_get_resolution (clutter_get_default_backend ());
             *length = num->val * multiplier * (resolution / 72.) * font_size;
           }
       }
@@ -2460,7 +2459,6 @@ font_size_from_term (StThemeNode *node,
 {
   if (term->type == TERM_IDENT)
     {
-      double resolution = clutter_backend_get_resolution (clutter_get_default_backend ());
       /* We work in integers to avoid double comparisons when converting back
        * from a size in pixels to a logical size.
        */
@@ -2663,11 +2661,12 @@ st_theme_node_get_font (StThemeNode *node)
   if (node->font_desc)
     return node->font_desc;
 
+  resolution = clutter_backend_get_resolution (clutter_get_default_backend ());
+
   node->font_desc = pango_font_description_copy (get_parent_font (node));
   parent_size = pango_font_description_get_size (node->font_desc);
   if (!pango_font_description_get_size_is_absolute (node->font_desc))
     {
-      double resolution = clutter_backend_get_resolution (clutter_get_default_backend ());
       parent_size *= (resolution / 72.);
     }
 


### PR DESCRIPTION
I found a performance gain in Muffin in not fetching the CoglContext from Clutter except to get the initial pointer, and so it makes sense to also do it here. Clutter has to fetch its context in get_default_backend(), which causes it to place a lock on Clutter's context. Its an intricate dance when we just need something that's already available.