### PR TITLE
Replace some GLib wrappers

### DIFF
--- a/src/cinnamon-app-system.c
+++ b/src/cinnamon-app-system.c
@@ -96,8 +96,8 @@ setup_merge_dir_symlink(void)
         g_file_make_symbolic_link (sym_file, merge_path, NULL, NULL);
     }
 
-    g_free (merge_path);
-    g_free (sym_path);
+    free (merge_path);
+    free (sym_path);
     g_object_unref (merge_file);
     g_object_unref (sym_file);
 }
@@ -147,7 +147,7 @@ cinnamon_app_system_finalize (GObject *object)
   g_hash_table_destroy (priv->running_apps);
   g_hash_table_destroy (priv->id_to_app);
   g_hash_table_destroy (priv->startup_wm_class_to_app);
-  g_slist_free_full (priv->known_vendor_prefixes, g_free);
+  g_slist_free_full (priv->known_vendor_prefixes, free);
   priv->known_vendor_prefixes = NULL;
 
   G_OBJECT_CLASS (cinnamon_app_system_parent_class)->finalize (object);
@@ -208,31 +208,31 @@ get_prefix_for_entry (GMenuTreeEntry *entry)
 
           t_id[id_len - name_len] = '\0';
           t1 = g_strdup(t_id);
-          g_free (prefix);
-          g_free (t_id);
-          g_free (name);
+          free (prefix);
+          free (t_id);
+          free (name);
           name = g_strdup (id);
           prefix = t1;
 
           g_object_unref (file);
           file = parent;
-          g_free (pname);
-          g_free (file_prefix);
+          free (pname);
+          free (file_prefix);
           file_prefix = NULL;
           break;
         }
 
       t = g_strconcat (pname, "-", name, NULL);
-      g_free (name);
+      free (name);
       name = t;
 
       t = g_strconcat (pname, "-", prefix, NULL);
-      g_free (prefix);
+      free (prefix);
       prefix = t;
 
       g_object_unref (file);
       file = parent;
-      g_free (pname);
+      free (pname);
     }
 
   if (file)
@@ -240,22 +240,22 @@ get_prefix_for_entry (GMenuTreeEntry *entry)
 
   if (strcmp (name, id) == 0)
     {
-      g_free (name);
+      free (name);
       if (file_prefix && !prefix)
         return file_prefix;
       if (file_prefix)
         {
           char *t = g_strconcat (prefix, "-", file_prefix, NULL);
-          g_free (prefix);
-          g_free (file_prefix);
+          free (prefix);
+          free (file_prefix);
           prefix = t;
         }
       return prefix;
     }
 
-  g_free (name);
-  g_free (prefix);
-  g_free (file_prefix);
+  free (name);
+  free (prefix);
+  free (file_prefix);
   g_return_val_if_reached (NULL);
 }
 
@@ -335,7 +335,7 @@ on_apps_tree_changed_cb (GMenuTree *tree,
 
   g_assert (tree == self->priv->apps_tree);
 
-  g_slist_free_full (self->priv->known_vendor_prefixes, g_free);
+  g_slist_free_full (self->priv->known_vendor_prefixes, free);
   self->priv->known_vendor_prefixes = NULL;
 
   if (!gmenu_tree_load_sync (self->priv->apps_tree, &error))
@@ -373,7 +373,7 @@ on_apps_tree_changed_cb (GMenuTree *tree,
         self->priv->known_vendor_prefixes = g_slist_append (self->priv->known_vendor_prefixes,
                                                             prefix);
       else
-        g_free (prefix);
+        free (prefix);
 
       app = g_hash_table_lookup (self->priv->id_to_app, id);
       if (app != NULL)
@@ -525,7 +525,7 @@ lookup_heuristic_basename (CinnamonAppSystem *system,
     {
       char *tmpid = g_strconcat ((char*)prefix->data, name, NULL);
       result = cinnamon_app_system_lookup_app (system, tmpid);
-      g_free (tmpid);
+      free (tmpid);
       if (result != NULL)
         return result;
     }
@@ -580,9 +580,9 @@ cinnamon_app_system_lookup_desktop_wmclass (CinnamonAppSystem *system,
 
   app = lookup_heuristic_basename (system, desktop_file);
 
-  g_free (canonicalized);
-  g_free (stripped_name);
-  g_free (desktop_file);
+  free (canonicalized);
+  free (stripped_name);
+  free (desktop_file);
 
   return app;
 }

--- a/src/cinnamon-app.c
+++ b/src/cinnamon-app.c
@@ -553,7 +553,7 @@ cinnamon_app_activate_full (CinnamonApp      *app,
               cinnamon_global_notify_error (global,
                                          msg,
                                          error->message);
-              g_free (msg);
+              free (msg);
               g_clear_error (&error);
             }
         }
@@ -1124,7 +1124,7 @@ cinnamon_app_dispose (GObject *object)
   while (app->running_state)
     _cinnamon_app_remove_window (app, app->running_state->windows->data);
 
-  g_clear_pointer (&app->keywords, g_free);
+  g_clear_pointer (&app->keywords, free);
 
   G_OBJECT_CLASS(cinnamon_app_parent_class)->dispose (object);
 }
@@ -1134,7 +1134,7 @@ cinnamon_app_finalize (GObject *object)
 {
   CinnamonApp *app = CINNAMON_APP (object);
 
-  g_free (app->window_id_string);
+  free (app->window_id_string);
 
   G_OBJECT_CLASS(cinnamon_app_parent_class)->finalize (object);
 }

--- a/src/cinnamon-app.h
+++ b/src/cinnamon-app.h
@@ -2,6 +2,7 @@
 #ifndef __CINNAMON_APP_H__
 #define __CINNAMON_APP_H__
 
+#include <stdlib.h>
 #include <clutter/clutter.h>
 #include <gio/gio.h>
 #include <meta/window.h>

--- a/src/cinnamon-global.c
+++ b/src/cinnamon-global.c
@@ -234,7 +234,7 @@ cinnamon_global_init (CinnamonGlobal *global)
     global->imagedir = imagedir;
   else
     {
-      g_free (imagedir);
+      free (imagedir);
       global->imagedir = g_strdup_printf ("%s/", datadir);
     }
 
@@ -771,7 +771,7 @@ cinnamon_global_set_stage_input_region (CinnamonGlobal *global,
     XFixesDestroyRegion (global->xdisplay, global->input_region);
 
   global->input_region = XFixesCreateRegion (global->xdisplay, rects, nrects);
-  g_free (rects);
+  free (rects);
 
   /* set_stage_input_mode() will figure out whether or not we
    * should actually change the input region right now.

--- a/src/cinnamon-mount-operation.c
+++ b/src/cinnamon-mount-operation.c
@@ -31,7 +31,7 @@
  * except for ask-password, as we don't want to handle that.
  *
  * Also, we need to workaround the fact that gjs doesn't support type
- * annotations for signals yet (so we can't effectively forward e.g. 
+ * annotations for signals yet (so we can't effectively forward e.g.
  * the GPid array to JS).
  * See https://bugzilla.gnome.org/show_bug.cgi?id=645978
  */
@@ -89,7 +89,7 @@ cinnamon_mount_operation_show_processes (GMountOperation *operation,
       self->priv->pids = NULL;
     }
 
-  g_free (self->priv->message);
+  free (self->priv->message);
   g_strfreev (self->priv->choices);
 
   /* save the parameters */
@@ -106,7 +106,7 @@ cinnamon_mount_operation_finalize (GObject *obj)
   CinnamonMountOperation *self = CINNAMON_MOUNT_OPERATION (obj);
 
   g_strfreev (self->priv->choices);
-  g_free (self->priv->message);
+  free (self->priv->message);
 
   if (self->priv->pids != NULL)
     {

--- a/src/cinnamon-perf-helper.c
+++ b/src/cinnamon-perf-helper.c
@@ -94,7 +94,7 @@ destroy_windows (void)
     {
       WindowInfo *info = l->data;
       gtk_widget_destroy (info->window);
-      g_free (info);
+      free (info);
     }
 
   g_list_free (our_windows);

--- a/src/cinnamon-perf-log.c
+++ b/src/cinnamon-perf-log.c
@@ -851,7 +851,7 @@ cinnamon_perf_log_dump_events (CinnamonPerfLog   *perf_log,
       g_string_append (output, " }");
 
       if (escaped_description != event->description)
-        g_free (escaped_description);
+        free (escaped_description);
     }
 
   g_string_append (output, " ]");
@@ -915,7 +915,7 @@ replay_to_json (gint64      time,
                                    g_value_get_string (arg));
 
       if (escaped != arg_str)
-        g_free (escaped);
+        free (escaped);
     }
   else
     {

--- a/src/cinnamon-recorder.c
+++ b/src/cinnamon-recorder.c
@@ -588,7 +588,7 @@ recorder_record_frame (CinnamonRecorder *recorder,
   /* TODO: Capture more than the first framebuffer. */
   for (i = 1; i < n_captures; i++)
     cairo_surface_destroy (captures[i].image);
-  g_free (captures);
+  free (captures);
 
   buffer = gst_buffer_new();
   memory = gst_memory_new_wrapped (0, data, size, 0, size,
@@ -963,7 +963,7 @@ recorder_set_pipeline (CinnamonRecorder *recorder,
     cinnamon_recorder_close (recorder);
 
   if (recorder->pipeline_description)
-    g_free (recorder->pipeline_description);
+    free (recorder->pipeline_description);
 
   recorder->pipeline_description = g_strdup (pipeline);
 
@@ -982,7 +982,7 @@ recorder_set_filename (CinnamonRecorder *recorder,
     cinnamon_recorder_close (recorder);
 
   if (recorder->filename)
-    g_free (recorder->filename);
+    free (recorder->filename);
 
   recorder->filename = g_strdup (filename);
 
@@ -1212,7 +1212,7 @@ get_absolute_path (char *maybe_relative)
     {
       char *cwd = g_get_current_dir ();
       path = g_build_filename (cwd, maybe_relative, NULL);
-      g_free (cwd);
+      free (cwd);
     }
 
   return path;
@@ -1303,7 +1303,7 @@ recorder_open_outfile (CinnamonRecorder *recorder)
         {
           char *path = get_absolute_path (filename->str);
           g_printerr ("Recording to %s\n", path);
-          g_free (path);
+          free (path);
 
           g_string_free (filename, TRUE);
           goto out;
@@ -1435,7 +1435,7 @@ recorder_pipeline_free (RecorderPipeline *pipeline)
 
   g_clear_object (&pipeline->recorder);
 
-  g_free (pipeline);
+  free (pipeline);
 }
 
 /* Function gets called on pipeline-global events; we use it to
@@ -1552,7 +1552,7 @@ recorder_open_pipeline (CinnamonRecorder *recorder)
   pipeline->pipeline = gst_parse_launch_full (parsed_pipeline, NULL,
                                               GST_PARSE_FLAG_FATAL_ERRORS,
                                               &error);
-  g_free (parsed_pipeline);
+  free (parsed_pipeline);
 
   if (pipeline->pipeline == NULL)
     {
@@ -1841,7 +1841,7 @@ cinnamon_recorder_close (CinnamonRecorder *recorder)
 
   recorder->state = RECORDER_STATE_CLOSED;
   recorder->count = 0;
-  g_free (recorder->unique);
+  free (recorder->unique);
   recorder->unique = NULL;
 
   /* Release the refcount we took when we started recording */

--- a/src/cinnamon-screenshot.c
+++ b/src/cinnamon-screenshot.c
@@ -65,8 +65,8 @@ on_screenshot_written (GObject *source,
 
   cairo_surface_destroy (screenshot_data->image);
   g_object_unref (screenshot_data->screenshot);
-  g_free (screenshot_data->filename);
-  g_free (screenshot_data);
+  free (screenshot_data->filename);
+  free (screenshot_data);
 }
 
 static void

--- a/src/cinnamon-tray-icon.c
+++ b/src/cinnamon-tray-icon.c
@@ -31,8 +31,8 @@ cinnamon_tray_icon_finalize (GObject *object)
 {
   CinnamonTrayIcon *icon = CINNAMON_TRAY_ICON (object);
 
-  g_free (icon->priv->title);
-  g_free (icon->priv->wm_class);
+  free (icon->priv->title);
+  free (icon->priv->wm_class);
 
   G_OBJECT_CLASS (cinnamon_tray_icon_parent_class)->finalize (object);
 }

--- a/src/cinnamon-util.c
+++ b/src/cinnamon-util.c
@@ -152,7 +152,7 @@ cinnamon_util_get_file_display_name (GFile *file, gboolean use_fallback)
 
       basename = g_file_get_basename (file);
       ret = g_filename_display_name (basename);
-      g_free (basename);
+      free (basename);
     }
 
   return ret;
@@ -215,7 +215,7 @@ cinnamon_util_get_icon_for_uri_known_folders (const char *uri)
       == 0)
     icon = "user-desktop";
 
-  g_free (path);
+  free (path);
 
   return icon;
 }
@@ -299,8 +299,8 @@ cinnamon_util_get_label_for_uri (const char *text_uri)
        */
        label = g_strdup_printf (_("%1$s: %2$s"),
                                 root_display, displayname);
-       g_free (root_display);
-       g_free (displayname);
+       free (root_display);
+       free (displayname);
     }
 
   g_object_unref (root);
@@ -690,7 +690,7 @@ cinnamon_get_file_contents_utf8_sync (const char *path,
     return NULL;
   if (!g_utf8_validate (contents, len, NULL))
     {
-      g_free (contents);
+      free (contents);
       g_set_error (error,
                    G_IO_ERROR,
                    G_IO_ERROR_FAILED,
@@ -726,7 +726,7 @@ get_file_contents_utf8_thread (GTask        *task,
         return;
       }
 
-    g_task_return_pointer (task, contents, g_free);
+    g_task_return_pointer (task, contents, free);
 }
 
 static void
@@ -749,7 +749,7 @@ get_file_contents_utf8_task_finished (GObject      *source,
 
     (* data->callback) (contents, data->user_data);
 
-    g_clear_pointer (&contents, g_free);
+    g_clear_pointer (&contents, free);
     g_slice_free (CinnamonFileContentsCallbackData, data);
 }
 
@@ -790,7 +790,7 @@ cinnamon_get_file_contents_utf8         (const char                   *path,
                      get_file_contents_utf8_task_finished,
                      data);
 
-  g_task_set_task_data (task, async_path, (GDestroyNotify) g_free);
+  g_task_set_task_data (task, async_path, (GDestroyNotify) free);
   g_task_run_in_thread (task, get_file_contents_utf8_thread);
 
   g_object_unref (task);
@@ -905,26 +905,26 @@ cinnamon_parse_search_provider (const char    *data,
     return TRUE;
 
   if (*icon_data_uri)
-    g_free (*icon_data_uri);
+    free (*icon_data_uri);
   else
     g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
                  "search provider doesn't have icon");
 
   if (*name)
-    g_free (*name);
+    free (*name);
   else if (error && !*error)
     g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
                  "search provider doesn't have ShortName");
 
   if (*url)
-    g_free (*url);
+    free (*url);
   else if (error && !*error)
     g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
                  "search provider doesn't have template for url");
 
   if (*langs)
     {
-      g_list_foreach (*langs, (GFunc)g_free, NULL);
+      g_list_foreach (*langs, (GFunc)free, NULL);
       g_list_free (*langs);
     }
 

--- a/src/cinnamon-window-tracker.c
+++ b/src/cinnamon-window-tracker.c
@@ -258,7 +258,7 @@ get_app_from_gapplication_id (MetaWindow  *window)
   if (app)
     g_object_ref (app);
 
-  g_free (desktop_file);
+  free (desktop_file);
   return app;
 }
 

--- a/src/cinnamon-xfixes-cursor.c
+++ b/src/cinnamon-xfixes-cursor.c
@@ -241,7 +241,7 @@ xfixes_cursor_reset_image (CinnamonXFixesCursor *xfixes_cursor)
                                                   cursor_data);
 
   if (free_cursor_data)
-    g_free (cursor_data);
+    free (cursor_data);
 
   if (sprite != COGL_INVALID_HANDLE)
     {

--- a/src/hotplug-sniffer/cinnamon-mime-sniffer.c
+++ b/src/hotplug-sniffer/cinnamon-mime-sniffer.c
@@ -99,7 +99,7 @@ init_mimetypes (void)
       gchar **types;
       gint idx;
 
-      image_type_table = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+      image_type_table = g_hash_table_new_full (g_str_hash, g_str_equal, free, NULL);
       video_type_table = g_hash_table_new (g_str_hash, g_str_equal);
       audio_type_table = g_hash_table_new (g_str_hash, g_str_equal);
       docs_type_table = g_hash_table_new (g_str_hash, g_str_equal);
@@ -269,7 +269,7 @@ deep_count_finish (DeepCountState *state)
 
   g_list_free_full (state->deep_count_subdirectories, g_object_unref);
 
-  g_free (state);
+  free (state);
 }
 
 static void

--- a/src/hotplug-sniffer/cinnamon-mime-sniffer.h
+++ b/src/hotplug-sniffer/cinnamon-mime-sniffer.h
@@ -24,6 +24,7 @@
 #ifndef __CINNAMON_MIME_SNIFFER_H__
 #define __CINNAMON_MIME_SNIFFER_H__
 
+#include <stdlib.h>
 #include <glib-object.h>
 #include <gio/gio.h>
 

--- a/src/hotplug-sniffer/hotplug-sniffer.c
+++ b/src/hotplug-sniffer/hotplug-sniffer.c
@@ -75,7 +75,7 @@ ensure_autoquit_on (void)
   if (g_getenv ("HOTPLUG_SNIFFER_PERSIST") != NULL)
     return;
 
-  autoquit_id = 
+  autoquit_id =
     g_timeout_add_seconds (AUTOQUIT_TIMEOUT,
                            autoquit_timeout_cb, NULL);
 }
@@ -144,7 +144,7 @@ handle_sniff_uri (InvocationData *data)
 
   ensure_autoquit_off ();
 
-  g_variant_get (data->parameters, 
+  g_variant_get (data->parameters,
                  "(&s)", &uri,
                  NULL);
   file = g_file_new_for_uri (uri);
@@ -300,7 +300,7 @@ print_debug (const gchar *format, ...)
   va_end (ap);
 
   g_print ("cinnamon-hotplug-sniffer[%d]: %s.%03d: %s\n", pid, timebuf, (gint) (now.tv_usec / 1000), s);
-  g_free (s);
+  free (s);
  out:
   ;
 }

--- a/src/run-js-test.c
+++ b/src/run-js-test.c
@@ -127,17 +127,17 @@ main(int argc, char **argv)
   stage = clutter_stage_get_default ();
   title = g_filename_display_basename (filename);
   clutter_stage_set_title (CLUTTER_STAGE (stage), title);
-  g_free (title);
+  free (title);
 
   /* evaluate the script */
   error = NULL;
   if (!gjs_context_eval (js_context, script, len,
                          filename, &code, &error)) {
-    g_free (script);
+    free (script);
     g_printerr ("%s\n", error->message);
     exit (1);
   }
 
-  g_free (script);
+  free (script);
   exit (code);
 }

--- a/src/st/st-background-effect.c
+++ b/src/st/st-background-effect.c
@@ -141,7 +141,7 @@ st_background_effect_pre_paint (ClutterEffect *effect)
         rowstride = (self->bg_width_i) * 4;
 
 
-        data = g_malloc (size);
+        data = malloc (size);
 
         cogl_read_pixels (self->bg_posx_i,
                           self->bg_posy_i,

--- a/src/st/st-background-effect.c
+++ b/src/st/st-background-effect.c
@@ -168,7 +168,7 @@ st_background_effect_pre_paint (ClutterEffect *effect)
                                                                        rowstride,
                                                                        data);
 
-            g_free (data);
+            free (data);
 
           }
       }
@@ -485,7 +485,7 @@ st_background_effect_class_init (StBackgroundEffectClass *klass)
   gobject_class->set_property = st_background_effect_set_property;
   gobject_class->get_property = st_background_effect_get_property;
   gobject_class->dispose = st_background_effect_dispose;
-  
+
   offscreen_class = CLUTTER_OFFSCREEN_EFFECT_CLASS (klass);
   offscreen_class->paint_target = st_background_effect_paint_target;
 
@@ -508,11 +508,11 @@ st_background_effect_init (StBackgroundEffect *self)
 
   if (G_UNLIKELY (klass->base_pipeline == NULL))
     {
-      ctx = clutter_backend_get_cogl_context (clutter_get_default_backend ());
+      ctx = st_get_cogl_context ();
 
       klass->base_pipeline = cogl_pipeline_new (ctx);
     }
-    
+
   self->pipeline0 = cogl_pipeline_copy (klass->base_pipeline);
   self->pipeline1 = cogl_pipeline_copy (klass->base_pipeline);
   self->pipeline2 = cogl_pipeline_copy (klass->base_pipeline);
@@ -601,7 +601,7 @@ st_background_effect_init (StBackgroundEffect *self)
   cogl_pipeline_set_layer_null_texture (self->pipeline3,
                                         0,
                                         COGL_TEXTURE_TYPE_2D);
-  
+
   cogl_pipeline_set_layer_null_texture (self->pipeline4,
                                         0,
                                         COGL_TEXTURE_TYPE_2D);
@@ -649,7 +649,7 @@ st_background_effect_init (StBackgroundEffect *self)
   cogl_pipeline_set_alpha_test_function (self->pipeline3,
                                          COGL_PIPELINE_ALPHA_FUNC_GEQUAL,
                                          0.004f);
-    
+
   cogl_pipeline_set_color_mask (self->pipeline3,
                                 COGL_COLOR_MASK_ALL);
 
@@ -660,7 +660,7 @@ st_background_effect_init (StBackgroundEffect *self)
   cogl_pipeline_set_alpha_test_function (self->pipeline4,
                                          COGL_PIPELINE_ALPHA_FUNC_GEQUAL,
                                          0.004f);
-    
+
   cogl_pipeline_set_color_mask (self->pipeline4,
                                 COGL_COLOR_MASK_ALL);
 

--- a/src/st/st-border-image.c
+++ b/src/st/st-border-image.c
@@ -46,7 +46,7 @@ st_border_image_finalize (GObject *object)
 {
   StBorderImage *image = ST_BORDER_IMAGE (object);
 
-  g_free (image->filename);
+  free (image->filename);
 
   G_OBJECT_CLASS (st_border_image_parent_class)->finalize (object);
 }

--- a/src/st/st-button.c
+++ b/src/st/st-button.c
@@ -360,7 +360,7 @@ st_button_finalize (GObject *gobject)
 {
   StButtonPrivate *priv = ST_BUTTON (gobject)->priv;
 
-  g_free (priv->text);
+  free (priv->text);
 
   G_OBJECT_CLASS (st_button_parent_class)->finalize (gobject);
 }
@@ -511,7 +511,7 @@ st_button_set_label (StButton    *button,
 
   priv = button->priv;
 
-  g_free (priv->text);
+  free (priv->text);
 
   if (text)
     priv->text = g_strdup (text);

--- a/src/st/st-clipboard.c
+++ b/src/st/st-clipboard.c
@@ -94,10 +94,10 @@ st_clipboard_finalize (GObject *object)
 {
   StClipboardPrivate *priv = ((StClipboard *) object)->priv;
 
-  g_free (priv->clipboard_text);
+  free (priv->clipboard_text);
   priv->clipboard_text = NULL;
 
-  g_free (priv->supported_targets);
+  free (priv->supported_targets);
   priv->supported_targets = NULL;
   priv->n_targets = 0;
 
@@ -237,7 +237,7 @@ st_clipboard_x11_event_filter (XEvent          *xev,
 
       clutter_x11_remove_filter ((ClutterX11FilterFunc) st_clipboard_x11_event_filter,
                                  filter_data);
-      g_free (filter_data);
+      free (filter_data);
       return CLUTTER_X11_FILTER_REMOVE;
     }
 
@@ -268,7 +268,7 @@ st_clipboard_x11_event_filter (XEvent          *xev,
                           ((ClutterX11FilterFunc) st_clipboard_x11_event_filter,
                           filter_data);
 
-  g_free (filter_data);
+  free (filter_data);
 
   if (data)
     XFree (data);
@@ -371,7 +371,7 @@ st_clipboard_set_text (StClipboard *clipboard,
   priv = clipboard->priv;
 
   /* make a copy of the text */
-  g_free (priv->clipboard_text);
+  free (priv->clipboard_text);
   priv->clipboard_text = g_strdup (text);
 
   /* tell X we own the clipboard selection */

--- a/src/st/st-entry.c
+++ b/src/st/st-entry.c
@@ -236,7 +236,7 @@ st_entry_finalize (GObject *object)
 {
   StEntryPrivate *priv = ST_ENTRY_PRIV (object);
 
-  g_free (priv->hint);
+  free (priv->hint);
   priv->hint = NULL;
 
   G_OBJECT_CLASS (st_entry_parent_class)->finalize (object);
@@ -1074,7 +1074,7 @@ st_entry_set_hint_text (StEntry     *entry,
 
   priv = entry->priv;
 
-  g_free (priv->hint);
+  free (priv->hint);
 
   priv->hint = g_strdup (text);
 
@@ -1167,7 +1167,7 @@ _st_entry_set_icon_from_file (StEntry       *entry,
       g_object_unref (file);
 
       new_icon = (ClutterActor*) st_texture_cache_load_uri_async (cache, uri, -1, -1);
-      g_free (uri);
+      free (uri);
     }
 
   _st_entry_set_icon  (entry, icon, new_icon);

--- a/src/st/st-icon.c
+++ b/src/st/st-icon.c
@@ -175,7 +175,7 @@ st_icon_finalize (GObject *gobject)
 
   if (priv->icon_name)
     {
-      g_free (priv->icon_name);
+      free (priv->icon_name);
       priv->icon_name = NULL;
     }
 
@@ -553,7 +553,7 @@ st_icon_set_icon_name (StIcon      *icon,
   if (g_strcmp0 (priv->icon_name, icon_name) == 0)
     return;
 
-  g_free (priv->icon_name);
+  free (priv->icon_name);
   priv->icon_name = g_strdup (icon_name);
 
   if (priv->gicon)
@@ -653,7 +653,7 @@ st_icon_set_gicon (StIcon *icon, GIcon *gicon)
 
   if (icon->priv->icon_name)
     {
-      g_free (icon->priv->icon_name);
+      free (icon->priv->icon_name);
       icon->priv->icon_name = NULL;
       g_object_notify (G_OBJECT (icon), "icon-name");
     }

--- a/src/st/st-im-text.c
+++ b/src/st/st-im-text.c
@@ -156,7 +156,7 @@ st_im_text_preedit_changed_cb (GtkIMContext *context,
                                    preedit_attrs,
                                    cursor_pos);
 
-  g_free (preedit_str);
+  free (preedit_str);
   pango_attr_list_unref (preedit_attrs);
 }
 

--- a/src/st/st-private.c
+++ b/src/st/st-private.c
@@ -186,7 +186,7 @@ _st_set_text_from_style (ClutterText *text,
   font = st_theme_node_get_font (theme_node);
   font_string = pango_font_description_to_string (font);
   clutter_text_set_font_name (text, font_string);
-  g_free (font_string);
+  free (font_string);
 
   decoration = st_theme_node_get_text_decoration (theme_node);
 
@@ -394,8 +394,8 @@ blur_pixels (guchar  *pixels_in,
                 }
             }
         }
-      g_free (kernel);
-      g_free (line);
+      free (kernel);
+      free (line);
     }
 
   return pixels_out;
@@ -428,7 +428,7 @@ _st_create_shadow_pipeline (StShadow     *shadow_spec,
   pixels_out = blur_pixels (pixels_in, width_in, height_in, rowstride_in,
                             shadow_spec->blur,
                             &width_out, &height_out, &rowstride_out);
-  g_free (pixels_in);
+  free (pixels_in);
 
   texture = st_cogl_texture_new_from_data_wrapper (width_out, height_out,
                                                    COGL_TEXTURE_NONE,
@@ -437,7 +437,7 @@ _st_create_shadow_pipeline (StShadow     *shadow_spec,
                                                    rowstride_out,
                                                    pixels_out);
 
-  g_free (pixels_out);
+  free (pixels_out);
 
   if (G_UNLIKELY (shadow_pipeline_template == NULL))
     {
@@ -625,7 +625,7 @@ _st_create_shadow_cairo_pattern (StShadow        *shadow_spec,
                                                      height_out,
                                                      rowstride_out);
   cairo_surface_set_user_data (surface_out, &shadow_pattern_user_data,
-                               pixels_out, (cairo_destroy_func_t) g_free);
+                               pixels_out, (cairo_destroy_func_t) free);
 
   dst_pattern = cairo_pattern_create_for_surface (surface_out);
   cairo_surface_destroy (surface_out);

--- a/src/st/st-private.c
+++ b/src/st/st-private.c
@@ -277,7 +277,7 @@ calculate_gaussian_kernel (float   sigma,
 
   half = n_values / 2;
 
-  ret = g_malloc (n_values * sizeof (gdouble));
+  ret = malloc (n_values * sizeof (gdouble));
   sum = 0.0;
 
   exp_divisor = 2 * sigma * sigma;

--- a/src/st/st-scroll-view-fade.c
+++ b/src/st/st-scroll-view-fade.c
@@ -465,7 +465,7 @@ st_scroll_view_fade_init (StScrollViewFade *self)
 
               g_warning (G_STRLOC ": Unable to compile the fade shader: %s",
                          log_buf);
-              g_free (log_buf);
+              free (log_buf);
 
               cogl_handle_unref (shader);
               shader = COGL_INVALID_HANDLE;

--- a/src/st/st-texture-cache.c
+++ b/src/st/st-texture-cache.c
@@ -172,15 +172,15 @@ st_texture_cache_init (StTextureCache *self)
                     G_CALLBACK (on_icon_theme_changed), self);
 
   self->priv->keyed_cache = g_hash_table_new_full (g_str_hash, g_str_equal,
-                                                   g_free, cogl_object_unref);
+                                                   free, cogl_object_unref);
 
   self->priv->keyed_surface_cache = g_hash_table_new_full (g_str_hash,
                                                            g_str_equal,
-                                                           g_free,
+                                                           free,
                                                            (GDestroyNotify) cairo_surface_destroy);
 
   self->priv->outstanding_requests = g_hash_table_new_full (g_str_hash, g_str_equal,
-                                                            g_free, NULL);
+                                                            free, NULL);
   self->priv->file_monitors = g_hash_table_new_full (g_str_hash, g_str_equal,
                                                      g_object_unref, g_object_unref);
 
@@ -323,15 +323,15 @@ texture_load_data_free (gpointer p)
         st_icon_colors_unref (data->colors);
     }
   else if (data->uri)
-    g_free (data->uri);
+    free (data->uri);
 
   if (data->key)
-    g_free (data->key);
+    free (data->key);
 
   if (data->textures)
     g_slist_free_full (data->textures, (GDestroyNotify) g_object_unref);
 
-  g_free (data);
+  free (data);
 }
 
 /**
@@ -467,7 +467,7 @@ impl_load_pixbuf_file (const char     *uri,
     }
 
   g_object_unref (file);
-  g_free (contents);
+  free (contents);
 
   return pixbuf;
 }
@@ -805,7 +805,7 @@ load_gicon_with_colors (StTextureCache    *cache,
       key = g_strdup_printf (CACHE_PREFIX_ICON "%s,size=%d,scale=%d",
                              gicon_string, size, scale);
     }
-  g_free (gicon_string);
+  free (gicon_string);
 
   texture = (ClutterActor *) create_default_texture ();
   clutter_actor_set_size (texture, size * scale, size * scale);
@@ -814,7 +814,7 @@ load_gicon_with_colors (StTextureCache    *cache,
     {
       /* If there's an outstanding request, we've just added ourselves to it */
       g_object_unref (info);
-      g_free (key);
+      free (key);
     }
   else
     {
@@ -906,15 +906,15 @@ file_changed_cb (GFileMonitor      *monitor,
 
   key = g_strconcat (CACHE_PREFIX_URI, uri, NULL);
   g_hash_table_remove (cache->priv->keyed_cache, key);
-  g_free (key);
+  free (key);
 
   key = g_strconcat (CACHE_PREFIX_URI_FOR_CAIRO, uri, NULL);
   g_hash_table_remove (cache->priv->keyed_surface_cache, key);
-  g_free (key);
+  free (key);
 
   g_signal_emit (cache, signals[TEXTURE_FILE_CHANGED], 0, uri);
 
-  g_free (uri);
+  free (uri);
 }
 
 static void
@@ -953,9 +953,9 @@ static void
 on_data_destroy (gpointer data)
 {
   AsyncImageData *d = (AsyncImageData *)data;
-  g_free (d->path);
+  free (d->path);
   g_object_unref (d->actor);
-  g_free (d);
+  free (d);
 }
 
 static void
@@ -1167,7 +1167,7 @@ st_texture_cache_load_icon_name (StTextureCache    *cache,
     case ST_ICON_SYMBOLIC:
       symbolic_name = symbolic_name_for_icon (name);
       themed = g_themed_icon_new (symbolic_name);
-      g_free (symbolic_name);
+      free (symbolic_name);
       texture = load_gicon_with_colors (cache, themed, size, cache->priv->scale,
                                         st_theme_node_get_icon_colors (theme_node));
       g_object_unref (themed);
@@ -1228,7 +1228,7 @@ st_texture_cache_load_uri_async (StTextureCache *cache,
   if (ensure_request (cache, key, policy, &request, texture))
     {
       /* If there's an outstanding request, we've just added ourselves to it */
-      g_free (key);
+      free (key);
     }
   else
     {
@@ -1296,7 +1296,7 @@ st_texture_cache_load_uri_sync_to_cogl_texture (StTextureCache *cache,
   ensure_monitor_for_uri (cache, uri);
 
 out:
-  g_free (key);
+  free (key);
   return texdata;
 }
 
@@ -1341,7 +1341,7 @@ st_texture_cache_load_uri_sync_to_cairo_surface (StTextureCache        *cache,
   ensure_monitor_for_uri (cache, uri);
 
 out:
-  g_free (key);
+  free (key);
   return surface;
 }
 
@@ -1412,7 +1412,7 @@ st_texture_cache_load_file_to_cogl_texture (StTextureCache *cache,
   texture = st_texture_cache_load_uri_sync_to_cogl_texture (cache, ST_TEXTURE_CACHE_POLICY_FOREVER,
                                                             uri, -1, -1, &error);
   g_object_unref (file);
-  g_free (uri);
+  free (uri);
 
   if (texture == NULL)
     {
@@ -1449,7 +1449,7 @@ st_texture_cache_load_file_to_cairo_surface (StTextureCache *cache,
   surface = st_texture_cache_load_uri_sync_to_cairo_surface (cache, ST_TEXTURE_CACHE_POLICY_FOREVER,
                                                              uri, -1, -1, &error);
   g_object_unref (file);
-  g_free (uri);
+  free (uri);
 
   if (surface == NULL)
     {
@@ -1526,7 +1526,7 @@ st_texture_cache_load_file_simple (StTextureCache *cache,
   texture = st_texture_cache_load_uri_sync (cache, ST_TEXTURE_CACHE_POLICY_FOREVER,
                                             uri, -1, -1, &error);
   g_object_unref (file);
-  g_free (uri);
+  free (uri);
   if (texture == NULL)
     {
       if (error)

--- a/src/st/st-theme-node-drawing.c
+++ b/src/st/st-theme-node-drawing.c
@@ -173,7 +173,7 @@ create_corner_material (StCornerSpec *corner)
                                                    rowstride,
                                                    data);
 
-  g_free (data);
+  free (data);
 
   return texture;
 }
@@ -397,7 +397,7 @@ st_theme_node_lookup_corner (StThemeNode    *node,
       cogl_handle_unref (texture);
     }
 
-  g_free (key);
+  free (key);
 
   return material;
 }
@@ -1273,7 +1273,7 @@ st_theme_node_prerender_background (StThemeNode *node)
 
   cairo_destroy (cr);
   cairo_surface_destroy (surface);
-  g_free (data);
+  free (data);
 
   return texture;
 }

--- a/src/st/st-theme-node.c
+++ b/src/st/st-theme-node.c
@@ -2879,7 +2879,7 @@ st_theme_node_get_border_image (StThemeNode *node)
           int border_left;
 
           GFile *file;
-          char *filename;
+          char *filename = NULL;
 
           /* Support border-image: none; to suppress a previously specified border image */
           if (term_is_none (term))

--- a/src/st/st-theme-node.c
+++ b/src/st/st-theme-node.c
@@ -65,7 +65,7 @@ maybe_free_properties (StThemeNode *node)
 {
   if (node->properties)
     {
-      g_free (node->properties);
+      free (node->properties);
       node->properties = NULL;
       node->n_properties = 0;
     }
@@ -131,10 +131,10 @@ st_theme_node_finalize (GObject *object)
 {
   StThemeNode *node = ST_THEME_NODE (object);
 
-  g_free (node->element_id);
+  free (node->element_id);
   g_strfreev (node->element_classes);
   g_strfreev (node->pseudo_classes);
-  g_free (node->inline_style);
+  free (node->inline_style);
 
   maybe_free_properties (node);
 
@@ -163,7 +163,7 @@ st_theme_node_finalize (GObject *object)
     }
 
   if (node->background_image)
-    g_free (node->background_image);
+    free (node->background_image);
 
   _st_theme_node_free_drawing_state (node);
 
@@ -192,7 +192,7 @@ split_on_whitespace (const gchar *s)
       cur = strtok_r (NULL, " \t\f\r\n", &temp);
     }
 
-  g_free (l);
+  free (l);
   g_ptr_array_add (arr, NULL);
   return (GStrv) g_ptr_array_free (arr, FALSE);
 }
@@ -1834,7 +1834,7 @@ _st_theme_node_ensure_background (StThemeNode *node)
           CRTerm *term;
           /* background: property sets all terms to specified or default values */
           node->background_color = TRANSPARENT_COLOR;
-          g_free (node->background_image);
+          free (node->background_image);
           node->background_image = NULL;
           node->background_position_set = FALSE;
           node->background_size = ST_BACKGROUND_SIZE_AUTO;
@@ -1980,7 +1980,7 @@ _st_theme_node_ensure_background (StThemeNode *node)
               else
                 base_stylesheet = NULL;
 
-              g_free (node->background_image);
+              free (node->background_image);
               file = _st_theme_resolve_url (node->theme,
                                             base_stylesheet,
                                             decl->value->content.str->stryng->str);
@@ -1993,12 +1993,12 @@ _st_theme_node_ensure_background (StThemeNode *node)
             }
           else if (term_is_inherit (decl->value))
             {
-              g_free (node->background_image);
+              free (node->background_image);
               node->background_image = g_strdup (st_theme_node_get_background_image (node->parent_node));
             }
           else if (term_is_none (decl->value))
             {
-              g_free (node->background_image);
+              free (node->background_image);
               node->background_image = NULL;
             }
         }
@@ -2017,7 +2017,7 @@ _st_theme_node_ensure_background (StThemeNode *node)
               else
                 base_stylesheet = NULL;
 
-              g_free (node->background_bumpmap);
+              free (node->background_bumpmap);
               file = _st_theme_resolve_url (node->theme,
                                             base_stylesheet,
                                             decl->value->content.str->stryng->str);
@@ -2029,12 +2029,12 @@ _st_theme_node_ensure_background (StThemeNode *node)
             }
           else if (term_is_inherit (decl->value))
             {
-              g_free (node->background_bumpmap);
+              free (node->background_bumpmap);
               node->background_bumpmap = g_strdup (st_theme_node_get_background_bumpmap (node->parent_node));
             }
           else if (term_is_none(decl->value))
             {
-              g_free (node->background_bumpmap);
+              free (node->background_bumpmap);
             }
         }
       else if (strcmp (property_name, "-gradient-direction") == 0)
@@ -2795,7 +2795,7 @@ st_theme_node_get_font (StThemeNode *node)
   if (family)
     {
       pango_font_description_set_family (node->font_desc, family);
-      g_free (family);
+      free (family);
     }
 
   if (size_set)
@@ -2971,7 +2971,7 @@ st_theme_node_get_border_image (StThemeNode *node)
           node->border_image = st_border_image_new (filename,
                                                     border_top, border_right, border_bottom, border_left);
 
-          g_free (filename);
+          free (filename);
 
           return node->border_image;
         }

--- a/src/st/st-theme.c
+++ b/src/st/st-theme.c
@@ -110,7 +110,7 @@ static void
 st_theme_init (StTheme *theme)
 {
   theme->stylesheets_by_filename = g_hash_table_new_full (g_str_hash, g_str_equal,
-                                                          (GDestroyNotify)g_free, (GDestroyNotify)cr_stylesheet_unref);
+                                                          (GDestroyNotify)free, (GDestroyNotify)cr_stylesheet_unref);
   theme->filenames_by_stylesheet = g_hash_table_new (g_direct_hash, g_direct_equal);
 }
 
@@ -363,10 +363,10 @@ st_theme_finalize (GObject * object)
   g_hash_table_destroy (theme->stylesheets_by_filename);
   g_hash_table_destroy (theme->filenames_by_stylesheet);
 
-  g_free (theme->application_stylesheet);
-  g_free (theme->theme_stylesheet);
-  g_free (theme->default_stylesheet);
-  g_free (theme->fallback_stylesheet);
+  free (theme->application_stylesheet);
+  free (theme->theme_stylesheet);
+  free (theme->default_stylesheet);
+  free (theme->fallback_stylesheet);
 
   if (theme->cascade)
     {
@@ -393,7 +393,7 @@ st_theme_set_property (GObject      *object,
 
         if (path != theme->application_stylesheet)
           {
-            g_free (theme->application_stylesheet);
+            free (theme->application_stylesheet);
             theme->application_stylesheet = g_strdup (path);
           }
 
@@ -405,7 +405,7 @@ st_theme_set_property (GObject      *object,
 
         if (path != theme->theme_stylesheet)
           {
-            g_free (theme->theme_stylesheet);
+            free (theme->theme_stylesheet);
             theme->theme_stylesheet = g_strdup (path);
           }
 
@@ -417,7 +417,7 @@ st_theme_set_property (GObject      *object,
 
         if (path != theme->default_stylesheet)
           {
-            g_free (theme->default_stylesheet);
+            free (theme->default_stylesheet);
             theme->default_stylesheet = g_strdup (path);
           }
 
@@ -429,7 +429,7 @@ st_theme_set_property (GObject      *object,
 
         if (path != theme->fallback_stylesheet)
           {
-            g_free (theme->fallback_stylesheet);
+            free (theme->fallback_stylesheet);
             theme->fallback_stylesheet = g_strdup (path);
           }
 
@@ -928,7 +928,7 @@ add_matched_properties (StTheme      *a_this,
                   }
 
                 if (filename)
-                  g_free (filename);
+                  free (filename);
               }
 
             if (import_rule->sheet != (CRStyleSheet *) - 1)
@@ -1096,7 +1096,7 @@ _st_theme_resolve_url (StTheme      *theme,
 
   if ((scheme = g_uri_parse_scheme (url)))
     {
-      g_free (scheme);
+      free (scheme);
       resource = g_file_new_for_uri (url);
     }
   else if (base_stylesheet != NULL)
@@ -1117,7 +1117,7 @@ _st_theme_resolve_url (StTheme      *theme,
       resource = g_file_resolve_relative_path (stylesheet, url);
 
       g_object_unref (stylesheet);
-      g_free (dirname);
+      free (dirname);
     }
   else
     {

--- a/src/st/st-types.h
+++ b/src/st/st-types.h
@@ -21,6 +21,7 @@
 #error "Only <st/st.h> can be included directly.h"
 #endif
 
+#include <stdlib.h>
 #include <glib-object.h>
 #include <clutter/clutter.h>
 #include <gtk/gtk.h>

--- a/src/st/st-widget.c
+++ b/src/st/st-widget.c
@@ -290,11 +290,11 @@ st_widget_finalize (GObject *gobject)
 {
   StWidgetPrivate *priv = ST_WIDGET (gobject)->priv;
 
-  g_free (priv->style_class);
-  g_free (priv->pseudo_class);
+  free (priv->style_class);
+  free (priv->pseudo_class);
   g_object_unref (priv->local_state_set);
-  g_free (priv->accessible_name);
-  g_free (priv->inline_style);
+  free (priv->accessible_name);
+  free (priv->inline_style);
 
   G_OBJECT_CLASS (st_widget_parent_class)->finalize (gobject);
 }
@@ -592,7 +592,7 @@ st_widget_get_theme_node (StWidget *widget)
                                     priv->important);
 
       if (pseudo_class != direction_pseudo_class)
-        g_free (pseudo_class);
+        free (pseudo_class);
 
       priv->theme_node = g_object_ref (st_theme_context_intern_node (context,
                                                                      tmp_node));
@@ -1067,7 +1067,7 @@ set_class_list (gchar       **class_list,
 {
   if (g_strcmp0 (*class_list, new_class_list) != 0)
     {
-      g_free (*class_list);
+      free (*class_list);
       *class_list = g_strdup (new_class_list);
       return TRUE;
     }
@@ -1087,7 +1087,7 @@ add_class_name (gchar       **class_list,
         return FALSE;
 
       new_class_list = g_strdup_printf ("%s %s", *class_list, class_name);
-      g_free (*class_list);
+      free (*class_list);
       *class_list = new_class_list;
     }
   else
@@ -1108,7 +1108,7 @@ remove_class_name (gchar       **class_list,
 
   if (strcmp (*class_list, class_name) == 0)
     {
-      g_free (*class_list);
+      free (*class_list);
       *class_list = NULL;
       return TRUE;
     }
@@ -1128,7 +1128,7 @@ remove_class_name (gchar       **class_list,
 
   new_class_list = g_strdup_printf ("%.*s%s", (int)(match - *class_list),
                                     *class_list, end);
-  g_free (*class_list);
+  free (*class_list);
   *class_list = new_class_list;
 
   return TRUE;
@@ -1386,7 +1386,7 @@ st_widget_set_style (StWidget  *actor,
 
   if (g_strcmp0 (style, priv->inline_style))
     {
-      g_free (priv->inline_style);
+      free (priv->inline_style);
       priv->inline_style = g_strdup (style);
 
       st_widget_style_changed (actor);
@@ -2368,7 +2368,7 @@ st_widget_set_accessible_name (StWidget *widget,
   g_return_if_fail (ST_IS_WIDGET (widget));
 
   if (widget->priv->accessible_name != NULL)
-    g_free (widget->priv->accessible_name);
+    free (widget->priv->accessible_name);
 
   widget->priv->accessible_name = g_strdup (name);
   g_object_notify (G_OBJECT (widget), "accessible-name");

--- a/src/st/test-theme.c
+++ b/src/st/test-theme.c
@@ -56,7 +56,7 @@ assert_font (StThemeNode *node,
       fail = TRUE;
     }
 
-  g_free (value);
+  free (value);
 }
 
 static char *
@@ -96,8 +96,8 @@ assert_text_decoration (StThemeNode     *node,
 	       test, node_description, es, vs);
       fail = TRUE;
 
-      g_free (es);
-      g_free (vs);
+      free (es);
+      free (vs);
     }
 }
 

--- a/src/tray/na-tray-manager.c
+++ b/src/tray/na-tray-manager.c
@@ -447,7 +447,7 @@ na_tray_manager_handle_begin_message (NaTrayManager       *manager,
       msg->len = len;
       msg->id = id;
       msg->remaining_len = msg->len;
-      msg->str = g_malloc (msg->len + 1);
+      msg->str = malloc (msg->len + 1);
       msg->str[msg->len] = '\0';
       manager->messages = g_list_prepend (manager->messages, msg);
     }

--- a/src/tray/na-tray-manager.c
+++ b/src/tray/na-tray-manager.c
@@ -313,7 +313,7 @@ out:
   g_object_unref (child);
 
   /* Free it since we tell the caller to stop calling us by returning FALSE */
-  g_free (packet);
+  free (packet);
   return FALSE;
 }
 
@@ -350,8 +350,8 @@ na_tray_manager_handle_dock_request (NaTrayManager       *manager,
 static void
 pending_message_free (PendingMessage *message)
 {
-  g_free (message->str);
-  g_free (message);
+  free (message->str);
+  free (message);
 }
 
 static void
@@ -750,7 +750,7 @@ na_tray_manager_manage_screen_x11 (NaTrayManager *manager,
   selection_atom_name = g_strdup_printf ("_NET_SYSTEM_TRAY_S%d",
 					 gdk_screen_get_number (screen));
   manager->selection_atom = gdk_atom_intern (selection_atom_name, FALSE);
-  g_free (selection_atom_name);
+  free (selection_atom_name);
 
   manager->invisible = invisible;
   g_object_ref (G_OBJECT (manager->invisible));
@@ -853,7 +853,7 @@ na_tray_manager_check_running_screen_x11 (GdkScreen *screen)
                                          gdk_screen_get_number (screen));
   selection_atom = gdk_x11_get_xatom_by_name_for_display (display,
                                                           selection_atom_name);
-  g_free (selection_atom_name);
+  free (selection_atom_name);
 
   if (XGetSelectionOwner (GDK_DISPLAY_XDISPLAY (display),
                           selection_atom) != None)


### PR DESCRIPTION
See https://github.com/linuxmint/muffin/pull/421

> This replaces a few GLib wrapper methods with direct C method calls. Through Typometer and a [window mapping test script](https://github.com/linuxmint/Cinnamon/pull/7251), I was [able to see a trend of better performance](https://docs.google.com/spreadsheets/d/1sPmE2Eod9mQ8LT0JNGAKvDTH1JIB8GsqpEZrLLAe5TA/edit?usp=sharing) using the C methods directly. While synthetic test results don't always represent normal work flows, the increase in responsiveness is noticeable during normal usage on my machine.
