### PR TITLE
window-list: Fix MetaWindowActor TypeError

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -1096,7 +1096,8 @@ class CinnamonWindowListApplet extends Applet.Applet {
     }
 
     _onWindowMonitorChanged(screen, metaWindow, monitor) {
-        if (!metaWindow.get_compositor_private().visible && !metaWindow.minimized) return;
+        const windowActor = metaWindow.get_compositor_private();
+        if (!windowActor || (!windowActor.visible && !metaWindow.minimized)) return;
         if (this._shouldAdd(metaWindow))
             this._addWindow(metaWindow, false);
         else


### PR DESCRIPTION
Fixes:

```
(cinnamon:1011): Cjs-WARNING **: 20:59:35.685: JS ERROR: TypeError: metaWindow.get_compositor_private(...) is null
_onWindowMonitorChanged@/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js:1099:14
```