### PR TITLE
Cinnamon Settings: Fix search for locales with a non-Latin character set

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
@@ -473,15 +473,8 @@ class MainWindow:
             self.search_entry.set_text("")
 
     def strip_accents(self, text):
-        try:
-            text = unicode(text, 'utf-8')
-        except NameError:
-            # unicode is default in Python 3
-            pass
-        text = unicodedata.normalize('NFD', text)
-        text = text.encode('ascii', 'ignore')
-        text = text.decode("utf-8")
-        return str(text)
+        text = unicodedata.normalize('NFKD', text)
+        return ''.join([c for c in text if not unicodedata.combining(c)])
 
     def filter_visible_function(self, model, iter, user_data = None):
         sidePage = model.get_value(iter, 2)


### PR DESCRIPTION
This is an alternative solution to https://github.com/linuxmint/cinnamon/pull/8668 for fixing https://github.com/linuxmint/cinnamon/issues/8662. It should work on all locales but I'm no localization expert. Please test.


> Currently all characters in a search string which can not be represented in the
> ASCII character set filtered from the search string. This happens to work for
> Latin based locales because the strings first get normalized to NFD, which
> represents e.g. 'é' as the base character 'e' followed by the combining
> character '´'. Only the combining characters get filtered and the base
> characters remain.
> 
> However, in locales, which do not use the Latin character set, the base
> characters get filtered as well and the search string ends up being empty.
> 
> Fix this by not converting to ASCII and instead filtering the combining
> characters explicitly.