### PR TITLE
modemManager: fix cjs warning

### DIFF
--- a/js/misc/modemManager.js
+++ b/js/misc/modemManager.js
@@ -252,7 +252,7 @@ const BroadbandModemCdmaInterface =
 
 const BroadbandModemCdmaProxy = Gio.DBusProxy.makeProxyWrapper(BroadbandModemCdmaInterface);
 
-const BroadbandModem = new Lang.Class({
+var BroadbandModem = new Lang.Class({
     Name: 'BroadbandModem',
 
     _init: function(path, capabilities) {


### PR DESCRIPTION
Please test before merge if this goes into 4.2.  Seems fine to me, but I don't want to risk any connection issue creeping in just before a new Cinnamon version goes out.