### PR TITLE
windowEffects: Fix opacity during the close effect, stacking during the minimize effect

### DIFF
--- a/js/ui/windowEffects.js
+++ b/js/ui/windowEffects.js
@@ -18,9 +18,16 @@ class Effect {
 
         // For the close effect, use the actual MetaWindowActor instead of the clone
         // because Clutter seems to have issues opacifying clones when the source is already destroyed.
-        if (this.name === 'close') {
+        if (this.name === 'close' || this.name === 'minimize') {
             source.show();
             this.actor = source;
+
+            this.originalX = source.x;
+            this.originalY = source.y;
+            this.originalScaleX = source.scale_x;
+            this.originalScaleY = source.scale_y;
+            this.originalWidth = source.width;
+            this.originalHeight = source.height;
         } else {
             this.actor = new Clone({
                 source,
@@ -51,10 +58,20 @@ class Effect {
 
         if (this.source !== this.actor) {
             global.overlay_group.remove_child(this.actor);
-        }
-
-        if (!this.actor.is_finalized()) {
             this.actor.destroy();
+        } else if (this.name === 'minimize') {
+            this.actor.hide();
+
+            // The properties of the MetaWindowActor have values from the last animation tween state.
+            // We need to restore the window to its original state, as muffin only handles Xorg state
+            // changes for these properties.
+            this.actor.opacity = this.originalOpacity;
+            this.actor.x = this.originalX;
+            this.actor.y = this.originalY;
+            this.actor.scale_x = this.originalScaleX;
+            this.actor.scale_y = this.originalScaleY;
+            this.actor.width = this.originalWidth;
+            this.actor.height = this.originalHeight;
         }
 
         panelManager.updatePanelsVisibility();

--- a/js/ui/windowEffects.js
+++ b/js/ui/windowEffects.js
@@ -51,7 +51,9 @@ class Effect {
 
         if (this.source !== this.actor) {
             global.overlay_group.remove_child(this.actor);
-        } else if (!this.actor.is_finalized()) {
+        }
+
+        if (!this.actor.is_finalized()) {
             this.actor.destroy();
         }
 

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -716,6 +716,9 @@ var WindowManager = class WindowManager {
 
     _mapWindow(cinnamonwm, actor) {
         let {meta_window} = actor;
+
+        if (!meta_window) return;
+
         if (meta_window.is_attached_dialog()) {
             this._checkDimming(meta_window.get_transient_for());
         }


### PR DESCRIPTION
It appears MetaWindowActor is being disposed during the effect because once switched over to applying the effect directly, we need a finalized check in `Effect.prototype._end`. This is breaking Clutter's ability to opacify the clone for some reason. We can apply the effect directly as a fix since there weren't any issues observed with the close effect in particular.

Depends on https://github.com/linuxmint/muffin/pull/508