### PR TITLE
Reduce public function invocation in C code for simple getters with no logic

### DIFF
--- a/src/cinnamon-app.c
+++ b/src/cinnamon-app.c
@@ -444,7 +444,7 @@ cinnamon_app_activate_window (CinnamonApp     *app,
 {
   GSList *windows;
 
-  if (cinnamon_app_get_state (app) != CINNAMON_APP_STATE_RUNNING)
+  if (app->state != CINNAMON_APP_STATE_RUNNING)
     return;
 
   windows = cinnamon_app_get_windows (app);
@@ -722,7 +722,7 @@ cinnamon_app_is_on_workspace (CinnamonApp *app,
 {
   GSList *iter;
 
-  if (cinnamon_app_get_state (app) == CINNAMON_APP_STATE_STARTING)
+  if (app->state == CINNAMON_APP_STATE_STARTING)
     {
       if (app->started_on_workspace == -1 ||
           meta_workspace_index (workspace) == app->started_on_workspace)
@@ -907,7 +907,7 @@ _cinnamon_app_handle_startup_sequence (CinnamonApp          *app,
    * if it's currently stopped, set it as our application focus,
    * but focus the no_focus window.
    */
-  if (starting && cinnamon_app_get_state (app) == CINNAMON_APP_STATE_STOPPED)
+  if (starting && app->state == CINNAMON_APP_STATE_STOPPED)
     {
       MetaScreen *screen = cinnamon_global_get_screen (cinnamon_global_get ());
       MetaDisplay *display = meta_screen_get_display (screen);
@@ -945,7 +945,7 @@ cinnamon_app_request_quit (CinnamonApp   *app)
   CinnamonGlobal *global;
   GSList *iter;
 
-  if (cinnamon_app_get_state (app) != CINNAMON_APP_STATE_RUNNING)
+  if (app->state != CINNAMON_APP_STATE_RUNNING)
     return FALSE;
 
   /* TODO - check for an XSMP connection; we could probably use that */

--- a/src/cinnamon-global-private.h
+++ b/src/cinnamon-global-private.h
@@ -2,9 +2,74 @@
 #ifndef __CINNAMON_GLOBAL_PRIVATE_H__
 #define __CINNAMON_GLOBAL_PRIVATE_H__
 
+#include <errno.h>
+#include <math.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "cinnamon-global.h"
+#include <X11/extensions/Xfixes.h>
+#include <cogl-pango/cogl-pango.h>
+#include <clutter/x11/clutter-x11.h>
+#include <gdk/gdkx.h>
+#include <gio/gio.h>
+#include <girepository.h>
+#include <meta/display.h>
+#include <meta/util.h>
+
+#include "cinnamon-enum-types.h"
+#include "cinnamon-global-private.h"
+#include "cinnamon-perf-log.h"
+#include "cinnamon-window-tracker.h"
+#include "cinnamon-wm.h"
+#include "st.h"
 
 #include <cjs/gjs.h>
+
+struct _CinnamonGlobal {
+  GObject parent;
+
+  ClutterStage *stage;
+  Window stage_xwindow;
+  GdkWindow *stage_gdk_window;
+
+  MetaDisplay *meta_display;
+  GdkDisplay *gdk_display;
+  Display *xdisplay;
+  MetaScreen *meta_screen;
+  GdkScreen *gdk_screen;
+
+  /* We use this window to get a notification from GTK+ when
+   * a widget in our process does a GTK+ grab.  See
+   * http://bugzilla.gnome.org/show_bug.cgi?id=570641
+   *
+   * This window is never mapped or shown.
+   */
+  GtkWindow *grab_notifier;
+  gboolean gtk_grab_active;
+
+  CinnamonStageInputMode input_mode;
+  XserverRegion input_region;
+
+  GjsContext *js_context;
+  MetaPlugin *plugin;
+  CinnamonWM *wm;
+  GSettings *settings;
+  GSettings *interface_settings;
+  const char *datadir;
+  const char *imagedir;
+  const char *userdatadir;
+  StFocusManager *focus_manager;
+
+  guint work_count;
+  GSList *leisure_closures;
+  guint leisure_function_id;
+
+  guint32 xdnd_timestamp;
+  gint64 last_gc_end_time;
+  guint ui_scale;
+};
 
 void _cinnamon_global_init            (const char *first_property_name,
                                     ...);

--- a/src/cinnamon-global.c
+++ b/src/cinnamon-global.c
@@ -2,75 +2,11 @@
 
 #include "config.h"
 
-#include <errno.h>
-#include <math.h>
-#include <stdarg.h>
-#include <stdlib.h>
-#include <string.h>
-
-#include <X11/extensions/Xfixes.h>
-#include <cogl-pango/cogl-pango.h>
-#include <clutter/x11/clutter-x11.h>
-#include <gdk/gdkx.h>
-#include <gio/gio.h>
-#include <girepository.h>
-#include <meta/display.h>
-#include <meta/util.h>
-
-#include "cinnamon-enum-types.h"
 #include "cinnamon-global-private.h"
-#include "cinnamon-perf-log.h"
-#include "cinnamon-window-tracker.h"
-#include "cinnamon-wm.h"
-#include "st.h"
 
 static CinnamonGlobal *the_object = NULL;
 
 static void grab_notify (GtkWidget *widget, gboolean is_grab, gpointer user_data);
-
-struct _CinnamonGlobal {
-  GObject parent;
-
-  ClutterStage *stage;
-  Window stage_xwindow;
-  GdkWindow *stage_gdk_window;
-
-  MetaDisplay *meta_display;
-  GdkDisplay *gdk_display;
-  Display *xdisplay;
-  MetaScreen *meta_screen;
-  GdkScreen *gdk_screen;
-
-  /* We use this window to get a notification from GTK+ when
-   * a widget in our process does a GTK+ grab.  See
-   * http://bugzilla.gnome.org/show_bug.cgi?id=570641
-   *
-   * This window is never mapped or shown.
-   */
-  GtkWindow *grab_notifier;
-  gboolean gtk_grab_active;
-
-  CinnamonStageInputMode input_mode;
-  XserverRegion input_region;
-
-  GjsContext *js_context;
-  MetaPlugin *plugin;
-  CinnamonWM *wm;
-  GSettings *settings;
-  GSettings *interface_settings;
-  const char *datadir;
-  const char *imagedir;
-  const char *userdatadir;
-  StFocusManager *focus_manager;
-
-  guint work_count;
-  GSList *leisure_closures;
-  guint leisure_function_id;
-
-  guint32 xdnd_timestamp;
-  gint64 last_gc_end_time;
-  guint ui_scale;
-};
 
 enum {
   PROP_0,


### PR DESCRIPTION
This moves the CinnamonGlobal struct to its private header file so its properties can be directly accessed within C code. Public functions are for bindings and consumer contexts, so let's trust GCC a little less and make sure these non-static functions are not incurring a performance penalty.