### PR TITLE
cinnamon-app: Simplify icon retrieval for window-backed apps

### DIFF
--- a/src/st/st-texture-cache.h
+++ b/src/st/st-texture-cache.h
@@ -76,9 +76,8 @@ st_texture_cache_load_sliced_image (StTextureCache *cache,
                                     GFunc           load_callback,
                                     gpointer        user_data);
 
-ClutterActor *st_texture_cache_bind_pixbuf_property (StTextureCache    *cache,
-                                                     GObject           *object,
-                                                     const char        *property_name);
+ClutterActor *st_texture_cache_load_from_pixbuf (GdkPixbuf *pixbuf,
+                                                 int        size);
 
 ClutterActor *st_texture_cache_load_gicon (StTextureCache *cache,
                                            StThemeNode    *theme_node,


### PR DESCRIPTION
Since the pixmap is cached in muffin, and icon-changed receivers destroy their icons on emission, there's no need for a complex caching solution dedicated to window-backed app icons.

Requires https://github.com/linuxmint/muffin/pull/422