### PR TITLE
Correctly handle icon/theme directories based on XDG directories

### DIFF
--- a/docs/reference/cinnamon-tutorials/write-applet.xml
+++ b/docs/reference/cinnamon-tutorials/write-applet.xml
@@ -34,7 +34,7 @@
       </listitem>
     </itemizedlist>
     <para>
-      Applets go in <code>~/.local/share/cinnamon/applets</code> (or in <code>/usr/share/cinnamon/applets</code> if you want them installed system-wide). So let’s go there and let’s create the files and folders necessary for any Cinnamon applet.
+      Applets go in <code>$XDG_DATA_HOME/cinnamon/applets</code>, defaulting to <code>~/.local/share/<code/> as per the XDG Base Directory Specification (or in <code>/usr/share/cinnamon/applets</code> if you want them installed system-wide). So let’s go there and let’s create the files and folders necessary for any Cinnamon applet.
     </para>
 
     <screen>

--- a/docs/reference/cinnamon-tutorials/xlet-translating.xml
+++ b/docs/reference/cinnamon-tutorials/xlet-translating.xml
@@ -25,7 +25,7 @@
       <programlisting>
         // l10n/translation support
         const UUID = "yourApplet@You";
-        Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale");
+        Gettext.bindtextdomain(UUID, GLib.get_user_data_dir() + "/locale");
 
         function _(str) {
             return Gettext.dgettext(UUID, str);

--- a/files/usr/bin/cinnamon-xlet-makepot
+++ b/files/usr/bin/cinnamon-xlet-makepot
@@ -6,7 +6,7 @@ import subprocess
 import collections
 import argparse
 
-LOCALE_DIR = os.path.join(os.path.expanduser('~'), '.local/share/locale')
+LOCALE_DIR = os.path.join(os.getenv('XDG_DATA_HOME', os.path.expanduser('~/.local/share')), 'locale')
 
 USAGE_DESCRIPTION = """\
 Parses files in an applet, desklet or extension's directories, \

--- a/files/usr/bin/xlet-about-dialog
+++ b/files/usr/bin/xlet-about-dialog
@@ -9,6 +9,8 @@ import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, GdkPixbuf
 
+xdg_config_home = os.getenv("XDG_CONFIG_HOME", os.path.expanduser("~/.config"))
+
 usage = """
 usage : xlet-about-dialog applets/desklets/extensions uuid
 """
@@ -78,7 +80,7 @@ class AboutDialog(Gtk.AboutDialog):
 
     def get_spices_id(self):
         try:
-            cache_path = os.path.join(os.path.expanduser('~'), '.cinnamon', 'spices.cache', self.stype[0:-1], 'index.json')
+            cache_path = os.path.join(xdg_config_home, 'cinnamon', 'spices.cache', self.stype[0:-1], 'index.json')
             if os.path.exists(cache_path):
                 with open(cache_path, 'r') as cache_file:
                     index_cache = json.load(cache_file)

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -303,7 +303,7 @@ class GroupedWindowListApplet extends Applet.Applet {
         this.actor.set_track_hover(false);
         // Declare vertical panel compatibility
         this.setAllowedLayout(Applet.AllowedLayout.BOTH);
-        Gettext.bindtextdomain(metadata.uuid, GLib.get_home_dir() + '/.local/share/locale');
+        Gettext.bindtextdomain(metadata.uuid, GLib.get_user_data_dir() + '/locale');
 
         this.getAutoStartApps();
         this.onSwitchWorkspace = throttle(this.onSwitchWorkspace, 100, true);

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/utils.py
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/utils.py
@@ -7,6 +7,8 @@ import sys
 
 CLI = sys.argv
 
+xdg_data_home = os.getenv('XDG_DATA_HOME', os.path.expanduser('~/.local/share'))
+
 def parse_args(command):
     return command.split(' ')
 
@@ -54,7 +56,7 @@ def handle_cli():
 
             # Since this is a window backed app, make sure it has an icon association.
 
-            icons_dir = '{}/.local/share/icons/hicolor/48x48/apps/'.format(os.getenv('HOME'))
+            icons_dir = '{}/icons/hicolor/48x48/apps/'.format(xdg_data_home)
 
             if '\\ ' in process_name:
                 process_name = process_name.replace('\\ ', ' ')
@@ -97,7 +99,7 @@ def handle_cli():
                           'application/x-msi;application/x-ms-shortcut; \n' \
 
             desktop_file = '{}.cinnamon-generated.desktop'.format(process_name)
-            desktop_path = '{}/.local/share/applications/{}'.format(os.getenv('HOME'), desktop_file)
+            desktop_path = os.path.join(xdg_data_home, 'applications', desktop_file)
 
             with open(desktop_path, 'w', encoding='utf-8') as desktop:
                 print(g_menu)

--- a/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
@@ -18,7 +18,7 @@ const SignalManager = imports.misc.signalManager;
 const PANEL_EDIT_MODE_KEY = 'panel-edit-mode';
 const PANEL_LAUNCHERS_KEY = 'panel-launchers';
 
-const CUSTOM_LAUNCHERS_PATH = GLib.get_home_dir() + '/.cinnamon/panel-launchers';
+const CUSTOM_LAUNCHERS_PATH = GLib.get_user_config_dir() + '/cinnamon/panel-launchers';
 
 let pressLauncher = null;
 

--- a/files/usr/share/cinnamon/cinnamon-desktop-editor/cinnamon-desktop-editor.py
+++ b/files/usr/share/cinnamon/cinnamon-desktop-editor/cinnamon-desktop-editor.py
@@ -25,9 +25,8 @@ import JsonSettingsWidgets
 gettext.install("cinnamon", "/usr/share/locale")
 # i18n for menu item
 
-#_ = gettext.gettext # bug !!! _ is already defined by gettext.install!
-home = os.path.expanduser("~")
-PANEL_LAUNCHER_PATH = os.path.join(home, ".cinnamon", "panel-launchers")
+xdg_config_home = os.getenv("XDG_CONFIG_HOME", os.path.expanduser("~/.config"))
+PANEL_LAUNCHER_PATH = os.path.join(xdg_config_home, "cinnamon", "panel-launchers")
 
 EXTENSIONS = (".png", ".xpm", ".svg")
 

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/ExtensionCore.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/ExtensionCore.py
@@ -18,7 +18,7 @@ from gi.repository import Gio, Gtk, GObject, Gdk, GdkPixbuf, Pango, GLib
 from SettingsWidgets import SidePage, SettingsStack, SettingsPage, SettingsWidget, SettingsLabel
 from Spices import Spice_Harvester, ThreadedTaskManager
 
-home = os.path.expanduser('~')
+xdg_data_home = os.getenv('XDG_DATA_HOME', os.path.expanduser('~/.local/share')
 
 SHOW_ALL = 0
 SHOW_ACTIVE = 1
@@ -61,7 +61,7 @@ def translate(uuid, string):
     #check for a translation for this xlet
     if uuid not in translations:
         try:
-            translations[uuid] = gettext.translation(uuid, home + '/.local/share/locale').gettext
+            translations[uuid] = gettext.translation(uuid, os.path.join(xdg_data_home, 'locale')).gettext
         except IOError:
             try:
                 translations[uuid] = gettext.translation(uuid, '/usr/share/locale').gettext

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
@@ -29,6 +29,7 @@ except ImportError:
     import simplejson as json
 
 home = os.path.expanduser("~")
+xdg_data_home = os.getenv("XDG_DATA_HOME", os.path.expanduser("~/.local/share"))
 locale_inst = '%s/.local/share/locale' % home
 settings_dir = '%s/.cinnamon/configs/' % home
 
@@ -166,8 +167,8 @@ class Spice_Harvester(GObject.Object):
         self.settings.connect('changed::%s' % self.enabled_key, self._update_status)
 
         if self.themes:
-            self.install_folder = '%s/.themes/' % (home)
-            self.spices_directories = (self.install_folder, )
+            self.install_folder = os.path.join(xdg_data_home, 'themes')
+            self.spices_directories = (self.install_folder)
         else:
             self.install_folder = '%s/.local/share/cinnamon/%ss/' % (home, self.collection_type)
             self.spices_directories = ('/usr/share/cinnamon/%ss/' % self.collection_type, self.install_folder)

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
@@ -28,6 +28,8 @@ try:
 except ImportError:
     import simplejson as json
 
+from os import.path import join as j
+
 home = os.path.expanduser("~")
 xdg_data_home = os.getenv("XDG_DATA_HOME", os.path.expanduser("~/.local/share"))
 locale_inst = '%s/.local/share/locale' % home
@@ -156,7 +158,7 @@ class Spice_Harvester(GObject.Object):
         self.total_jobs = 0
         self.download_total_files = 0
         self.download_current_file = 0
-        self.cache_folder = '%s/.cinnamon/spices.cache/%s/' % (home, self.collection_type)
+        self.cache_folder = os.path.join(xdg_config_home, "cinnamon", "spices.cache", self.collection_types)
 
         if self.themes:
             self.settings = Gio.Settings.new('org.cinnamon.theme')
@@ -170,7 +172,7 @@ class Spice_Harvester(GObject.Object):
             self.install_folder = os.path.join(xdg_data_home, 'themes')
             self.spices_directories = (self.install_folder)
         else:
-            self.install_folder = '%s/.local/share/cinnamon/%ss/' % (home, self.collection_type)
+            self.install_folder = os.path.join(xdg_data_home, "cinnamon", self.collection_type + "s")
             self.spices_directories = ('/usr/share/cinnamon/%ss/' % self.collection_type, self.install_folder)
 
         self._load_metadata()

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_applets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_applets.py
@@ -47,7 +47,7 @@ class AppletsViewSidePage(SidePage):
         self.stack.add_titled(download_applets_page, "more", _("Download"))
 
 class ManageAppletsPage(ManageSpicesPage):
-    directories = [("%s/.local/share/cinnamon/applets") % GLib.get_home_dir(), "/usr/share/cinnamon/applets"]
+    directories = [("%s/cinnamon/applets") % GLib.get_user_data_dir(), "/usr/share/cinnamon/applets"]
     collection_type = "applet"
     installed_page_title = _("Installed applets")
     instance_button_text = _("Add")

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_backgrounds.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_backgrounds.py
@@ -26,6 +26,8 @@ from GSettingsWidgets import *
 
 gettext.install("cinnamon", "/usr/share/locale")
 
+xdg_config_home = os.getenv("XDG_CONFIG_HOME", os.path.expanduser("~/.config"))
+
 BACKGROUND_COLOR_SHADING_TYPES = [
     ("solid", _("Solid color")),
     ("horizontal", _("Horizontal gradient")),
@@ -344,7 +346,7 @@ class Module:
 
     def get_user_backgrounds(self):
         self.user_backgrounds = []
-        path = os.path.expanduser("~/.cinnamon/backgrounds/user-folders.lst")
+        path = os.path.join(xdg_config_home, "cinnamon", "backgrounds", "user-folders.lst")
         if os.path.exists(path):
             with open(path) as f:
                 folders = f.readlines()
@@ -467,10 +469,10 @@ class Module:
                         break
 
     def update_folder_list(self):
-        path = os.path.expanduser("~/.cinnamon/backgrounds")
+        path = os.path.join(xdg_config_home, "cinnamon", "backgrounds")
         if not os.path.exists(path):
             os.makedirs(path, mode=0o755, exist_ok=True)
-        path = os.path.expanduser("~/.cinnamon/backgrounds/user-folders.lst")
+        path = os.path.expanduser(xdg_config_home, "cinnamon", "backgrounds", "user-folders.lst")
         if len(self.user_backgrounds) == 0:
             file_data = ""
         else:

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_desklets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_desklets.py
@@ -69,7 +69,7 @@ class DeskletsViewSidePage(SidePage):
         settings.add_reveal_row(GSettingsSpinButton(_("Width of desklet snap grid"), "org.cinnamon", "desklet-snap-interval", "", 0, 100, 1, 5), "org.cinnamon", "desklet-snap")
 
 class ManageDeskletsPage(ManageSpicesPage):
-    directories = [("%s/.local/share/cinnamon/desklets") % GLib.get_home_dir(), "/usr/share/cinnamon/desklets"]
+    directories = [("%s/cinnamon/desklets") % GLib.get_user_data_dir(), "/usr/share/cinnamon/desklets"]
     collection_type = "desklet"
     installed_page_title = _("Installed desklets")
     instance_button_text = _("Add")

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_extensions.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_extensions.py
@@ -47,7 +47,7 @@ class ExtensionViewSidePage(SidePage):
         self.stack.add_titled(download_extensions_page, "more", _("Download"))
 
 class ManageExtensionsPage(ManageSpicesPage):
-    directories = ['/usr/share/cinnamon/extensions', ("%s/.local/share/cinnamon/extensions") % GLib.get_home_dir()]
+    directories = ['/usr/share/cinnamon/extensions', ("%s/cinnamon/extensions") % GLib.get_user_data_dir()]
     collection_type = "extension"
     installed_page_title = _("Installed extensions")
     instance_button_text = _("Enable")

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
@@ -130,14 +130,14 @@ class Module:
 
             self.builder = self.sidePage.builder
 
-            for path in [os.path.expanduser("~/.themes"), os.path.expanduser("~/.icons")]:
+            for path in ICON_FOLDERS[0] + THEME_FOLDERS[0]:
                 try:
                     os.makedirs(path)
                 except OSError:
                     pass
 
             self.monitors = []
-            for path in [os.path.expanduser("~/.themes"), "/usr/share/themes", os.path.expanduser("~/.icons"), "/usr/share/icons"]:
+            for path in ICON_FOLDERS + THEME_FOLDERS:
                 if os.path.exists(path):
                     file_obj = Gio.File.new_for_path(path)
                     try:
@@ -413,7 +413,7 @@ class Module:
         return res
 
     def update_cursor_theme_link(self, path, name):
-        default_dir = os.path.join(os.path.expanduser("~"), ".icons", "default")
+        default_dir = os.path.join(ICON_FOLDERS[0], "default")
         index_path = os.path.join(default_dir, "index.theme")
 
         try:

--- a/files/usr/share/cinnamon/cinnamon-settings/xlet-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/xlet-settings.py
@@ -4,6 +4,7 @@ import gi
 gi.require_version('Gtk', '3.0')
 gi.require_version('XApp', '1.0')
 
+import os
 import sys
 from setproctitle import setproctitle
 import config
@@ -20,7 +21,8 @@ from gi.repository import Gtk, Gio, XApp
 # i18n
 gettext.install("cinnamon", "/usr/share/locale")
 
-home = os.path.expanduser("~")
+xdg_config_home = os.getenv("XDG_CONFIG_HOME", os.path.expanduser("~/.config"))
+xdg_data_home = os.getenv("XDG_DATA_HOME", os.path.expanduser("~/.local/share"))
 
 translations = {}
 
@@ -61,7 +63,7 @@ def translate(uuid, string):
     #check for a translation for this xlet
     if uuid not in translations:
         try:
-            translations[uuid] = gettext.translation(uuid, home + "/.local/share/locale").gettext
+            translations[uuid] = gettext.translation(uuid, os.path.join(xdg_data_home, "locale")).gettext
         except IOError:
             try:
                 translations[uuid] = gettext.translation(uuid, "/usr/share/locale").gettext
@@ -170,7 +172,7 @@ class MainWindow(object):
     def load_xlet_data (self):
         self.xlet_dir = "/usr/share/cinnamon/%ss/%s" % (self.type, self.uuid)
         if not os.path.exists(self.xlet_dir):
-            self.xlet_dir = "%s/.local/share/cinnamon/%ss/%s" % (home, self.type, self.uuid)
+            self.xlet_dir = os.path.join(xdg_data_home, "cinnamon", self.type, self.uuid)
 
         if os.path.exists("%s/metadata.json" % self.xlet_dir):
             raw_data = open("%s/metadata.json" % self.xlet_dir).read()
@@ -264,7 +266,7 @@ class MainWindow(object):
 
     def load_instances(self):
         self.instance_info = []
-        path = "%s/.cinnamon/configs/%s" % (home, self.uuid)
+        path = os.path.join(xdg_config_home, "cinnamon", "configs", self.uuid)
         instances = 0
         dir_items = sorted(os.listdir(path))
         try:

--- a/files/usr/share/cinnamon/desklets/launcher@cinnamon.org/desklet.js
+++ b/files/usr/share/cinnamon/desklets/launcher@cinnamon.org/desklet.js
@@ -10,7 +10,7 @@ const Desklet = imports.ui.desklet;
 const PopupMenu = imports.ui.popupMenu;
 const Util = imports.misc.util;
 
-const CUSTOM_LAUNCHERS_PATH = GLib.get_home_dir() + '/.cinnamon/panel-launchers/';
+const CUSTOM_LAUNCHERS_PATH = GLib.get_user_config_dir() + '/cinnamon/panel-launchers/';
 
 const ICON_SIZE = 48;
 const ANIM_ICON_SIZE = 40;

--- a/files/usr/share/cinnamon/desklets/launcher@cinnamon.org/editorDialog.py
+++ b/files/usr/share/cinnamon/desklets/launcher@cinnamon.org/editorDialog.py
@@ -11,8 +11,8 @@ from gi.repository import Gtk, Gio
 SCHEMAS = "org.cinnamon.desklets.launcher"
 LAUNCHER_KEY = "launcher-list"
 
-HOME_DIR = os.path.expanduser("~")+"/"
-CUSTOM_LAUNCHERS_PATH = HOME_DIR + ".cinnamon/panel-launchers/"
+xdg_config_home = os.getenv("XDG_CONFIG_HOME", os.path.expanduser("~/.config"))
+CUSTOM_LAUNCHERS_PATH = os.path.join(xdg_config_home, "cinnamon", "panel-launchers/")
 EDITOR_DIALOG_UI_PATH = "/usr/share/cinnamon/desklets/launcher@cinnamon.org/editorDialog.ui"
 
 class EditorDialog:

--- a/js/misc/fileUtils.js
+++ b/js/misc/fileUtils.js
@@ -84,7 +84,7 @@ function recursivelyDeleteDir(dir) {
 function getUserDesktopDir() {
 
     // Didn't find a function returning the user desktop dir, so parsing the user-dirs.dirs file to get it
-    let userdirsFile = Gio.file_new_for_path(GLib.get_home_dir()+"/.config/user-dirs.dirs");
+    let userdirsFile = Gio.file_new_for_path(GLib.get_user_config_dir()+"/user-dirs.dirs");
     let path;
     if (userdirsFile.query_exists(null)){
         try{

--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -333,7 +333,7 @@ function removeAppletFromPanels(appletDefinition, deleteConfig, changed = false)
 }
 
 function _removeAppletConfigFile(uuid, instanceId) {
-    let config_path = (GLib.get_home_dir() + "/" +
+    let config_path = (GLib.get_user_config_dir() + "/" +
                                ".cinnamon" + "/" +
                                  "configs" + "/" +
                                       uuid + "/" +
@@ -590,7 +590,7 @@ function createApplet(extension, appletDefinition, panel = null) {
     applet.panel = panel;
     appletDefinition.applet = applet;
 
-    Gettext.bindtextdomain(applet._uuid, GLib.get_home_dir() + "/.local/share/locale");
+    Gettext.bindtextdomain(applet._uuid, GLib.get_user_data_dir() + "/locale");
 
     applet.finalizeContextMenu();
 

--- a/js/ui/deskletManager.js
+++ b/js/ui/deskletManager.js
@@ -274,8 +274,8 @@ function _unloadDesklet(deskletDefinition, deleteConfig) {
 }
 
 function _removeDeskletConfigFile(uuid, instanceId) {
-    let config_path = (GLib.get_home_dir() + "/" +
-                               ".cinnamon" + "/" +
+    let config_path = (GLib.get_user_config_dir() + "/" +
+                               "cinnamon" + "/" +
                                  "configs" + "/" +
                                       uuid + "/" +
                                 instanceId + ".json");

--- a/js/ui/settings.js
+++ b/js/ui/settings.js
@@ -675,7 +675,7 @@ XletSettingsBase.prototype = {
     },
 
     _ensureSettingsFiles: function() {
-        let configPath = [GLib.get_home_dir(), ".cinnamon", "configs", this.uuid].join("/");
+        let configPath = [GLib.get_user_settings_dir(), "cinnamon", "configs", this.uuid].join("/");
         let configDir = Gio.file_new_for_path(configPath);
         if (!configDir.query_exists(null)) configDir.make_directory_with_parents(null);
         this.file = configDir.get_child(this.instanceId + ".json");


### PR DESCRIPTION
In commit b4338cb6c0fe4e3dc3d0befbff9b1bd3fa93844f partial support was added for using the XDG directories in order to locate these; however, not all the code was wired up to actually use this.