### PR TITLE
power@cinnamon.org: improved support for multiple batteries

### DIFF
--- a/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
@@ -594,12 +594,12 @@ class CinnamonPowerApplet extends Applet.TextIconApplet {
                     if (this.labelinfo !== "nothing") {
                         for (let i = 0; i < this._devices.length; i++) {
                             labelText += i + ': ';
-                            let [device_id, vendor, model, device_type, icon, percentage, state, battery_level, seconds] = this._devices[i];
+                            let [, , , , , percentage, , , seconds] = this._devices[i];
                             if (this.labelinfo == "time" && seconds != 0) {
                                 let time = Math.round(seconds / 60);
                                 let minutes = time % 60;
                                 let hours = Math.floor(time / 60);
-                                labelText += C_("time of battery remaining", "%d:%02d").format(hours,minutes);
+                                labelText += C_("time of battery remaining", "%d:%02d").format(hours, minutes);
                             }
                             else if (this.labelinfo == "percentage" || (this.labelinfo == "percentage_time" && seconds == 0)) {
                                 labelText += C_("percent of battery remaining", "%d%%").format(Math.round(percentage));

--- a/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
@@ -581,7 +581,7 @@ class CinnamonPowerApplet extends Applet.TextIconApplet {
             // The menu is built. Below, we update the information present in the panel (icon, tooltip and label)
             this.set_applet_enabled(true);
             let panel_device = null;
-            if (this._primaryDevice != null && (!this.showmulti || this._devices.length == 1)) {
+            if (this._primaryDevice != null && (!this.showmulti || this._devices.length === 1)) {
                 this.showDeviceInPanel(this._primaryDevice);
             }
             else {
@@ -595,13 +595,13 @@ class CinnamonPowerApplet extends Applet.TextIconApplet {
                         for (let i = 0; i < this._devices.length; i++) {
                             labelText += i + ': ';
                             let [, , , , , percentage, , , seconds] = this._devices[i];
-                            if (this.labelinfo == "time" && seconds != 0) {
+                            if (this.labelinfo == "time" && seconds !== 0) {
                                 let time = Math.round(seconds / 60);
                                 let minutes = time % 60;
                                 let hours = Math.floor(time / 60);
                                 labelText += C_("time of battery remaining", "%d:%02d").format(hours, minutes);
                             }
-                            else if (this.labelinfo == "percentage" || (this.labelinfo == "percentage_time" && seconds == 0)) {
+                            else if (this.labelinfo == "percentage" || (this.labelinfo == "percentage_time" && seconds === 0)) {
                                 labelText += C_("percent of battery remaining", "%d%%").format(Math.round(percentage));
                             }
                             else if (this.labelinfo == "percentage_time") {

--- a/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
@@ -581,7 +581,7 @@ class CinnamonPowerApplet extends Applet.TextIconApplet {
             // The menu is built. Below, we update the information present in the panel (icon, tooltip and label)
             this.set_applet_enabled(true);
             let panel_device = null;
-            if (this._primaryDevice != null && !this.showmulti) {
+            if (this._primaryDevice != null && (!this.showmulti || this._devices.length == 1)) {
                 this.showDeviceInPanel(this._primaryDevice);
             }
             else {

--- a/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
@@ -355,6 +355,7 @@ class CinnamonPowerApplet extends Applet.TextIconApplet {
             this._proxy.connect("g-properties-changed", Lang.bind(this, this._devicesChanged));
             global.settings.connect('changed::device-aliases', Lang.bind(this, this._on_device_aliases_changed));
             this.settings.bind("labelinfo", "labelinfo", this._devicesChanged);
+            this.settings.bind("showmulti", "showmulti", this._devicesChanged);
 
             this._devicesChanged();
         }));
@@ -580,7 +581,7 @@ class CinnamonPowerApplet extends Applet.TextIconApplet {
             // The menu is built. Below, we update the information present in the panel (icon, tooltip and label)
             this.set_applet_enabled(true);
             let panel_device = null;
-            if (this._primaryDevice != null) {
+            if (this._primaryDevice != null && !this.showmulti) {
                 this.showDeviceInPanel(this._primaryDevice);
             }
             else {
@@ -589,8 +590,34 @@ class CinnamonPowerApplet extends Applet.TextIconApplet {
                 }
                 else if (this._devices.length > 1) {
                     // Show a summary
+                    let labelText = "";
+                    if (this.labelinfo !== "nothing") {
+                        for (let i = 0; i < this._devices.length; i++) {
+                            labelText += i + ': ';
+                            let [device_id, vendor, model, device_type, icon, percentage, state, battery_level, seconds] = this._devices[i];
+                            if (this.labelinfo == "time" && seconds != 0) {
+                                let time = Math.round(seconds / 60);
+                                let minutes = time % 60;
+                                let hours = Math.floor(time / 60);
+                                labelText += C_("time of battery remaining", "%d:%02d").format(hours,minutes);
+                            }
+                            else if (this.labelinfo == "percentage" || (this.labelinfo == "percentage_time" && seconds == 0)) {
+                                labelText += C_("percent of battery remaining", "%d%%").format(Math.round(percentage));
+                            }
+                            else if (this.labelinfo == "percentage_time") {
+                                let time = Math.round(seconds / 60);
+                                let minutes = Math.floor(time % 60);
+                                let hours = Math.floor(time / 60);
+                                labelText += C_("percent of battery remaining", "%d%%").format(Math.round(percentage)) + " (" +
+                                    C_("time of battery remaining", "%d:%02d").format(hours,minutes) + ")";
+                            }
+                            if (i !== this._devices.length - 1) {
+                                labelText += '  ';
+                            }
+                        }    
+                    }
                     this.set_applet_tooltip(devices_stats.join(", "));
-                    this.set_applet_label("");
+                    this.set_applet_label(labelText);
                     let icon = this._proxy.Icon;
                     if(icon) {
                         if (icon != this.panel_icon_name) {

--- a/files/usr/share/cinnamon/applets/power@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/power@cinnamon.org/settings-schema.json
@@ -9,5 +9,11 @@
             "Show percentage and time remaining": "percentage_time",
             "Hide label": "nothing"
         }
+    },
+    "showmulti" : {
+        "type" : "switch",
+        "default" : false,
+        "description": "Always show all batteries",
+        "tooltip": "Check this to always show multiple batteries in the panel, regardless of whether one of them is marked primary."
     }
 }


### PR DESCRIPTION
This is my attempt at a fix for issue #4979 .
It also adds one new configuration setting for this applet, "Always show all batteries", as in some cases with multiple batteries one battery will report as primary regardless of intended use; this setting forces multiple battery behavior in that case.