### PR TITLE
Add a display settings python module

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
@@ -70,7 +70,6 @@ CATEGORIES = [
 CONTROL_CENTER_MODULES = [
     #         Label                              Module ID                Icon                         Category      Keywords for filter
     [_("Network"),                          "network",            "cs-network",                 "hardware",      _("network, wireless, wifi, ethernet, broadband, internet")],
-    [_("Display"),                          "display",            "cs-display",                 "hardware",      _("display, screen, monitor, layout, resolution, dual, lcd")],
     [_("Color"),                            "color",              "cs-color",                   "hardware",      _("color, profile, display, printer, output")],
     [_("Graphics Tablet"),                  "wacom",              "cs-tablet",                  "hardware",      _("wacom, digitize, tablet, graphics, calibrate, stylus")]
 ]
@@ -101,6 +100,7 @@ TABS = {
     "backgrounds":      {"images": 0, "settings": 1},
     "default":          {"preferred": 0, "removable": 1},
     "desklets":         {"installed": 0, "more": 1, "download": 1, "general": 2},
+    "display":          {"layout": 0, "settings": 1},
     "effects":          {"effects": 0, "customize": 1},
     "extensions":       {"installed": 0, "more": 1, "download": 1},
     "keyboard":         {"typing": 0, "shortcuts": 1, "layouts": 2},

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_display.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_display.py
@@ -1,0 +1,44 @@
+#!/usr/bin/python3
+
+from GSettingsWidgets import *
+
+class Module:
+    name = "display"
+    comment = _("Manage display settings")
+    category = "hardware"
+
+    def __init__(self, content_box):
+        keywords = _("display, screen, monitor, layout, resolution, dual, lcd")
+        self.sidePage = SidePage(_("Display"), "cs-display", keywords, content_box, module=self)
+
+    def on_module_selected(self):
+        if not self.loaded:
+            print("Loading Display module")
+
+            self.sidePage.stack = SettingsStack()
+            self.sidePage.add_widget(self.sidePage.stack)
+
+            page = SettingsPage()
+            self.sidePage.stack.add_titled(page, "layout", _("Layout"))
+
+            try:
+                settings = page.add_section(_("Layout"))
+                widget = SettingsWidget()
+                content = self.sidePage.content_box.c_manager.get_c_widget("display")
+                widget.pack_start(content, True, True, 0)
+                settings.add_row(widget)
+
+            except Exception as detail:
+                print(detail)
+
+            page = SettingsPage()
+            self.sidePage.stack.add_titled(page, "settings", _("Settings"))
+            settings = page.add_section(_("Settings"))
+
+            ui_scales = [[0, _("Auto")], [1, _("Normal")], [2, _("Double (Hi-DPI)")]]
+            combo = GSettingsComboBox(_("User interface scaling:"), "org.cinnamon.desktop.interface", "scaling-factor", ui_scales, valtype=int)
+            settings.add_row(combo)
+
+            switch = GSettingsSwitch(_("Disable automatic screen rotation"), "org.cinnamon.settings-daemon.peripherals.touchscreen", "orientation-lock")
+            switch.set_tooltip_text(_("Select this option to disable automatic screen rotation on hardware equipped with supported accelerometers."))
+            settings.add_row(switch)

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_general.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_general.py
@@ -20,26 +20,6 @@ class Module:
             page = SettingsPage()
             self.sidePage.add_widget(page)
 
-            settings = page.add_section(_("Desktop Scaling"))
-
-            ui_scales = [[0, _("Auto")], [1, _("Normal")], [2, _("Double (Hi-DPI)")]]
-            combo = GSettingsComboBox(_("User interface scaling:"), "org.cinnamon.desktop.interface", "scaling-factor", ui_scales, valtype=int)
-            settings.add_row(combo)
-
-            # Some applications hard code the GNOME path for HiDPI settings,
-            # which is stupid, but we'll be nice and supply them with the right
-            # values.
-            schema = Gio.SettingsSchemaSource.get_default().lookup("org.gnome.desktop.interface", False)
-            if schema is not None:
-                gnome_settings = Gio.Settings(schema="org.gnome.desktop.interface")
-
-                def on_changed(widget):
-                    tree_iter = widget.get_active_iter()
-                    if tree_iter is not None:
-                        gnome_settings["scaling-factor"] = combo.model[tree_iter][0]
-
-                combo.content_widget.connect('changed', on_changed)
-
             settings = page.add_section(_("Compositor Options"))
 
             size_group = Gtk.SizeGroup.new(Gtk.SizeGroupMode.HORIZONTAL)
@@ -53,10 +33,6 @@ class Module:
             settings.add_row(switch)
 
             settings = page.add_section(_("Miscellaneous Options"))
-
-            switch = GSettingsSwitch(_("Disable automatic screen rotation"), "org.cinnamon.settings-daemon.peripherals.touchscreen", "orientation-lock")
-            switch.set_tooltip_text(_("Select this option to disable automatic screen rotation on hardware equipped with supported accelerometers."))
-            settings.add_row(switch)
 
             switch = GSettingsSwitch(_("Enable timer when logging out or shutting down"), "org.cinnamon.SessionManager", "quit-delay-toggle")
             settings.add_row(switch)


### PR DESCRIPTION
Doing this so we can move the display related settings from General->Display
Just import the C module for now and put the new settings on their own
page