### PR TITLE
Enable management of system-wide extensions through the spices settings UI

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
@@ -170,10 +170,7 @@ class Spice_Harvester(GObject.Object):
             self.spices_directories = (self.install_folder, '%s/.themes/' % (home))
         else:
             self.install_folder = '%s/.local/share/cinnamon/%ss/' % (home, self.collection_type)
-            if self.collection_type == 'extension':
-                self.spices_directories = (self.install_folder, )
-            else:
-                self.spices_directories = ('/usr/share/cinnamon/%ss/' % self.collection_type, self.install_folder)
+            self.spices_directories = ('/usr/share/cinnamon/%ss/' % self.collection_type, self.install_folder)
 
         self._load_metadata()
 


### PR DESCRIPTION
Exetensions under `/usr/share/cinnamon/extensions/` didn't appear in the list of installed extensions. There was no way of loading, unloading or configuring them through the settings interface.