### PR TITLE
Update cs_windows.py: Add setting for new window focus

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_windows.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_windows.py
@@ -82,7 +82,12 @@ class Module:
             widget = GSettingsSwitch(_("Bring windows which require attention to the current workspace"), "org.cinnamon", "bring-windows-to-current-workspace")
             settings.add_row(widget)
 
-            widget = GSettingsSwitch(_("Prevent focus stealing"), "org.cinnamon", "prevent-focus-stealing")
+            widget = GSettingsSwitch(_("Prevent windows which require attention from stealing focus"), "org.cinnamon", "prevent-focus-stealing")
+            settings.add_row(widget)
+
+            stealing_options = [["strict", _("Strict")], ["smart", _("Smart")]]
+            widget = GSettingsComboBox(_("Control how new windows get focus"), "org.cinnamon.desktop.wm.preferences", "focus-new-windows", stealing_options)
+            widget.set_tooltip_text(_("This option provides additional control over how newly created windows get focus. It has two possible values; 'smart' applies the user's normal focus mode, and 'strict' results in windows started from a terminal not being given focus."))
             settings.add_row(widget)
 
             widget = GSettingsSwitch(_("Attach dialog windows to the parent window"), "org.cinnamon.muffin", "attach-modal-dialogs")


### PR DESCRIPTION
A long-overdue follow-up to #3071. I consistently hit a problem where I have Python code running in a terminal in the background that pops up windows and steals focus. For a minimal example, I run this:
```
$ python -c "import time; time.sleep(1.); from matplotlib import pyplot as plt; plt.figure(); time.sleep(1.)"
```
then click away to some other program (vscode, a different terminal) and start typing.

So this PR:

1. Exposes the `org.cinnamon.desktop.wm.preferences:focus-new-windows` setting, which prevents this behavior when set to `strict`
2. Clarifies the wording of the old `"Prevent focus stealing"` to make it clear that it only deals with windows that request attention (not new windows)

New option in use:

![Screenshot from 2019-08-16 10-04-35](https://user-images.githubusercontent.com/2365790/63173979-05735e00-c00f-11e9-91c3-b91c16ba84f6.png)

cc @crobarcro this might help with #8059, might not. If it does not, I suggest you look into general gnome focus prevention stealing tips (usually involving `dconf`) to see if any tweaks work. If you find one that does, it can be added to the GUI. That's how I made this PR (after hours of messing with the `cinnamon/js/ui` code only to realize that the focus stealers were not even being routed through there!).