### PR TITLE
cinnamon-doc-system: Switch back to GSList

### DIFF
--- a/src/cinnamon-doc-system.h
+++ b/src/cinnamon-doc-system.h
@@ -32,6 +32,6 @@ GType cinnamon_doc_system_get_type (void) G_GNUC_CONST;
 
 CinnamonDocSystem* cinnamon_doc_system_get_default (void);
 
-GList *cinnamon_doc_system_get_all (CinnamonDocSystem    *system);
+GSList *cinnamon_doc_system_get_all (CinnamonDocSystem    *system);
 
 #endif /* __CINNAMON_DOC_SYSTEM_H__ */


### PR DESCRIPTION
GSList usage seems to perform better in CinnamonDocSystem. This switches back to it while preserving the warning reductions with appropriate casting, and the prepend + reverse trick. Not seeing any GCC warnings from cinnamon-doc-system.c.

Measurements:

![image](https://user-images.githubusercontent.com/6859057/55765011-5a84df00-5a33-11e9-9870-733cc7b8fe25.png)

https://openbenchmarking.org/result/1904086-SP-APRIL848805&obr_sor=y