### PR TITLE
Remove All Caps from default workspace naming

### DIFF
--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -585,7 +585,7 @@ function _trimWorkspaceNames(index) {
 }
 
 function _makeDefaultWorkspaceName(index) {
-    return _("WORKSPACE") + " " + (index + 1).toString();
+    return _("Workspace") + " " + (index + 1).toString();
 }
 
 /**


### PR DESCRIPTION
This replace the default workspace name with one that isn't ALL CAPS. Nowhere else in the DE interface really uses all caps and its less pleasing to the eye