### PR TITLE
Consider the "last-edited" field as integer even when enclosed in quotation marks.

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
@@ -446,7 +446,7 @@ class Spice_Harvester(GObject.Object):
             return False
 
         try:
-            return self.meta_map[uuid]["last-edited"] < self.index_cache[uuid]["last_edited"]
+            return int(self.meta_map[uuid]["last-edited"]) < self.index_cache[uuid]["last_edited"]
         except Exception as e:
             return False
 


### PR DESCRIPTION
The problem was revealed in the issue https://github.com/linuxmint/cinnamon-spices-applets/issues/2216.

The metadata.json file of some xlets installed for a long time contains a "last-edited" field enclosed in quotation marks. So, it's considered a string and not an integer.

The comparison of dates can not be done and the available update is not available for download by Cinnamon Settings [Applets|Desklets|Extensions].

This simple modification solves the problem.
