### PR TITLE
cinnamon-settings-users.py: update symlink vulnerability fix

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings-users/cinnamon-settings-users.py
+++ b/files/usr/share/cinnamon/cinnamon-settings-users/cinnamon-settings-users.py
@@ -673,6 +673,10 @@ class Module:
                 image.thumbnail((96, 96), Image.ANTIALIAS)
                 face_path = os.path.join(user.get_home_dir(), ".face")
                 try:
+                    try:
+                        os.remove(face_path)
+                    except:
+                        pass
                     priv_helper.drop_privs(user)
                     image.save(face_path, "png")
                 finally:
@@ -709,9 +713,14 @@ class Module:
                 user = model[treeiter][INDEX_USER_OBJECT]
                 user.set_icon_file(path)
                 self.face_image.set_from_file(path)
+                face_path = os.path.join(user.get_home_dir(), ".face")
                 try:
+                    try:
+                        os.remove(face_path)
+                    except:
+                        pass
                     priv_helper.drop_privs(user)
-                    shutil.copy(path, os.path.join(user.get_home_dir(), ".face"))
+                    shutil.copy(path, face_path)
                 finally:
                     priv_helper.restore_privs()
                 model.set_value(treeiter, INDEX_USER_PICTURE, GdkPixbuf.Pixbuf.new_from_file_at_size(path, 48, 48))

--- a/files/usr/share/cinnamon/cinnamon-settings-users/cinnamon-settings-users.py
+++ b/files/usr/share/cinnamon/cinnamon-settings-users/cinnamon-settings-users.py
@@ -675,7 +675,7 @@ class Module:
                 try:
                     try:
                         os.remove(face_path)
-                    except:
+                    except OSError:
                         pass
                     priv_helper.drop_privs(user)
                     image.save(face_path, "png")
@@ -717,7 +717,7 @@ class Module:
                 try:
                     try:
                         os.remove(face_path)
-                    except:
+                    except OSError:
                         pass
                     priv_helper.drop_privs(user)
                     shutil.copy(path, face_path)


### PR DESCRIPTION
A security hole was fixed in #7683, where a user's .face file being
modified with root privileges allowed a symlink attack to overwrite
root-owned data.

Unfortunately, this fix is incomplete - simply dropping privileges
means that users who previously had an older .face file would be
unable to overwrite it. The old code left .face owned by root.

This fix first removes the old .face file as root, then drops
privileges and writes the new .face file.

This bug is explained further in #8298 