### PR TITLE
Cinnamon-0.1.typelib: do not link to libnm typelib

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -239,7 +239,7 @@ libcinnamon_la_LIBADD = $(CINNAMON_LIBS) $(MUFFIN_LIBS) $(libcinnamon_libadd)
 libcinnamon_la_CPPFLAGS = $(MUFFIN_CFLAGS) $(cinnamon_cflags)
 
 Cinnamon-0.1.gir: libcinnamon.la St-1.0.gir
-Cinnamon_0_1_gir_INCLUDES = Clutter-0 ClutterX11-0 CoglPango-0 Cogl-0 Meta-Muffin.0 Soup-2.4 CMenu-3.0 NM-1.0
+Cinnamon_0_1_gir_INCLUDES = Clutter-0 ClutterX11-0 CoglPango-0 Cogl-0 Meta-Muffin.0 Soup-2.4 CMenu-3.0
 Cinnamon_0_1_gir_CFLAGS = $(libcinnamon_la_CPPFLAGS) -I $(srcdir)
 Cinnamon_0_1_gir_LIBS = libcinnamon.la
 Cinnamon_0_1_gir_FILES = $(libcinnamon_la_gir_sources)


### PR DESCRIPTION
Nothing in libcinnamon uses libnm, and the typelib does not need to either. In fact, the only part of cinnamon that uses libnm is the applet network@cinnamon.org and that directly imports.gi.NM, so it doesn't need to get it via exposure through the GObject bindings for cinnamon itself.

Removing references to NM from the Cinnamon typelib and rebuilding cinnamon results in a fully working Cinnamon desktop and a fully working network applet, so there is no downside to just dropping it.

Motivated by #8617 except I want to get it right -- there is no reason this cannot be a fully generic solution. We don't need a configure switch for a purely simple case of overlinking.