### PR TITLE
appsys: a couple changes for more optimal muffin usage

### DIFF
--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -1623,7 +1623,7 @@ function isInteresting(metaWindow) {
         return false;
 
     // Include any window the tracker finds interesting
-    if (tracker.is_window_interesting(metaWindow)) {
+    if (metaWindow.is_interesting()) {
         return true;
     }
 

--- a/js/ui/windowAttentionHandler.js
+++ b/js/ui/windowAttentionHandler.js
@@ -42,7 +42,7 @@ WindowAttentionHandler.prototype = {
         }
 
         try {
-            if (this._tracker.is_window_interesting(window)) {
+            if (window.is_interesting()) {
                 if (global.settings.get_boolean("bring-windows-to-current-workspace")) {
                     window.change_workspace(global.screen.get_active_workspace());
                 }

--- a/src/cinnamon-app.c
+++ b/src/cinnamon-app.c
@@ -960,7 +960,7 @@ cinnamon_app_request_quit (CinnamonApp   *app)
     {
       MetaWindow *win = iter->data;
 
-      if (!cinnamon_window_tracker_is_window_interesting (cinnamon_window_tracker_get_default (), win))
+      if (!meta_window_is_interesting (win))
         continue;
 
       meta_window_delete (win, cinnamon_global_get_current_time (global));

--- a/src/cinnamon-app.c
+++ b/src/cinnamon-app.c
@@ -960,7 +960,7 @@ cinnamon_app_request_quit (CinnamonApp   *app)
     {
       MetaWindow *win = iter->data;
 
-      if (!meta_window_is_interesting (win))
+      if (!meta_window_can_close (win))
         continue;
 
       meta_window_delete (win, cinnamon_global_get_current_time (global));

--- a/src/cinnamon-window-tracker.c
+++ b/src/cinnamon-window-tracker.c
@@ -146,40 +146,7 @@ cinnamon_window_tracker_class_init (CinnamonWindowTrackerClass *klass)
 gboolean
 cinnamon_window_tracker_is_window_interesting (CinnamonWindowTracker *tracker, MetaWindow *window)
 {
-  if (meta_window_is_override_redirect (window)
-      || meta_window_is_skip_taskbar (window))
-    return FALSE;
-
-  switch (meta_window_get_window_type (window))
-    {
-      /* Definitely ignore these. */
-      case META_WINDOW_DESKTOP:
-      case META_WINDOW_DOCK:
-      case META_WINDOW_SPLASHSCREEN:
-      /* Should have already been handled by override_redirect above,
-       * but explicitly list here so we get the "unhandled enum"
-       * warning if in the future anything is added.*/
-      case META_WINDOW_DROPDOWN_MENU:
-      case META_WINDOW_POPUP_MENU:
-      case META_WINDOW_TOOLTIP:
-      case META_WINDOW_NOTIFICATION:
-      case META_WINDOW_COMBO:
-      case META_WINDOW_DND:
-      case META_WINDOW_OVERRIDE_OTHER:
-        return FALSE;
-      case META_WINDOW_NORMAL:
-      case META_WINDOW_DIALOG:
-      case META_WINDOW_MODAL_DIALOG:
-      case META_WINDOW_MENU:
-      case META_WINDOW_TOOLBAR:
-      case META_WINDOW_UTILITY:
-        break;
-      default:
-        g_warning("cinnamon_window_tracker_is_window_interesting: default reached");
-      break;
-    }
-
-  return TRUE;
+  return meta_window_is_interesting (window);
 }
 
 /**
@@ -511,7 +478,7 @@ track_window (CinnamonWindowTracker *self,
 {
   CinnamonApp *app;
 
-  if (!cinnamon_window_tracker_is_window_interesting (self, window))
+  if (!meta_window_is_interesting (window))
     return;
 
   app = get_app_for_window (self, window);
@@ -553,7 +520,7 @@ disassociate_window (CinnamonWindowTracker   *self,
 
   g_hash_table_remove (self->window_to_app, window);
 
-  if (cinnamon_window_tracker_is_window_interesting (self, window))
+  if (meta_window_is_interesting (window))
     {
       _cinnamon_app_remove_window (app, window);
       g_signal_handlers_disconnect_by_func (window, G_CALLBACK(on_wm_class_changed), self);


### PR DESCRIPTION
- Use meta_window_is_interesting

The main benefit to this is it can be slightly more efficient when using pointers in muffin, and easier access on the prototype in JS.

- app: Close all closable windows from quit() 

> There's no relation between a window being hidden from overview/taskbars
and a window not being closable - currently we effectively disable the
fallback quit action for any application with open transients, which
simply doesn't make sense.
> Instead, only exclude windows for which the close action has been
explicitly disabled.

Requires https://github.com/linuxmint/muffin/pull/418