### PR TITLE
option to restart without user extensions

### DIFF
--- a/files/usr/bin/cinnamon-launcher
+++ b/files/usr/bin/cinnamon-launcher
@@ -32,15 +32,22 @@ elif os.path.exists("/usr/bin/tint2"):
 
 def confirm_restart():
     d = Gtk.Dialog(title=None, parent=None, flags=0)
+    d.set_default_size(400,-1)
     d.add_buttons(Gtk.STOCK_NO, Gtk.ResponseType.NO,
                   Gtk.STOCK_YES, Gtk.ResponseType.YES)
     d.set_keep_above(True)
-    d.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
+    d.set_position(Gtk.WindowPosition.CENTER)
     box = d.get_content_area()
     c = Gtk.CheckButton(label="Disable local extensions")
     label = Gtk.Label()
     label.set_line_wrap(True)
-    label.set_markup("<span size='large'><b>%s</b></span>\n\n%s\n\n" % (("Cinnamon just crashed. You are currently running in Fallback Mode."), ("Do you want to restart Cinnamon?")))
+    label.set_markup("<span size='large'><b>%s</b></span>\n\n%s\n\n%s\n\n" %
+            (
+                ("Cinnamon just crashed. You are currently running in Fallback Mode."),
+                ("Do you want to restart Cinnamon?"),
+                ("If you suspect the source of the crashes might be local extensions "
+                 "or applets, you can disable all user supplied extensions using the checkbox below.")
+            ))
     box.add(label)
     box.add(c)
     label.show_all()
@@ -52,7 +59,6 @@ def confirm_restart():
             os.environ["CINNAMON_TROUBLESHOOT"] = "1"
         return(True)
     return(False)
-
 
 if __name__ == "__main__":
     setproctitle("cinnamon-launcher")

--- a/files/usr/bin/cinnamon-launcher
+++ b/files/usr/bin/cinnamon-launcher
@@ -31,14 +31,27 @@ elif os.path.exists("/usr/bin/tint2"):
 
 
 def confirm_restart():
-    d = Gtk.MessageDialog(parent=None, flags=0, message_type=Gtk.MessageType.WARNING, buttons=Gtk.ButtonsType.YES_NO)
+    d = Gtk.Dialog(title=None, parent=None, flags=0)
+    d.add_buttons(Gtk.STOCK_NO, Gtk.ResponseType.NO,
+                  Gtk.STOCK_YES, Gtk.ResponseType.YES)
     d.set_keep_above(True)
     d.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
-    d.set_markup("<span size='large'><b>%s</b></span>\n\n%s" % (_("Cinnamon just crashed. You are currently running in Fallback Mode."), _("Do you want to restart Cinnamon?")))
-    d.show_all()
+    box = d.get_content_area()
+    c = Gtk.CheckButton(label="Disable local extensions")
+    label = Gtk.Label()
+    label.set_line_wrap(True)
+    label.set_markup("<span size='large'><b>%s</b></span>\n\n%s\n\n" % (("Cinnamon just crashed. You are currently running in Fallback Mode."), ("Do you want to restart Cinnamon?")))
+    box.add(label)
+    box.add(c)
+    label.show_all()
+    c.show_all()
     resp = d.run()
     d.destroy()
-    return (resp == Gtk.ResponseType.YES)
+    if resp == Gtk.ResponseType.YES:
+        if c.get_active():
+            os.environ["CINNAMON_TROUBLESHOOT"] = "1"
+        return(True)
+    return(False)
 
 
 if __name__ == "__main__":

--- a/files/usr/bin/cinnamon-launcher
+++ b/files/usr/bin/cinnamon-launcher
@@ -33,19 +33,19 @@ elif os.path.exists("/usr/bin/tint2"):
 def confirm_restart():
     d = Gtk.Dialog(title=None, parent=None, flags=0)
     d.set_default_size(400,-1)
-    d.add_buttons(Gtk.STOCK_NO, Gtk.ResponseType.NO,
-                  Gtk.STOCK_YES, Gtk.ResponseType.YES)
+    d.add_buttons(_("No"),  Gtk.ResponseType.NO,
+                  _("Yes"), Gtk.ResponseType.YES)
     d.set_keep_above(True)
     d.set_position(Gtk.WindowPosition.CENTER)
     box = d.get_content_area()
-    c = Gtk.CheckButton(label="Disable local extensions")
+    c = Gtk.CheckButton(label=_("Disable local extensions"))
     label = Gtk.Label()
     label.set_line_wrap(True)
     label.set_markup("<span size='large'><b>%s</b></span>\n\n%s\n\n%s\n\n" %
             (
-                ("Cinnamon just crashed. You are currently running in Fallback Mode."),
-                ("Do you want to restart Cinnamon?"),
-                ("If you suspect the source of the crashes might be local extensions "
+                _("Cinnamon just crashed. You are currently running in Fallback Mode."),
+                _("Do you want to restart Cinnamon?"),
+                _("If you suspect the source of the crashes might be local extensions "
                  "or applets, you can disable all user supplied extensions using the checkbox below.")
             ))
     box.add(label)

--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -572,10 +572,12 @@ function reloadExtension(uuid, type) {
 }
 
 function findExtensionDirectory(uuid, userDir, folder) {
-    let dirPath = `${userDir}/${uuid}`;
-    let dir = Gio.file_new_for_path(dirPath);
-    if (dir.query_file_type(Gio.FileQueryInfoFlags.NONE, null) === Gio.FileType.DIRECTORY) {
-        return dir;
+    if (!GLib.getenv('CINNAMON_TROUBLESHOOT')) {
+        let dirPath = `${userDir}/${uuid}`;
+        let dir = Gio.file_new_for_path(dirPath);
+        if (dir.query_file_type(Gio.FileQueryInfoFlags.NONE, null) === Gio.FileType.DIRECTORY) {
+            return dir;
+        }
     }
 
     let systemDataDirs = GLib.get_system_data_dirs();


### PR DESCRIPTION
A user might have installed broken extensions/applets/etc that make cinnamon fail to start. At the moment the `cinnamon-launcher` falls back to starting a fallback panel, but the registered three fallback panels might not be installed, which would leave the user with an empty desktop without any feedback.

In case starting cinnamon fails, a dialog is shown that allows to restart cinnamon. A checkbutton is added that allows disabling applets/extensions etc from user's home directory. If the checkbutton is checked, the env var CINNAMON_TROUBLESHOOT=1 is set.

When searching for extension's directory, only search user directories if this variable is not set.
