### PR TITLE
Partially revert "cinnamon-global.c: fix repaint function signatures"

### DIFF
--- a/src/cinnamon-global.c
+++ b/src/cinnamon-global.c
@@ -796,19 +796,22 @@ global_stage_notify_height (GObject    *gobject,
   g_object_notify (G_OBJECT (global), "screen-height");
 }
 
-static void
+static gboolean
 global_stage_before_paint (gpointer data)
 {
   cinnamon_perf_log_event (cinnamon_perf_log_get_default (),
                         "clutter.stagePaintStart");
 
+  return TRUE;
 }
 
-static void
+static gboolean
 global_stage_after_paint (gpointer data)
 {
   cinnamon_perf_log_event (cinnamon_perf_log_get_default (),
                         "clutter.stagePaintDone");
+
+  return TRUE;
 }
 
 static void


### PR DESCRIPTION
This partially reverts commit d592d54819c257fc77268f4c972bd9f738c53a96.

These functions had the correct return type before, only the param-
eter type was incorrect. Third time's a charm... Hopefully?

fixes: d592d54819c257fc77268f4c972bd9f738c53a96