### PR TITLE
Allow line wrapping in System Info labels

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
@@ -160,6 +160,7 @@ class Module:
                 labelKey.get_style_context().add_class("dim-label")
                 labelValue = Gtk.Label.new(value)
                 labelValue.set_selectable(True)
+                labelValue.set_line_wrap(True)
                 widget.pack_end(labelValue, False, False, 0)
                 settings.add_row(widget)
 


### PR DESCRIPTION
Hi,

Output strings for some hardware can be quite lengthy. For some screen resolution / font-size combinations this can result in a System Info window that exceeds the width of the screen - e.g. for this user with Font sizes set to 13 on a 1280 x 1024 screen - https://forums.linuxmint.com/viewtopic.php?p=1686784#p1686784

Allowing these labels to wrap should avoid this issue. 