### PR TITLE
layout: Misc. clean up

### DIFF
--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -41,10 +41,6 @@ Monitor.prototype = {
     }
 };
 
-const syncPointer = throttle(function() {
-    global.sync_pointer();
-}, 1000, false);
-
 /**
  * #LayoutManager
  *
@@ -691,7 +687,7 @@ Chrome.prototype = {
 
             /* Pointer only needs to be updated to account for tray icon popup windows, which
                will be reflected by the global.display.popup_window_visible return value. */
-            syncPointer();
+            Mainloop.idle_add_full(1000, () => global.sync_pointer());
         } else {
             this._queueUpdateRegions();
         }

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -663,7 +663,7 @@ Chrome.prototype = {
 
     _queueUpdateRegions: function() {
         if (!this._updateRegionIdle && !this._freezeUpdateCount)
-            this._updateRegionIdle = Mainloop.idle_add_full(Mainloop.PRIORITY_HIGH, () => this.updateRegions());
+            this._updateRegionIdle = Mainloop.idle_add_full(-200, () => this.updateRegions());
     },
 
     freezeUpdateRegions: function() {

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -41,15 +41,14 @@ Monitor.prototype = {
     }
 };
 
-function intersect (src1, src2) {
-    let dest = {};
+function intersect (dest, src2) {
     let dest_x, dest_y;
     let dest_w, dest_h;
 
-    dest_x = Math.max(src1.x, src2.x);
-    dest_y = Math.max(src1.y, src2.y);
-    dest_w = Math.min(src1.x + src1.width, src2.x + src2.width) - dest_x;
-    dest_h = Math.min(src1.y + src1.height, src2.y + src2.height) - dest_y;
+    dest_x = Math.max(dest.x, src2.x);
+    dest_y = Math.max(dest.y, src2.y);
+    dest_w = Math.min(dest.x + dest.width, src2.x + src2.width) - dest_x;
+    dest_h = Math.min(dest.y + dest.height, src2.y + src2.height) - dest_y;
 
     if (dest_w > 0 && dest_h > 0) {
         dest.x = dest_x;
@@ -745,7 +744,7 @@ Chrome.prototype = {
         if (this.struts.length) this.updateStruts();
     },
 
-    updateRegions: function() {
+    updateRegions: function(updateNeeded = false) {
         let trackedActorsLength = this._trackedActors.length;
         let rects = [];
         let struts = [];
@@ -757,6 +756,10 @@ Chrome.prototype = {
         if (this._updateRegionIdle) {
             Mainloop.source_remove(this._updateRegionIdle);
             this._updateRegionIdle = 0;
+        }
+
+        if (updateNeeded) {
+            rectsChanged = strutsChanged = true;
         }
 
         for (; i < trackedActorsLength; i++) {
@@ -794,12 +797,12 @@ Chrome.prototype = {
                     if (m) rect = intersect(rect, m);
                 }
 
-                let refRect = findIndex(this.rects, function(rect) {
+                let refRect = findIndex(this.rects, function(r) {
                     return (
-                        rect.x === x &&
-                        rect.y === y &&
-                        rect.width === w &&
-                        rect.height === h
+                        r.x === rect.x &&
+                        r.y === rect.y &&
+                        r.width === rect.width &&
+                        r.height === rect.height
                     );
                 });
 
@@ -877,10 +880,7 @@ Chrome.prototype = {
                     strutsChanged = true;
                 }
 
-                struts.push({
-                    rect,
-                    side
-                });
+                struts.push({rect, side});
             }
         }
 

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -428,7 +428,7 @@ Chrome.prototype = {
 
         this._layoutManager.connect('monitors-changed', () => this._relayout());
         global.screen.connect('restacked', () => {
-            Mainloop.idle_add_full(400, () => this._windowsRestacked());
+            Mainloop.idle_add_full(1000, () => this._windowsRestacked());
         });
         global.screen.connect('in-fullscreen-changed', () => this._updateVisibility());
         global.window_manager.connect('switch-workspace', () => this._queueUpdateRegions());

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -427,7 +427,7 @@ Chrome.prototype = {
         this._trackedActors = [];
 
         this._layoutManager.connect('monitors-changed', () => this._relayout());
-        global.screen.connect('restacked', () => {
+        global.display.connect('notify::focus-window', () => {
             Mainloop.idle_add_full(1000, () => this._windowsRestacked());
         });
         global.screen.connect('in-fullscreen-changed', () => this._updateVisibility());
@@ -663,7 +663,7 @@ Chrome.prototype = {
 
     _queueUpdateRegions: function() {
         if (!this._updateRegionIdle && !this._freezeUpdateCount)
-            this._updateRegionIdle = Mainloop.idle_add_full(-200, () => this.updateRegions());
+            this._updateRegionIdle = Mainloop.idle_add(() => this.updateRegions(), Meta.PRIORITY_BEFORE_REDRAW);
     },
 
     freezeUpdateRegions: function() {
@@ -735,7 +735,7 @@ Chrome.prototype = {
                 if (actorData.actor.maybeGet("_delegate") instanceof Panel.Panel
                     && actorData.actor._delegate.isHideable()) {
                     let m = this._monitors[actorData.actor._delegate.monitorIndex];
-                    if (m) [, rect] = rect.intersect(new Meta.Rectangle(m));
+                    if (m) [, rect] = rect.intersect(m);
                 }
 
                 rects.push(rect);

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -768,6 +768,9 @@ Chrome.prototype = {
             let [w, h] = actorData.actor.get_transformed_size();
 
             if (isNaN(x) || isNaN(y) || isNaN(w) || isNaN(h)) {
+                // If the actor isn't giving us a valid size/position, skip it
+                // It would make the loop fail with an exception and affect the
+                // other actors
                 continue;
             }
 

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -495,7 +495,7 @@ Chrome.prototype = {
     },
 
     _findActor: function(actor) {
-        for (let i = 0; i < this._trackedActors.length; i++) {
+        for (let i = 0, len = this._trackedActors.length; i < len; i++) {
             let actorData = this._trackedActors[i];
             if (actorData.actor == actor)
                 return i;
@@ -562,7 +562,7 @@ Chrome.prototype = {
     },
 
     _updateVisibility: function() {
-        for (let i = 0; i < this._trackedActors.length; i++) {
+        for (let i = 0, len = this._trackedActors.length; i < len; i++) {
             let actorData = this._trackedActors[i], visible;
             if (!actorData.isToplevel)
                 continue;
@@ -613,14 +613,16 @@ Chrome.prototype = {
         // First look at what monitor the center of the rectangle is at
         let cx = x + w/2;
         let cy = y + h/2;
-        for (let i = 0; i < this._monitors.length; i++) {
+        let len = this._monitors.length;
+
+        for (let i = 0; i < len; i++) {
             let monitor = this._monitors[i];
             if (cx >= monitor.x && cx < monitor.x + monitor.width &&
                 cy >= monitor.y && cy < monitor.y + monitor.height)
                 return [i, monitor];
         }
         // If the center is not on a monitor, return the first overlapping monitor
-        for (let i = 0; i < this._monitors.length; i++) {
+        for (let i = 0; i < len; i++) {
             let monitor = this._monitors[i];
             if (x + w > monitor.x && x < monitor.x + monitor.width &&
                 y + h > monitor.y && y < monitor.y + monitor.height)
@@ -705,7 +707,7 @@ Chrome.prototype = {
 
         let wantsInputRegion = !this._isPopupWindowVisible;
 
-        for (let i = 0; i < this._trackedActors.length; i++) {
+        for (let i = 0, len = this._trackedActors.length; i < len; i++) {
             let actorData = this._trackedActors[i];
             if (!(actorData.affectsInputRegion && wantsInputRegion) && !actorData.affectsStruts)
                 continue;
@@ -799,7 +801,7 @@ Chrome.prototype = {
         global.set_stage_input_region(rects);
 
         let screen = global.screen;
-        for (let w = 0; w < screen.n_workspaces; w++) {
+        for (let w = 0, len = screen.n_workspaces; w < len; w++) {
             let workspace = screen.get_workspace_by_index(w);
             workspace.set_builtin_struts(struts);
         }

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -680,41 +680,19 @@ Chrome.prototype = {
     },
 
     _windowsRestacked: function() {
-        let isPopupWindowVisible = false;
-        let changed = false;
-
-        // This function can get called frequently enough that it might make sense
-        // to use signals, and manage an array instead of calling get_children().
-        const children = global.top_window_group.get_children();
         const {_isPopupWindowVisible} = this;
 
-        for (let i = 0, len = children.length; i < len; i++) {
-            switch (children[i].meta_window.get_window_type()) {
-                case Meta.WindowType.DROPDOWN_MENU:
-                case Meta.WindowType.POPUP_MENU:
-                case Meta.WindowType.COMBO:
-                    isPopupWindowVisible = true;
-            }
+        this._isPopupWindowVisible = global.display.popup_window_visible();
 
-            if (_isPopupWindowVisible !== isPopupWindowVisible) {
-                changed = true;
-                break;
-            }
-
-            if (isPopupWindowVisible) break;
-        }
-
-        if (changed) {
+        if (_isPopupWindowVisible != this._isPopupWindowVisible) {
             this._updateVisibility();
+
+            /* Pointer only needs to be updated to account for tray icon popup windows, which
+               will be reflected by the global.display.popup_window_visible return value. */
+            syncPointer();
         } else {
             this._queueUpdateRegions();
         }
-
-        this._isPopupWindowVisible = isPopupWindowVisible;
-
-        // Figure out where the pointer is in case we lost track of
-        // it during a grab.
-        syncPointer();
     },
 
     updateRegions: function() {

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -739,10 +739,7 @@ Chrome.prototype = {
                 if (actorData.actor.maybeGet("_delegate") instanceof Panel.Panel
                     && actorData.actor._delegate.isHideable()) {
                     let m = this._monitors[actorData.actor._delegate.monitorIndex];
-                    if (m) {
-                        let mr = {x: m.x, y: m.y, width: m.width, height: m.height};
-                        [, rect] = rect.intersect(new Meta.Rectangle(mr));
-                    }
+                    if (m) [, rect] = rect.intersect(new Meta.Rectangle(m));
                 }
 
                 rects.push(rect);

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -52,6 +52,10 @@ Monitor.prototype = {
     }
 };
 
+function syncPointer() {
+    global.sync_pointer();
+}
+
 /**
  * #LayoutManager
  *
@@ -694,10 +698,6 @@ Chrome.prototype = {
     },
 
     _windowsRestacked: function() {
-        // Figure out where the pointer is in case we lost track of
-        // it during a grab.
-        global.sync_pointer();
-
         let isPopupWindowVisible = global.top_window_group.get_children().some(isPopupMetaWindow);
         let popupVisibilityChanged = this._isPopupWindowVisible !== isPopupWindowVisible;
         this._isPopupWindowVisible = isPopupWindowVisible;
@@ -705,6 +705,10 @@ Chrome.prototype = {
             this._updateVisibility();
         else
             this._queueUpdateRegions();
+
+        // Figure out where the pointer is in case we lost track of
+        // it during a grab.
+        Mainloop.idle_add_full(Mainloop.PRIORITY_LOW, syncPointer);
     },
 
     updateRegions: function() {

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -19,6 +19,7 @@ const EdgeFlip = imports.ui.edgeFlip;
 const HotCorner = imports.ui.hotCorner;
 const DeskletManager = imports.ui.deskletManager;
 const Panel = imports.ui.panel;
+const {throttle} = imports.misc.util;
 
 const STARTUP_ANIMATION_TIME = 0.5;
 
@@ -39,6 +40,10 @@ Monitor.prototype = {
         return global.screen.get_monitor_in_fullscreen(this.index);
     }
 };
+
+const syncPointer = throttle(function() {
+    global.sync_pointer();
+}, 1000, false);
 
 /**
  * #LayoutManager
@@ -709,7 +714,7 @@ Chrome.prototype = {
 
         // Figure out where the pointer is in case we lost track of
         // it during a grab.
-        global.sync_pointer();
+        syncPointer();
     },
 
     updateRegions: function() {

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -508,6 +508,8 @@ PanelManager.prototype = {
             }
         }
         global.settings.set_strv("panels-enabled", list);
+
+        Main.layoutManager._chrome.updateRegions(true);
     },
 
     /**
@@ -2535,7 +2537,8 @@ Panel.prototype = {
         }
 
         this._updatePanelVisibility();
-        Main.layoutManager._chrome.modifyActorParams(this.actor, { affectsStruts: this._autohideSettings == "false" });
+        Main.layoutManager._chrome.modifyActorParams(this.actor, { affectsStruts: this._autohideSettings == "false"});
+        Main.layoutManager._chrome.updateRegions(true);
     },
     /**
      * _getScaledPanelHeight:

--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -2324,6 +2324,8 @@ var PopupMenu = class PopupMenu extends PopupMenuBase {
         if (!this.isOpen)
             return;
 
+        const isInChrome = Main.layoutManager._chrome._findActor(this.actor) > -1;
+
         this.isOpen = false;
         global.menuStackLength -= 1;
 
@@ -2359,6 +2361,8 @@ var PopupMenu = class PopupMenu extends PopupMenuBase {
                     this.actor.hide();
                     this.actor.remove_clip();
                     this.actor.set_size(-1, -1);
+
+                    if (isInChrome) Main.layoutManager._chrome.updateRegions(true);
                 }
             }
 
@@ -2388,6 +2392,8 @@ var PopupMenu = class PopupMenu extends PopupMenuBase {
         else {
             this.animating = false;
             this.actor.hide();
+
+            if (isInChrome) Main.layoutManager._chrome.updateRegions(true);
         }
         this.emit('open-state-changed', false);
     }

--- a/src/cinnamon-global-private.h
+++ b/src/cinnamon-global-private.h
@@ -31,6 +31,7 @@ struct _CinnamonGlobal {
   GObject parent;
 
   ClutterStage *stage;
+  ClutterInputDevice *clutter_device;
   Window stage_xwindow;
   GdkWindow *stage_gdk_window;
 


### PR DESCRIPTION
- A couple fixes for #8351
  - Lower priority of `global.sync_pointer`
  - Fix usage of undefined property `this._isPopupMenuVisible`, which caused `wantsInputRegion` to always be true.
- Removes all usage of Lang.bind with [arrow functions used instead](https://jsperf.com/bind-vs-arrow-function).
- `global.sync_pointer`: This is an old workaround needed so Clutter emits enter/leave events when a window grabs the pointer without our knowledge, but it calls heavy GDK methods that cause round trips. Even worse, the restacked signal is emitted a few times per second on my machine. That is a muffin bug, but until it's fixed we can't afford the latency incurred from pointer syncing (or at least I can't).
- Moves popup window visibility logic to muffin, which will be more efficient because it is already iterating the MetaWindowActor instances on stack syncs.
- Changes the restacked signal to focus-window notify, and Lowers priority of the callback, which seems to be emitting every second. The `restacked` signal was emitting every second on my machine.

180e884de6d2f4631798aa8ac033625b41f8b330

If a JS function is called enough, it can be faster to stay in JS and not call back C bindings to avoid context switching.

- Converted `meta_rectangle_intersect` to JS
- Cache the rects and struts as JS objects, so we don't hold a bunch of boxed refs implicitly. The caching lets us detect strut/rect change, in which case the C functions are called. The user will be interacting with
applications, not the Cinnamon UI most of the time, so this is an important improvement.
- We don't have per-workspace panels, so there is no need to recalculate everything on workspace switch, number change. Since we do listen to workspace switching signals, there is no need to set struts for every workspace.

Seeing lower CPU and memory usage from this commit.

**Depends on** https://github.com/linuxmint/muffin/pull/445