### PR TITLE
sound applet: show seekbar for Audacious

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -362,7 +362,9 @@ class Seeker extends Slider.Slider {
     }
 
     _setCanSeek(seek) {
-        if (seek && this._mediaServerPlayer.Rate === 1) {
+        let playback_rate = this._mediaServerPlayer.Rate;
+        // Hide seek for non-standard speeds except: 0 may mean paused, Audacious returns null
+        if (seek && (playback_rate === 1 || !playback_rate)) {
             this.canSeek = true;
             this.actor.show();
             this._updateTimer();


### PR DESCRIPTION
Audacious returns an invalid value for `MediaPlayer2.Player.Rate`, which should be set to the current playback speed rate or 1 if not supported.

This partially fixes the issue #8690.