### PR TITLE
Add RegExp escape utility function and use it in the menu

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -2689,7 +2689,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
 
         let res = [];
         let exactMatch = null;
-        let regexpPattern = new RegExp("\\b"+pattern);
+        let regexpPattern = new RegExp("\\b" + Util.escapeRegExp(pattern));
 
         for (let i in this._applicationsButtons) {
             let app = this._applicationsButtons[i].app;

--- a/js/misc/util.js
+++ b/js/misc/util.js
@@ -43,6 +43,20 @@ const _urlRegexp = new RegExp(
         ')' +
     ')', 'gi');
 
+
+/**
+ * escapeRegExp:
+ * @str: (String) a string to escape
+ *
+ * Escapes a string for use within a regular expression.
+ *
+ * Returns: (String) the escaped string
+ */
+function escapeRegExp(str) {
+    // from: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+}
+
 /**
  * findUrls:
  * @str: string to find URLs in


### PR DESCRIPTION
This prevents js errors when you type reserved characters like \ or [ and such into the search box.

**Behavior change:**
Besides avoiding js errors when an incomplete regex is typed by the user, this effectively disables regex searching via the menu search box. On master, the menu search is basically a regex-enabled search field where the query is prefixed with the regex `\b` word boundary metacharacter. A user typing in
`(applet|panel)` would have a perfectly valid regex search that matches both "applet" and "panel", but not mid-word. Many JS errors will be printed while typing that, but after `)` the search will work fine.

**Options:**

1. If we actually want a regex-enabled search then the error spamming can be avoided, but there needs to be a feedback mechanism in the UI itself to report invalid search strings.
2. If we don't want regex-enabled search then this PR escapes the user input and uses it as a string literal.