### PR TITLE
Add code to update workspace names if gsettings changes

### DIFF
--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -459,6 +459,7 @@ function start() {
 
     wmSettings = new Gio.Settings({schema_id: "org.cinnamon.desktop.wm.preferences"})
     workspace_names = wmSettings.get_strv("workspace-names");
+    wmSettings.connect("changed::workspace-names", onWorkspaceNamesSettingChanged);
 
     global.screen.connect('notify::n-workspaces', _nWorkspacesChanged);
 
@@ -624,6 +625,19 @@ function getWorkspaceName(index) {
         wsName :
         _makeDefaultWorkspaceName(index);
 }
+
+/**
+ * updateWorkspacenames:
+ * 
+ * updates the workspace names if changed in the settings backend
+ * 
+ */
+function onWorkspaceNamesSettingChanged() {
+    workspace_names = wmSettings.get_strv("workspace-names");
+    _trimWorkspaceNames();
+}
+
+
 
 /**
  * hasDefaultWorkspaceName:


### PR DESCRIPTION
This pull request adds the ability for Cinnamon to update the workspace names in real time as soon as the
settings/dconf "workspace-names" schema changes. 

This achieves the same objective as  this pull request: https://github.com/linuxmint/cinnamon/pull/1993,  but 
updated to match the current code such as using "workspace-names" rather than the deprecated 
"workspace-names-override" schema and using "wmSettings" rather than "global.settings" in main.js

This solves issue https://github.com/linuxmint/cinnamon/issues/8508

These changes have been tested on Linux Mint 19.1 Cinnamon, Cinnamon version 4.0.10.

The previous issue was closed as the developers believed there was no valid usecase, but i believe that 
this feature can be very useful, as it is the only way for external programs to change the names of 
workspaces, instantaneously, without requiring cinnamon to be restarted. By combining this feature with the 
ability to change the number of workspaces, workspace managers can be created that are able to add, 
remove and rename workspaces. I am making such a workspace manager now, which i will be happy to 
share with the Linux Mint  community.