### PR TITLE
cinnamon-settings: add 'update' to --sort option available values

### DIFF
--- a/files/usr/bin/cinnamon-settings
+++ b/files/usr/bin/cinnamon-settings
@@ -78,6 +78,7 @@ Module options:
                                 'score' or 1 (by default)
                                 'date' or 2
                                 'installed' or 3
+                                'update' or 4
 Example:
     $ cinnamon-settings applets -t download -s date
 

--- a/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
@@ -194,7 +194,7 @@ class MainWindow:
                         visible_child = sidePage.stack.get_visible_child()
                         if self.tab == 1 \
                         and hasattr(visible_child, 'sort_combo') \
-                        and self.sort in range(4):
+                        and self.sort in range(5):
                             visible_child.sort_combo.set_active(self.sort)
                             visible_child.sort_changed()
                     else:
@@ -395,7 +395,7 @@ class MainWindow:
             #   cinnamon-settings.py desklets -t 2
             # Please note that useless or wrong arguments are ignored.
             opts = []
-            sorts_literal = {"name":0, "score":1, "date":2, "installed":3}
+            sorts_literal = {"name":0, "score":1, "date":2, "installed":3, "update":4}
             tabs_literal = {"default":0}
             if arg1 in TABS.keys():
                 tabs_literal = TABS[arg1]

--- a/man/cinnamon-settings.1
+++ b/man/cinnamon-settings.1
@@ -133,6 +133,8 @@ Possible choices are:
  - \fBdate\fP or \fB2\fP
 .br
  - \fBinstalled\fP or \fB3\fP
+.br
+ - \fBupdate\fP or \fB4\fP (upgradable Spices first, then acts as \fBdate\fP)
 
 .SH OPTIONS
 The following options are supported:
@@ -181,7 +183,7 @@ or
 $ \fBcinnamon-settings applets -t 1\fP
 
 .TP
-To open the download tab of a type of Spices (applets, desklets, extensions, themes), sorting them by 'name', 'score', 'date' or 'installed', use the '--sort=' or '-s' argument:
+To open the download tab of a type of Spices (applets, desklets, extensions, themes), sorting them by 'name', 'score', 'date', 'installed' or 'update', use the '--sort=' or '-s' argument:
 .br
 $ \fBcinnamon-settings TYPE --tab=download --sort=SORT\fP
 .br
@@ -191,7 +193,7 @@ $ \fBcinnamon-settings TYPE -t 1 -s SORT\fP
 .br
 where TYPE can be \fBapplets\fP, \fBdesklets\fP, \fBextensions\fP or \fBthemes\fP
 .br
-and SORT can be \fBname\fP (or \fB0\fP), \fBscore\fP (or \fB1\fP), \fBdate\fP (or \fB2\fP), \fBinstalled\fP (or \fB3\fP)
+and SORT can be \fBname\fP (or \fB0\fP), \fBscore\fP (or \fB1\fP), \fBdate\fP (or \fB2\fP), \fBinstalled\fP (or \fB3\fP), \fBupdate\fP (or \fB4\fP)
 
 Example:
 .br
@@ -201,4 +203,4 @@ $ \fBcinnamon-settings applets -t 1 -s date\fP
 .BR cinnamon-menu-editor (1)
 
 .SH "CONTRIBUTORS"
-Nicolas Bourdaud (nbourdau) and Claude Clerc (claudiux).
+Claude Clerc (claudiux) and Nicolas Bourdaud (nbourdau).


### PR DESCRIPTION
Hi @clefebvre,

This PR is related to #8902. 

It allows users to use commands such as `cinnamon-settings applets -t download -s update` to open the Download tab with applets sorted by available update.

It also updates man page.

Best regards.
Claudiux