### PR TITLE
appsys: Adjust for performance

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -57,21 +57,6 @@ fi
 
 AM_CONDITIONAL(BUILD_RECORDER, $build_recorder)
 
-AC_ARG_ENABLE([systemd],
-              AS_HELP_STRING([--enable-systemd], [Use systemd]),
-              [enable_systemd=$enableval],
-              [enable_systemd=auto])
-AS_IF([test x$enable_systemd != xno], [
-  AC_MSG_CHECKING([for libsystemd-journal])
-  PKG_CHECK_EXISTS([libsystemd-journal],
-                   [have_systemd=yes
-                    AC_DEFINE([HAVE_SYSTEMD], [1], [Define if we have systemd])],
-                   [have_systemd=no])
-  AC_MSG_RESULT($have_systemd)
-])
-
-AC_MSG_RESULT($enable_systemd)
-
 CLUTTER_MIN_VERSION=0
 GOBJECT_INTROSPECTION_MIN_VERSION=0.9.2
 GJS_MIN_VERSION=3.2.0
@@ -97,10 +82,6 @@ SHARED_PCS="gio-2.0 >= $GIO_MIN_VERSION
              gobject-introspection-1.0 >= $GOBJECT_INTROSPECTION_MIN_VERSION
              polkit-agent-1 >= $POLKIT_MIN_VERSION xfixes
              libnm atk-bridge-2.0"
-
-if test x$have_systemd = xyes; then
-  SHARED_PCS="${SHARED_PCS} libsystemd-journal"
-fi
 
 PKG_CHECK_MODULES(CINNAMON, $SHARED_PCS)
 

--- a/configure.ac
+++ b/configure.ac
@@ -72,7 +72,7 @@ SHARED_PCS="gio-2.0 >= $GIO_MIN_VERSION
              gtk+-3.0 >= $GTK_MIN_VERSION
              libmuffin >= $MUFFIN_MIN_VERSION
              cjs-1.0 >= $GJS_MIN_VERSION
-             $recorder_modules
+             libcinnamon-menu-3.0 $recorder_modules
              gdk-x11-3.0 libsoup-2.4 gl
              muffin-cogl-pango-0
              muffin-cogl-path-0

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -2367,8 +2367,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         this.categoriesBox.add_actor(this._allAppsCategoryButton.actor);
         this._categoryButtons.push(this._allAppsCategoryButton);
 
-        let tree = new CMenu.Tree({ menu_basename: "cinnamon-applications.menu" });
-        tree.load_sync();
+        let tree = appsys.get_tree();
         let root = tree.get_root_directory();
         let dirs = [];
         let iter = root.iter();

--- a/src/cinnamon-app-system.h
+++ b/src/cinnamon-app-system.h
@@ -5,6 +5,9 @@
 #include <gio/gio.h>
 #include <clutter/clutter.h>
 #include <meta/window.h>
+// TODO: Remove this silly check from cmenu
+#define GMENU_I_KNOW_THIS_IS_UNSTABLE
+#include <gmenu-tree.h>
 
 #include "cinnamon-app.h"
 
@@ -30,5 +33,7 @@ GSList         *cinnamon_app_system_get_all                   (CinnamonAppSystem
 GSList         *cinnamon_app_system_get_running               (CinnamonAppSystem  *self);
 
 char         ***cinnamom_app_system_search                    (const char *search_string);
+
+GMenuTree * cinnamon_app_system_get_tree (CinnamonAppSystem *self);
 
 #endif /* __CINNAMON_APP_SYSTEM_H__ */

--- a/src/cinnamon-app.c
+++ b/src/cinnamon-app.c
@@ -516,7 +516,7 @@ cinnamon_app_activate_window (CinnamonApp     *app,
         window = most_recent_transient;
 
 
-      if (!cinnamon_window_tracker_is_window_interesting (cinnamon_window_tracker_get_default (), window))
+      if (!meta_window_is_interesting (window))
         {
           /* We won't get notify::user-time signals for uninteresting windows,
            * which means that an app's last_user_time won't get updated.
@@ -1085,9 +1085,6 @@ cinnamon_app_request_quit (CinnamonApp   *app)
   for (iter = app->running_state->windows; iter; iter = iter->next)
     {
       MetaWindow *win = iter->data;
-
-      if (!meta_window_is_interesting (win))
-        continue;
 
       meta_window_delete (win, cinnamon_global_get_current_time (global));
     }

--- a/src/cinnamon-app.c
+++ b/src/cinnamon-app.c
@@ -946,7 +946,7 @@ _cinnamon_app_add_window (CinnamonApp        *app,
   app->running_state->window_sort_stale = TRUE;
   app->running_state->windows = g_slist_prepend (app->running_state->windows, g_object_ref (window));
   g_signal_connect (window, "unmanaged", G_CALLBACK(cinnamon_app_on_unmanaged), app);
-  g_signal_connect (window, "notify::user-time", G_CALLBACK(cinnamon_app_on_user_time_changed), app);
+  g_signal_connect_after (window, "notify::user-time", G_CALLBACK(cinnamon_app_on_user_time_changed), app);
 
   user_time = meta_window_get_user_time (window);
   if (user_time > app->running_state->last_user_time)

--- a/src/cinnamon-app.c
+++ b/src/cinnamon-app.c
@@ -1083,7 +1083,7 @@ cinnamon_app_request_quit (CinnamonApp   *app)
     {
       MetaWindow *win = iter->data;
 
-      if (!cinnamon_window_tracker_is_window_interesting (cinnamon_window_tracker_get_default (), win))
+      if (!meta_window_is_interesting (win))
         continue;
 
       meta_window_delete (win, cinnamon_global_get_current_time (global));

--- a/src/cinnamon-app.c
+++ b/src/cinnamon-app.c
@@ -16,12 +16,6 @@
 #include "cinnamon-window-tracker-private.h"
 #include "st.h"
 
-#ifdef HAVE_SYSTEMD
-#include <systemd/sd-journal.h>
-#include <errno.h>
-#include <unistd.h>
-#endif
-
 typedef enum {
   MATCH_NONE,
   MATCH_SUBSTRING, /* Not prefix, substring */
@@ -1068,29 +1062,6 @@ cinnamon_app_request_quit (CinnamonApp   *app)
   return TRUE;
 }
 
-#if !defined(HAVE_GIO_DESKTOP_LAUNCH_URIS_WITH_FDS) && defined(HAVE_SYSTEMD)
-/* This sets up the launched application to log to the journal
- * using its own identifier, instead of just "cinnamon-session".
- */
-static void
-app_child_setup (gpointer user_data)
-{
-  const char *appid = user_data;
-  int res;
-  int journalfd = sd_journal_stream_fd (appid, LOG_INFO, FALSE);
-  if (journalfd >= 0)
-    {
-      do
-        res = dup2 (journalfd, 1);
-      while (G_UNLIKELY (res == -1 && errno == EINTR));
-      do
-        res = dup2 (journalfd, 2);
-      while (G_UNLIKELY (res == -1 && errno == EINTR));
-      (void) close (journalfd);
-    }
-}
-#endif
-
 static void
 wait_pid (GDesktopAppInfo *appinfo,
           GPid             pid,
@@ -1141,40 +1112,12 @@ cinnamon_app_launch (CinnamonApp     *app,
   flags = G_SPAWN_SEARCH_PATH | G_SPAWN_DO_NOT_REAP_CHILD |
           G_SPAWN_LEAVE_DESCRIPTORS_OPEN;
 
-#ifdef HAVE_GIO_DESKTOP_LAUNCH_URIS_WITH_FDS
-  /* Optimized spawn path, avoiding a child_setup function */
-  {
-    int journalfd = -1;
-
-#ifdef HAVE_SYSTEMD
-    journalfd = sd_journal_stream_fd (cinnamon_app_get_id (app), LOG_INFO, FALSE);
-#endif /* HAVE_SYSTEMD */
-
-    ret = g_desktop_app_info_launch_uris_as_manager_with_fds (app->info, NULL,
-                                                              context,
-                                                              flags,
-                                                              NULL, NULL,
-                                                              wait_pid, NULL,
-                                                              -1,
-                                                              journalfd,
-                                                              journalfd,
-                                                              error);
-
-    if (journalfd >= 0)
-      (void) close (journalfd);
-  }
-#else /* !HAVE_GIO_DESKTOP_LAUNCH_URIS_WITH_FDS */
   ret = g_desktop_app_info_launch_uris_as_manager (app->info, NULL,
                                                    context,
                                                    flags,
-#ifdef HAVE_SYSTEMD
-                                                   app_child_setup, (gpointer)cinnamon_app_get_id (app),
-#else
                                                    NULL, NULL,
-#endif
                                                    wait_pid, NULL,
                                                    error);
-#endif /* HAVE_GIO_DESKTOP_LAUNCH_URIS_WITH_FDS */
   g_object_unref (context);
 
   return ret;

--- a/src/cinnamon-app.c
+++ b/src/cinnamon-app.c
@@ -36,6 +36,9 @@ typedef enum {
 typedef struct {
   guint refcount;
 
+  /* Last time the user interacted with any of this application's windows */
+  guint32 last_user_time;
+
   /* Signal connection to dirty window sort list on workspace changes */
   guint workspace_switch_id;
 
@@ -512,6 +515,16 @@ cinnamon_app_activate_window (CinnamonApp     *app,
                                                   meta_window_get_user_time (most_recent_transient)))
         window = most_recent_transient;
 
+
+      if (!cinnamon_window_tracker_is_window_interesting (cinnamon_window_tracker_get_default (), window))
+        {
+          /* We won't get notify::user-time signals for uninteresting windows,
+           * which means that an app's last_user_time won't get updated.
+           * Update it here instead.
+           */
+          app->running_state->last_user_time = timestamp;
+        }
+
       if (active != workspace)
         meta_workspace_activate_with_focus (workspace, window, timestamp);
       else
@@ -772,23 +785,6 @@ cinnamon_app_is_on_workspace (CinnamonApp *app,
   return FALSE;
 }
 
-static int
-cinnamon_app_get_last_user_time (CinnamonApp *app)
-{
-  GSList *iter;
-  guint32 last_user_time;
-
-  last_user_time = 0;
-
-  if (app->running_state != NULL)
-    {
-      for (iter = app->running_state->windows; iter; iter = iter->next)
-        last_user_time = MAX (last_user_time, meta_window_get_user_time (iter->data));
-    }
-
-  return (int)last_user_time;
-}
-
 static gboolean
 cinnamon_app_is_minimized (CinnamonApp *app)
 {
@@ -849,8 +845,7 @@ cinnamon_app_compare (CinnamonApp *app,
         return -1;
       else if (!app->running_state->windows && other->running_state->windows)
         return 1;
-
-      return cinnamon_app_get_last_user_time (other) - cinnamon_app_get_last_user_time (app);
+      return other->running_state->last_user_time - app->running_state->last_user_time;
     }
 
   return 0;
@@ -922,6 +917,8 @@ cinnamon_app_on_user_time_changed (MetaWindow *window,
 {
   g_assert (app->running_state != NULL);
 
+  app->running_state->last_user_time = meta_window_get_user_time (window);
+
   /* Ideally we don't want to emit windows-changed if the sort order
    * isn't actually changing. This check catches most of those.
    */
@@ -952,6 +949,8 @@ void
 _cinnamon_app_add_window (CinnamonApp        *app,
                        MetaWindow      *window)
 {
+  guint32 user_time;
+
   if (app->running_state && g_slist_find (app->running_state->windows, window))
     return;
 
@@ -964,6 +963,10 @@ _cinnamon_app_add_window (CinnamonApp        *app,
   app->running_state->windows = g_slist_prepend (app->running_state->windows, g_object_ref (window));
   g_signal_connect (window, "unmanaged", G_CALLBACK(cinnamon_app_on_unmanaged), app);
   g_signal_connect (window, "notify::user-time", G_CALLBACK(cinnamon_app_on_user_time_changed), app);
+
+  user_time = meta_window_get_user_time (window);
+  if (user_time > app->running_state->last_user_time)
+    app->running_state->last_user_time = user_time;
 
   if (app->state != CINNAMON_APP_STATE_STARTING)
     cinnamon_app_state_transition (app, CINNAMON_APP_STATE_RUNNING);

--- a/src/cinnamon-app.h
+++ b/src/cinnamon-app.h
@@ -72,9 +72,6 @@ int cinnamon_app_compare_by_name (CinnamonApp *app, CinnamonApp *other);
 
 int cinnamon_app_compare (CinnamonApp *app, CinnamonApp *other);
 
-void cinnamon_app_update_window_actions (CinnamonApp *app, MetaWindow *window);
-void cinnamon_app_update_app_menu       (CinnamonApp *app, MetaWindow *window);
-
 gboolean cinnamon_app_get_busy          (CinnamonApp *app);
 
 G_END_DECLS

--- a/src/cinnamon-window-tracker.c
+++ b/src/cinnamon-window-tracker.c
@@ -143,40 +143,7 @@ cinnamon_window_tracker_class_init (CinnamonWindowTrackerClass *klass)
 gboolean
 cinnamon_window_tracker_is_window_interesting (CinnamonWindowTracker *tracker, MetaWindow *window)
 {
-  if (meta_window_is_override_redirect (window)
-      || meta_window_is_skip_taskbar (window))
-    return FALSE;
-
-  switch (meta_window_get_window_type (window))
-    {
-      /* Definitely ignore these. */
-      case META_WINDOW_DESKTOP:
-      case META_WINDOW_DOCK:
-      case META_WINDOW_SPLASHSCREEN:
-      /* Should have already been handled by override_redirect above,
-       * but explicitly list here so we get the "unhandled enum"
-       * warning if in the future anything is added.*/
-      case META_WINDOW_DROPDOWN_MENU:
-      case META_WINDOW_POPUP_MENU:
-      case META_WINDOW_TOOLTIP:
-      case META_WINDOW_NOTIFICATION:
-      case META_WINDOW_COMBO:
-      case META_WINDOW_DND:
-      case META_WINDOW_OVERRIDE_OTHER:
-        return FALSE;
-      case META_WINDOW_NORMAL:
-      case META_WINDOW_DIALOG:
-      case META_WINDOW_MODAL_DIALOG:
-      case META_WINDOW_MENU:
-      case META_WINDOW_TOOLBAR:
-      case META_WINDOW_UTILITY:
-        break;
-      default:
-        g_warning("cinnamon_window_tracker_is_window_interesting: default reached");
-      break;
-    }
-
-  return TRUE;
+  return meta_window_is_interesting (window);
 }
 
 /**
@@ -506,6 +473,9 @@ static void
 track_window (CinnamonWindowTracker *self,
               MetaWindow      *window)
 {
+  if (!meta_window_is_interesting (window))
+    return;
+
   CinnamonApp *app;
 
   app = get_app_for_window (self, window);
@@ -537,6 +507,9 @@ static void
 disassociate_window (CinnamonWindowTracker   *self,
                      MetaWindow        *window)
 {
+  if (!meta_window_is_interesting (window))
+    return;
+
   CinnamonApp *app;
 
   app = g_hash_table_lookup (self->window_to_app, window);

--- a/src/cinnamon-window-tracker.c
+++ b/src/cinnamon-window-tracker.c
@@ -468,11 +468,6 @@ update_focus_app (CinnamonWindowTracker *self)
   new_focus_win = meta_display_get_focus_window (cinnamon_global_get_display (cinnamon_global_get ()));
   new_focus_app = new_focus_win ? cinnamon_window_tracker_get_window_app (self, new_focus_win) : NULL;
 
-  if (new_focus_app) {
-    cinnamon_app_update_window_actions (new_focus_app, new_focus_win);
-    cinnamon_app_update_app_menu (new_focus_app, new_focus_win);
-  }
-
   set_focus_app (self, new_focus_app);
   g_clear_object (&new_focus_app);
 }
@@ -716,7 +711,7 @@ cinnamon_window_tracker_get_window_app (CinnamonWindowTracker *tracker,
  * Returns: (transfer none): A #CinnamonApp, or %NULL if none
  */
 CinnamonApp *
-cinnamon_window_tracker_get_app_from_pid (CinnamonWindowTracker *self, 
+cinnamon_window_tracker_get_app_from_pid (CinnamonWindowTracker *self,
                                        int                 pid)
 {
   GSList *running = cinnamon_app_system_get_running (cinnamon_app_system_get_default());


### PR DESCRIPTION
After f8fadd5be74196e3197323124b8eca657d9770c6, I've been noticing increased lag on my relatively high-res display setup. This is an attempt to regain some of the performance lost. Synthetic tests do slightly hint towards there being less performance with the new app system changes. After discussions on slack, I seem to be the only one, but haven't heard from anyone who also is using multiple high-resolution displays (2K+), so if anyone is able to test this along with the muffin patch it would be appreciated.

One other thing of note with my computer is it has low clocks at 2GHz, and I think this makes CPU usage on cinnamon, being a single threaded application, more noticeable.

**Requires** https://github.com/linuxmint/muffin/pull/418