### PR TITLE
cinnamon-doc-system: tidyup of recents

### DIFF
--- a/src/cinnamon-doc-system.h
+++ b/src/cinnamon-doc-system.h
@@ -32,6 +32,6 @@ GType cinnamon_doc_system_get_type (void) G_GNUC_CONST;
 
 CinnamonDocSystem* cinnamon_doc_system_get_default (void);
 
-GSList *cinnamon_doc_system_get_all (CinnamonDocSystem    *system);
+GList *cinnamon_doc_system_get_all (CinnamonDocSystem    *system);
 
 #endif /* __CINNAMON_DOC_SYSTEM_H__ */


### PR DESCRIPTION
slists and glists were mixed up, there was a compile warning with the macro,
and I took the opportunity to put in the normal prepend/reverse trick