### PR TITLE
layout.js: fix typo

### DIFF
--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -715,7 +715,7 @@ Chrome.prototype = {
             this._updateRegionIdle = 0;
         }
 
-        let wantsInputRegion = !this._isPopupMenuVisible;
+        let wantsInputRegion = !this._isPopupWindowVisible;
 
         for (let i = 0; i < this._trackedActors.length; i++) {
             let actorData = this._trackedActors[i];


### PR DESCRIPTION
This is only needed if either #8465 or #8467 don't get merged. I just want to make sure the typo is fixed. If either is merged then this can be closed.

This should've been changed to `Window` from `Menu`. Thanks to @jaszhix for noticing.