### PR TITLE
Update Spyces.py - Bypass all caches downloading json and zip files

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
@@ -34,10 +34,10 @@ settings_dir = '%s/.cinnamon/configs/' % home
 
 URL_SPICES_HOME = "https://cinnamon-spices.linuxmint.com"
 URL_MAP = {
-    'applet': URL_SPICES_HOME + "/json/applets.json",
-    'theme': URL_SPICES_HOME + "/json/themes.json",
-    'desklet': URL_SPICES_HOME + "/json/desklets.json",
-    'extension': URL_SPICES_HOME + "/json/extensions.json"
+    'applet': URL_SPICES_HOME + "/json/applets.json?",
+    'theme': URL_SPICES_HOME + "/json/themes.json?",
+    'desklet': URL_SPICES_HOME + "/json/desklets.json?",
+    'extension': URL_SPICES_HOME + "/json/extensions.json?"
 }
 
 ABORT_NONE = 0
@@ -607,7 +607,7 @@ class Spice_Harvester(GObject.Object):
     def _install(self, job):
         uuid = job['uuid']
 
-        download_url = URL_SPICES_HOME + self.index_cache[uuid]['file']
+        download_url = URL_SPICES_HOME + self.index_cache[uuid]['file'] + "?"
         self.current_uuid = uuid
 
         fd, ziptempfile = tempfile.mkstemp()

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
@@ -15,6 +15,7 @@ try:
     import dbus
     from PIL import Image
     import datetime
+    import uuid as uuidlib
     import proxygsettings
 except Exception as detail:
     print(detail)
@@ -393,7 +394,7 @@ class Spice_Harvester(GObject.Object):
             else:
                 connection = HTTPSConnection(host, timeout=15)
             headers = { "Accept-Encoding": "identity", "Host": host, "User-Agent": "Python/3" }
-            connection.request("GET", parsed_url.path, headers=headers)
+            connection.request("GET", parsed_url.path + "?" + parsed_url.query, headers=headers)
             urlobj = connection.getresponse()
             assert urlobj.getcode() == 200
 
@@ -524,7 +525,7 @@ class Spice_Harvester(GObject.Object):
         self._push_job(job)
 
     def _download_cache(self, load_assets=True):
-        download_url = URL_MAP[self.collection_type]
+        download_url = URL_MAP[self.collection_type] + str(uuidlib.uuid4())
 
         filename = os.path.join(self.cache_folder, "index.json")
         if self._download(filename, download_url, binary=False) is None:
@@ -607,7 +608,7 @@ class Spice_Harvester(GObject.Object):
     def _install(self, job):
         uuid = job['uuid']
 
-        download_url = URL_SPICES_HOME + self.index_cache[uuid]['file'] + "?"
+        download_url = URL_SPICES_HOME + self.index_cache[uuid]['file'] + "?" + str(uuidlib.uuid4())
         self.current_uuid = uuid
 
         fd, ziptempfile = tempfile.mkstemp()


### PR DESCRIPTION
Simple addition of a question mark at the end of their URL to download, bypassing all caches, the latest version of json and zip files.

An alternative to this PR could be to clear the server cache each time a new version of a Spice has arrived.