### PR TITLE
overview: Fix some thumbnails not appearing

### DIFF
--- a/js/ui/workspace.js
+++ b/js/ui/workspace.js
@@ -107,6 +107,8 @@ WindowClone.prototype = {
         this.actor.set_position(x, y);
         this.origX = x;
         this.origY = y;
+
+        this.realWindow.queue_redraw();
     },
 
     closeWindow: function() {
@@ -144,6 +146,8 @@ WindowClone.prototype = {
     },
 
     destroy: function () {
+        if (this.actor.is_finalized()) return;
+
         this.actor.destroy();
     },
 


### PR DESCRIPTION
This is happening because windows are not always eligible to paint a texture after they're initialized. They are lazy loaded, and this does not impact normal window operation. When the obscured optimization in Muffin is disabled via `meta_window_actor_set_obscured`, a redraw is already being queued. The thumbnail clones work without issue everywhere else, so I'm suspecting  it has something to do with this abstracted `WindowClone` class that is preventing MetaWindowActor redraws.

Ref https://github.com/linuxmint/cinnamon/issues/8454#issuecomment-496640069