### PR TITLE
Menu applet: Various improvements

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/appUtils.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/appUtils.js
@@ -1,0 +1,109 @@
+const Cinnamon = imports.gi.Cinnamon;
+const CMenu = imports.gi.CMenu;
+
+const Util = imports.misc.util;
+
+let appsys = Cinnamon.AppSystem.get_default();
+
+// sort apps by their latinised name
+function appSort(a, b) {
+    a = Util.latinise(a[0].get_name().toLowerCase());
+    b = Util.latinise(b[0].get_name().toLowerCase());
+    return a > b;
+}
+
+// sort cmenu directories with admin and prefs categories last
+function dirSort(a, b) {
+    let menuIdA = a.get_menu_id().toLowerCase();
+    let menuIdB = b.get_menu_id().toLowerCase();
+
+    let prefCats = ["administration", "preferences"];
+    let prefIdA = prefCats.indexOf(menuIdA);
+    let prefIdB = prefCats.indexOf(menuIdB);
+
+    if (prefIdA < 0 && prefIdB >= 0) {
+        return -1;
+    }
+    if (prefIdA >= 0 && prefIdB < 0) {
+        return 1;
+    }
+
+    let nameA = a.get_name().toLowerCase();
+    let nameB = b.get_name().toLowerCase();
+
+    if (nameA > nameB) {
+        return 1;
+    }
+    if (nameA < nameB) {
+        return -1;
+    }
+    return 0;
+}
+
+/* returns all apps and the categories they belong to, and all top level categories
+ *
+ * [
+ *   [
+ *     app 1,
+ *     [
+ *       top level category 1,
+ *       random category,
+ *       random category
+ *     ]
+ *   ],
+ *   ...
+ * ],
+ * [
+ *   top level category 1,
+ *   top level category 2,
+ *   top level category 3,
+ *   top level category 4,
+ *   ...
+ * ] */
+function getApps() {
+    let apps = new Map();
+    let dirs = [];
+
+    let tree = appsys.get_tree();
+    let root = tree.get_root_directory();
+    let iter = root.iter();
+    let nextType;
+
+    while ((nextType = iter.next()) != CMenu.TreeItemType.INVALID) {
+        if (nextType == CMenu.TreeItemType.DIRECTORY) {
+            let dir = iter.get_directory();
+            if (loadDirectory(dir, dir, apps))
+                dirs.push(dir);
+        }
+    }
+
+    dirs.sort(dirSort);
+    let sortedApps = Array.from(apps.entries()).sort(appSort);
+
+    return [sortedApps, dirs];
+}
+
+// load all apps and their categories from a cmenu directory
+// into 'apps' Map
+function loadDirectory(dir, top_dir, apps) {
+    let iter = dir.iter();
+    let has_entries = false;
+    let nextType;
+    while ((nextType = iter.next()) != CMenu.TreeItemType.INVALID) {
+        if (nextType == CMenu.TreeItemType.ENTRY) {
+            let desktopId = iter.get_entry().get_desktop_file_id();
+            let app = appsys.lookup_app(desktopId);
+            if (!app || app.get_nodisplay())
+                continue;
+
+            has_entries = true;
+            if (apps.has(app))
+                apps.get(app).push(dir.get_menu_id());
+            else
+                apps.set(app, [top_dir.get_menu_id()]);
+        } else if (nextType == CMenu.TreeItemType.DIRECTORY) {
+            has_entries = loadDirectory(iter.get_directory(), top_dir, apps);
+        }
+    }
+    return has_entries;
+}

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -192,7 +192,18 @@ class SimpleMenuItem {
         return Clutter.EVENT_PROPAGATE;
     }
 
-    addIcon(iconSize, iconName, gicon=null, symbolic=false) {
+    /**
+     * Adds an StIcon as the next child, acessible as `this.icon`.
+     *
+     * Either an icon name or gicon is required. Only one icon is supported by the
+     * base SimpleMenuItem.
+     *
+     * @param {number}  iconSize - The icon size in px.
+     * @param {string}  iconName - (optional) The icon name string.
+     * @param {object}  gicon    - (optional) A gicon.
+     * @param {boolean} symbolic - (optional) Whether the icon should be symbolic. Default: false.
+     */
+    addIcon(iconSize, iconName='', gicon=null, symbolic=false) {
         if (this.icon)
             return;
 
@@ -209,7 +220,26 @@ class SimpleMenuItem {
         this.actor.add_actor(this.icon);
     }
 
-    addLabel(label="", styleClass=null) {
+    /**
+     * Removes the icon previously added with addIcon()
+     */
+    removeIcon() {
+        if (!this.icon)
+            return;
+        this.icon.destroy();
+        this.icon = null;
+    }
+
+    /**
+     * Adds an StLabel as the next child, accessible as `this.label`.
+     *
+     * Only one label is supported by the base SimpleMenuItem prototype.
+     *
+     * @param {string} label      - (optional) An unformatted string. If markup is required, use
+     *                               native methods directly: `this.label.clutter_text.set_markup()`.
+     * @param {string} styleClass - (optional) A style class for the label.
+     */
+    addLabel(label='', styleClass=null) {
         if (this.label)
             return;
 
@@ -220,10 +250,30 @@ class SimpleMenuItem {
         this.actor.add_actor(this.label);
     }
 
+    /**
+     * Removes the label previously added with addLabel()
+     */
+    removeLabel() {
+        if (!this.label)
+            return;
+        this.label.destroy();
+        this.label = null;
+    }
+
+    /**
+     * Adds a ClutterActor as the next child.
+     *
+     * @param {ClutterActor} child
+     */
     addActor(child) {
         this.actor.add_actor(child);
     }
 
+    /**
+     * Removes a ClutterActor.
+     *
+     * @param {ClutterActor} child
+     */
     removeActor(child) {
         this.actor.remove_actor(child);
     }

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -886,8 +886,6 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
 
         this.setAllowedLayout(Applet.AllowedLayout.BOTH);
 
-        this.initial_load_done = false;
-
         this.set_applet_tooltip(_("Menu"));
         this.menuManager = new PopupMenu.PopupMenuManager(this);
         this.menu = new Applet.AppletPopupMenu(this, orientation);
@@ -946,7 +944,6 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         this._previousTreeSelectedActor = null;
         this._activeContainer = null;
         this._activeActor = null;
-        this.menuIsOpening = false;
         this._knownApps = new Set(); // Used to keep track of apps that are already installed, so we can highlight newly installed ones
         this._appsWereRefreshed = false;
         this._canUninstallApps = GLib.file_test("/usr/bin/cinnamon-remove-application", GLib.FileTest.EXISTS);
@@ -1077,10 +1074,6 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         this._updateIconAndLabel();
     }
 
-    on_applet_added_to_panel () {
-        this.initial_load_done = true;
-    }
-
     on_applet_removed_from_panel () {
         Main.keybindingManager.removeHotKey("overlay-key-" + this.instance_id);
     }
@@ -1114,7 +1107,6 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
 
     _onOpenStateChanged(menu, open) {
         if (open) {
-            this.menuIsOpening = true;
             this.actor.add_style_pseudo_class('active');
             global.stage.set_key_focus(this.searchEntry);
             this._selectedItemIndex = null;
@@ -2533,43 +2525,39 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
     }
 
     _onSearchTextChanged (se, prop) {
-        if (this.menuIsOpening) {
-            this.menuIsOpening = false;
+        let searchString = this.searchEntry.get_text();
+        let searchActive = !(searchString == '' || searchString == this.searchEntry.hint_text);
+        if (!this.searchActive && !searchActive)
             return;
-        } else {
-            let searchString = this.searchEntry.get_text();
-            if (searchString == '' && !this.searchActive)
-                return;
-            this.searchActive = searchString != '';
-            this._fileFolderAccessActive = this.searchActive && this.searchFilesystem;
-            this._clearAllSelections();
 
-            if (this.searchActive) {
-                this.searchEntry.set_secondary_icon(this._searchActiveIcon);
-                if (this._searchIconClickedId == 0) {
-                    this._searchIconClickedId = this.searchEntry.connect('secondary-icon-clicked',
-                        Lang.bind(this, function() {
-                            this.resetSearch();
-                            this._select_category(null);
-                        }));
-                }
-                this._setCategoriesButtonActive(false);
-                this.lastSelectedCategory = "search"
-                this._doSearch();
-            } else {
-                if (this._searchIconClickedId > 0)
-                    this.searchEntry.disconnect(this._searchIconClickedId);
-                this._searchIconClickedId = 0;
-                this.searchEntry.set_secondary_icon(this._searchInactiveIcon);
-                this._previousSearchPattern = "";
-                this._setCategoriesButtonActive(true);
-                this._select_category(null);
-                this._allAppsCategoryButton.actor.style_class = "menu-category-button-selected";
-                this._activeContainer = null;
-                this.selectedAppTitle.set_text("");
-                this.selectedAppDescription.set_text("");
+        this.searchActive = searchActive;
+        this._fileFolderAccessActive = searchActive && this.searchFilesystem;
+        this._clearAllSelections();
+
+        if (searchActive) {
+            this.searchEntry.set_secondary_icon(this._searchActiveIcon);
+            if (!this._searchIconClickedId) {
+                this._searchIconClickedId =
+                    this.searchEntry.connect('secondary-icon-clicked', () => {
+                        this.resetSearch();
+                        this._select_category(null);
+                    });
             }
-            return;
+            this._setCategoriesButtonActive(false);
+            this.lastSelectedCategory = "search"
+            this._doSearch();
+        } else {
+            if (this._searchIconClickedId > 0)
+                this.searchEntry.disconnect(this._searchIconClickedId);
+            this._searchIconClickedId = 0;
+            this.searchEntry.set_secondary_icon(this._searchInactiveIcon);
+            this._previousSearchPattern = "";
+            this._setCategoriesButtonActive(true);
+            this._select_category(null);
+            this._allAppsCategoryButton.actor.style_class = "menu-category-button-selected";
+            this._activeContainer = null;
+            this.selectedAppTitle.set_text("");
+            this.selectedAppDescription.set_text("");
         }
     }
 

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1744,7 +1744,6 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                     let favorites = AppFavorites.getAppFavorites().getFavorites();
                     let numFavorites = favorites.length;
                     AppFavorites.getAppFavorites().removeFavorite(item_actor._delegate.app.get_id());
-                    this.toggleContextMenu(item_actor._delegate)
                     if (this._selectedItemIndex == (numFavorites-1))
                         item_actor = this.favoritesBox.get_child_at_index(this._selectedItemIndex-1);
                     else

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -989,6 +989,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         this.settings = new Settings.AppletSettings(this, "menu@cinnamon.org", instance_id);
 
         this.settings.bind("show-places", "showPlaces", () => this.queueRefresh(RefreshFlags.PLACE));
+        this.settings.bind("show-recents", "showRecents", () => this.queueRefresh(RefreshFlags.RECENT));
 
         this._appletEnterEventId = 0;
         this._appletLeaveEventId = 0;
@@ -2130,7 +2131,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
 
         this._recentButtons = [];
 
-        if (!this.privacy_settings.get_boolean(REMEMBER_RECENT_KEY)) {
+        if (!this.showRecents || !this.privacy_settings.get_boolean(REMEMBER_RECENT_KEY)) {
             for (let i = 0; i < this._categoryButtons.length; i++) {
                 if (this._categoryButtons[i].categoryId === 'recent') {
                     this._categoryButtons[i].destroy();

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/settings-schema.json
@@ -25,7 +25,7 @@
         "menu-layout" : {
             "type" : "section",
             "title" : "Layout and content",
-            "keys" : ["show-category-icons", "show-application-icons", "favbox-show", "favbox-min-height", "show-places", "menu-editor-button"]
+            "keys" : ["show-category-icons", "show-application-icons", "favbox-show", "favbox-min-height", "show-places", "show-recents", "menu-editor-button"]
         },
         "menu-behave" : {
             "type" : "section",
@@ -94,6 +94,12 @@
     "default" : true,
     "description": "Show bookmarks and places",
     "tooltip": "Choose whether or not to show bookmarks and places in the menu."
+ },
+ "show-recents" : {
+   "type" : "switch",
+   "default" : true,
+   "description": "Show recents",
+   "tooltip": "Choose whether or not to show recents in the menu."
  },
 "enable-autoscroll" : {
     "type" : "switch",


### PR DESCRIPTION
Cleanups and improvements:

- Moves appsys code to a separate file
- Removes some code that doesn't do anything or isn't useful
- Use newer string helpers where they fit better
- VectorBox is only created on init and reused instead of being recreated many times as the mouse moves over categoriesBox

Search:

- Exit earlier when the pattern is effectively the same (only whitespace added at start or end)
- Trigger code now passes the pattern to _doSearch() so we don't have to process the pattern twice.
- Use String.trim() instead of two RegEx's

Bugfix:

- We tried to close a favorite context menu when the item was deleted, but there is no context menu so don't try that.

Rework of the refresh mechanism:

- Refreshing uses a single queue function and flags to set which type.
- All buttons are now hidden by default if the menu is closed.
- Refreshing no longer disturbs adjacent button types (so an app refresh doesn't require a places and recent refresh)
- Category and ApplicationsBox children no longer are recreated when show icons is toggled. The icon is always added and shows or hides as necessary.
- Recent clear button now respects "Show Application Icons" setting, and is bold so it is more differentiated from the normal recents.
- Search path completion and search provider buttons now respect "Show Application Icons", but they don't support toggling. They are either shown or not for the entire button lifetime. These buttons are transient and only exist during a short time, so it's not worth implementing. Closing the menu when toggling the setting will destroy them anyways.

- Add the ability to disable recents. As it was before this commit, you had to turn it off in privacy settings to hide it from the menu, and that turns it off completely.

Fixes #8768 
Fixes linuxmint/alpha-testing#12
Supersedes #8785 #8786 #8787 #8788 