### PR TITLE
Create unique names for desktop apps with duplicate display names.

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -2276,10 +2276,9 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         while ((nextType = iter.next()) != CMenu.TreeItemType.INVALID) {
             if (nextType == CMenu.TreeItemType.ENTRY) {
                 let entry = iter.get_entry();
-                let appInfo = entry.get_app_info();
-                if (appInfo && !appInfo.get_nodisplay()) {
+                let app = appsys.lookup_app(entry.get_desktop_file_id());
+                if (!app.get_nodisplay()) {
                     has_entries = true;
-                    let app = appsys.lookup_app(entry.get_desktop_file_id());
                     let app_key = app.get_id();
                     if (app_key == null) {
                         app_key = app.get_name() + ":" +

--- a/src/cinnamon-app-private.h
+++ b/src/cinnamon-app-private.h
@@ -26,7 +26,12 @@ void _cinnamon_app_do_match (CinnamonApp         *app,
                           GSList           *terms,
                           GSList          **prefix_results,
                           GSList          **substring_results);
-
+const char * _cinnamon_app_get_common_name (CinnamonApp *app);
+void         _cinnamon_app_set_unique_name (CinnamonApp *app, gchar *unique_name);
+const char * _cinnamon_app_get_unique_name (CinnamonApp *app);
+const char * _cinnamon_app_get_executable (CinnamonApp *app);
+const char * _cinnamon_app_get_desktop_path (CinnamonApp *app);
+void         _cinnamon_app_set_hidden_as_duplicate (CinnamonApp *app, gboolean hide);
 G_END_DECLS
 
 #endif /* __CINNAMON_APP_PRIVATE_H__ */

--- a/src/cinnamon-app.h
+++ b/src/cinnamon-app.h
@@ -46,6 +46,8 @@ ClutterActor *cinnamon_app_create_icon_texture_for_window (CinnamonApp   *app,
 const char *cinnamon_app_get_name (CinnamonApp *app);
 const char *cinnamon_app_get_description (CinnamonApp *app);
 const char *cinnamon_app_get_keywords (CinnamonApp *app);
+gboolean cinnamon_app_get_nodisplay (CinnamonApp *app);
+
 gboolean cinnamon_app_is_window_backed (CinnamonApp *app);
 
 void cinnamon_app_activate_window (CinnamonApp *app, MetaWindow *window, guint32 timestamp);


### PR DESCRIPTION
need to:

- ~~prettify exec or flatpak names (capitalize, strip paths)~~
- ~~handle OnlyShowIn/NotShowIn cases with identical executables (i.e. nautilus has two - one for gnome/unity, another for *not* gnome/unity.  Cinnamon-menus accepts both as valid for a cinnamon session.~~
- ~~implement a hardcoded list if necessary for corner cases~~
- optimize

