### PR TITLE
[WIP] cinnamon-window-tracker.c: Add support for desktop files from flatpaks

### DIFF
--- a/src/cinnamon-app-system.c
+++ b/src/cinnamon-app-system.c
@@ -708,17 +708,16 @@ on_apps_tree_changed_cb (GMenuTree *tree,
 
       if (sandbox_type == CINNAMON_APP_SANDBOX_TYPE_FLATPAK)
       {
-        GList *flatpak_renamed_from, *l;
+        GList *flatpak_renamed_from;
         GHashTableIter flatpakIter;
         gpointer flatpakKey, flatpakValue;
 
         flatpak_renamed_from = cinnamon_app_get_flatpak_renamed_from (app);
-        l = flatpak_renamed_from;
-        while (l)
+        while (flatpak_renamed_from)
           {
             g_hash_table_replace (self->priv->desktop_filename_to_flatpak_app,
-                                  (gchar*)(l->data), app);
-            l = l->next;
+                                  (gchar*)(flatpak_renamed_from->data), g_object_ref (app));
+            flatpak_renamed_from = flatpak_renamed_from->next;
           }
 
         // unmap removed filenames

--- a/src/cinnamon-app-system.h
+++ b/src/cinnamon-app-system.h
@@ -48,6 +48,10 @@ CinnamonApp       *cinnamon_app_system_lookup_startup_wmclass       (CinnamonApp
 CinnamonApp       *cinnamon_app_system_lookup_desktop_wmclass       (CinnamonAppSystem *system,
                                                                      const char     *wmclass);
 
+CinnamonApp       *cinnamon_app_system_lookup_startup_wmclass_for_flatpak_app (CinnamonAppSystem *system,
+                                                                               const char     *wmclass);
+CinnamonApp       *cinnamon_app_system_lookup_desktop_wmclass_for_flatpak_app (CinnamonAppSystem *system,
+                                                                               const char        *wmclass);
 
 GSList         *cinnamon_app_system_get_all                   (CinnamonAppSystem  *system);
 

--- a/src/cinnamon-app.c
+++ b/src/cinnamon-app.c
@@ -818,7 +818,6 @@ static void
 update_flatpak_info (CinnamonApp *app)
 {
   gchar** flatpak_renamed_from = NULL;
-  gchar* tmp;
   guint len, i;
 
   g_list_free_full (app->flatpak_renamed_from, g_free);
@@ -828,6 +827,7 @@ update_flatpak_info (CinnamonApp *app)
       (g_desktop_app_info_has_key (app->info, "X-Flatpak") ||
        g_desktop_app_info_has_key (app->info, "X-Flatpak-RenamedFrom")))
     {
+      gchar* tmp;
       app->sandbox_type = CINNAMON_APP_SANDBOX_TYPE_FLATPAK;
       tmp = g_desktop_app_info_get_string (app->info, "X-Flatpak-RenamedFrom");
       if (!tmp)

--- a/src/cinnamon-app.c
+++ b/src/cinnamon-app.c
@@ -830,6 +830,10 @@ update_flatpak_info (CinnamonApp *app)
     {
       app->sandbox_type = CINNAMON_APP_SANDBOX_TYPE_FLATPAK;
       tmp = g_desktop_app_info_get_string (app->info, "X-Flatpak-RenamedFrom");
+      if (!tmp)
+      {
+        tmp = g_strdup ((char*) gmenu_tree_entry_get_desktop_file_id (app->entry));
+      }
       flatpak_renamed_from = g_strsplit (tmp, ";", -1);
       len = g_strv_length (flatpak_renamed_from);
 

--- a/src/cinnamon-app.h
+++ b/src/cinnamon-app.h
@@ -33,6 +33,11 @@ typedef enum {
   CINNAMON_APP_STATE_RUNNING
 } CinnamonAppState;
 
+typedef enum {
+  CINNAMON_APP_SANDBOX_TYPE_NONE =    0,
+  CINNAMON_APP_SANDBOX_TYPE_FLATPAK = 1 << 0
+} CinnamonAppSandboxType;
+
 GType cinnamon_app_get_type (void) G_GNUC_CONST;
 
 const char *cinnamon_app_get_id (CinnamonApp *app);
@@ -81,6 +86,10 @@ gboolean cinnamon_app_launch (CinnamonApp     *app,
                            int           workspace,
                            char        **startup_id,
                            GError      **error);
+
+CinnamonAppSandboxType cinnamon_app_get_sandbox_type (CinnamonApp *app);
+
+GList *cinnamon_app_get_flatpak_renamed_from (CinnamonApp *app);
 
 G_END_DECLS
 


### PR DESCRIPTION
This adds support for associating windows from flatpaks with their respective .desktop-file.
This is needed for pinning them to window lists like our builtin Grouped Window List.

Depends on https://github.com/linuxmint/muffin/pull/527