### PR TITLE
Use ConsoleKit instead of old upower for suspend/hibernate (cs_power.py)

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_power.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_power.py
@@ -547,6 +547,7 @@ def get_available_options(up_client):
     can_hibernate = False
     can_hybrid_sleep = False
 
+    # Try logind first
     try:
         connection = Gio.bus_get_sync(Gio.BusType.SYSTEM, None)
         proxy = Gio.DBusProxy.new_sync(
@@ -561,6 +562,24 @@ def get_available_options(up_client):
         can_suspend = proxy.CanSuspend() == "yes"
         can_hibernate = proxy.CanHibernate() == "yes"
         can_hybrid_sleep = proxy.CanHybridSleep() == "yes"
+    except:
+        pass
+
+    # Next try ConsoleKit
+    try:
+        connection = Gio.bus_get_sync(Gio.BusType.SYSTEM, None)
+        proxy = Gio.DBusProxy.new_sync(
+            connection,
+            Gio.DBusProxyFlags.NONE,
+            None,
+            "org.freedesktop.ConsoleKit",
+            "/org/freedesktop/ConsoleKit/Manager",
+            "org.freedesktop.ConsoleKit.Manager",
+            None)
+
+        can_suspend = can_suspend or (proxy.CanSuspend() == "yes")
+        can_hibernate = can_hibernate or (proxy.CanHybridSleep() == "yes")
+        can_hybrid_sleep = can_hybrid_sleep or (proxy.CanHybridSleep() == "yes")
     except:
         pass
 

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_power.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_power.py
@@ -583,14 +583,6 @@ def get_available_options(up_client):
     except:
         pass
 
-    # New versions of upower does not have get_can_suspend function
-    try:
-        can_suspend = can_suspend or up_client.get_can_suspend()
-        can_hibernate = can_hibernate or up_client.get_can_hibernate()
-        can_hybrid_sleep = can_hibernate or up_client.get_can_hybrid_sleep()
-    except:
-        pass
-
     def remove(options, item):
         for option in options:
             if option[0] == item:


### PR DESCRIPTION
Since this has been implemented in cinnamon-settings-daemon, it should be enabled here too.