### PR TITLE
layoutManager: Always update regions when untracking an actor

### DIFF
--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -563,7 +563,7 @@ Chrome.prototype = {
         actor.disconnect(actorData.allocationId);
         actor.disconnect(actorData.parentSetId);
 
-        this._queueUpdateRegions();
+        this._queueUpdateRegions(true);
     },
 
     _actorReparented: function(actor) {


### PR DESCRIPTION
This fixes an input region issue when some desklets are lowered below the window group.