### PR TITLE
Sound settings: Fix setActiveDevice

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_sound.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_sound.py
@@ -676,11 +676,11 @@ class Module:
             return
 
         model = view.get_model()
-        newDevice = model.get_value(model.get_iter(selected[0]), 3)
-        id = getattr(self.controller, "lookup_"+type+"_id")(newDevice)
-        if id != None and id != getattr(self, type+"Id"):
-            getattr(self.controller, "change_"+type)(id)
-            self.profile.setDevice(id)
+        newDeviceId = model.get_value(model.get_iter(selected[0]), 3)
+        newDevice = getattr(self.controller, "lookup_"+type+"_id")(newDeviceId)
+        if newDevice != None and newDeviceId != getattr(self, type+"Id"):
+            getattr(self.controller, "change_"+type)(newDevice)
+            self.profile.setDevice(newDevice)
 
     def deviceAdded(self, c, id, type):
         device = getattr(self.controller, "lookup_"+type+"_id")(id)


### PR DESCRIPTION
Should fix #8189.
The problem here is that there's a mix up between the device and device id objects. `newDevice` is actually the device id and `id` is actually the device but it's treated as the id. When comparing `id != getattr(self, type+"Id")` the comparison is of the device to an integer. This is always true, so the next statements are always executed, regardless of whether the device has changed. This causes the infinite recursion in the issue.