### PR TITLE
Spices.py: fix disabling of desklets and extensions

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
@@ -774,7 +774,14 @@ class Spice_Harvester(GObject.Object):
         enabled_extensions = self.settings.get_strv(self.enabled_key)
         new_list = []
         for enabled_extension in enabled_extensions:
-            if enabled_extension.split(':')[3].strip('!') != uuid:
+            if self.collection_type == 'applet':
+                enabled_uuid = enabled_extension.split(':')[3].strip('!')
+            elif self.collection_type == 'desklet':
+                enabled_uuid = enabled_extension.split(':')[0].strip('!')
+            else:
+                enabled_uuid = enabled_extension
+
+            if enabled_uuid != uuid:
                 new_list.append(enabled_extension)
         self.settings.set_strv(self.enabled_key, new_list)
 


### PR DESCRIPTION
This was broken by #8309 which fixed an issue with applets but the fix didn't consider that desklets and extensions use a slightly different format for the gsettings key. This pr adds handling for all extension types.