### PR TITLE
Issue template: Request info about daily builds PPA usage

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,7 @@
 
 ```
  * Cinnamon version (cinnamon --version)
+   - Please specify if you are using the daily builds PPA (https://launchpad.net/~linuxmint-daily-build-team/+archive/ubuntu/daily-builds).
  * Distribution - (Mint 17.2, Arch, Fedora 25, etc...)
  * Graphics hardware *and* driver used
  * 32 or 64 bit


### PR DESCRIPTION
There are a lot of issues indicating Cinnamon 4.0 usage, but it's not clear if this is the maintenance release or master via the PPA.