### PR TITLE
Workspace switcher: shade labels of empty workspaces in simple button mode

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -1537,6 +1537,10 @@ StScrollBar StButton#vhandle:hover {
     box-shadow: inset 0px 0px 8px 1px rgba(255,255,255, 0.7);
 }
 
+.workspace-button:shaded {
+    color: #13191c;
+}
+
 /* Controls the style when using the "Visual representation" option */
 .workspace-graph {
     padding: 3px;

--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
@@ -227,20 +227,23 @@ class SimpleButton extends WorkspaceButton {
     }
 
     activate(active) {
-        if (active)
+        if (active) {
             this.actor.add_style_pseudo_class('outlined');
+        }
         else {
             this.actor.remove_style_pseudo_class('outlined');
             this.update();
         }
     }
-	
+
     shade(empty) {
-        if (empty)
+        if (empty) {
             this.actor.add_style_pseudo_class('shaded');
-        else
+        }
+        else {
             this.actor.remove_style_pseudo_class('shaded');
-            }
+        }
+    }
 	
     update() {
         let empty = true;

--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
@@ -223,6 +223,7 @@ class SimpleButton extends WorkspaceButton {
         let label = new St.Label({ text: (index + 1).toString() });
         label.clutter_text.set_ellipsize(Pango.EllipsizeMode.NONE);
         this.actor.set_child(label);
+        this.shade(true);
     }
 
     activate(active) {
@@ -230,6 +231,28 @@ class SimpleButton extends WorkspaceButton {
             this.actor.add_style_pseudo_class('outlined');
         else
             this.actor.remove_style_pseudo_class('outlined');
+            this.update();
+    }
+	
+	shade(empty) {
+		if (empty)
+			this.actor.add_style_pseudo_class('shaded');
+		else
+			this.actor.remove_style_pseudo_class('shaded');
+	}
+	
+	update() {
+		let empty = true;
+        let windows = this.workspace.list_windows();
+        windows = windows.filter( Main.isInteresting );
+        windows = windows.filter(
+            function(w) {
+                return !w.is_skip_taskbar();
+            });
+		if (windows.length != 0) {
+		 	empty = false;
+		}
+		this.shade(empty);
     }
 }
 

--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
@@ -229,26 +229,27 @@ class SimpleButton extends WorkspaceButton {
     activate(active) {
         if (active)
             this.actor.add_style_pseudo_class('outlined');
-        else
+        else {
             this.actor.remove_style_pseudo_class('outlined');
             this.update();
+        }
     }
 	
-	shade(empty) {
-		if (empty)
-			this.actor.add_style_pseudo_class('shaded');
-		else
-			this.actor.remove_style_pseudo_class('shaded');
+    shade(empty) {
+        if (empty)
+            this.actor.add_style_pseudo_class('shaded');
+        else
+            this.actor.remove_style_pseudo_class('shaded');
 	}
 	
-	update() {
+    update() {
         let empty = true;
         let windows = this.workspace.list_windows();
         windows = windows.filter( Main.isInteresting );
-		if (windows.length != 0) {
-		 	empty = false;
-		}
-		this.shade(empty);
+        if (windows.length !== 0) {
+            empty = false;
+        }
+        this.shade(empty);
     }
 }
 

--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
@@ -245,10 +245,6 @@ class SimpleButton extends WorkspaceButton {
         let empty = true;
         let windows = this.workspace.list_windows();
         windows = windows.filter( Main.isInteresting );
-        windows = windows.filter(
-            function(w) {
-                return !w.is_skip_taskbar();
-            });
 		if (windows.length != 0) {
 		 	empty = false;
 		}

--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
@@ -240,7 +240,7 @@ class SimpleButton extends WorkspaceButton {
             this.actor.add_style_pseudo_class('shaded');
         else
             this.actor.remove_style_pseudo_class('shaded');
-	}
+            }
 	
     update() {
         let empty = true;

--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
@@ -236,23 +236,19 @@ class SimpleButton extends WorkspaceButton {
         }
     }
 
-    shade(empty) {
-        if (empty) {
+    shade(used) {
+        if (!used) {
             this.actor.add_style_pseudo_class('shaded');
         }
         else {
             this.actor.remove_style_pseudo_class('shaded');
         }
     }
-	
+    
     update() {
-        let empty = true;
         let windows = this.workspace.list_windows();
-        windows = windows.filter( Main.isInteresting );
-        if (windows.length !== 0) {
-            empty = false;
-        }
-        this.shade(empty);
+        let used = windows.some(Main.isInteresting);
+        this.shade(used);
     }
 }
 

--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
@@ -223,7 +223,7 @@ class SimpleButton extends WorkspaceButton {
         let label = new St.Label({ text: (index + 1).toString() });
         label.clutter_text.set_ellipsize(Pango.EllipsizeMode.NONE);
         this.actor.set_child(label);
-        this.shade(true);
+        this.update();
     }
 
     activate(active) {
@@ -242,7 +242,7 @@ class SimpleButton extends WorkspaceButton {
 	}
 	
 	update() {
-		let empty = true;
+        let empty = true;
         let windows = this.workspace.list_windows();
         windows = windows.filter( Main.isInteresting );
         windows = windows.filter(


### PR DESCRIPTION
- Darkens labels of empty workspaces in "simple buttons" mode. Workspaces with only minimized windows are considered "not empty"

This PR includes a workspace-button pseudoclass in cinnamon.css to define the darkened label. I'm not sure if this is acceptable for compatibility reasons, but I'm not sure of another way to accomplish this
