### PR TITLE
cs_default.py: fix missing declaration causing crash when desc not found

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_default.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_default.py
@@ -443,6 +443,7 @@ class OtherTypeDialog(Gtk.Dialog):
         return True
 
     def getDescription(self, content_type):
+        description = None
         for d in other_defs:
             if content_type == d[DEF_CONTENT_TYPE]:
                 s = d[DEF_LABEL]


### PR DESCRIPTION
Fixes #8853 