### PR TITLE
Spices.py: don't try to load themes twice

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
@@ -167,7 +167,7 @@ class Spice_Harvester(GObject.Object):
 
         if self.themes:
             self.install_folder = '%s/.themes/' % (home)
-            self.spices_directories = (self.install_folder, '%s/.themes/' % (home))
+            self.spices_directories = (self.install_folder, )
         else:
             self.install_folder = '%s/.local/share/cinnamon/%ss/' % (home, self.collection_type)
             if self.collection_type == 'extension':


### PR DESCRIPTION
Reduce by half the number of "`there was a problem trying to read metadata.json`" warnings. Speed up loading.