### PR TITLE
Revert layout.js optimizations

### DIFF
--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -563,7 +563,7 @@ Chrome.prototype = {
         actor.disconnect(actorData.allocationId);
         actor.disconnect(actorData.parentSetId);
 
-        this._queueUpdateRegions(true);
+        this._queueUpdateRegions();
     },
 
     _actorReparented: function(actor) {

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -8,6 +8,7 @@ const Clutter = imports.gi.Clutter;
 const Cinnamon = imports.gi.Cinnamon;
 const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
+const Lang = imports.lang;
 const Mainloop = imports.mainloop;
 const Meta = imports.gi.Meta;
 const Signals = imports.signals;
@@ -19,9 +20,19 @@ const EdgeFlip = imports.ui.edgeFlip;
 const HotCorner = imports.ui.hotCorner;
 const DeskletManager = imports.ui.deskletManager;
 const Panel = imports.ui.panel;
-const {findIndex, map} = imports.misc.util;
 
 const STARTUP_ANIMATION_TIME = 0.5;
+
+function isPopupMetaWindow(actor) {
+    switch(actor.meta_window.get_window_type()) {
+    case Meta.WindowType.DROPDOWN_MENU:
+    case Meta.WindowType.POPUP_MENU:
+    case Meta.WindowType.COMBO:
+        return true;
+    default:
+        return false;
+    }
+}
 
 function Monitor(index, geometry) {
     this._init(index, geometry);
@@ -40,29 +51,6 @@ Monitor.prototype = {
         return global.screen.get_monitor_in_fullscreen(this.index);
     }
 };
-
-function intersect (dest, src2) {
-    let dest_x, dest_y;
-    let dest_w, dest_h;
-
-    dest_x = Math.max(dest.x, src2.x);
-    dest_y = Math.max(dest.y, src2.y);
-    dest_w = Math.min(dest.x + dest.width, src2.x + src2.width) - dest_x;
-    dest_h = Math.min(dest.y + dest.height, src2.y + src2.height) - dest_y;
-
-    if (dest_w > 0 && dest_h > 0) {
-        dest.x = dest_x;
-        dest.y = dest_y;
-        dest.width = dest_w;
-        dest.height = dest_h;
-        return dest;
-    }
-
-    dest.width = 0;
-    dest.height = 0;
-
-    return dest;
-}
 
 /**
  * #LayoutManager
@@ -102,9 +90,9 @@ LayoutManager.prototype = {
 
         this._monitorsChanged();
 
-        global.settings.connect("changed::enable-edge-flip", () => this._onEdgeFlipChanged());
-        global.settings.connect("changed::edge-flip-delay", () => this._onEdgeFlipChanged());
-        global.screen.connect('monitors-changed', () => this._monitorsChanged());
+        global.settings.connect("changed::enable-edge-flip", Lang.bind(this, this._onEdgeFlipChanged));
+        global.settings.connect("changed::edge-flip-delay", Lang.bind(this, this._onEdgeFlipChanged));
+        global.screen.connect('monitors-changed', Lang.bind(this, this._monitorsChanged));
     },
 
     _onEdgeFlipChanged: function(){
@@ -256,16 +244,16 @@ LayoutManager.prototype = {
         this._chrome.modifyActorParams(this.keyboardBox, { affectsStruts: true });
         this._chrome.updateRegions();
 
-        this._keyboardHeightNotifyId = this.keyboardBox.connect('notify::height', () => {
-            if (this.keyboardBox.y) {
+        this._keyboardHeightNotifyId = this.keyboardBox.connect('notify::height', Lang.bind(this, function () {
+            if (this.keyboardBox.y != 0) {
                 this.keyboardBox.y = this.focusMonitor.y + this.focusMonitor.height - this.keyboardBox.height;
             }
-        });
+        }));
 
     },
 
     queueHideKeyboard: function() {
-        if (this.hideIdleId) {
+        if (this.hideIdleId != 0) {
             Mainloop.source_remove(this.hideIdleId);
             this.hideIdleId = 0;
         }
@@ -275,10 +263,10 @@ LayoutManager.prototype = {
             this._keyboardHeightNotifyId = 0;
         }
 
-        this.hideIdleId = Mainloop.idle_add(() => this.hideKeyboard());
+        this.hideIdleId = Mainloop.idle_add(Lang.bind(this, this.hideKeyboard));
     },
 
-    hideKeyboard: function () {
+    hideKeyboard: function (immediate) {
         if (Main.messageTray) Main.messageTray.hide();
 
         this.keyboardBox.hide();
@@ -446,26 +434,28 @@ Chrome.prototype = {
         this._primaryIndex = -1;
         this._updateRegionIdle = 0;
         this._freezeUpdateCount = 0;
-        this._trackedActors = [];
-        this.rects = [];
-        this.struts = [];
 
-        this._layoutManager.connect('monitors-changed', () => this._relayout());
-        global.display.connect('notify::focus-window', () => {
-            Mainloop.idle_add_full(1000, () => this._windowsRestacked());
-        });
-        global.screen.connect('in-fullscreen-changed', () => this._updateVisibility());
-        global.window_manager.connect('switch-workspace', () => this.onWorkspaceChanged());
+        this._trackedActors = [];
+
+        this._layoutManager.connect('monitors-changed',
+                                    Lang.bind(this, this._relayout));
+        global.screen.connect('restacked',
+                              Lang.bind(this, this._windowsRestacked));
+        global.screen.connect('in-fullscreen-changed', Lang.bind(this, this._updateVisibility));
+        global.window_manager.connect('switch-workspace', Lang.bind(this, this._queueUpdateRegions));
 
         // Need to update struts on new workspaces when they are added
-        global.screen.connect('notify::n-workspaces', () => this.onWorkspaceChanged());
+        global.screen.connect('notify::n-workspaces',
+                              Lang.bind(this, this._queueUpdateRegions));
 
         this._relayout();
     },
 
     init: function() {
-        Main.overview.connect('showing', () => this._overviewShowing());
-        Main.overview.connect('hidden', () => this._overviewHidden());
+        Main.overview.connect('showing',
+                              Lang.bind(this, this._overviewShowing));
+        Main.overview.connect('hidden',
+                              Lang.bind(this, this._overviewHidden));
     },
 
     addActor: function(actor, params) {
@@ -515,7 +505,7 @@ Chrome.prototype = {
     },
 
     _findActor: function(actor) {
-        for (let i = 0, len = this._trackedActors.length; i < len; i++) {
+        for (let i = 0; i < this._trackedActors.length; i++) {
             let actorData = this._trackedActors[i];
             if (actorData.actor == actor)
                 return i;
@@ -541,9 +531,12 @@ Chrome.prototype = {
         actorData.actor = actor;
         if (actorData.addToWindowgroup) actorData.isToplevel = actor.get_parent() == global.window_group;
         else actorData.isToplevel = actor.get_parent() == Main.uiGroup;
-        actorData.visibleId = actor.connect('notify::visible', () => this._queueUpdateRegions());
-        actorData.allocationId = actor.connect('notify::allocation', () => this._queueUpdateRegions());
-        actorData.parentSetId = actor.connect('parent-set', (a) => this._actorReparented(a));
+        actorData.visibleId = actor.connect('notify::visible',
+                                            Lang.bind(this, this._queueUpdateRegions));
+        actorData.allocationId = actor.connect('notify::allocation',
+                                               Lang.bind(this, this._queueUpdateRegions));
+        actorData.parentSetId = actor.connect('parent-set',
+                                              Lang.bind(this, this._actorReparented));
         // Note that destroying actor will unset its parent, so we don't
         // need to connect to 'destroy' too.
 
@@ -566,7 +559,7 @@ Chrome.prototype = {
         this._queueUpdateRegions();
     },
 
-    _actorReparented: function(actor) {
+    _actorReparented: function(actor, oldParent) {
         let i = this._findActor(actor);
         if (i == -1)
             return;
@@ -582,7 +575,7 @@ Chrome.prototype = {
     },
 
     _updateVisibility: function() {
-        for (let i = 0, len = this._trackedActors.length; i < len; i++) {
+        for (let i = 0; i < this._trackedActors.length; i++) {
             let actorData = this._trackedActors[i], visible;
             if (!actorData.isToplevel)
                 continue;
@@ -633,16 +626,14 @@ Chrome.prototype = {
         // First look at what monitor the center of the rectangle is at
         let cx = x + w/2;
         let cy = y + h/2;
-        let len = this._monitors.length;
-
-        for (let i = 0; i < len; i++) {
+        for (let i = 0; i < this._monitors.length; i++) {
             let monitor = this._monitors[i];
             if (cx >= monitor.x && cx < monitor.x + monitor.width &&
                 cy >= monitor.y && cy < monitor.y + monitor.height)
                 return [i, monitor];
         }
         // If the center is not on a monitor, return the first overlapping monitor
-        for (let i = 0; i < len; i++) {
+        for (let i = 0; i < this._monitors.length; i++) {
             let monitor = this._monitors[i];
             if (x + w > monitor.x && x < monitor.x + monitor.width &&
                 y + h > monitor.y && y < monitor.y + monitor.height)
@@ -687,7 +678,8 @@ Chrome.prototype = {
 
     _queueUpdateRegions: function() {
         if (!this._updateRegionIdle && !this._freezeUpdateCount)
-            this._updateRegionIdle = Mainloop.idle_add(() => this.updateRegions(), Meta.PRIORITY_BEFORE_REDRAW);
+            this._updateRegionIdle = Mainloop.idle_add(Lang.bind(this, this.updateRegions),
+                                                       Meta.PRIORITY_BEFORE_REDRAW);
     },
 
     freezeUpdateRegions: function() {
@@ -702,67 +694,30 @@ Chrome.prototype = {
     },
 
     _windowsRestacked: function() {
-        const {_isPopupWindowVisible} = this;
+        // Figure out where the pointer is in case we lost track of
+        // it during a grab.
+        global.sync_pointer();
 
-        this._isPopupWindowVisible = global.display.popup_window_visible();
-
-        if (_isPopupWindowVisible != this._isPopupWindowVisible) {
+        let isPopupWindowVisible = global.top_window_group.get_children().some(isPopupMetaWindow);
+        let popupVisibilityChanged = this._isPopupWindowVisible !== isPopupWindowVisible;
+        this._isPopupWindowVisible = isPopupWindowVisible;
+        if (popupVisibilityChanged)
             this._updateVisibility();
-
-            /* Pointer only needs to be updated to account for tray icon popup windows, which
-               will be reflected by the global.display.popup_window_visible return value. */
-            Mainloop.idle_add_full(1000, () => global.sync_pointer());
-        } else {
+        else
             this._queueUpdateRegions();
-        }
     },
 
-    /* Avoid calling into C code unless we absolutely have to, including their
-       constructors - this improves CPU usage. updateRegions gets called too
-       much, and the net effect is more time spent context switching.*/
-    updateRects: function() {
-        global.set_stage_input_region(
-            map(this.rects, function(rect) {
-                return new Meta.Rectangle(rect);
-            })
-        );
-    },
-
-    updateStruts: function() {
-        global.screen.get_active_workspace().set_builtin_struts(
-            map(this.struts, function(strut) {
-                return new Meta.Strut({
-                    rect: new Meta.Rectangle(strut.rect),
-                    side: strut.side
-                })
-            })
-        );
-    },
-
-    onWorkspaceChanged: function() {
-        if (this.rects.length) this.updateRects();
-        if (this.struts.length) this.updateStruts();
-    },
-
-    updateRegions: function(updateNeeded = false) {
-        let trackedActorsLength = this._trackedActors.length;
-        let rects = [];
-        let struts = [];
-        let rectsChanged = false;
-        let strutsChanged = false;
-        let wantsInputRegion = !this._isPopupWindowVisible;
-        let i = 0;
+    updateRegions: function() {
+        let rects = [], struts = [], i;
 
         if (this._updateRegionIdle) {
             Mainloop.source_remove(this._updateRegionIdle);
             this._updateRegionIdle = 0;
         }
 
-        if (updateNeeded) {
-            rectsChanged = strutsChanged = true;
-        }
+        let wantsInputRegion = !this._isPopupWindowVisible;
 
-        for (; i < trackedActorsLength; i++) {
+        for (let i = 0; i < this._trackedActors.length; i++) {
             let actorData = this._trackedActors[i];
             if (!(actorData.affectsInputRegion && wantsInputRegion) && !actorData.affectsStruts)
                 continue;
@@ -787,28 +742,17 @@ Chrome.prototype = {
                 && actorData.actor.get_paint_visibility()
                 && !Main.uiGroup.get_skip_paint(actorData.actor)) {
 
-                let rect = {x, y, width: w, height: h};
+                let rect = new Meta.Rectangle({ x: x, y: y, width: w, height: h});
 
                 // special case for hideable panel actors:
                 // clip any off-monitor input region
                 if (actorData.actor.maybeGet("_delegate") instanceof Panel.Panel
                     && actorData.actor._delegate.isHideable()) {
                     let m = this._monitors[actorData.actor._delegate.monitorIndex];
-                    if (m) rect = intersect(rect, m);
-                }
-
-                let refRect = findIndex(this.rects, function(r) {
-                    return (
-                        r.x === rect.x &&
-                        r.y === rect.y &&
-                        r.width === rect.width &&
-                        r.height === rect.height
-                    );
-                });
-
-                /* Check if the rect exists, if so, set the parent scope's changed variable. */
-                if (refRect === -1) {
-                    rectsChanged = true;
+                    if (m) {
+                        let mr = {x: m.x, y: m.y, width: m.width, height: m.height};
+                        [, rect] = rect.intersect(new Meta.Rectangle(mr));
+                    }
                 }
 
                 rects.push(rect);
@@ -858,38 +802,19 @@ Chrome.prototype = {
                 else
                     continue;
 
-                let rect = {
-                    x: x1,
-                    y: y1,
-                    width: x2 - x1,
-                    height: y2 - y1
-                };
-
-                /* Check if the strut exists, if so, set the parent scope's changed variable. */
-                let refStrut = findIndex(this.struts, function(strut) {
-                    return (
-                        rect.x === strut.rect.x &&
-                        rect.y === strut.rect.y &&
-                        rect.width === strut.rect.width &&
-                        rect.height === strut.rect.height &&
-                        strut.side === side
-                    )
-                });
-
-                if (refStrut === -1) {
-                    strutsChanged = true;
-                }
-
-                struts.push({rect, side});
+                let strutRect = new Meta.Rectangle({ x: x1, y: y1, width: x2 - x1, height: y2 - y1});
+                let strut = new Meta.Strut({ rect: strutRect, side: side });
+                struts.push(strut);
             }
         }
 
-        /* Cache the rects and struts for the next comparison. */
-        this.rects = rects;
-        this.struts = struts;
+        global.set_stage_input_region(rects);
 
-        if (rectsChanged) this.updateRects();
-        if (strutsChanged) this.updateStruts();
+        let screen = global.screen;
+        for (let w = 0; w < screen.n_workspaces; w++) {
+            let workspace = screen.get_workspace_by_index(w);
+            workspace.set_builtin_struts(struts);
+        }
 
         return false;
     }

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -454,7 +454,7 @@ Chrome.prototype = {
         global.display.connect('notify::focus-window', () => {
             Mainloop.idle_add_full(1000, () => this._windowsRestacked());
         });
-        global.screen.connect('in-fullscreen-changed', () => this._updateVisibility(true));
+        global.screen.connect('in-fullscreen-changed', () => this._updateVisibility());
         global.window_manager.connect('switch-workspace', () => this.onWorkspaceChanged());
 
         // Need to update struts on new workspaces when they are added
@@ -581,7 +581,7 @@ Chrome.prototype = {
         }
     },
 
-    _updateVisibility: function(updateNeeded = false) {
+    _updateVisibility: function() {
         for (let i = 0, len = this._trackedActors.length; i < len; i++) {
             let actorData = this._trackedActors[i], visible;
             if (!actorData.isToplevel)
@@ -609,7 +609,7 @@ Chrome.prototype = {
                 visible = true;
             Main.uiGroup.set_skip_paint(actorData.actor, !visible);
         }
-        this._queueUpdateRegions(updateNeeded);
+        this._queueUpdateRegions();
     },
 
     _overviewShowing: function() {
@@ -685,9 +685,9 @@ Chrome.prototype = {
         return this._primaryIndex; // Not on any monitor, pretend its on the primary
     },
 
-    _queueUpdateRegions: function(updateNeeded = false) {
+    _queueUpdateRegions: function() {
         if (!this._updateRegionIdle && !this._freezeUpdateCount)
-            this._updateRegionIdle = Mainloop.idle_add(() => this.updateRegions(updateNeeded), Meta.PRIORITY_BEFORE_REDRAW);
+            this._updateRegionIdle = Mainloop.idle_add(() => this.updateRegions(), Meta.PRIORITY_BEFORE_REDRAW);
     },
 
     freezeUpdateRegions: function() {

--- a/js/ui/messageTray.js
+++ b/js/ui/messageTray.js
@@ -1845,8 +1845,6 @@ MessageTray.prototype = {
         }
         this._notification = null;
         this._notificationRemoved = false;
-
-        Main.layoutManager._chrome.updateRegions(true);
     },
 
     _expandNotification: function(autoExpanding) {

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -508,8 +508,6 @@ PanelManager.prototype = {
             }
         }
         global.settings.set_strv("panels-enabled", list);
-
-        Main.layoutManager._chrome.updateRegions(true);
     },
 
     /**
@@ -2537,8 +2535,7 @@ Panel.prototype = {
         }
 
         this._updatePanelVisibility();
-        Main.layoutManager._chrome.modifyActorParams(this.actor, { affectsStruts: this._autohideSettings == "false"});
-        Main.layoutManager._chrome.updateRegions(true);
+        Main.layoutManager._chrome.modifyActorParams(this.actor, { affectsStruts: this._autohideSettings == "false" });
     },
     /**
      * _getScaledPanelHeight:

--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -2324,8 +2324,6 @@ var PopupMenu = class PopupMenu extends PopupMenuBase {
         if (!this.isOpen)
             return;
 
-        const isInChrome = Main.layoutManager._chrome._findActor(this.actor) > -1;
-
         this.isOpen = false;
         global.menuStackLength -= 1;
 
@@ -2361,8 +2359,6 @@ var PopupMenu = class PopupMenu extends PopupMenuBase {
                     this.actor.hide();
                     this.actor.remove_clip();
                     this.actor.set_size(-1, -1);
-
-                    if (isInChrome) Main.layoutManager._chrome.updateRegions(true);
                 }
             }
 
@@ -2392,8 +2388,6 @@ var PopupMenu = class PopupMenu extends PopupMenuBase {
         else {
             this.animating = false;
             this.actor.hide();
-
-            if (isInChrome) Main.layoutManager._chrome.updateRegions(true);
         }
         this.emit('open-state-changed', false);
     }

--- a/src/cinnamon-global-private.h
+++ b/src/cinnamon-global-private.h
@@ -31,7 +31,6 @@ struct _CinnamonGlobal {
   GObject parent;
 
   ClutterStage *stage;
-  ClutterInputDevice *clutter_device;
   Window stage_xwindow;
   GdkWindow *stage_gdk_window;
 

--- a/src/cinnamon-global.c
+++ b/src/cinnamon-global.c
@@ -972,9 +972,6 @@ _cinnamon_global_set_plugin (CinnamonGlobal *global,
   global->meta_display = meta_screen_get_display (global->meta_screen);
   global->xdisplay = meta_display_get_xdisplay (global->meta_display);
 
-  global->clutter_device = clutter_device_manager_get_core_device (clutter_device_manager_get_default (),
-                                                                   CLUTTER_POINTER_DEVICE);
-
   global->gdk_display = gdk_x11_lookup_xdisplay (global->xdisplay);
   global->gdk_screen = gdk_display_get_screen (global->gdk_display,
                                                meta_screen_get_screen_number (global->meta_screen));
@@ -1280,10 +1277,19 @@ void
 cinnamon_global_sync_pointer (CinnamonGlobal *global)
 {
   int x, y;
-  unsigned int mask;
+  GdkDeviceManager *gmanager;
+  GdkDevice *gdevice;
+  GdkScreen *gscreen;
+  GdkModifierType mods;
   ClutterMotionEvent event;
 
-  meta_display_get_pointer (global->meta_display, &x, &y, &mask);
+  gmanager = gdk_display_get_device_manager (global->gdk_display);
+  gdevice = gdk_device_manager_get_client_pointer (gmanager);
+  gdk_device_get_position (gdevice, &gscreen, &x, &y);
+  gdk_device_get_state (gdevice,
+                        gdk_screen_get_root_window (gscreen),
+                        NULL,
+                        &mods);
 
   event.type = CLUTTER_MOTION;
   event.time = cinnamon_global_get_current_time (global);
@@ -1295,9 +1301,10 @@ cinnamon_global_sync_pointer (CinnamonGlobal *global)
   event.stage = global->stage;
   event.x = x;
   event.y = y;
-  event.modifier_state = mask;
+  event.modifier_state = mods;
   event.axes = NULL;
-  event.device = global->clutter_device;
+  event.device = clutter_device_manager_get_core_device (clutter_device_manager_get_default (),
+                                                         CLUTTER_POINTER_DEVICE);
 
   /* Leaving event.source NULL will force clutter to look it up, which
    * will generate enter/leave events as a side effect, if they are


### PR DESCRIPTION
https://github.com/linuxmint/cinnamon/commit/74d14ea9cbb01849d46cda8673d668a6861e29b4 introduced regressions in tooltips and input regions.

- https://github.com/linuxmint/cinnamon/commit/bd6c1929e6985cea8158dabe7de1ccb4776f5ffc, https://github.com/linuxmint/cinnamon/commit/21ae0cde0b9dc908be2f0df94051150909f7210b and https://github.com/linuxmint/cinnamon/commit/08fa99ea5a8236fcf1879e1c95861ea4599abed4 fixed input regions regressions. It's likely they're all fixed now, but we can't be certain. 

- https://github.com/linuxmint/alpha-testing/issues/15 could be fixed by reverting just a portion of https://github.com/linuxmint/cinnamon/commit/74d14ea9cbb01849d46cda8673d668a6861e29b4 (the one which deals with mouse cursor queries) but this close to release it's probably better to pass on troublesome optimizations and to re-plan them for the next release.
