### PR TITLE
[WIP] Control redshift from cinnamon settings (night light)

### DIFF
--- a/data/org.cinnamon.gschema.xml.in
+++ b/data/org.cinnamon.gschema.xml.in
@@ -31,7 +31,7 @@
     </key>
 
     <key name="enabled-applets" type="as">
-      <default>['panel1:left:0:menu@cinnamon.org', 'panel1:left:1:show-desktop@cinnamon.org', 'panel1:left:2:grouped-window-list@cinnamon.org', 'panel1:right:0:systray@cinnamon.org', 'panel1:right:1:xapp-status@cinnamon.org', 'panel1:right:2:notifications@cinnamon.org', 'panel1:right:3:printers@cinnamon.org', 'panel1:right:4:removable-drives@cinnamon.org', 'panel1:right:5:keyboard@cinnamon.org', 'panel1:right:6:bluetooth@cinnamon.org', 'panel1:right:7:network@cinnamon.org', 'panel1:right:8:sound@cinnamon.org', 'panel1:right:9:power@cinnamon.org', 'panel1:right:10:calendar@cinnamon.org']</default>
+      <default>['panel1:left:0:menu@cinnamon.org', 'panel1:left:2:grouped-window-list@cinnamon.org', 'panel1:right:0:systray@cinnamon.org', 'panel1:right:1:xapp-status@cinnamon.org', 'panel1:right:2:notifications@cinnamon.org', 'panel1:right:3:printers@cinnamon.org', 'panel1:right:4:removable-drives@cinnamon.org', 'panel1:right:5:keyboard@cinnamon.org', 'panel1:right:6:bluetooth@cinnamon.org', 'panel1:right:7:network@cinnamon.org', 'panel1:right:8:sound@cinnamon.org', 'panel1:right:9:power@cinnamon.org', 'panel1:right:10:calendar@cinnamon.org', 'panel1:left:1:show-desktop@cinnamon.org']</default>
       <_summary>Uuids of applets to enable</_summary>
       <_description>
         Cinnamon applets have a uuid property; this key lists applets

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py
@@ -10,22 +10,21 @@ import operator
 CAN_BACKEND.append("List")
 
 JSON_SETTINGS_PROPERTIES_MAP = {
-    "description"      : "label",
-    "min"              : "mini",
-    "max"              : "maxi",
-    "step"             : "step",
-    "units"            : "units",
-    "show-value"       : "show_value",
-    "select-dir"       : "dir_select",
-    "height"           : "height",
-    "tooltip"          : "tooltip",
-    "possible"         : "possible",
-    "expand-width"     : "expand_width",
-    "columns"          : "columns",
-    "event-sounds"     : "event_sounds",
-    "default_icon"     : "default_icon",
-    "icon_categories"  : "icon_categories",
-    "default_category" : "default_category"
+    "description"     : "label",
+    "min"             : "mini",
+    "max"             : "maxi",
+    "step"            : "step",
+    "units"           : "units",
+    "show-value"      : "show_value",
+    "select-dir"      : "dir_select",
+    "height"          : "height",
+    "tooltip"         : "tooltip",
+    "possible"        : "possible",
+    "expand-width"    : "expand_width",
+    "columns"         : "columns",
+    "event-sounds"    : "event_sounds",
+    "default_icon"    : "default_icon",
+    "icon_categories" : "icon_categories"
 }
 
 OPERATIONS = ['<=', '>=', '<', '>', '!=', '=']

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
@@ -923,7 +923,7 @@ class IconChooser(SettingsWidget):
     bind_prop = "icon"
     bind_dir = Gio.SettingsBindFlags.DEFAULT
 
-    def __init__(self, label, default_icon=None, icon_categories=[], default_category=None, expand_width=False, size_group=None, dep_key=None, tooltip=""):
+    def __init__(self, label, default_icon=None, icon_categories=[], expand_width=False, size_group=None, dep_key=None, tooltip=""):
         super(IconChooser, self).__init__(dep_key=dep_key)
 
         self.label = SettingsLabel(label)
@@ -937,9 +937,6 @@ class IconChooser(SettingsWidget):
 
         for category in icon_categories:
             dialog.add_custom_category(category['name'], category['icons'])
-
-        if default_category is not None:
-            self.content_widget.set_default_category(default_category)
 
         self.pack_start(self.label, False, False, 0)
         self.pack_end(self.content_widget, expand_width, expand_width, 0)

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_nightlight.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_nightlight.py
@@ -1,0 +1,11 @@
+#!/usr/bin/python3
+
+from GSettingsWidgets import *
+
+class Module:
+    name = "night light"
+    comment = _("Cinnamon redshift settings")
+    category = "prefs"
+
+    def __init__(self, content_box):
+        WIP


### PR DESCRIPTION
This PR is based on https://github.com/linuxmint/cinnamon/issues/8895

I propose this features (https://github.com/jonls/redshift/blob/master/redshift.conf.sample):
[ ] Enable/Disable
[ ] Autostart (default: on)
[ ] Smooth fade (On/Off)
[ ] Schedule (automatic (geoclue2) or manually)
[ ] Your Position (automatic or manually)
[ ] Configuration of the adjustment-method (all screens, only first etc)
[ ] Temp-day
[ ] Temp-night
