### PR TITLE
st: Move allocation calls out of paint vfuncs

### DIFF
--- a/src/st/st-icon.c
+++ b/src/st/st-icon.c
@@ -46,6 +46,9 @@ struct _StIconPrivate
 {
   ClutterActor *icon_texture;
   ClutterActor *pending_texture;
+
+  ClutterActorBox *allocation;
+
   guint         opacity_handler_id;
 
   GIcon        *gicon;
@@ -55,6 +58,9 @@ struct _StIconPrivate
   gint          theme_icon_size; /* icon size from theme node */
   gint          icon_size;       /* icon size we are using */
   gint          icon_scale;
+
+  float         height, width;
+  gboolean      size_changed;
 
   CoglPipeline  *shadow_pipeline;
 
@@ -66,7 +72,6 @@ G_DEFINE_TYPE_WITH_PRIVATE (StIcon, st_icon, ST_TYPE_WIDGET)
 
 static void st_icon_update               (StIcon *icon);
 static gboolean st_icon_update_icon_size (StIcon *icon);
-static void st_icon_update_shadow_pipeline (StIcon *icon);
 static void st_icon_clear_shadow_pipeline (StIcon *icon);
 
 #define DEFAULT_ICON_SIZE 48
@@ -177,6 +182,46 @@ st_icon_finalize (GObject *gobject)
   G_OBJECT_CLASS (st_icon_parent_class)->finalize (gobject);
 }
 
+/* Copied from st-widget.c */
+static void
+st_icon_allocate (ClutterActor          *actor,
+                    const ClutterActorBox *box,
+                    ClutterAllocationFlags flags)
+{
+  StIcon *self = ST_ICON (actor);
+  StIconPrivate *priv = self->priv;
+  StThemeNode *theme_node = st_widget_get_theme_node (self);
+  ClutterActorBox content_box;
+  float width, height;
+
+  /* Note that we can't just chain up to clutter_actor_real_allocate --
+   * Clutter does some dirty tricks for backwards compatibility.
+   * Clutter also passes the actor's allocation directly to the layout
+   * manager, meaning that we can't modify it for children only.
+   */
+
+  clutter_actor_set_allocation (actor, box, flags);
+
+  st_theme_node_get_content_box (theme_node, box, &content_box);
+
+  clutter_actor_box_get_size (&content_box, &width, &height);
+
+  if (width != priv->width || height != priv->height)
+    {
+      priv->width = width;
+      priv->height = height;
+      priv->size_changed = TRUE;
+      priv->allocation = &content_box;
+    }
+
+  /* If we've chained up to here, we want to allocate the children using the
+   * currently installed layout manager */
+  clutter_layout_manager_allocate (clutter_actor_get_layout_manager (actor),
+                                    CLUTTER_CONTAINER (actor),
+                                    &content_box,
+                                    flags);
+}
+
 static void
 st_icon_paint (ClutterActor *actor)
 {
@@ -187,16 +232,23 @@ st_icon_paint (ClutterActor *actor)
 
   if (priv->icon_texture)
     {
-      st_icon_update_shadow_pipeline (icon);
+      if (priv->shadow_spec && (priv->shadow_pipeline == NULL || priv->size_changed))
+        {
+          priv->size_changed = FALSE;
+          st_icon_clear_shadow_pipeline (icon);
+
+          priv->shadow_pipeline =
+            _st_create_shadow_pipeline_from_actor (priv->shadow_spec,
+                                                  priv->icon_texture);
+
+          if (priv->shadow_pipeline)
+            clutter_size_init (&priv->shadow_size, priv->width, priv->height);
+        }
       if (priv->shadow_pipeline)
         {
-          ClutterActorBox allocation;
-
-          clutter_actor_get_allocation_box (priv->icon_texture, &allocation);
-
           _st_paint_shadow_with_opacity (priv->shadow_spec,
                                          priv->shadow_pipeline,
-                                         &allocation,
+                                         priv->allocation,
                                          clutter_actor_get_paint_opacity (priv->icon_texture));
         }
 
@@ -243,6 +295,7 @@ st_icon_class_init (StIconClass *klass)
   object_class->finalize = st_icon_finalize;
 
   actor_class->paint = st_icon_paint;
+  actor_class->allocate = st_icon_allocate;
 
   widget_class->style_changed = st_icon_style_changed;
 
@@ -279,20 +332,25 @@ static void
 st_icon_init (StIcon *self)
 {
   ClutterLayoutManager *layout_manager;
+  StIconPrivate *priv;
 
-  self->priv = st_icon_get_instance_private (self);
+  self->priv = priv = st_icon_get_instance_private (self);
 
   layout_manager = clutter_bin_layout_new (CLUTTER_BIN_ALIGNMENT_FILL,
                                            CLUTTER_BIN_ALIGNMENT_FILL);
 
   clutter_actor_set_layout_manager (CLUTTER_ACTOR (self), layout_manager);
-  self->priv->icon_size = DEFAULT_ICON_SIZE;
-  self->priv->prop_icon_size = -1;
-  self->priv->icon_type = DEFAULT_ICON_TYPE;
+  priv->icon_size = DEFAULT_ICON_SIZE;
+  priv->prop_icon_size = -1;
+  priv->icon_type = DEFAULT_ICON_TYPE;
 
-  self->priv->shadow_pipeline = NULL;
+  priv->shadow_pipeline = NULL;
 
-  self->priv->icon_scale = 1;
+  priv->icon_scale = 1;
+
+  priv->width = -1;
+  priv->height = -1;
+  priv->size_changed = TRUE;
 }
 
 static void
@@ -302,35 +360,6 @@ st_icon_clear_shadow_pipeline (StIcon *icon)
 
   g_clear_pointer (&priv->shadow_pipeline, cogl_object_unref);
   clutter_size_init (&priv->shadow_size, 0, 0);
-}
-
-static void
-st_icon_update_shadow_pipeline (StIcon *icon)
-{
-  StIconPrivate *priv = icon->priv;
-
-  if (priv->icon_texture && priv->shadow_spec)
-    {
-      ClutterActorBox box;
-      float width, height;
-
-      clutter_actor_get_allocation_box (CLUTTER_ACTOR (icon), &box);
-      clutter_actor_box_get_size (&box, &width, &height);
-
-      if (priv->shadow_pipeline == NULL ||
-          priv->shadow_size.width != width ||
-          priv->shadow_size.height != height)
-        {
-          st_icon_clear_shadow_pipeline (icon);
-
-          priv->shadow_pipeline =
-            _st_create_shadow_pipeline_from_actor (priv->shadow_spec,
-                                                   priv->icon_texture);
-
-          if (priv->shadow_pipeline)
-            clutter_size_init (&priv->shadow_size, width, height);
-        }
-    }
 }
 
 static void

--- a/src/st/st-label.c
+++ b/src/st/st-label.c
@@ -184,9 +184,10 @@ st_label_allocate (ClutterActor          *actor,
       priv->shadow_width = width;
       priv->shadow_height = height;
       priv->size_changed = TRUE;
-
-      clutter_actor_allocate (priv->label, &content_box, flags);
+      priv->allocation = &content_box;
     }
+
+  clutter_actor_allocate (priv->label, &content_box, flags);
 }
 
 static void
@@ -220,12 +221,9 @@ st_label_paint (ClutterActor *actor)
 
       if (priv->text_shadow_pipeline != NULL)
         {
-          ClutterActorBox allocation;
-          clutter_actor_get_allocation_box (priv->label, &allocation);
-
           _st_paint_shadow_with_opacity (shadow_spec,
                                          priv->text_shadow_pipeline,
-                                         &allocation,
+                                         priv->allocation,
                                          clutter_actor_get_paint_opacity (priv->label));
         }
     }

--- a/src/st/st-label.c
+++ b/src/st/st-label.c
@@ -57,8 +57,10 @@ enum
 struct _StLabelPrivate
 {
   ClutterActor *label;
+  ClutterActorBox *allocation;
 
   gboolean orphan;
+  gboolean size_changed;
 
   CoglPipeline  *text_shadow_pipeline;
   float         shadow_width;
@@ -169,12 +171,22 @@ st_label_allocate (ClutterActor          *actor,
   StLabelPrivate *priv = ST_LABEL (actor)->priv;
   StThemeNode *theme_node = st_widget_get_theme_node (ST_WIDGET (actor));
   ClutterActorBox content_box;
+  float width, height;
 
   clutter_actor_set_allocation (actor, box, flags);
 
   st_theme_node_get_content_box (theme_node, box, &content_box);
 
-  clutter_actor_allocate (priv->label, &content_box, flags);
+  clutter_actor_box_get_size (&content_box, &width, &height);
+
+  if (width != priv->shadow_width || height != priv->shadow_height)
+    {
+      priv->shadow_width = width;
+      priv->shadow_height = height;
+      priv->size_changed = TRUE;
+
+      clutter_actor_allocate (priv->label, &content_box, flags);
+    }
 }
 
 static void
@@ -198,29 +210,24 @@ st_label_paint (ClutterActor *actor)
 
   if (shadow_spec)
     {
-      ClutterActorBox allocation;
-      float width, height;
-
-      clutter_actor_get_allocation_box (priv->label, &allocation);
-      clutter_actor_box_get_size (&allocation, &width, &height);
-
-      if (priv->text_shadow_pipeline == NULL ||
-          width != priv->shadow_width ||
-          height != priv->shadow_height)
+      if (priv->text_shadow_pipeline == NULL || priv->size_changed)
         {
+          priv->size_changed = FALSE;
           g_clear_pointer (&priv->text_shadow_pipeline, cogl_object_unref);
 
-          priv->shadow_width = width;
-          priv->shadow_height = height;
           priv->text_shadow_pipeline = _st_create_shadow_pipeline_from_actor (shadow_spec, priv->label);
-
         }
 
       if (priv->text_shadow_pipeline != NULL)
-        _st_paint_shadow_with_opacity (shadow_spec,
-                                       priv->text_shadow_pipeline,
-                                       &allocation,
-                                       clutter_actor_get_paint_opacity (priv->label));
+        {
+          ClutterActorBox allocation;
+          clutter_actor_get_allocation_box (priv->label, &allocation);
+
+          _st_paint_shadow_with_opacity (shadow_spec,
+                                         priv->text_shadow_pipeline,
+                                         &allocation,
+                                         clutter_actor_get_paint_opacity (priv->label));
+        }
     }
 
   clutter_actor_paint (priv->label);
@@ -268,13 +275,15 @@ st_label_init (StLabel *label)
 
   label->priv = priv = st_label_get_instance_private (label);
 
-  label->priv->label = g_object_new (CLUTTER_TYPE_TEXT,
+  priv->label = g_object_new (CLUTTER_TYPE_TEXT,
                                      "ellipsize", PANGO_ELLIPSIZE_END,
                                      NULL);
-  label->priv->text_shadow_pipeline = NULL;
-  label->priv->shadow_width = -1.;
-  label->priv->shadow_height = -1.;
-  label->priv->orphan = FALSE;
+  priv->text_shadow_pipeline = NULL;
+  priv->shadow_width = -1.;
+  priv->shadow_height = -1.;
+  priv->orphan = FALSE;
+  priv->size_changed = TRUE;
+
 
   /* This will ensure our pointer gets cleared the moment the ClutterText becomes invalid */
   g_object_add_weak_pointer (G_OBJECT (label->priv->label), (gpointer) &label->priv->label);


### PR DESCRIPTION
The allocation will only ever change inside the allocation vfunc. Caching some of this can avoid some unnecessary computations and redraws.