### PR TITLE
Notifications: add support for silent notifications

### DIFF
--- a/js/ui/messageTray.js
+++ b/js/ui/messageTray.js
@@ -433,6 +433,7 @@ Notification.prototype = {
         // 'transient' is a reserved keyword in JS, so we have to use an alternate variable name
         this.isTransient = false;
         this.expanded = false;
+        this.silent = false;
         this._destroyed = false;
         this._useActionIcons = false;
         this._customContent = false;
@@ -530,9 +531,11 @@ Notification.prototype = {
                                         titleMarkup: false,
                                         bannerMarkup: false,
                                         bodyMarkup: false,
+                                        silent: false,
                                         clear: false });
 
         this._customContent = params.customContent;
+        this.silent = params.silent;
 
         let oldFocus = global.stage.key_focus;
 
@@ -1690,7 +1693,9 @@ MessageTray.prototype = {
 
         let margin = this._notification._table.get_theme_node().get_length('margin-from-right-edge-of-screen');
         this._notificationBin.x = monitor.x + monitor.width - this._notification._table.width - margin - rightGap;
-        Main.soundManager.play('notification');
+        if (!this._notification.silent || this._notification.urgency >= Urgency.HIGH) {
+            Main.soundManager.play('notification');
+        }
         if (this._notification.urgency == Urgency.CRITICAL) {
             Main.layoutManager._chrome.modifyActorParams(this._notificationBin, { visibleInFullscreen: true });
         } else {

--- a/js/ui/notificationDaemon.js
+++ b/js/ui/notificationDaemon.js
@@ -20,7 +20,7 @@ const AUTOCLEAR_BLACKLIST = ['chromium', 'firefox', 'google chrome'];
 let nextNotificationId = 1;
 
 // Should really be defined in Gio.js
-const BusIface = 
+const BusIface =
     '<node> \
         <interface name="org.freedesktop.DBus"> \
             <method name="GetConnectionUnixProcessID"> \
@@ -272,7 +272,7 @@ NotificationDaemon.prototype = {
         this._expireTimer = 0;
         return false;
     },
- 
+
     // Sends a notification to the notification daemon. Returns the id allocated to the notification.
     NotifyAsync: function(params, invocation) {
         let [appName, replacesId, icon, summary, body, actions, hints, timeout] = params;
@@ -308,6 +308,8 @@ NotificationDaemon.prototype = {
                 // early versions of the spec; 'icon_data' should only be used if 'image-path' is not available
                 hints['image-data'] = hints['icon_data'];
 
+        hints['suppress-sound'] = hints.maybeGet('suppress-sound') == true;
+
         let ndata = { appName: appName,
                       icon: icon,
                       summary: summary,
@@ -334,7 +336,7 @@ NotificationDaemon.prototype = {
         } else {    // Custom expiration.
              expires = ndata.expires = Date.now()+timeout;
         }
- 
+
         // Does this notification expire?
         if (expires != 0) {
             // Find place in the notification queue.
@@ -410,7 +412,8 @@ NotificationDaemon.prototype = {
         if (notification == null) {    // Create a new notification!
             notification = new MessageTray.Notification(source, summary, body,
                                                         { icon: iconActor,
-                                                          bannerMarkup: true });
+                                                          bannerMarkup: true,
+                                                          silent: hints['suppress-sound'] });
             ndata.notification = notification;
             notification.connect('destroy', Lang.bind(this,
                 function(n, reason) {
@@ -447,7 +450,8 @@ NotificationDaemon.prototype = {
         } else {
             notification.update(summary, body, { icon: iconActor,
                                                  bannerMarkup: true,
-                                                 clear: true });
+                                                 clear: true,
+                                                 silent: hints['suppress-sound'] });
         }
 
         // We only display a large image if an icon is also specified.
@@ -520,7 +524,7 @@ NotificationDaemon.prototype = {
             // 'icon-multi',
             'icon-static',
             'persistence',
-            // 'sound',
+            'sound',
         ];
     },
 


### PR DESCRIPTION
The 'suppress-sound' parameter is defined in the freedesktop notifcation specification.
This is useful for informative notifications with less importance, like for example when a new song starts in a music player.