### PR TITLE
extension.js: fix variable scope regression

### DIFF
--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -572,9 +572,10 @@ function reloadExtension(uuid, type) {
 }
 
 function findExtensionDirectory(uuid, userDir, folder) {
+    let dir, dirPath;
     if (!GLib.getenv('CINNAMON_TROUBLESHOOT')) {
-        let dirPath = `${userDir}/${uuid}`;
-        let dir = Gio.file_new_for_path(dirPath);
+        dirPath = `${userDir}/${uuid}`;
+        dir = Gio.file_new_for_path(dirPath);
         if (dir.query_file_type(Gio.FileQueryInfoFlags.NONE, null) === Gio.FileType.DIRECTORY) {
             return dir;
         }


### PR DESCRIPTION
The declarations were moved inside a conditional so the other uses were undeclared.

Cjs-Message: 15:53:47.091: JS WARNING: [/usr/share/cinnamon/js/ui/extension.js 585]: assignment to undeclared variable dirPath
Cjs-Message: 15:53:47.091: JS WARNING: [/usr/share/cinnamon/js/ui/extension.js 586]: assignment to undeclared variable dir

fixes: 3bb0e598219131b760b6b1ed2a5d9cfab40034fa