### PR TITLE
Melange/lookingGlass: better introspected object inspection

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-looking-glass/page_inspect.py
+++ b/files/usr/share/cinnamon/cinnamon-looking-glass/page_inspect.py
@@ -3,6 +3,19 @@
 import pageutils
 from gi.repository import Gtk
 
+# keep in sync with lookingGlass.js
+NON_INSPECTABLE_TYPES = [
+    'boolean',
+    'function',
+    'importer',
+    'null',
+    'number',
+    'prototype',
+    'string',
+    'symbol',
+    'undefined'
+]
+
 class InspectView(pageutils.BaseListView):
     def __init__(self, parent):
         self.parent = parent
@@ -129,7 +142,7 @@ class ModulePage(pageutils.WindowAndActionBars):
             self.insert.set_sensitive(True)
 
     def updateInspector(self, path, objType, name, value, pushToStack=False):
-        if objType in ("array", "object"):
+        if objType not in NON_INSPECTABLE_TYPES:
             if pushToStack:
                 self.pushInspectionElement()
 

--- a/js/ui/lookingGlass.js
+++ b/js/ui/lookingGlass.js
@@ -30,7 +30,6 @@ var commandHeader = 'const Clutter = imports.gi.Clutter; ' +
                     /* Utility functions...we should probably be able to use these
                      * in Cinnamon core code too. */
                     'const stage = global.stage; ' +
-                    'const color = function(pixel) { let c= new Clutter.Color(); c.from_pixel(pixel); return c; }; ' +
                     /* Special lookingGlass functions */
                     'const it = Main.lookingGlass.getIt(); ' +
                     'const a = Lang.bind(Main.lookingGlass, Main.lookingGlass.getWindowApp); '+


### PR DESCRIPTION
- Removes utility function `color(pixel)` from the lookingGlass eval template as this clutter function isn't actually introspected(anymore?) and thus won't work.
- Massive object inspector rework. Description from commit:

Since GObject properties are lazily loaded into their JS wrapper
objects, we can't easily inspect them and get all of the available
properties, functions, etc. This adds a pretty hacky method to
obtain them by looking up all of the introspection data, then looking
up each property on the target object.

This should only ever be used with melange for debugging purposes. Since
this causes _every_ property to be cached into JS, some of which are
additional GObjects/GBoxed/etc, it can and probably does cause higher
memory usage and possibly other weird side effects.

