### PR TITLE
all/python: use setproctitle

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -94,6 +94,7 @@ Depends:
  python3-pexpect,
  python3-pil,
  python3-pyinotify,
+ python3-setproctitle,
  streamer,
  wget,
  xapps-common,

--- a/files/usr/bin/cinnamon-file-dialog
+++ b/files/usr/bin/cinnamon-file-dialog
@@ -8,6 +8,9 @@ Usage:
 """
 
 import sys
+from setproctitle import setproctitle
+setproctitle("cinnamon-file-dialog")
+
 from gi.repository import Gtk
 
 cancelButton = (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)

--- a/files/usr/bin/cinnamon-killer-daemon
+++ b/files/usr/bin/cinnamon-killer-daemon
@@ -6,6 +6,7 @@ and runs in the background to detect that keybinding
 
 import os
 import syslog
+from setproctitle import setproctitle
 
 import gi
 gi.require_version('Keybinder', '3.0')  # noqa
@@ -53,5 +54,6 @@ class KillerDaemon:
 
 
 if __name__ == '__main__':
+    setproctitle("cinnamon-killer-daemon")
     daemon = KillerDaemon()
     Gtk.main()

--- a/files/usr/bin/cinnamon-launcher
+++ b/files/usr/bin/cinnamon-launcher
@@ -6,6 +6,7 @@
 import os
 import sys
 import gettext
+from setproctitle import setproctitle
 
 import gi
 gi.require_version('Gtk', '3.0')  # noqa
@@ -41,6 +42,7 @@ def confirm_restart():
 
 
 if __name__ == "__main__":
+    setproctitle("cinnamon-launcher")
     cinnamon_pid = os.fork()
     if cinnamon_pid == 0:
         os.execvp("cinnamon", ("cinnamon", "--replace", ) + tuple(sys.argv[1:]))

--- a/files/usr/bin/cinnamon-menu-editor
+++ b/files/usr/bin/cinnamon-menu-editor
@@ -6,6 +6,7 @@ Usage:  cinnamon-menu-editor
 """
 
 import sys
+from setproctitle import setproctitle
 
 sys.path.insert(0, '/usr/share/cinnamon/cinnamon-menu-editor')  # noqa
 from cme import MainWindow
@@ -24,4 +25,5 @@ def main():
 
 
 if __name__ == '__main__':
+    setproctitle("cinnamon-menu-editor")
     main()

--- a/files/usr/bin/cinnamon-preview-gtk-theme
+++ b/files/usr/bin/cinnamon-preview-gtk-theme
@@ -6,12 +6,14 @@ Usage:  cinnamon-preview-gtk-theme theme-name
 """
 
 import sys
+from setproctitle import setproctitle
 
 import gi
 gi.require_version("Gtk", "3.0")  # noqa
 from gi.repository import Gtk
 
 if __name__ == '__main__':
+    setproctitle("cinnamon-preview-gtk-theme")
     import signal
     signal.signal(signal.SIGINT, signal.SIG_DFL)
 

--- a/files/usr/bin/cinnamon-subprocess-wrapper
+++ b/files/usr/bin/cinnamon-subprocess-wrapper
@@ -8,8 +8,10 @@ Usage:  cinnamon-subprocess-wrapper ls ~/
 import subprocess
 import sys
 import dbus
+from setproctitle import setproctitle
 
 if __name__ == "__main__":
+    setproctitle("cinnamon-subprocess-wrapper")
     process_id = int(sys.argv[1])
     try:
         result = subprocess.check_output(sys.argv[2:])

--- a/files/usr/share/cinnamon/cinnamon-desktop-editor/cinnamon-desktop-editor.py
+++ b/files/usr/share/cinnamon/cinnamon-desktop-editor/cinnamon-desktop-editor.py
@@ -7,6 +7,7 @@ import glob
 from optparse import OptionParser
 import shutil
 import subprocess
+from setproctitle import setproctitle
 
 import gi
 gi.require_version("Gtk", "3.0")
@@ -419,6 +420,7 @@ class Main:
         Gtk.main_quit()
 
 if __name__ == "__main__":
+    setproctitle("cinnamon-desktop-editor")
     Gtk.Window.set_default_icon_name(DEFAULT_ICON_NAME)
     Main()
     Gtk.main()

--- a/files/usr/share/cinnamon/cinnamon-looking-glass/cinnamon-looking-glass.py
+++ b/files/usr/share/cinnamon/cinnamon-looking-glass/cinnamon-looking-glass.py
@@ -22,6 +22,7 @@ import pageutils
 from lookingglass_proxy import LookingGlassProxy
 import signal
 signal.signal(signal.SIGINT, signal.SIG_DFL)
+from setproctitle import setproctitle
 
 MELANGE_DBUS_NAME = "org.Cinnamon.Melange"
 MELANGE_DBUS_PATH = "/org/Cinnamon/Melange"
@@ -546,6 +547,7 @@ If you defined a hotkey for Melange, pressing it while Melange is visible it wil
         self.notebook.set_current_page(page)
 
 if __name__ == "__main__":
+    setproctitle("cinnamon-looking-glass")
     DBusGMainLoop(set_as_default=True)
 
     sessionBus = dbus.SessionBus ()

--- a/files/usr/share/cinnamon/cinnamon-screensaver-lock-dialog/cinnamon-screensaver-lock-dialog.py
+++ b/files/usr/share/cinnamon/cinnamon-screensaver-lock-dialog/cinnamon-screensaver-lock-dialog.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 import gettext
 import pwd
+from setproctitle import setproctitle
 
 import gi
 gi.require_version("Gtk", "3.0")
@@ -61,5 +62,6 @@ class MainWindow:
         Gtk.main_quit()
 
 if __name__ == "__main__":
+    setproctitle("cinnamon-screensaver-lock-dialog")
     MainWindow()
     Gtk.main()

--- a/files/usr/share/cinnamon/cinnamon-settings-users/cinnamon-settings-users.py
+++ b/files/usr/share/cinnamon/cinnamon-settings-users/cinnamon-settings-users.py
@@ -9,6 +9,7 @@ import shutil
 import re
 import subprocess
 from random import randint
+from setproctitle import setproctitle
 
 import PIL
 from PIL import Image
@@ -950,5 +951,6 @@ class Module:
 
 
 if __name__ == "__main__":
+    setproctitle("cinnamon-settings-users")
     module = Module()
     Gtk.main()

--- a/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
@@ -12,6 +12,7 @@ import urllib.request as urllib
 from functools import cmp_to_key
 import unicodedata
 import config
+from setproctitle import setproctitle
 
 import gi
 gi.require_version('Gtk', '3.0')
@@ -607,6 +608,7 @@ class MainWindow:
         Gtk.main_quit()
 
 if __name__ == "__main__":
+    setproctitle("cinnamon-settings")
     import signal
 
     ps = proxygsettings.get_proxy_settings()

--- a/files/usr/share/cinnamon/cinnamon-settings/xlet-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/xlet-settings.py
@@ -5,6 +5,7 @@ gi.require_version('Gtk', '3.0')
 gi.require_version('XApp', '1.0')
 
 import sys
+from setproctitle import setproctitle
 import config
 sys.path.append(config.currentPath + "/bin")
 import gettext
@@ -488,6 +489,7 @@ class MainWindow(object):
         Gtk.main_quit()
 
 if __name__ == "__main__":
+    setproctitle("xlet-settings")
     import signal
     if len(sys.argv) < 3:
         print("Error: requres type and uuid")

--- a/files/usr/share/cinnamon/cinnamon-slideshow/cinnamon-slideshow.py
+++ b/files/usr/share/cinnamon/cinnamon-slideshow/cinnamon-slideshow.py
@@ -6,6 +6,7 @@ from dbus.mainloop.glib import DBusGMainLoop
 import random
 import os, locale
 from xml.etree import ElementTree
+from setproctitle import setproctitle
 
 SLIDESHOW_DBUS_NAME = "org.Cinnamon.Slideshow"
 SLIDESHOW_DBUS_PATH = "/org/Cinnamon/Slideshow"
@@ -308,6 +309,7 @@ class CinnamonSlideshow(dbus.service.Object):
 ###############
 
 if __name__ == "__main__":
+    setproctitle("cinnamon-slideshow")
     DBusGMainLoop(set_as_default=True)
 
     sessionBus = dbus.SessionBus ()


### PR DESCRIPTION
This makes all of our standard python programs set an easier to
identify name in the process list. Build/translation utils were
not included.