### PR TITLE
Xlets removal confirmation dialogs

### DIFF
--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -15,6 +15,7 @@ const Flashspot = imports.ui.flashspot;
 const ModalDialog = imports.ui.modalDialog;
 const Signals = imports.signals;
 const Gettext = imports.gettext;
+const Cinnamon = imports.gi.Cinnamon;
 
 var AllowedLayout = {  // the panel layout that an applet is suitable for
     VERTICAL: 'vertical',
@@ -558,8 +559,16 @@ var Applet = class Applet {
                 .format(this._(this._meta.name)),
                    "edit-delete",
                    St.IconType.SYMBOLIC);
-            this.context_menu_item_remove.connect('activate', Lang.bind(this, function() {
-                AppletManager._removeAppletFromPanel(this._uuid, this.instance_id);
+            this.context_menu_item_remove.connect('activate', Lang.bind(this, function(actor, event) {
+                if (Clutter.ModifierType.CONTROL_MASK & Cinnamon.get_event_state(event)) {
+                    AppletManager._removeAppletFromPanel(this._uuid, this.instance_id);
+                } else {
+                    let dialog = new ModalDialog.ConfirmDialog(
+                        _("Are you sure you want to remove %s?").format(this._meta.name),
+                        () => AppletManager._removeAppletFromPanel(this._uuid, this.instance_id)
+                    );
+                    dialog.open();
+                }
             }));
         }
 

--- a/js/ui/desklet.js
+++ b/js/ui/desklet.js
@@ -236,7 +236,17 @@ var Desklet = class Desklet {
         }
 
         this.context_menu_item_remove = new PopupMenu.PopupMenuItem(_("Remove this desklet"));
-        this.context_menu_item_remove.connect("activate", Lang.bind(this, this._onRemoveDesklet));
+        this.context_menu_item_remove.connect("activate", Lang.bind(this, function(actor, event) {
+            if (Clutter.ModifierType.CONTROL_MASK & Cinnamon.get_event_state(event)) {
+                this._onRemoveDesklet();
+            } else {
+                let dialog = new ModalDialog.ConfirmDialog(
+                    _("Are you sure you want to remove %s?").format(this._meta.name),
+                    () => this._onRemoveDesklet()
+                );
+                dialog.open();
+            }
+        }));
         this._menu.addMenuItem(this.context_menu_item_remove);
     }
 


### PR DESCRIPTION
This PR adds confirmation dialogs when trying to remove applets/desklets from their *Remove* context menu items. If the <kbd>Control</kbd> key is pressed when trying to remove an xlet, the xlet will be removed without confirmation.

### Notes

- I added the confirmation dialog to the desklets and not just to the applets to keep the behaivor of both types of xlets somewhat homogeneous.
- I added the <kbd>Control</kbd> key behavior just to avoid a possible annoyance. If one wants to remove several xlets, one can simply press the <kbd>Control</kbd> key to remove the rest of the xlets and avoid the confirmation dialog.