### PR TITLE
Workspace switcher applet settings: add tooltip with informative note

### DIFF
--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/settings-schema.json
@@ -2,6 +2,7 @@
     "display_type": {
         "type": "combobox",
         "description": "Type of display",
+        "tooltip": "Note that the visual representation will only work if your panel is large enough to display it properly, otherwise the simple style will be used.",
         "default": "visual",
         "options" : {
             "A visual representation of the workspaces": "visual",


### PR DESCRIPTION
The visual representation of the workspace switcher currently doesn't work well with a really small panel, so we've been suppressing it in that case. This simply adds a tooltip that explains this to the user so that they don't get confused or think there's a bug.