### PR TITLE
cinnamon-settings-ui: Remove the hack to center the stack switcher

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
@@ -224,9 +224,6 @@ class MainWindow:
 
         self.stack_switcher = self.builder.get_object("stack_switcher")
 
-        m, n = self.button_back.get_preferred_width()
-        self.stack_switcher.set_margin_end(n)
-
         self.search_entry = self.builder.get_object("search_box")
         self.search_entry.set_placeholder_text(_("Search"))
         self.search_entry.connect("changed", self.onSearchTextChanged)

--- a/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.ui
+++ b/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.ui
@@ -1,202 +1,204 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.16.1 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.0"/>
-      <object class="GtkBox" id="main_box">
+  <object class="GtkBox" id="main_box">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="orientation">vertical</property>
+    <child>
+      <object class="GtkToolbar" id="top_bar">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="orientation">vertical</property>
+        <property name="toolbar_style">icons</property>
         <child>
-          <object class="GtkToolbar" id="top_bar">
+          <object class="GtkToolItem" id="toolbutton1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="toolbar_style">icons</property>
+            <property name="valign">center</property>
             <child>
-              <object class="GtkToolItem" id="toolbutton1">
+              <object class="GtkStack" id="header_stack">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="valign">center</property>
                 <child>
-                  <object class="GtkStack" id="header_stack">
+                  <object class="GtkBox" id="hbox2">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
+                    <property name="border_width">1</property>
                     <child>
-                      <object class="GtkBox" id="hbox2">
+                      <object class="GtkEntry" id="search_box">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="border_width">1</property>
-                        <child>
-                          <object class="GtkEntry" id="search_box">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="halign">start</property>
-                            <property name="invisible_char">●</property>
-                            <property name="width_chars">25</property>
-                            <property name="caps_lock_warning">False</property>
-                            <property name="primary_icon_name">edit-find-symbolic</property>
-                            <property name="secondary_icon_name">edit-clear-symbolic</property>
-                            <property name="placeholder_text">Search...</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="pack_type">end</property>
-                          </packing>
-                        </child>
+                        <property name="can_focus">True</property>
+                        <property name="halign">start</property>
+                        <property name="invisible_char">●</property>
+                        <property name="width_chars">25</property>
+                        <property name="caps_lock_warning">False</property>
+                        <property name="primary_icon_name">edit-find-symbolic</property>
+                        <property name="secondary_icon_name">edit-clear-symbolic</property>
+                        <property name="placeholder_text">Search...</property>
                       </object>
                       <packing>
-                        <property name="title">side_view</property>
-                        <property name="name">side_view</property>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="pack_type">end</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="name">side_view</property>
+                    <property name="title">side_view</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="box2">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="border_width">1</property>
+                    <child>
+                      <object class="GtkButton" id="button_back">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="focus_on_click">False</property>
+                        <property name="receives_default">True</property>
+                        <child>
+                          <object class="GtkImage" id="image1">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="icon_name">go-previous-symbolic</property>
+                          </object>
+                        </child>
+                        <style>
+                          <class name="raised"/>
+                          <class name="image-button"/>
+                        </style>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child type="center">
+                      <object class="GtkStackSwitcher" id="stack_switcher">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">center</property>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
                         <property name="position">2</property>
                       </packing>
                     </child>
-                    <child>
-                      <object class="GtkBox" id="box2">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="border_width">1</property>
-                        <child>
-                          <object class="GtkButton" id="button_back">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">True</property>
-                            <property name="focus_on_click">False</property>
-                            <child>
-                              <object class="GtkImage" id="image1">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="icon_name">go-previous-symbolic</property>
-                              </object>
-                            </child>
-                            <style>
-                              <class name="raised"/>
-                              <class name="image-button"/>
-                            </style>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkStackSwitcher" id="stack_switcher">
-                            <property name="visible">True</property>
-                            <property name="halign">center</property>
-                            <property name="homogeneous">True</property>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="title">content_box</property>
-                        <property name="name">content_box</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
                   </object>
+                  <packing>
+                    <property name="name">content_box</property>
+                    <property name="title">content_box</property>
+                    <property name="position">1</property>
+                  </packing>
                 </child>
-                <style>
-                  <class name="raised"/>
-                </style>
               </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="homogeneous">False</property>
-              </packing>
             </child>
             <style>
-              <class name="primary-toolbar"/>
+              <class name="raised"/>
             </style>
           </object>
           <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
+            <property name="expand">True</property>
+            <property name="homogeneous">False</property>
           </packing>
         </child>
+        <style>
+          <class name="primary-toolbar"/>
+        </style>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkStack" id="main_stack">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <child>
-          <object class="GtkStack" id="main_stack">
+          <object class="GtkScrolledWindow" id="side_view_sw">
+            <property name="height_request">125</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can_focus">True</property>
+            <property name="hscrollbar_policy">never</property>
             <child>
-              <object class="GtkScrolledWindow" id="side_view_sw">
-                <property name="height_request">125</property>
+              <object class="GtkViewport" id="viewport2">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="hscrollbar_policy">never</property>
-                <child>
-                  <object class="GtkViewport" id="viewport2">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="vexpand">True</property>
-                    <property name="vscroll_policy">natural</property>
-                    <property name="shadow_type">none</property>
-                    <child>
-                      <object class="GtkBox" id="category_box">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="valign">start</property>
-                        <property name="border_width">10</property>
-                        <property name="orientation">vertical</property>
-                        <child>
-                          <placeholder/>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="title">Hello World</property>
-                <property name="name">side_view_page</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkScrolledWindow" id="content_box_sw">
-                <property name="can_focus">True</property>
-                <property name="hexpand">True</property>
+                <property name="can_focus">False</property>
                 <property name="vexpand">True</property>
-                <property name="hscrollbar_policy">never</property>
+                <property name="vscroll_policy">natural</property>
+                <property name="shadow_type">none</property>
                 <child>
-                  <object class="GtkViewport" id="viewport1">
+                  <object class="GtkBox" id="category_box">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="vexpand">True</property>
-                    <property name="shadow_type">none</property>
+                    <property name="valign">start</property>
+                    <property name="border_width">10</property>
+                    <property name="orientation">vertical</property>
                     <child>
-                      <object class="GtkVBox" id="content_box">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="hexpand">True</property>
-                        <property name="vexpand">True</property>
-                        <property name="border_width">6</property>
-                        <property name="spacing">3</property>
-                        <child>
-                          <placeholder/>
-                        </child>
-                      </object>
+                      <placeholder/>
                     </child>
                   </object>
                 </child>
               </object>
-              <packing>
-                <property name="name">content_box_page</property>
-                <property name="position">2</property>
-              </packing>
             </child>
           </object>
           <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
+            <property name="name">side_view_page</property>
+            <property name="title">Hello World</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkScrolledWindow" id="content_box_sw">
+            <property name="can_focus">True</property>
+            <property name="hexpand">True</property>
+            <property name="vexpand">True</property>
+            <property name="hscrollbar_policy">never</property>
+            <child>
+              <object class="GtkViewport" id="viewport1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="vexpand">True</property>
+                <property name="shadow_type">none</property>
+                <child>
+                  <object class="GtkVBox" id="content_box">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                    <property name="hexpand">True</property>
+                    <property name="vexpand">True</property>
+                    <property name="border_width">6</property>
+                    <property name="spacing">3</property>
+                    <child>
+                      <placeholder/>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="name">content_box_page</property>
             <property name="position">1</property>
           </packing>
         </child>
       </object>
+      <packing>
+        <property name="expand">True</property>
+        <property name="fill">True</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+  </object>
 </interface>


### PR DESCRIPTION
When the back button is hidden the hack we used to center the stack switcher
stops it from being centered. Nowadays we have gtk_box_set_center_widget().
Use that instead so the stack switcher is always centered correctly.