### PR TITLE
calendar: Remove duplicate prototype override, unused function

### DIFF
--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
@@ -10,7 +10,7 @@ const Settings = imports.ui.settings;
 const Calendar = require('./calendar');
 const CinnamonDesktop = imports.gi.CinnamonDesktop;
 
-class CinnamonCalendarApplet extends TextApplet {
+class CinnamonCalendarApplet extends Applet.TextApplet {
     constructor(orientation, panel_height, instance_id) {
         super(orientation, panel_height, instance_id);
 

--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
@@ -10,29 +10,7 @@ const Settings = imports.ui.settings;
 const Calendar = require('./calendar');
 const CinnamonDesktop = imports.gi.CinnamonDesktop;
 
-String.prototype.capitalize = function() {
-    return this.charAt(0).toUpperCase() + this.slice(1);
-}
-
-function _onVertSepRepaint (area)
-{
-    let cr = area.get_context();
-    let themeNode = area.get_theme_node();
-    let [width, height] = area.get_surface_size();
-    let stippleColor = themeNode.get_color('-stipple-color');
-    let stippleWidth = themeNode.get_length('-stipple-width');
-    let x = Math.floor(width/2) + 0.5;
-    cr.moveTo(x, 0);
-    cr.lineTo(x, height);
-    Clutter.cairo_set_source_color(cr, stippleColor);
-    cr.setDash([1, 3], 1); // Hard-code for now
-    cr.setLineWidth(stippleWidth);
-    cr.stroke();
-
-    cr.$dispose();
-};
-
-class CinnamonCalendarApplet extends Applet.TextApplet {
+class CinnamonCalendarApplet extends TextApplet {
     constructor(orientation, panel_height, instance_id) {
         super(orientation, panel_height, instance_id);
 


### PR DESCRIPTION
Modifying prototypes after initialization makes it harder for Spidermonkey to optimize property access. Since String is a built-in global, this can affect most of Cinnamon.

https://mathiasbynens.be/notes/prototypes