### PR TITLE
 wm: Apply window effects to clones

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -8,7 +8,7 @@ const DND = imports.ui.dnd;
 const Tooltips = imports.ui.tooltips;
 const PopupMenu = imports.ui.popupMenu;
 const {SignalManager} = imports.misc.signalManager;
-const {each, findIndex, unref} = imports.misc.util;
+const {each, findIndex, unref, getIconGeometry} = imports.misc.util;
 const {createStore} = imports.misc.state;
 
 const {AppMenuButtonRightClickMenu, HoverMenuController, AppThumbnailHoverMenu} = require('./menus');
@@ -425,13 +425,11 @@ class AppGroup {
 
         // Call set_icon_geometry for support of Cinnamon's minimize animation
         if (this.groupState.metaWindows.length > 0 && this.actor.realized) {
-            let rect = new Meta.Rectangle();
-            [rect.x, rect.y] = this.actor.get_transformed_position();
-            [rect.width, rect.height] = this.actor.get_transformed_size();
+            let iconGeometry = getIconGeometry(this.actor);
 
             each(this.groupState.metaWindows, (metaWindow) => {
                 if (metaWindow) {
-                    metaWindow.set_icon_geometry(rect);
+                    metaWindow.iconGeometry = iconGeometry;
                 }
             });
         }
@@ -854,6 +852,8 @@ class AppGroup {
             this.signals.connect(metaWindow, 'notify::gtk-application-id', (w) => this.onAppChange(w));
             this.signals.connect(metaWindow, 'notify::wm-class', (w) => this.onAppChange(w));
 
+            metaWindow.iconGeometry = getIconGeometry(this.actor);
+
             this.signals.connect(metaWindow, 'icon-changed', (w) => this.setIcon(w));
 
             if (metaWindow.progress !== undefined) {
@@ -893,6 +893,8 @@ class AppGroup {
         this.signals.disconnect('notify::appears-focused', metaWindow);
         this.signals.disconnect('notify::gtk-application-id', metaWindow);
         this.signals.disconnect('notify::wm-class', metaWindow);
+
+        metaWindow.iconGeometry = null;
 
         this.groupState.metaWindows.splice(refWindow, 1);
 

--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -61,6 +61,7 @@ const PopupMenu = imports.ui.popupMenu;
 const Settings = imports.ui.settings;
 const SignalManager = imports.misc.signalManager;
 const Tooltips = imports.ui.tooltips;
+const {getIconGeometry} = imports.misc.util;
 
 const MAX_TEXT_LENGTH = 1000;
 const FLASH_INTERVAL = 500;
@@ -605,7 +606,7 @@ class AppMenuButton {
         [rect.x, rect.y] = this.actor.get_transformed_position();
         [rect.width, rect.height] = this.actor.get_transformed_size();
 
-        this.metaWindow.set_icon_geometry(rect);
+        this.metaWindow.iconGeometry = getIconGeometry(this.actor);
     }
 
     _getPreferredWidth(actor, forHeight, alloc) {
@@ -1247,6 +1248,8 @@ class CinnamonWindowListApplet extends Applet.Applet {
         let appButton = new AppMenuButton(this, metaWindow, alert);
         this.manager_container.add_actor(appButton.actor);
 
+        metaWindow.iconGeometry = getIconGeometry(appButton.actor);
+
         this._windows.push(appButton);
 
         /* We want to make the AppMenuButtons look like they are ordered by
@@ -1267,6 +1270,9 @@ class CinnamonWindowListApplet extends Applet.Applet {
 
     _removeWindow(metaWindow) {
         let i = this._windows.length;
+
+        metaWindow.iconGeometry = null;
+
         // Do an inverse loop because we might remove some elements
         while (i--) {
             if (this._windows[i].metaWindow == metaWindow) {

--- a/js/misc/util.js
+++ b/js/misc/util.js
@@ -709,3 +709,17 @@ function getGObjectPropertyValues(obj, r = 0) {
     }
     return jsRepresentation;
 }
+
+/**
+ * getIconGeometry:
+ * @actor (Clutter.Actor): Clutter actor to base icon position upon
+ *
+ * Returns (object): Rectangle values of the icon's position and size
+ */
+function getIconGeometry(actor) {
+    let x, y, width, height;
+    [x, y] = actor.get_transformed_position();
+    [width, height] = actor.get_transformed_size();
+
+    return {x, y, width, height};
+}

--- a/js/ui/windowEffects.js
+++ b/js/ui/windowEffects.js
@@ -31,9 +31,12 @@ class Effect {
     }
 
     _end() {
-        const {source} = this;
+        if (isFinalized(this.source)) {
+            this.actor = this.source = null;
+            return;
+        }
 
-        global.window_manager[this.wmCompleteName](source);
+        global.window_manager[this.wmCompleteName](this.source);
 
         global.overlay_group.remove_child(this.actor);
         removeTweens(this.actor);

--- a/js/ui/windowEffects.js
+++ b/js/ui/windowEffects.js
@@ -167,9 +167,9 @@ var Map = class Map extends Effect {
             case WindowType.MENU:
             case WindowType.DROPDOWN_MENU:
             case WindowType.POPUP_MENU:
-                let [width, height] = this.source.get_allocation_box().get_size();
-                let [destX, destY] = this.source.get_transformed_position();
-                let [pointerX, pointerY] = global.get_pointer();
+                let [, height] = this.source.get_allocation_box().get_size();
+                let [, destY] = this.source.get_transformed_position();
+                let [, pointerY] = global.get_pointer();
                 let top = destY + (height * 0.5);
 
                 if (pointerY < top)
@@ -268,6 +268,12 @@ var Minimize = class Minimize extends Close {
 
     traditional(cinnamonwm, time, transition) {
         let geom = this.source.meta_window.iconGeometry;
+
+        if (!geom) {
+            this.scale(cinnamonwm, time, transition); // fall-back effect
+            return;
+        }
+
         this.actor.set_scale(1, 1);
         let xDest, yDest, xScale, yScale;
         xDest = geom.x;
@@ -295,6 +301,8 @@ var Unminimize = class Unminimize extends Effect {
 
     traditional(cinnamonwm, time, transition) {
         let geom = this.source.meta_window.iconGeometry;
+
+        if (!geom) return;
 
         this.actor.set_scale(0.1, 0.1);
         this.actor.opacity = 0;

--- a/js/ui/windowEffects.js
+++ b/js/ui/windowEffects.js
@@ -1,51 +1,76 @@
-const {Gravity} = imports.gi.Clutter;
+const {Gravity, Clone} = imports.gi.Clutter;
 const {Rectangle, WindowType} = imports.gi.Meta;
-const {layoutManager} = imports.ui.main;
+const Main = imports.ui.main;
+const {layoutManager} = Main;
 const {addTween, removeTweens} = imports.ui.tweener;
 
 class Effect {
     constructor(endWindowEffect) {
         this.endWindowEffect = endWindowEffect;
+        this.originalOpacity = 0;
+        this.actor = null;
+        this.source = null;
     }
 
-    _end(actor) {
-        actor.set_scale(1, 1);
-        actor.opacity = actor.orig_opacity || 255;
-        actor.move_anchor_point_from_gravity(Gravity.NORTH_WEST);
+    setActor(source) {
+        if (this.actor) return;
+
+        this.originalOpacity = source.opacity;
+        this.actor = new Clone({
+            source,
+            reactive: false,
+            width: source.width,
+            height: source.height,
+            x: source.x,
+            y: source.y
+        });
+
+        global.overlay_group.add_child(this.actor);
+        global.overlay_group.set_child_above_sibling(this.actor, null);
+
+        this.source = source;
     }
 
-    _fadeWindow(cinnamonwm, actor, opacity, time, transition) {
-        addTween(actor, {
+    _end() {
+        if (!this.actor) return;
+
+        global.overlay_group.remove_child(this.actor);
+        this.actor.destroy();
+        this.actor = this.source = null;
+    }
+
+    _fadeWindow(cinnamonwm, opacity, time, transition) {
+        addTween(this.actor, {
             opacity,
             time,
             min: 0,
             max: 255,
             transition,
-            onComplete: () => this.endWindowEffect(cinnamonwm, this.name, actor),
+            onComplete: () => this.endWindowEffect(cinnamonwm, this.name, this.source),
         });
     }
 
-    _scaleWindow(cinnamonwm, actor, scale_x, scale_y, time, transition, keepAnchorPoint) {
+    _scaleWindow(cinnamonwm, scale_x, scale_y, time, transition, keepAnchorPoint) {
         if (!keepAnchorPoint)
-            actor.move_anchor_point_from_gravity(Gravity.CENTER);
+            this.actor.move_anchor_point_from_gravity(Gravity.CENTER);
 
-        addTween(actor, {
+        addTween(this.actor, {
             scale_x,
             scale_y,
             time,
             min: 0,
             transition,
-            onComplete: () => this.endWindowEffect(cinnamonwm, this.name, actor),
+            onComplete: () => this.endWindowEffect(cinnamonwm, this.name, this.source),
         });
     }
 
-    _moveWindow(cinnamonwm, actor, x, y, time, transition) {
-        addTween(actor, {
+    _moveWindow(cinnamonwm, x, y, time, transition) {
+        addTween(this.actor, {
             x,
             y,
             time,
             transition,
-            onComplete: () => this.endWindowEffect(cinnamonwm, this.name, actor),
+            onComplete: () => this.endWindowEffect(cinnamonwm, this.name, this.source),
         });
     }
 };
@@ -59,102 +84,107 @@ var Map = class Map extends Effect {
         this.wmCompleteName = 'completed_map';
     }
 
-    scale(cinnamonwm, actor, time, transition) {
-        actor.set_scale(0, 0);
-        this._scaleWindow(cinnamonwm, actor, 1, 1, time, transition);
+    _end() {
+        this.source.show();
+        super._end();
     }
 
-    fade(cinnamonwm, actor, time, transition) {
-        actor.opacity = 0;
-        this._fadeWindow(cinnamonwm, actor, actor.orig_opacity, time, transition);
+    scale(cinnamonwm, time, transition) {
+        this.actor.set_scale(0, 0);
+        this._scaleWindow(cinnamonwm, 1, 1, time, transition);
     }
 
-    blend(cinnamonwm, actor, time, transition) {
-        actor.opacity = 0;
-        actor.set_scale(1.5, 1.5);
-        this._fadeWindow(cinnamonwm, actor, actor.orig_opacity, time, transition);
-        this._scaleWindow(cinnamonwm, actor, 1, 1, time, transition);
+    fade(cinnamonwm, time, transition) {
+        this.actor.opacity = 0;
+        this._fadeWindow(cinnamonwm, this.originalOpacity, time, transition);
     }
 
-    move(cinnamonwm, actor, time, transition) {
-        let [width, height] = actor.get_allocation_box().get_size();
-        let [xDest, yDest] = actor.get_transformed_position();
+    blend(cinnamonwm, time, transition) {
+        this.actor.opacity = 0;
+        this.actor.set_scale(1.5, 1.5);
+        this._fadeWindow(cinnamonwm, this.originalOpacity, time, transition);
+        this._scaleWindow(cinnamonwm, 1, 1, time, transition);
+    }
+
+    move(cinnamonwm, time, transition) {
+        let [width, height] = this.actor.get_allocation_box().get_size();
+        let [xDest, yDest] = this.source.get_transformed_position();
         xDest += width /= 2;
         yDest += height /= 2;
 
         let [xSrc, ySrc] = global.get_pointer();
         xSrc -= width;
         ySrc -= height;
-        actor.set_position(xSrc, ySrc);
+        this.actor.set_position(xSrc, ySrc);
 
-        actor.set_scale(0, 0);
+        this.actor.set_scale(0, 0);
 
-        this._scaleWindow(cinnamonwm, actor, 1, 1, time, transition);
-        this._moveWindow(cinnamonwm, actor, xDest, yDest, time, transition);
+        this._scaleWindow(cinnamonwm, 1, 1, time, transition);
+        this._moveWindow(cinnamonwm, xDest, yDest, time, transition);
     }
 
-    flyUp(cinnamonwm, actor, time, transition) {
+    flyUp(cinnamonwm, time, transition) {
         // FIXME: somehow we need this line to get the correct position, without it will return [0, 0]
-        actor.get_allocation_box().get_size();
-        let [xDest, yDest] = actor.get_transformed_position();
+        this.actor.get_allocation_box().get_size();
+        let [xDest, yDest] = this.source.get_transformed_position();
         let ySrc = global.stage.get_height();
 
-        actor.set_position(xDest, ySrc);
+        this.actor.set_position(xDest, ySrc);
 
         let dist = Math.abs(ySrc - yDest);
         time *= dist / layoutManager.primaryMonitor.height * 2; // The transition time set is the time if the animation starts/ends at the middle of the screen. Scale it proportional to the actual distance so that the speed of all animations will be constant.
 
-        this._moveWindow(cinnamonwm, actor, xDest, yDest, time, transition);
+        this._moveWindow(cinnamonwm, xDest, yDest, time, transition);
 
     }
 
-    flyDown(cinnamonwm, actor, time, transition) {
+    flyDown(cinnamonwm, time, transition) {
         // FIXME - see also flyUp
-        actor.get_allocation_box().get_size();
-        let [xDest, yDest] = actor.get_transformed_position();
-        let ySrc = -actor.get_allocation_box().get_height();
+        this.actor.get_allocation_box().get_size();
+        let [xDest, yDest] = this.source.get_transformed_position();
+        let ySrc = -this.source.get_allocation_box().get_height();
 
-        actor.set_position(xDest, ySrc);
+        this.actor.set_position(xDest, ySrc);
 
         let dist = Math.abs(ySrc - yDest);
         time *= dist / layoutManager.primaryMonitor.height * 2; // The time time set is the time if the animation starts/ends at the middle of the screen. Scale it proportional to the actual distance so that the speed of all animations will be constant.
 
-        this._moveWindow(cinnamonwm, actor, xDest, yDest, time, transition);
+        this._moveWindow(cinnamonwm, xDest, yDest, time, transition);
     }
 
-    traditional(cinnamonwm, actor, time, transition) {
-        switch (actor.meta_window.window_type) {
+    traditional(cinnamonwm, time, transition) {
+        switch (this.source.meta_window.window_type) {
             case WindowType.NORMAL:
             case WindowType.MODAL_DIALOG:
             case WindowType.DIALOG:
-                actor.set_pivot_point(0, 0);
-                actor.scale_x = 0.94;
-                actor.scale_y = 0.94;
-                actor.opacity = 0;
-                this._fadeWindow(cinnamonwm, actor, actor.orig_opacity, time, transition);
-                this._scaleWindow(cinnamonwm, actor, 1, 1, time, transition);
+                this.actor.set_pivot_point(0, 0);
+                this.actor.scale_x = 0.94;
+                this.actor.scale_y = 0.94;
+                this.actor.opacity = 0;
+                this._fadeWindow(cinnamonwm, this.originalOpacity, time, transition);
+                this._scaleWindow(cinnamonwm, 1, 1, time, transition);
                 break;
             case WindowType.MENU:
             case WindowType.DROPDOWN_MENU:
             case WindowType.POPUP_MENU:
-                let [width, height] = actor.get_allocation_box().get_size();
-                let [destX, destY] = actor.get_transformed_position();
+                let [width, height] = this.source.get_allocation_box().get_size();
+                let [destX, destY] = this.source.get_transformed_position();
                 let [pointerX, pointerY] = global.get_pointer();
                 let top = destY + (height * 0.5);
 
                 if (pointerY < top)
-                    actor.set_pivot_point(0, 0);
+                    this.actor.set_pivot_point(0, 0);
                 else
-                    actor.set_pivot_point(0, 1);
+                    this.actor.set_pivot_point(0, 1);
 
-                actor.scale_x = 1;
-                actor.scale_y = 0.9;
-                actor.opacity = 0;
-                this._scaleWindow(cinnamonwm, actor, 1, 1, time, transition, true);
-                this._fadeWindow(cinnamonwm, actor, actor.orig_opacity, time, transition);
+                this.actor.scale_x = 1;
+                this.actor.scale_y = 0.9;
+                this.actor.opacity = 0;
+                this._scaleWindow(cinnamonwm, 1, 1, time, transition, true);
+                this._fadeWindow(cinnamonwm, this.originalOpacity, time, transition);
                 break;
             default:
-                this._fadeWindow(cinnamonwm, actor, actor.orig_opacity, time, transition);
+                this._fadeWindow(cinnamonwm, this.originalOpacity, time, transition);
         }
     }
 }
@@ -168,66 +198,58 @@ var Close = class Close extends Effect {
         this.wmCompleteName = 'completed_destroy';
     }
 
-    _end(actor) {
-        let parent = actor.get_meta_window().get_transient_for();
-        if (parent && actor._parentDestroyId) {
-            parent.disconnect(actor._parentDestroyId);
-            actor._parentDestroyId = 0;
-        }
+    scale(cinnamonwm, time, transition) {
+        this._scaleWindow(cinnamonwm, 0, 0, time, transition);
     }
 
-    scale(cinnamonwm, actor, time, transition) {
-        this._scaleWindow(cinnamonwm, actor, 0, 0, time, transition);
+    fade(cinnamonwm, time, transition) {
+        removeTweens(this.actor);
+        this._fadeWindow(cinnamonwm, 0, time, transition);
     }
 
-    fade(cinnamonwm, actor, time, transition) {
-        removeTweens(actor);
-        this._fadeWindow(cinnamonwm, actor, 0, time, transition);
+    blend(cinnamonwm, time, transition) {
+        this._fadeWindow(cinnamonwm, 0, time, transition);
+        this._scaleWindow(cinnamonwm, 1.5, 1.5, time, transition);
     }
 
-    blend(cinnamonwm, actor, time, transition) {
-        this._fadeWindow(cinnamonwm, actor, 0, time, transition);
-        this._scaleWindow(cinnamonwm, actor, 1.5, 1.5, time, transition);
-    }
-
-    move(cinnamonwm, actor, time, transition) {
+    move(cinnamonwm, time, transition) {
         let [xDest, yDest] = global.get_pointer();
 
-        this._scaleWindow(cinnamonwm, actor, 0, 0, time, transition);
-        this._moveWindow(cinnamonwm, actor, xDest, yDest, time, transition);
+        this._scaleWindow(cinnamonwm, 0, 0, time, transition);
+        this._moveWindow(cinnamonwm, xDest, yDest, time, transition);
     }
 
-    flyUp(cinnamonwm, actor, time, transition) {
-        let xDest = actor.get_transformed_position()[0];
-        let yDest = -actor.get_allocation_box().get_height();
+    flyUp(cinnamonwm, time, transition) {
+        let xDest = this.source.get_transformed_position()[0];
+        let yDest = -this.source.get_allocation_box().get_height();
 
-        let dist = Math.abs(actor.get_transformed_position()[1] - yDest);
+        let dist = Math.abs(this.source.get_transformed_position()[1] - yDest);
         time *= dist / layoutManager.primaryMonitor.height * 2; // The time time set is the time if the animation starts/ends at the middle of the screen. Scale it proportional to the actual distance so that the speed of all animations will be constant.
 
-        this._moveWindow(cinnamonwm, actor, xDest, yDest, time, transition);
+        this._moveWindow(cinnamonwm, xDest, yDest, time, transition);
     }
 
-    flyDown(cinnamonwm, actor, time, transition) {
-        let xDest = actor.get_transformed_position()[0];
+    flyDown(cinnamonwm, time, transition) {
+        let xDest = this.source.get_transformed_position()[0];
         let yDest = global.stage.get_height();
 
-        let dist = Math.abs(actor.get_transformed_position()[1] - yDest);
+        let dist = Math.abs(this.source.get_transformed_position()[1] - yDest);
         time *= dist / layoutManager.primaryMonitor.height * 2; // The transition time set is the time if the animation starts/ends at the middle of the screen. Scale it proportional to the actual distance so that the speed of all animations will be constant.
 
-        this._moveWindow(cinnamonwm, actor, xDest, yDest, time, transition);
+        this._moveWindow(cinnamonwm, xDest, yDest, time, transition);
     }
 
-    traditional(cinnamonwm, actor, time, transition) {
-        switch (actor.meta_window.window_type) {
+    traditional(cinnamonwm, time, transition) {
+        switch (this.source.meta_window.window_type) {
             case WindowType.NORMAL:
             case WindowType.MODAL_DIALOG:
             case WindowType.DIALOG:
-                actor.set_pivot_point(0, 0);
-                this._scaleWindow(cinnamonwm, actor, 0.88, 0.88, time, transition);
-                this._fadeWindow(cinnamonwm, actor, 0, time, transition);
+                this.actor.set_pivot_point(0, 0);
+                this._scaleWindow(cinnamonwm, 0.88, 0.88, time, transition);
+                this._fadeWindow(cinnamonwm, 0, time, transition);
                 break;
             default:
-                this.scale(cinnamonwm, actor, time, transition);
+                this.scale(cinnamonwm, time, transition);
         }
     }
 }
@@ -244,24 +266,18 @@ var Minimize = class Minimize extends Close {
         this._end = Effect.prototype._end;
     }
 
-    traditional(cinnamonwm, actor, time, transition) {
-        let success;
-        let geom = new Rectangle();
-        success = actor.meta_window.get_icon_geometry(geom);
-        if (success) {
-            actor.set_scale(1, 1);
-            let xDest, yDest, xScale, yScale;
-            xDest = geom.x;
-            yDest = geom.y;
-            xScale = geom.width / actor.width;
-            yScale = geom.height / actor.height;
-            actor.meta_window._cinnamonwm_has_origin = true;
-            this._moveWindow(cinnamonwm, actor, xDest, yDest, time, transition);
-            this._scaleWindow(cinnamonwm, actor, xScale, yScale, time, transition, true);
-            this._fadeWindow(cinnamonwm, actor, 0, time, transition);
-        } else {
-            this.scale(cinnamonwm, actor, time, transition); // fall-back effect
-        }
+    traditional(cinnamonwm, time, transition) {
+        let geom = this.source.meta_window.iconGeometry;
+        this.actor.set_scale(1, 1);
+        let xDest, yDest, xScale, yScale;
+        xDest = geom.x;
+        yDest = geom.y;
+        xScale = geom.width / this.actor.width;
+        yScale = geom.height / this.actor.height;
+        this.source.meta_window._cinnamonwm_has_origin = true;
+        this._moveWindow(cinnamonwm, xDest, yDest, time, transition);
+        this._scaleWindow(cinnamonwm, xScale, yScale, time, transition, true);
+        this._fadeWindow(cinnamonwm, 0, time, transition);
     }
 }
 
@@ -277,23 +293,18 @@ var Unminimize = class Unminimize extends Effect {
         this._end = Map.prototype._end;
     }
 
-    traditional(cinnamonwm, actor, time, transition) {
-        let success;
-        let geom = new Rectangle();
-        success = actor.meta_window.get_icon_geometry(geom);
-        if (success) {
-            actor.set_scale(0.1, 0.1);
-            actor.opacity = 0;
-            let xSrc = geom.x;
-            let ySrc = geom.y;
-            let [xDest, yDest] = actor.get_transformed_position();
-            actor.set_position(xSrc, ySrc);
-            this._moveWindow(cinnamonwm, actor, xDest, yDest, time, transition);
-            this._scaleWindow(cinnamonwm, actor, 1, 1, time, transition, true);
-            this._fadeWindow(cinnamonwm, actor, actor.orig_opacity, time, transition);
-        } else {
-            global.logWarning('windowEffects.Unminimize: No origin found.');
-        }
+    traditional(cinnamonwm, time, transition) {
+        let geom = this.source.meta_window.iconGeometry;
+
+        this.actor.set_scale(0.1, 0.1);
+        this.actor.opacity = 0;
+        let xSrc = geom.x;
+        let ySrc = geom.y;
+        let [xDest, yDest] = this.source.get_transformed_position();
+        this.actor.set_position(xSrc, ySrc);
+        this._moveWindow(cinnamonwm, xDest, yDest, time, transition);
+        this._scaleWindow(cinnamonwm, 1, 1, time, transition, true);
+        this._fadeWindow(cinnamonwm, this.originalOpacity, time, transition);
     }
 }
 
@@ -306,20 +317,20 @@ var Tile = class Tile extends Effect {
         this.wmCompleteName = 'completed_tile';
     }
 
-    scale(cinnamonwm, actor, time, transition, args) {
+    scale(cinnamonwm, time, transition, args) {
         let [targetX, targetY, targetWidth, targetHeight] = args;
 
-        if (targetWidth === actor.width) targetWidth -= 1;
-        if (targetHeight === actor.height) targetHeight -= 1;
+        if (targetWidth === this.actor.width) targetWidth -= 1;
+        if (targetHeight === this.actor.height) targetHeight -= 1;
 
-        let scale_x = targetWidth / actor.width;
-        let scale_y = targetHeight / actor.height;
-        let anchor_x = (actor.x - targetX) * actor.width / (targetWidth - actor.width);
-        let anchor_y = (actor.y - targetY) * actor.height / (targetHeight - actor.height);
+        let scale_x = targetWidth / this.actor.width;
+        let scale_y = targetHeight / this.actor.height;
+        let anchor_x = (this.actor.x - targetX) * this.actor.width / (targetWidth - this.actor.width);
+        let anchor_y = (this.actor.y - targetY) * this.actor.height / (targetHeight - this.actor.height);
 
-        actor.move_anchor_point(anchor_x, anchor_y);
+        this.actor.move_anchor_point(anchor_x, anchor_y);
 
-        this._scaleWindow(cinnamonwm, actor, scale_x, scale_y, time, transition, true);
+        this._scaleWindow(cinnamonwm, scale_x, scale_y, time, transition, true);
     }
 }
 

--- a/js/ui/windowEffects.js
+++ b/js/ui/windowEffects.js
@@ -31,7 +31,7 @@ class Effect {
     }
 
     _end() {
-        if (isFinalized(this.source)) {
+        if (this.source.is_finalized()) {
             this.actor = this.source = null;
             return;
         }

--- a/js/ui/windowEffects.js
+++ b/js/ui/windowEffects.js
@@ -240,6 +240,11 @@ var Close = class Close extends Effect {
     }
 
     traditional(cinnamonwm, time, transition) {
+        if (!this.source.meta_window) {
+            this._end();
+            return;
+        }
+
         switch (this.source.meta_window.window_type) {
             case WindowType.NORMAL:
             case WindowType.MODAL_DIALOG:

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -602,6 +602,10 @@ var WindowManager = class WindowManager {
 
         let type = this.settingsState[`${key}-effect`];
 
+        each(this.effects, (effect, key) => {
+            if (effect.actor || effect.source) this._endWindowEffect(cinnamonwm, key, effect.source);
+        });
+
         effect.setActor(actor);
         this[effect.arrayName].push(effect.actor);
         actor.current_effect_name = name;

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -753,7 +753,7 @@ var WindowManager = class WindowManager {
             });
         }
 
-        if (meta_window.minimized || isFinalized(actor)) {
+        if (meta_window.minimized || actor.is_finalized()) {
             cinnamonwm.completed_destroy(actor);
             return;
         }

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -444,7 +444,6 @@ class HudPreview {
 var WindowManager = class WindowManager {
     constructor() {
         this.iconGeometries = [];
-        this.minimized = [];
 
         this.effects = {
             map: new Map(),


### PR DESCRIPTION
96f62eb54e99f87d5bf970677178b897f5f4e425

This solves some rendering issues with effects after the last few rounds of muffin changes. By separating effects from MetaWindowActor, we can call expensive custom Clutter vfuncs less, and have more compositional control over the end result without worrying about breaking the compositor.

Ref #8454 

**Depends on** https://github.com/linuxmint/muffin/pull/464