### PR TITLE
Panel launchers rework

### DIFF
--- a/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
@@ -61,16 +61,16 @@ class PanelAppLauncherMenu extends Applet.AppletPopupMenu {
         this.addMenuItem(subMenu);
 
         item = new PopupMenu.PopupIconMenuItem(_("About..."), "dialog-question", St.IconType.SYMBOLIC);
-        this._signals.connect(item, 'activate', Lang.bind(this._launcher._applet, this._launcher._applet.openAbout));
+        this._signals.connect(item, 'activate', Lang.bind(this._launcher.launchersBox, this._launcher.launchersBox.openAbout));
         subMenu.menu.addMenuItem(item);
 
         item = new PopupMenu.PopupIconMenuItem(_("Configure..."), "system-run", St.IconType.SYMBOLIC);
-        this._signals.connect(item, 'activate', Lang.bind(this._launcher._applet, this._launcher._applet.configureApplet));
+        this._signals.connect(item, 'activate', Lang.bind(this._launcher.launchersBox, this._launcher.launchersBox.configureApplet));
         subMenu.menu.addMenuItem(item);
 
         item = new PopupMenu.PopupIconMenuItem(_("Remove '%s'").format(_("Panel launchers")), "edit-delete", St.IconType.SYMBOLIC);
         this._signals.connect(item, 'activate', Lang.bind(this, function() {
-            AppletManager._removeAppletFromPanel(this._launcher._applet._uuid, this._launcher._applet.instance_id);
+            AppletManager._removeAppletFromPanel(this._launcher.launchersBox._uuid, this._launcher.launchersBox.instance_id);
         }));
         subMenu.menu.addMenuItem(item);
     }
@@ -99,11 +99,9 @@ class PanelAppLauncherMenu extends Applet.AppletPopupMenu {
 
 class PanelAppLauncher extends DND.LauncherDraggable {
     constructor(launchersBox, app, appinfo, orientation, icon_size) {
-        super();
+        super(launchersBox);
         this.app = app;
         this.appinfo = appinfo;
-        this.launchersBox = launchersBox;
-        this._applet = launchersBox;
         this.orientation = orientation;
         this.icon_size = icon_size;
 
@@ -163,7 +161,7 @@ class PanelAppLauncher extends DND.LauncherDraggable {
     _onDragEnd() {
         this._dragging = false;
         this._tooltip.preventShow = false;
-        this._applet._clearDragPlaceholder();
+        this.launchersBox._clearDragPlaceholder();
     }
 
     _onDragCancelled() {

--- a/js/ui/dnd.js
+++ b/js/ui/dnd.js
@@ -843,16 +843,12 @@ GenericDragPlaceholderItem.prototype = {
     }
 };
 
-function LauncherDraggable() {
-    this._init();
-}
+var LauncherDraggable = class {
+    constructor(launchersBox) {
+        this.launchersBox = launchersBox;
+    }
 
-LauncherDraggable.prototype = {
-    _init: function() {
-        this.launchersBox = null;
-    },
-
-    getId: function() {
+    getId() {
         /* Implemented by draggable launchers */
         global.logError("Could not complete drag-and-drop.  Launcher does not implement LauncherDraggable");
     }


### PR DESCRIPTION
I'm not sure if the hit testing will be accurate or not in hidpi since I am using direct actor size values and not transformed size. I am unsure which is the correct method to use since we get pre-transformed mouse coordinates from the DND code. It is easy to fix if it's incorrect now, but if it works the extra transformation overhead is best avoided.

I completely removed behavior that caused multiple full reloads. A comment said it was overkill but easier to get the scaled size correct that way. I haven't noticed any icon scaling issues, and have no idea what case this code was designed for(maybe hidpi?). It's extremely inefficient and also can cause extra visual disruptions. If we don't need this, it is also best left out.

This reworks:

- Applets sync state when changed from cinnamon itself (not from settings) without excess reloading
- DND works differently for local vs remote drags now (rearrange vs dragging in a launcher from other applet) to simplify index tracking. local objects rearrange in real time (reset if drag cancelled), remote objects still use a placeholder
- DND methods split from applet object onto the actual launcher container actor so we don't have to transform from applet-relative to container-relative coordinates
- Don't use multiple names for the same object.

fixes: multiple issues on master with DND incorrectly dropping and losing launchers (settings corruption), specific positions that cause excessive placeholders to be added, etc