### PR TITLE
window-list: don't flash focused windows

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -741,7 +741,7 @@ class AppMenuButton {
     }
 
     getAttention() {
-        if (this._needsAttention)
+        if (this._needsAttention || this._hasFocus())
             return false;
 
         this._needsAttention = true;
@@ -750,7 +750,7 @@ class AppMenuButton {
     }
 
     _flashButton() {
-        if (!this._needsAttention)
+        if (!this._needsAttention || this._hasFocus())
             return;
 
         let counter = 0;


### PR DESCRIPTION
For whatever reason these are getting the flash alert incorrectly. I
don't see how it could be related to my recent rework of flashButton()
but I also don't know what else could have caused this. Either way,
it's incorrect to flash a window that's already focused so avoid it.