### PR TITLE
git ignore auto-generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,17 @@ stamp-h1
 tests/Makefile
 tests/Makefile.in
 tests/run-test.sh
+/.vscode/
+/config.h.in~
+/debian/.debhelper/
+/debian/autoreconf.after
+/debian/autoreconf.before
+/debian/*.log
+/debian/*.substvars
+/debian/cinnamon-common/
+/debian/cinnamon-dbg/
+/debian/cinnamon-doc/
+/debian/cinnamon/
+/debian/files
+/debian/debhelper-build-stamp
+/debian/tmp/


### PR DESCRIPTION
This also ignores the .vscode directory, which stores some binaries needed for intellisense to work in C files. Otherwise autotools deletes them and header includes will be reset.