### PR TITLE
Cinnamon Settings: Adding capability to open specific tab and choose sort type

### DIFF
--- a/files/usr/bin/cinnamon-settings
+++ b/files/usr/bin/cinnamon-settings
@@ -2,16 +2,83 @@
 
 """ Launch the cinnamon-settings utility, or a specific settings module
 
-Usage:  cinnamon-settings [optional module name]
+Usage:
+    To open System Settings:
+$ cinnamon-settings
+
+    To open the settings of a particular module:
+$ cinnamon-settings module_name
+
+    To open the settings of an applet, a desklet or an extension downloaded by the user:
+$ cinnamon-settings applets|desklets|extensions UUID
+Example:
+$ cinnamon-settings applets SpicesUpdate@claudiux
+
+    To add a xlet on a specific panel:
+$ cinnamon-settings applets|desklets|extensions panel1|panel2|panel3|panel4
+
+    To open a particular tab of the settings of a module, use the '--tab=' or '-t' argument:
+$ cinnamon-settings module_name --tab=x
+or
+$ cinnamon-settings module_name -t x
+(where x is the tab name (e.g. download) or the tab number (e.g. 1))
+Example:
+$ cinnamon-settings applets --tab=download
+
+    To open the 'download' tab of a type of Spices (applets, desklets, extensions, themes), sorting
+    them by 'name', 'score', 'date' or 'installed', use the '--sort=' or '-s' argument:
+$ cinnamon-settings applets|desklets|extensions|themes --tab=1 --sort=name|score|date|installed
+or
+$ cinnamon-settings applets|desklets|extensions|themes -t 1 -s name|score|date|installed
+Example:
+$ cinnamon-settings applets -t 1 -s date
+
+Available modules, their tab names and corresponding numbers:
+    "MODULE_NAME":  {"TAB_NAME": TAB_NUMBER, ... }
+    "accessibility":{"visual": 0, "keyboard": 1, "typing": 2, "mouse": 3},
+    "applets":      {"installed": 0, "more": 1, "download": 1},
+    "backgrounds":  {"images": 0, "settings": 1},
+    "default":      {"preferred": 0, "removable": 1},
+    "desklets":     {"installed": 0, "more": 1, "download": 1, "general": 2},
+    "effects":      {"effects": 0, "customize": 1},
+    "extensions":   {"installed": 0, "more": 1, "download": 1},
+    "keyboard":     {"typing": 0, "shortcuts": 1, "layouts": 2},
+    "mouse":        {"mouse": 0, "touchpad": 1},
+    "power":        {"power": 0, "batteries": 1, "brightness": 2},
+    "screensaver":  {"settings": 0, "customize": 1},
+    "sound":        {"output": 0, "input": 1, "sounds": 2, "applications": 3, "settings": 4},
+    "themes":       {"themes": 0, "download": 1, "options": 2},
+    "windows":      {"titlebar": 0, "behavior": 1, "alttab": 2},
+    "workspaces":   {"osd": 0, "settings": 1}
+
+Available types of sort, and corresponding numbers:
+    "name":0, "score":1, "date":2, "installed":3
 """
 
+import getopt
 import os
 import sys
+
+opts = []
+try:
+    if len(sys.argv) > 2:
+        opts = getopt.getopt(sys.argv[2:], "t:s:", ["tab=", "sort="])[0]
+except getopt.GetoptError:
+    pass
+
+optional_args = False
+for opt, arg in opts:
+    if opt in ("-t", "--tab", "-s", "--sort"):
+        optional_args = True
+        break
 
 if len(sys.argv) > 1:
     module = sys.argv[1]
     if module in ("applets", "desklets", "extensions") and len(sys.argv) > 2 and sys.argv[2][0:5] != "panel":
-        os.execvp("/usr/share/cinnamon/cinnamon-settings/xlet-settings.py", (" ", module[0:-1]) + tuple(sys.argv[2:]))
+        if not optional_args:
+            os.execvp("/usr/share/cinnamon/cinnamon-settings/xlet-settings.py", (" ", module[0:-1]) + tuple(sys.argv[2:]))
+        elif os.path.exists("/usr/share/cinnamon/cinnamon-settings/modules/cs_%s.py" % module):
+            os.execvp("/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py", (" ",) + tuple(sys.argv[1:]))
     elif os.path.exists("/usr/share/cinnamon/cinnamon-settings/modules/cs_%s.py" % module):
         os.execvp("/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py", (" ",) + tuple(sys.argv[1:]))
     elif os.path.exists("/usr/bin/cinnamon-control-center"):

--- a/files/usr/bin/cinnamon-settings
+++ b/files/usr/bin/cinnamon-settings
@@ -59,6 +59,44 @@ import getopt
 import os
 import sys
 
+def usage():
+    print("""Usage:
+cinnamon-settings [MODULE [OPTIONS]] [HELP_OPTION]
+
+Help option (HELP_OPTION):
+    -h, --help              Displays help message (e.g. this message).
+
+Module options:
+    -t, --tab               Opens the specified tab (see list in manpage) of
+                            module settings.
+
+    -s, --sort              xlets modules option.
+                            xlets are 'applets', 'desklets', 'extensions'
+                            and 'themes'.
+                            Sorts the xlets by:
+                                'name' or 0
+                                'score' or 1 (by default)
+                                'date' or 2
+                                'installed' or 3
+Example:
+    $ cinnamon-settings applets -t download -s date
+
+For complete description and examples, see the manpage: cinnamon-settings(1)
+    """)
+    exit(2)
+
+opts = []
+try:
+    if len(sys.argv) > 1:
+        opts = getopt.getopt(sys.argv[1:], "h", ["help"])[0]
+except getopt.GetoptError:
+    pass
+
+for opt, arg in opts:
+    if opt in ("-h", "--help"):
+        usage()
+        break
+
 opts = []
 try:
     if len(sys.argv) > 2:

--- a/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
@@ -93,6 +93,25 @@ STANDALONE_MODULES = [
     [_("Manage Services and Units"),     "systemd-manager-pkexec",              "cs-sources",         "admin",          _("systemd, units, services, systemctl, init")]
 ]
 
+TABS = {
+    # KEY (cs_KEY.py): {"tab_name": tab_number, ... }
+    "accessibility":{"visual": 0, "keyboard": 1, "typing": 2, "mouse": 3},
+    "applets":      {"installed": 0, "more": 1},
+    "backgrounds":  {"images": 0, "settings": 1},
+    "default":      {"preferred": 0, "removable": 1},
+    "desklets":     {"installed": 0, "more": 1, "general": 2},
+    "effects":      {"effects": 0, "customize": 1},
+    "extensions":   {"installed": 0, "more": 1},
+    "keyboard":     {"typing": 0, "shortcuts": 1, "layouts": 2},
+    "mouse":        {"mouse": 0, "touchpad": 1},
+    "power":        {"power": 0, "batteries": 1, "brightness": 2},
+    "screensaver":  {"settings": 0, "customize": 1},
+    "sound":        {"output": 0, "input": 1, "sounds": 2, "applications": 3, "settings": 4},
+    "themes":       {"themes": 0, "download": 1, "options": 2},
+    "windows":      {"titlebar": 0, "behavior": 1, "alttab": 2},
+    "workspaces":   {"osd": 0, "settings": 1}
+}
+
 def print_timing(func):
     # decorate functions with @print_timing to output how long they take to run.
     def wrapper(*arg):
@@ -343,43 +362,16 @@ class MainWindow:
             opts = []
             sorts_literal = {"name":0, "score":1, "date":2, "installed":3}
             arg1 = sys.argv[1]
-            if arg1 == "accessibility":
-                tabs_literal = {"visual": 0, "keyboard": 1, "typing": 2, "mouse": 3}
-            elif arg1 == "applets":
-                tabs_literal = {"installed": 0, "more": 1}
-            elif arg1 == "backgrounds":
-                tabs_literal = {"images": 0, "settings": 1}
-            elif arg1 == "default":
-                tabs_literal = {"preferred": 0, "removable": 1}
-            elif arg1 == "desklets":
-                tabs_literal = {"installed": 0, "more": 1, "general": 2}
-            elif arg1 == "effects":
-                tabs_literal = {"effects": 0, "customize": 1}
-            elif arg1 == "extensions":
-                tabs_literal = {"installed": 0, "more": 1}
-            elif arg1 == "keyboard":
-                tabs_literal = {"typing": 0, "shortcuts": 1, "layouts": 2}
-            elif arg1 == "mouse":
-                tabs_literal = {"mouse": 0, "touchpad": 1}
-            elif arg1 == "power":
-                tabs_literal = {"power": 0, "batteries": 1, "brightness": 2}
-            elif arg1 == "screensaver":
-                tabs_literal = {"settings": 0, "customize": 1}
-            elif arg1 == "sound":
-                tabs_literal = {"output": 0, "input": 1, "sounds": 2, "applications": 3,
-                                "settings": 4}
-            elif arg1 == "themes":
-                tabs_literal = {"themes": 0, "download": 1, "options": 2}
-            elif arg1 == "windows":
-                tabs_literal = {"titlebar": 0, "behavior": 1, "alttab": 2}
-            elif arg1 == "workspaces":
-                tabs_literal = {"osd": 0, "settings": 1}
+            tabs_literal = {"default":0}
+            if arg1 in TABS.keys():
+                tabs_literal = TABS[arg1]
 
             try:
                 if len(sys.argv) > 2:
                     opts = getopt.getopt(sys.argv[2:], "t:s:", ["tab=", "sort="])[0]
             except getopt.GetoptError:
                 pass
+
             for opt, arg in opts:
                 if opt in ("-t", "--tab"):
                     if arg.isdecimal():

--- a/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
@@ -94,34 +94,35 @@ STANDALONE_MODULES = [
 ]
 
 TABS = {
-    # KEY (cs_KEY.py): {"tab_name": tab_number, ... }
-    "universal-access":{"visual": 0, "keyboard": 1, "typing": 2, "mouse": 3},
-    "applets":      {"installed": 0, "more": 1, "download": 1},
-    "backgrounds":  {"images": 0, "settings": 1},
-    "default":      {"preferred": 0, "removable": 1},
-    "desklets":     {"installed": 0, "more": 1, "download": 1, "general": 2},
-    "effects":      {"effects": 0, "customize": 1},
-    "extensions":   {"installed": 0, "more": 1, "download": 1},
-    "keyboard":     {"typing": 0, "shortcuts": 1, "layouts": 2},
-    "mouse":        {"mouse": 0, "touchpad": 1},
-    "power":        {"power": 0, "batteries": 1, "brightness": 2},
-    "screensaver":  {"settings": 0, "customize": 1},
-    "sound":        {"output": 0, "input": 1, "sounds": 2, "applications": 3, "settings": 4},
-    "themes":       {"themes": 0, "download": 1, "options": 2},
-    "windows":      {"titlebar": 0, "behavior": 1, "alttab": 2},
-    "workspaces":   {"osd": 0, "settings": 1}
+    # KEY (cs_KEY.py) : {"tab_name": tab_number, ... }
+    "universal-access": {"visual": 0, "keyboard": 1, "typing": 2, "mouse": 3},
+    "applets":          {"installed": 0, "more": 1, "download": 1},
+    "backgrounds":      {"images": 0, "settings": 1},
+    "default":          {"preferred": 0, "removable": 1},
+    "desklets":         {"installed": 0, "more": 1, "download": 1, "general": 2},
+    "effects":          {"effects": 0, "customize": 1},
+    "extensions":       {"installed": 0, "more": 1, "download": 1},
+    "keyboard":         {"typing": 0, "shortcuts": 1, "layouts": 2},
+    "mouse":            {"mouse": 0, "touchpad": 1},
+    "power":            {"power": 0, "batteries": 1, "brightness": 2},
+    "screensaver":      {"settings": 0, "customize": 1},
+    "sound":            {"output": 0, "input": 1, "sounds": 2, "applications": 3, "settings": 4},
+    "themes":           {"themes": 0, "download": 1, "options": 2},
+    "windows":          {"titlebar": 0, "behavior": 1, "alttab": 2},
+    "workspaces":       {"osd": 0, "settings": 1}
 }
 
 ARG_REWRITE = {
     'accessibility':    'universal-access',
     'screen':           'display',
+    'screens':          'display',
     'bluetooth':        'blueberry',
     'hotcorners':       'hotcorner',
     'accounts':         'online-accounts',
     'colors':           'color',
     'me':               'user',
     'lightdm-settings': 'pkexec lightdm-settings',
-    'login-screen':      'pkexec lightdm-settings',
+    'login-screen':     'pkexec lightdm-settings',
     'window':           'windows',
     'background':       'backgrounds',
     'driver-manager':   'pkexec driver-manager',

--- a/man/cinnamon-settings.1
+++ b/man/cinnamon-settings.1
@@ -1,12 +1,202 @@
-.TH CINNAMON-SETTINGS 1 2012-07-23  Cinnamon "cinnamon manual"
+.TH CINNAMON-SETTINGS 1 2019-02-10  Cinnamon "cinnamon manual"
 .SH NAME
 cinnamon-settings \- Configuration panel for cinnamon
 .SH SYNOPSIS
-.SY cinnamon-settings
+.B cinnamon-settings [-h]
+.br
+\fBcinnamon-settings\fP MODULE [\fB-t\fP TAB]
+.br
+\fBcinnamon-settings\fP \fBapplets\fP PANEL
+.br
+\fBcinnamon-settings\fP \fBapplets\fP|\fBdesklets\fP|\fBextensions\fP [UUID [\fB-i\fP INSTANCE]] [\fB-t\fP TAB_INDEX]
+.br
+\fBcinnamon-settings\fP \fBapplets\fP|\fBdesklets\fP|\fBextensions\fP UUID INSTANCE
+.br
+\fBcinnamon-settings\fP \fBapplets\fP|\fBdesklets\fP|\fBextensions\fP|\fBthemes\fP [\fB-t\fP TAB]
+.br
+\fBcinnamon-settings\fP \fBapplets\fP|\fBdesklets\fP|\fBextensions\fP|\fBthemes -t download\fP [\fB-s\fP SORT]
 .SH DESCRIPTION
 .LP
-\fBcinnamon-settings\fP runs the graphical user interface allowing to
-configure cinnamon
+\fBcinnamon-settings\fP runs the graphical user interface allowing to configure Cinnamon.
+
+It can also be used to run the graphical user interface allowing to configure a specific module, add applets to a panel, and manage \fIxlets\fP.
+.SH MODULE
+Specifying a module allows to configure it directly.
+.br
+The following modules are available. You can use name or synonym.
+.br
+The modules with \fB*\fP have a configuration interface with tabs. Each tab can be directly opened (see TAB section below).
+.br
+The modules with \fB**\fP need root rights to open their configuration interface. So the only tab that will always be open is the first one.
+
+    \fBNAME                      SYNONYMS\fP
+    applets\fB*\fP
+    backgrounds\fB*\fP              background
+    blueberry                 bluetooth
+    calendar
+    cinnamon-settings-users** users
+    color                     colors
+    default\fB*\fP
+    desklets\fB*\fP
+    desktop
+    display                   screen, screens
+    driver-manager\fB**\fP          drivers
+    effects\fB*\fP
+    extensions\fB*\fP
+    fonts
+    general
+    gufw**                    firewall
+    hotcorner                 hotcorners
+    info                      infos
+    keyboard\fB*\fP
+    lightdm-settings\fB**\fP        login-screen
+    mintlocale                language, locale
+    mintlocale-im             input-method
+    mintsources\fB**\fP             sources
+    mouse\fB*\fP
+    network                   networks
+    notifications
+    nvidia-settings           nvidia
+    online-accounts           accounts
+    panel                     panels
+    power\fB*\fP
+    privacy
+    screensaver\fB*\fP
+    sound\fB*\fP
+    startup
+    system-config-printer     printer, printers
+    themes\fB*\fP
+    tiling
+    universal-access\fB*\fP         accessibility
+    user                      me
+    wacom                     tablet
+    windows\fB*\fP                  window
+    workspaces\fB*\fP
+
+.SH "TAB and TAB_INDEX"
+Here the modules whose configuration interface contains tabs. Specifying its name or index by the \fB-t\fP option allows to open directly this tab in the configuration interface.
+.br
+
+    \fBNAME\fP              \fBTAB_NAME: TAB_INDEX, ...\fP
+    universal-access  visual: 0, keyboard: 1, typing: 2, mouse: 3
+    applets           installed: 0, more: 1, download: 1
+    backgrounds       images: 0, settings: 1
+    default           preferred: 0, removable: 1
+    desklets          installed: 0, more: 1, download: 1, general: 2
+    effects           effects: 0, customize: 1,
+    extensions        installed: 0, more: 1, download: 1
+    keyboard          typing: 0, shortcuts: 1, layouts: 2
+    mouse             mouse: 0, touchpad: 1,
+    power             power: 0, batteries: 1, brightness: 2
+    screensaver       settings: 0, customize: 1
+    sound             output: 0, input: 1, sounds: 2,
+                      applications: 3, settings: 4
+    themes            themes: 0, download: 1, options: 2
+    windows           titlebar: 0, behavior: 1, alttab: 2
+    workspaces        osd: 0, settings: 1
+
+.SH PANEL
+PANEL is the panel on which the user want install some \fBapplets\fP.
+User desktop can have up to four panels.
+.br
+\fBpanel1\fP is the first panel (panel by default).
+.br
+\fBpanel2\fP, \fBpanel3\fP and \fBpanel4\fP exist only if the user has created them.
+
+.SH "UUID and INSTANCE"
+The applets, desklets, extensions and themes are the \fIxlets\fP.
+.br
+
+Each xlet has an UUID (Universal Unique IDentifier). The structure of an UUID is xlet_name@author, except for themes.
+.br
+
+There are two kinds of xlets: System and Spices.
+.br
+
+System xlets are in \fB/usr/share/cinnamon/applets/\fP, \fB/usr/share/cinnamon/desklets/\fP and \fB/usr/share/themes/\fP; their UUID ends with '@cinnamon.org' except for themes. There is no system extension.
+.br
+
+Spices are xlets offered by developers to the Cinnamon team, which evaluates and validates them. Complete description of these Spices can be found at https://cinnamon-spices.linuxmint.com/.
+.br
+The Spices installed by user are in \fB~/.local/share/cinnamon\fP (for applets, desklets and extensions) and in \fB~/.themes\fP.
+
+INSTANCE argument is reserved to developers. When an applet or desklet has multiple instances, the configuration interface of each of them can be directly opened by this INSTANCE argument. Users have neither the possibility nor the need to know the value of INSTANCE.
+
+.SH SORT
+.TP
+Possible choices are:
+.br
+ - \fBname\fP or \fB0\fP
+.br
+ - \fBscore\fP or \fB1\fP (default value)
+.br
+ - \fBdate\fP or \fB2\fP
+.br
+ - \fBinstalled\fP or \fB3\fP
+
+.SH OPTIONS
+The following options are supported:
+.TP
+\fB-h\fP, \fB--help\fP
+Print a help text describing the supported command-line options, and then exit.
+.TP
+\fB-s\fP SORT, \fB--sort=\fPSORT
+Specific to the 'download' tab (see below) for \fBapplets\fP, \fBdesklets\fP, \fBextensions\fP and \fBthemes\fP modules.
+.TP
+\fB-t\fP TAB, \fB--tab=\fPTAB
+Select the tab to open in the settings. Possible choices are:
+ - A number from 0 to \fIn\fP-1, where \fIn\fP is the number of available tabs.
+ - The name of the tab (see list below).
+
+.SH EXAMPLES
+.TP
+To open System Settings:
+$ \fBcinnamon-settings\fP
+
+.TP
+To open the printer settings:
+.br
+$ \fBcinnamon-settings printers\fP
+
+.TP
+To open the settings of an installed applet, desklet or extension:
+$ \fBcinnamon-settings\fP TYPE UUID
+.br
+Examples:
+.br
+$ \fBcinnamon-settings applets SpicesUpdate@claudiux\fP
+.br
+$ \fBcinnamon-settings desklets photoframe@cinnamon.org\fP
+.br
+$ \fBcinnamon-settings extensions watermark@germanfr\fP
+.TP
+To add some applets on the second panel (if exists):
+$ \fBcinnamon-settings applets panel2\fP
+.TP
+To open the download tab of the applets settings:
+$ \fBcinnamon-settings applets --tab=download\fP
+.br
+or
+.br
+$ \fBcinnamon-settings applets -t 1\fP
+
+.TP
+To open the download tab of a type of Spices (applets, desklets, extensions, themes), sorting them by 'name', 'score', 'date' or 'installed', use the '--sort=' or '-s' argument:
+.br
+$ \fBcinnamon-settings TYPE --tab=download --sort=SORT\fP
+.br
+or
+.br
+$ \fBcinnamon-settings TYPE -t 1 -s SORT\fP
+.br
+where TYPE can be \fBapplets\fP, \fBdesklets\fP, \fBextensions\fP or \fBthemes\fP
+.br
+and SORT can be \fBname\fP (or \fB0\fP), \fBscore\fP (or \fB1\fP), \fBdate\fP (or \fB2\fP), \fBinstalled\fP (or \fB3\fP)
+
+Example:
+.br
+$ \fBcinnamon-settings applets -t 1 -s date\fP
+
 .SH "SEE ALSO"
 .BR cinnamon-menu-editor (1)
 

--- a/man/cinnamon-settings.1
+++ b/man/cinnamon-settings.1
@@ -200,3 +200,5 @@ $ \fBcinnamon-settings applets -t 1 -s date\fP
 .SH "SEE ALSO"
 .BR cinnamon-menu-editor (1)
 
+.SH "CONTRIBUTORS"
+Nicolas Bourdaud (nbourdau) and Claude Clerc (claudiux).


### PR DESCRIPTION
Usage:
`/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py applets 1 2`
opens the Applets window of Cinnamon Settings directly on Download tab (tab 1) with list of applets sorted by date (sort type 2).

The _applets_ word can be replaced by _desklets_, _extensions_ or _themes_.

The first number corresponds to the tab to open (tab 0 by default); the second number corresponds to the type of sorting:

- 0: sorting by name;
- 1: sorting by popularity;
- 2: sorting by date;
- 3: installed first.

This PR was requested by @jaszhix in https://github.com/linuxmint/cinnamon-spices-applets/pull/2235#issuecomment-456601075.

These changes do not affect all other settings.

Best regards.
Claudiux