### PR TITLE
Sound applet enhancements

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -1068,6 +1068,9 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
     }
 
     _toggle_out_mute() {
+        if (!this._output)
+            return;
+
         if (this._output.is_muted) {
             this._output.change_is_muted(false);
             this.mute_out_switch.setToggleState(false);
@@ -1078,6 +1081,9 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
     }
 
     _toggle_in_mute() {
+        if (!this._input)
+            return;
+
         if (this._input.is_muted) {
             this._input.change_is_muted(false);
             this.mute_in_switch.setToggleState(false);

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -626,9 +626,10 @@ class Player extends PopupMenu.PopupMenuSection {
         }));
 
         //get the desktop entry and pass it to the applet
-        this._prop.GetRemote(MEDIA_PLAYER_2_NAME, "DesktopEntry", Lang.bind(this, function(value) {
-            this._applet.passDesktopEntry(value[0].unpack());
-        }));
+        this._prop.GetRemote(MEDIA_PLAYER_2_NAME, "DesktopEntry", (result, error) => {
+            if (!error)
+                this._applet.passDesktopEntry(result[0].unpack());
+        });
     }
 
     _setName(status) {
@@ -924,7 +925,7 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
                         if (name_regex.test(name)) {
                             this._dbus.GetNameOwnerRemote(name, Lang.bind(this,
                                 function(owner) {
-                                    this._addPlayer(name, owner);
+                                    this._addPlayer(name, owner[0]);
                                 }
                             ));
                         }

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -629,14 +629,14 @@ class Player extends PopupMenu.PopupMenuSection {
 
     _updateControls() {
         this._prop.GetRemote(MEDIA_PLAYER_2_PLAYER_NAME, 'CanGoNext', (value, error) => {
-            let canGoNext = true;
+            let canGoNext = false;
             if (!error)
                 canGoNext = value[0].unpack();
             this._nextButton.setEnabled(canGoNext);
         });
 
         this._prop.GetRemote(MEDIA_PLAYER_2_PLAYER_NAME, 'CanGoPrevious', (value, error) => {
-            let canGoPrevious = true;
+            let canGoPrevious = false;
             if (!error)
                 canGoPrevious = value[0].unpack();
             this._prevButton.setEnabled(canGoPrevious);

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -1117,9 +1117,10 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
             this._players[this._activePlayer]._mediaServerPlayer.PreviousRemote();
         } else if (buttonId === 9) {
             this._players[this._activePlayer]._mediaServerPlayer.NextRemote();
+        } else {
+            return Applet.Applet.prototype._onButtonPressEvent.call(this, actor, event);
         }
-
-        return Applet.Applet.prototype._onButtonPressEvent.call(this, actor, event);
+        return Clutter.EVENT_STOP;
     }
 
     setIcon(icon, source) {


### PR DESCRIPTION
Needs testing.

- Fixes js error when muting with default settings and no input.
- Fixes chromium mpris js error. we were unpacking a return value while error was set.
- Fixes removing player instances when cinnamon started with a player already open (typically only in crash or cinnamon --restart case)
- Defaults Next/Previous options to disabled for error/no dbus property case.
- Consume button press event when we act on it, instead of chaining up and possibly handling it twice and/or propagating it
- Converts all callbacks to arrow functions and removes Lang import
- Trivial spacing fixes