### PR TITLE
Implement simple calculator in Cinnamon Menu

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -2647,6 +2647,22 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
             this._fileFolderAccessActive = this.searchActive && this.searchFilesystem;
             this._clearAllSelections();
 
+	    clearTimeout(this.searchTimeout);
+            this.searchTimeout = setTimeout(function() {
+               if (searchString.match(/([-+]?[0-9]*\.?[0-9]+[\/\+\-\*])+([-+]?[0-9]*\.?[0-9]+)/)) {
+                 let result = String(eval(searchString));
+                 let source = new MessageTray.SystemNotificationSource();
+                 Main.messageTray.add(source);
+                 let notification = new MessageTray.Notification(source,
+                                                            `${searchString} =`,
+                                                            result);
+                 notification.setTransient(true);
+                 notification.setUrgency(MessageTray.Urgency.NORMAL);
+                 source.notify(notification);
+              }
+
+            }, 500);
+
             if (this.searchActive) {
                 this.searchEntry.set_secondary_icon(this._searchActiveIcon);
                 if (this._searchIconClickedId == 0) {

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -2647,8 +2647,11 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
             this._fileFolderAccessActive = this.searchActive && this.searchFilesystem;
             this._clearAllSelections();
 
-	    clearTimeout(this.searchTimeout);
-            this.searchTimeout = setTimeout(function() {
+	    if (typeof this.searchTimeout !== "undefined") { 
+		clearTimeout(this.searchTimeout);
+            }
+
+            this.searchTimeout = setTimeout(() => {
                if (searchString.match(/([-+]?[0-9]*\.?[0-9]+[\/\+\-\*])+([-+]?[0-9]*\.?[0-9]+)/)) {
                  let result = String(eval(searchString));
                  let source = new MessageTray.SystemNotificationSource();
@@ -2660,7 +2663,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                  notification.setUrgency(MessageTray.Urgency.NORMAL);
                  source.notify(notification);
               }
-
+              this.searchTimeout = null;
             }, 500);
 
             if (this.searchActive) {


### PR DESCRIPTION
A simple but straightforward way to implement a calculator in the Cinnamon Menu. 

I liked how in OSX Spotlight search you have the ability to write some math and it evaluates it for you. 

With very minimal google-fu to understand how Cinammon applets work, I managed to scratch my own itch and implement something similar.

Even though using  'eval' is fugly, the regex in the back makes it somewhat safer... so that I don't have to implement a math parser.  

Added to my repo for posterity. Feel free to modify and improve as you see fit. 