### PR TITLE
General optimizations

### DIFF
--- a/js/ui/deskletManager.js
+++ b/js/ui/deskletManager.js
@@ -77,7 +77,7 @@ function init(){
         global.settings.connect('changed::' + DESKLET_SNAP_INTERVAL_KEY, _onDeskletSnapChanged);
 
         deskletsLoaded = true;
-        enableMouseTracking(true);
+        updateMouseTracking();
         global.log(`DeskletManager started in ${new Date().getTime() - startTime} ms`);
     });
 }
@@ -86,7 +86,8 @@ function getDeskletDefinition(definition) {
     return queryCollection(definitions, definition);
 }
 
-function enableMouseTracking(enable) {
+function updateMouseTracking() {
+    let enable = definitions.length > 0;
     if (enable && !mouseTrackTimoutId) {
         mouseTrackTimoutId = Mainloop.timeout_add(500, checkMouseTracking);
     } else if (!enable && mouseTrackTimoutId) {
@@ -252,7 +253,7 @@ function _onEnabledDeskletsChanged() {
 
     // Make sure all desklet extensions are loaded.
     // Once loaded, the desklets will add themselves via finishExtensionLoad
-    initEnabledDesklets();
+    initEnabledDesklets().then(updateMouseTracking);
 }
 
 function _unloadDesklet(deskletDefinition, deleteConfig) {

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -694,6 +694,10 @@ Chrome.prototype = {
     },
 
     _windowsRestacked: function() {
+        // Figure out where the pointer is in case we lost track of
+        // it during a grab.
+        global.sync_pointer();
+
         let isPopupWindowVisible = global.top_window_group.get_children().some(isPopupMetaWindow);
         let popupVisibilityChanged = this._isPopupWindowVisible !== isPopupWindowVisible;
         this._isPopupWindowVisible = isPopupWindowVisible;

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -694,7 +694,10 @@ Chrome.prototype = {
     },
 
     _windowsRestacked: function() {
-        if (this._isPopupWindowVisible != global.top_window_group.get_children().some(isPopupMetaWindow))
+        let isPopupWindowVisible = global.top_window_group.get_children().some(isPopupMetaWindow);
+        let popupVisibilityChanged = this._isPopupWindowVisible !== isPopupWindowVisible;
+        this._isPopupWindowVisible = isPopupWindowVisible;
+        if (popupVisibilityChanged)
             this._updateVisibility();
         else
             this._queueUpdateRegions();
@@ -708,8 +711,7 @@ Chrome.prototype = {
             this._updateRegionIdle = 0;
         }
 
-        let isPopupMenuVisible = global.top_window_group.get_children().some(isPopupMetaWindow);
-        let wantsInputRegion = !isPopupMenuVisible;
+        let wantsInputRegion = !this._isPopupMenuVisible;
 
         for (let i = 0; i < this._trackedActors.length; i++) {
             let actorData = this._trackedActors[i];
@@ -803,7 +805,6 @@ Chrome.prototype = {
         }
 
         global.set_stage_input_region(rects);
-        this._isPopupWindowVisible = isPopupMenuVisible;
 
         let screen = global.screen;
         for (let w = 0; w < screen.n_workspaces; w++) {

--- a/js/ui/magnifier.js
+++ b/js/ui/magnifier.js
@@ -73,11 +73,42 @@ Magnifier.prototype = {
         // Magnifier is a manager of ZoomRegions.
         this._zoomRegions = [];
 
-        this.enabled = false;
-
         this._appSettings = new Gio.Settings({ schema_id: APPLICATIONS_SCHEMA });
         this._settings = new Gio.Settings({ schema_id: MAGNIFIER_SCHEMA });
 
+        this._initialized = false;
+        this.update_mag_id = 0;
+        this.enabled = this._appSettings.get_boolean(SHOW_KEY);
+
+        this._appSettings.connect('changed::' + SHOW_KEY,
+            () => {
+                this.enabled = this._appSettings.get_boolean(SHOW_KEY);
+                let factor = parseFloat(this._settings.get_double(MAG_FACTOR_KEY).toFixed(2));
+                if (this.enabled) {
+                    if (factor > 1.0)
+                        this.setActive(true);
+                    else
+                        this._initialize();
+                } else {
+                    if (this.isActive())
+                        this.setActive(false);
+                }
+            });
+
+        // Export to dbus.
+        magDBusService = new MagnifierDBus.CinnamonMagnifier(this.enabled);
+        magInputHandler = new MagnifierInputHandler(this);
+
+        let factor = parseFloat(this._settings.get_double(MAG_FACTOR_KEY).toFixed(2));
+        if (this.enabled && factor > 1.0)
+            this.setActive(true);
+    },
+
+    _initialize: function() {
+        if (this._initialized)
+            return;
+
+        this._initialized = true;
         // Create small clutter tree for the magnified mouse.
         let xfixesCursor = Cinnamon.XFixesCursor.get_for_stage(global.stage);
         this._mouseSprite = new Clutter.Texture();
@@ -85,37 +116,17 @@ Magnifier.prototype = {
         this._cursorRoot = new Clutter.Group();
         this._cursorRoot.add_actor(this._mouseSprite);
 
-        // Create the first ZoomRegion and initialize it according to the
-        // magnification settings.
-
-        let mask;
-        [this.xMouse, this.yMouse, mask] = global.get_pointer();
-
-        let aZoomRegion = new ZoomRegion(this, this._cursorRoot);
-        this._zoomRegions.push(aZoomRegion);
-        let activeAtLaunch = this._settingsInit(aZoomRegion);
-        aZoomRegion.scrollContentsTo(this.xMouse, this.yMouse);
+        [this.xMouse, this.yMouse, ] = global.get_pointer();
 
         xfixesCursor.connect('cursor-change', Lang.bind(this, this._updateMouseSprite));
         this._xfixesCursor = xfixesCursor;
 
-        this._appSettings.connect('changed::' + SHOW_KEY,
-                                  Lang.bind(this, function() {
-            this.enabled = this._appSettings.get_boolean(SHOW_KEY);
-            let factor = parseFloat(this._settings.get_double(MAG_FACTOR_KEY).toFixed(2));
-            this.setActive(this.enabled && factor > 1.0);
-        }));
-
-        this.enabled = this._appSettings.get_boolean(SHOW_KEY);
-
-        // Export to dbus.
-        magDBusService = new MagnifierDBus.CinnamonMagnifier(this.enabled);
-
-        this.setActive(this.enabled && activeAtLaunch);
-
-        magInputHandler = new MagnifierInputHandler(this);
-
-        this.update_mag_id = 0;
+        // Create the first ZoomRegion and initialize it according to the
+        // magnification settings.
+        let aZoomRegion = new ZoomRegion(this, this._cursorRoot);
+        this._zoomRegions.push(aZoomRegion);
+        aZoomRegion.scrollContentsTo(this.xMouse, this.yMouse);
+        this._settingsInit(aZoomRegion);
     },
 
     /**
@@ -123,6 +134,7 @@ Magnifier.prototype = {
      * Show the system mouse pointer.
      */
     showSystemCursor: function() {
+        this._initialize();
         this._xfixesCursor.show();
     },
 
@@ -131,6 +143,7 @@ Magnifier.prototype = {
      * Hide the system mouse pointer.
      */
     hideSystemCursor: function() {
+        this._initialize();
         this._xfixesCursor.hide();
     },
 
@@ -140,6 +153,11 @@ Magnifier.prototype = {
      * @activate:   Boolean to activate or de-activate the magnifier.
      */
     setActive: function(activate) {
+        if (!activate && !this._initialized)
+            return;
+
+        this._initialize();
+
         this._zoomRegions.forEach (function(zoomRegion, index, array) {
             zoomRegion.setActive(activate);
         });
@@ -173,6 +191,8 @@ Magnifier.prototype = {
      *                  of the magnified view.
      */
     setMagFactor: function(xMagFactor, yMagFactor) {
+        this._initialize();
+
         let zr = this.getZoomRegions()[0];
         zr.setMagFactor(xMagFactor, yMagFactor);
 
@@ -201,6 +221,7 @@ Magnifier.prototype = {
      * Turn on mouse tracking, if not already doing so.
      */
     startTrackingMouse: function() {
+        this._initialize();
         if (!this._mouseTrackingId)
             this._mouseTrackingId = Mainloop.timeout_add(
                 MOUSE_POLL_FREQUENCY,
@@ -234,6 +255,8 @@ Magnifier.prototype = {
      * @return      true.
      */
     scrollToMousePos: function() {
+        this._initialize();
+
         let [xMouse, yMouse, mask] = global.get_pointer();
 
         if (xMouse != this.xMouse || yMouse != this.yMouse) {
@@ -269,11 +292,13 @@ Magnifier.prototype = {
      * @return          The newly created ZoomRegion.
      */
     createZoomRegion: function(xMagFactor, yMagFactor, roi, viewPort) {
+        this._initialize();
+
         let zoomRegion = new ZoomRegion(this, this._cursorRoot);
         zoomRegion.setViewPort(viewPort);
 
         // We ignore the redundant width/height on the ROI
-        let fixedROI = new Object(roi);
+        let fixedROI = Object.assign({}, roi);
         fixedROI.width = viewPort.width / xMagFactor;
         fixedROI.height = viewPort.height / yMagFactor;
         zoomRegion.setROI(fixedROI);
@@ -289,6 +314,8 @@ Magnifier.prototype = {
      * @zoomRegion:     The zoomRegion to add.
      */
     addZoomRegion: function(zoomRegion) {
+        this._initialize();
+
         if(zoomRegion) {
             this._zoomRegions.push(zoomRegion);
             if (!this.isTrackingMouse())
@@ -310,6 +337,9 @@ Magnifier.prototype = {
      * Remove all the zoom regions from this Magnfier's ZoomRegion list.
      */
     clearAllZoomRegions: function() {
+        if (!this._initialized)
+            return;
+
         for (let i = 0; i < this._zoomRegions.length; i++)
             this._zoomRegions[i].setActive(false);
 
@@ -323,6 +353,8 @@ Magnifier.prototype = {
      * Add and show a cross hair centered on the magnified mouse.
      */
     addCrosshairs: function() {
+        this._initialize();
+
         if (!this._crossHairs)
             this._crossHairs = new Crosshairs();
 
@@ -367,11 +399,11 @@ Magnifier.prototype = {
      * @color:  The color as a string, e.g. '#ff0000ff' or 'red'.
      */
     setCrosshairsColor: function(color) {
-        /* return; code below crashes under latest cjs
         if (this._crossHairs) {
-            let clutterColor = Clutter.Color.from_string(color);
-            this._crossHairs.setColor(clutterColor);
-        } */
+            let [success, cc] = Clutter.Color.from_string(color);
+            if (success)
+                this._crossHairs.setColor(cc);
+        }
     },
 
     /**
@@ -479,14 +511,14 @@ Magnifier.prototype = {
      * Get whether the crosshairs are clipped by the mouse image.
      * @return:   Whether the crosshairs are clipped.
      */
-     getCrosshairsClip: function() {
+    getCrosshairsClip: function() {
         if (this._crossHairs) {
             let [clipWidth, clipHeight] = this._crossHairs.getClip();
             return (clipWidth > 0 && clipHeight > 0);
         }
         else
             return false;
-     },
+    },
 
     //// Private methods ////
 
@@ -574,7 +606,7 @@ Magnifier.prototype = {
         }));
 
         return ret > 1.0;
-   },
+    },
 
     _updateScreenPosition: function() {
         // Applies only to the first zoom region.

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -464,7 +464,6 @@ function start() {
 
     global.screen.connect('window-entered-monitor', _windowEnteredMonitor);
     global.screen.connect('window-left-monitor', _windowLeftMonitor);
-    global.screen.connect('restacked', _windowsRestacked);
 
     global.display.connect('gl-video-memory-purged', loadTheme);
 
@@ -767,13 +766,6 @@ function _windowEnteredMonitor(metaScreen, monitorIndex, metaWin) {
     // might make that workspace non-empty
     if (monitorIndex == layoutManager.primaryIndex)
         _queueCheckWorkspaces();
-}
-
-function _windowsRestacked() {
-    // Figure out where the pointer is in case we lost track of
-    // it during a grab. (In particular, if a trayicon popup menu
-    // is dismissed, see if we need to close the message tray.)
-    global.sync_pointer();
 }
 
 function _queueCheckWorkspaces() {

--- a/js/ui/notificationDaemon.js
+++ b/js/ui/notificationDaemon.js
@@ -534,6 +534,9 @@ NotificationDaemon.prototype = {
     },
 
     _onFocusAppChanged: function() {
+        if (!this._sources.length)
+            return;
+
         let tracker = Cinnamon.WindowTracker.get_default();
         if (!tracker.focus_app)
             return;


### PR DESCRIPTION
Simple profiling with the GJS/CJS profiler revealed:
1. paths being called relatively frequently when the features they support weren't enabled:
-magnifier cursor update
-desklet mouse tracker
2. window restack connections are always a top consumer on general non-cinnamon-ui usage
3. <s>uiGroup is always allocating, and the allocate does nothing beyond default</s>
4. notification daemon is always checking the WindowTracker to clear notifications, even when there are none