### PR TITLE
st-label: Move St-specific shadow processing out of the paint vfunc

### DIFF
--- a/src/st/st-label.c
+++ b/src/st/st-label.c
@@ -204,7 +204,7 @@ st_label_paint (ClutterActor *actor)
       clutter_actor_get_allocation_box (priv->label, &allocation);
       clutter_actor_box_get_size (&allocation, &width, &height);
 
-      if (priv->text_shadow_pipeline == NULL ||
+      if (!priv->text_shadow_pipeline ||
           width != priv->shadow_width ||
           height != priv->shadow_height)
         {
@@ -216,7 +216,7 @@ st_label_paint (ClutterActor *actor)
           priv->text_shadow_pipeline = _st_create_shadow_pipeline_from_actor (shadow_spec, priv->label);
         }
 
-      if (priv->text_shadow_pipeline != NULL)
+      if (priv->text_shadow_pipeline)
         _st_paint_shadow_with_opacity (shadow_spec,
                                        priv->text_shadow_pipeline,
                                        &allocation,

--- a/src/st/st-label.c
+++ b/src/st/st-label.c
@@ -208,12 +208,12 @@ st_label_paint (ClutterActor *actor)
           width != priv->shadow_width ||
           height != priv->shadow_height)
         {
-          g_clear_pointer (&priv->text_shadow_pipeline, cogl_object_unref);
+          if (priv->text_shadow_pipeline)
+            cogl_object_unref (priv->text_shadow_pipeline);
 
           priv->shadow_width = width;
           priv->shadow_height = height;
           priv->text_shadow_pipeline = _st_create_shadow_pipeline_from_actor (shadow_spec, priv->label);
-
         }
 
       if (priv->text_shadow_pipeline != NULL)

--- a/src/st/st-label.c
+++ b/src/st/st-label.c
@@ -57,10 +57,8 @@ enum
 struct _StLabelPrivate
 {
   ClutterActor *label;
-  ClutterActorBox *allocation;
 
   gboolean orphan;
-  gboolean size_changed;
 
   CoglPipeline  *text_shadow_pipeline;
   float         shadow_width;
@@ -171,21 +169,10 @@ st_label_allocate (ClutterActor          *actor,
   StLabelPrivate *priv = ST_LABEL (actor)->priv;
   StThemeNode *theme_node = st_widget_get_theme_node (ST_WIDGET (actor));
   ClutterActorBox content_box;
-  float width, height;
 
   clutter_actor_set_allocation (actor, box, flags);
 
   st_theme_node_get_content_box (theme_node, box, &content_box);
-
-  clutter_actor_box_get_size (&content_box, &width, &height);
-
-  if (width != priv->shadow_width || height != priv->shadow_height)
-    {
-      priv->shadow_width = width;
-      priv->shadow_height = height;
-      priv->size_changed = TRUE;
-      priv->allocation = &content_box;
-    }
 
   clutter_actor_allocate (priv->label, &content_box, flags);
 }
@@ -211,21 +198,29 @@ st_label_paint (ClutterActor *actor)
 
   if (shadow_spec)
     {
-      if (priv->text_shadow_pipeline == NULL || priv->size_changed)
+      ClutterActorBox allocation;
+      float width, height;
+
+      clutter_actor_get_allocation_box (priv->label, &allocation);
+      clutter_actor_box_get_size (&allocation, &width, &height);
+
+      if (priv->text_shadow_pipeline == NULL ||
+          width != priv->shadow_width ||
+          height != priv->shadow_height)
         {
-          priv->size_changed = FALSE;
           g_clear_pointer (&priv->text_shadow_pipeline, cogl_object_unref);
 
+          priv->shadow_width = width;
+          priv->shadow_height = height;
           priv->text_shadow_pipeline = _st_create_shadow_pipeline_from_actor (shadow_spec, priv->label);
+
         }
 
       if (priv->text_shadow_pipeline != NULL)
-        {
-          _st_paint_shadow_with_opacity (shadow_spec,
-                                         priv->text_shadow_pipeline,
-                                         priv->allocation,
-                                         clutter_actor_get_paint_opacity (priv->label));
-        }
+        _st_paint_shadow_with_opacity (shadow_spec,
+                                       priv->text_shadow_pipeline,
+                                       &allocation,
+                                       clutter_actor_get_paint_opacity (priv->label));
     }
 
   clutter_actor_paint (priv->label);
@@ -273,15 +268,13 @@ st_label_init (StLabel *label)
 
   label->priv = priv = st_label_get_instance_private (label);
 
-  priv->label = g_object_new (CLUTTER_TYPE_TEXT,
+  label->priv->label = g_object_new (CLUTTER_TYPE_TEXT,
                                      "ellipsize", PANGO_ELLIPSIZE_END,
                                      NULL);
-  priv->text_shadow_pipeline = NULL;
-  priv->shadow_width = -1.;
-  priv->shadow_height = -1.;
-  priv->orphan = FALSE;
-  priv->size_changed = TRUE;
-
+  label->priv->text_shadow_pipeline = NULL;
+  label->priv->shadow_width = -1.;
+  label->priv->shadow_height = -1.;
+  label->priv->orphan = FALSE;
 
   /* This will ensure our pointer gets cleared the moment the ClutterText becomes invalid */
   g_object_add_weak_pointer (G_OBJECT (label->priv->label), (gpointer) &label->priv->label);

--- a/src/st/st-label.c
+++ b/src/st/st-label.c
@@ -202,7 +202,9 @@ st_label_paint (ClutterActor *actor)
       float width, height;
 
       clutter_actor_get_allocation_box (priv->label, &allocation);
-      clutter_actor_box_get_size (&allocation, &width, &height);
+
+      width = allocation.x2 - allocation.x1;
+      height = allocation.y2 - allocation.y1;
 
       if (!priv->text_shadow_pipeline ||
           width != priv->shadow_width ||

--- a/src/st/st-private.h
+++ b/src/st/st-private.h
@@ -28,6 +28,7 @@
 #include "st-widget.h"
 #include "st-bin.h"
 #include "st-shadow.h"
+#include "st-theme-node-transition.h"
 
 G_BEGIN_DECLS
 
@@ -78,5 +79,42 @@ void _st_paint_shadow_with_opacity (StShadow        *shadow_spec,
                                     CoglPipeline    *shadow_pipeline,
                                     ClutterActorBox *box,
                                     guint8           paint_opacity);
+
+/*
+ * Forward declaration for sake of StWidgetChild
+ */
+struct _StWidgetPrivate
+{
+  StTheme      *theme;
+  StThemeNode  *theme_node;
+  gchar        *pseudo_class;
+  gchar        *style_class;
+  gchar        *inline_style;
+
+  StThemeNodeTransition *transition_animation;
+
+  guint      is_style_dirty : 1;
+  guint      draw_bg_color : 1;
+  guint      draw_border_internal : 1;
+  guint      track_hover : 1;
+  guint      hover : 1;
+  guint      can_focus : 1;
+  guint      important : 1;
+
+  StTextDirection   direction;
+
+  AtkObject *accessible;
+  AtkRole accessible_role;
+  AtkStateSet *local_state_set;
+
+  ClutterActor *label_actor;
+  gchar *accessible_name;
+
+  /* Even though Clutter has first_child/last_child properties,
+   * we need to keep track of the old first/last children so
+   * that we can remove the pseudo classes on them. */
+  StWidget *prev_last_child;
+  StWidget *prev_first_child;
+};
 
 #endif /* __ST_PRIVATE_H__ */

--- a/src/st/st-widget.c
+++ b/src/st/st-widget.c
@@ -47,43 +47,6 @@
 #include <gtk/gtk.h>
 #include <atk/atk-enum-types.h>
 
-/*
- * Forward declaration for sake of StWidgetChild
- */
-struct _StWidgetPrivate
-{
-  StTheme      *theme;
-  StThemeNode  *theme_node;
-  gchar        *pseudo_class;
-  gchar        *style_class;
-  gchar        *inline_style;
-
-  StThemeNodeTransition *transition_animation;
-
-  guint      is_style_dirty : 1;
-  guint      draw_bg_color : 1;
-  guint      draw_border_internal : 1;
-  guint      track_hover : 1;
-  guint      hover : 1;
-  guint      can_focus : 1;
-  guint      important : 1;
-
-  StTextDirection   direction;
-
-  AtkObject *accessible;
-  AtkRole accessible_role;
-  AtkStateSet *local_state_set;
-
-  ClutterActor *label_actor;
-  gchar *accessible_name;
-
-  /* Even though Clutter has first_child/last_child properties,
-   * we need to keep track of the old first/last children so
-   * that we can remove the pseudo classes on them. */
-  StWidget *prev_last_child;
-  StWidget *prev_first_child;
-};
-
 /**
  * SECTION:st-widget
  * @short_description: Base class for stylable actors


### PR DESCRIPTION
This is basically a redo of 37d75d48e4f0214e498dd559ee257946ad3fed6f, which didn't work because the size didn't propagate until the next redraw.

Ref https://github.com/linuxmint/cinnamon/issues/8454#issuecomment-493608833