### PR TITLE
st-texture-cache: use a slightly more efficient linked list method

### DIFF
--- a/src/st/st-texture-cache.c
+++ b/src/st/st-texture-cache.c
@@ -1019,9 +1019,10 @@ load_sliced_image (GTask        *result,
         {
           GdkPixbuf *pixbuf = gdk_pixbuf_new_subpixbuf (pix, x, y, data->grid_width, data->grid_height);
           g_assert (pixbuf != NULL);
-          res = g_list_append (res, pixbuf);
+          res = g_list_prepend (res, pixbuf);
         }
     }
+  res = g_list_reverse (res);
   /* We don't need the original pixbuf anymore, though the subpixbufs
      will hold a reference. */
   g_object_unref (pix);


### PR DESCRIPTION
difficult to test not knowing how many sliced images are flying around.  A batch of menu load tests came up around 20ms faster afterwards on average, though with high variability in the test results both before and after so I might be kidding myself.  No regressions in evidence, not that I would expect that as this is a well tried approach.  https://developer.gnome.org/glib/stable/glib-Doubly-Linked-Lists.html#g-list-append
