### PR TITLE
menu applet: if all recents are hidden act like there are none

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -2044,15 +2044,14 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
              * as it happens a lot) */
             this.categoriesBox.set_child_above_sibling(this.recentButton.actor, null);
 
-            if (this.RecentManager._infosByTimestamp.length > 0) {
+            let recents = this.RecentManager._infosByTimestamp.filter(info => !info.name.startsWith("."));
+            if (recents.length > 0) {
                 this.noRecentDocuments = false;
 
-                Util.each(this.RecentManager._infosByTimestamp, (info) => {
-                    if (!info.name.startsWith(".")) {
-                        let button = new RecentButton(this, info);
-                        this._recentButtons.push(button);
-                        this.applicationsBox.add_actor(button.actor);
-                    }
+                Util.each(recents, (info) => {
+                    let button = new RecentButton(this, info);
+                    this._recentButtons.push(button);
+                    this.applicationsBox.add_actor(button.actor);
                 });
                 let button = new SimpleMenuItem(this, { name: _("Clear list"),
                                                         description: ("Clear all recent documents"),


### PR DESCRIPTION
So we don't show the clear recents button with an empty list.