### PR TITLE
grouped-window-list: setStyleOptions still getting called if labels on

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -870,7 +870,6 @@ class AppGroup {
             // Set the initial button label as not all windows will get updated via signals initially.
             if (this.state.settings.titleDisplay > 1) {
                 this.onWindowTitleChanged(metaWindow);
-                this.state.trigger('updateThumbnailsStyle');
             }
             if (refWindow === -1) {
                 metaWindows.push(metaWindow);

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -1011,8 +1011,6 @@ class AppGroup {
                 && this.groupState.appId.indexOf(global.display.focus_window.wm_class.toLowerCase()) === -1) {
                 this.hideLabel();
             }
-            // Re-orient the menu after the focus button expands
-            if (this.hoverMenu) this.hoverMenu.setStyleOptions(false);
         }
     }
 

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appList.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appList.js
@@ -375,9 +375,6 @@ class AppList {
 
         if (refApp > -1) {
             this.appList[refApp].windowRemoved(metaWorkspace, metaWindow, refWindow, (appId, isFavoriteApp) => {
-                if (this.state.settings.titleDisplay > 1) {
-                    this.state.trigger('updateThumbnailsStyle');
-                }
 
                 isFavoriteApp = isFavoriteApp && (this.state.settings.groupApps || this.getWindowCount(appId) === 0);
                 if (isFavoriteApp) {

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -304,7 +304,6 @@ class GroupedWindowListApplet extends Applet.Applet {
             cycleWindows: (e, source) => this.handleScroll(e, source),
             openAbout: () => this.openAbout(),
             configureApplet: () => this.configureApplet(),
-            updateThumbnailsStyle: () => null // Silence missing key warnings
         });
 
         this.settings = new AppletSettings(this.state.settings, metadata.uuid, instance_id);

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
@@ -877,12 +877,6 @@ class AppThumbnailHoverMenu extends PopupMenu.PopupMenu {
         this.groupState = groupState;
         this.setCustomStyleClass("grouped-window-list-thumbnail-menu");
 
-        this.stateConnectId = this.state.connect({
-            updateThumbnailsStyle: () => {
-                if (this.groupState.metaWindows.length === 0) return;
-            }
-        });
-
         this.connectId = this.groupState.connect({
             hoverMenuClose: () => {
                 this.shouldClose = true;
@@ -1240,7 +1234,6 @@ class AppThumbnailHoverMenu extends PopupMenu.PopupMenu {
         }
         this.removeAll();
         super.destroy();
-        this.state.disconnect(this.stateConnectId);
         this.groupState.disconnect(this.connectId);
         unref(this, RESERVE_KEYS);
     }

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
@@ -880,7 +880,6 @@ class AppThumbnailHoverMenu extends PopupMenu.PopupMenu {
         this.stateConnectId = this.state.connect({
             updateThumbnailsStyle: () => {
                 if (this.groupState.metaWindows.length === 0) return;
-                this.setStyleOptions();
             }
         });
 

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
@@ -1218,10 +1218,6 @@ class AppThumbnailHoverMenu extends PopupMenu.PopupMenu {
         for (let i = 0; i < this.appThumbnails.length; i++) {
             if (this.appThumbnails[i]) {
                 this.appThumbnails[i].refreshThumbnail();
-                // Make sure Clutter updates, otherwise setStyleOptions is called afterwards,
-                // and will be calculating styles from old actor values because it closes the menu
-                // to avoid incorrect padding values.
-                this.appThumbnails[i].thumbnailActor.realize();
             }
         }
     }


### PR DESCRIPTION
fixes #8687 
The first commit is the fix, the second two strip out progressively more code that is not required with setStyleOptions gone.