### PR TITLE
menu-applet: don't show user-hidden categories

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/appUtils.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/appUtils.js
@@ -72,6 +72,8 @@ function getApps() {
     while ((nextType = iter.next()) != CMenu.TreeItemType.INVALID) {
         if (nextType == CMenu.TreeItemType.DIRECTORY) {
             let dir = iter.get_directory();
+            if (dir.get_is_nodisplay())
+                continue;
             if (loadDirectory(dir, dir, apps))
                 dirs.push(dir);
         }


### PR DESCRIPTION
I inadvertently removed this feature in the refactoring. User-
hidden directories are marked nodisplay and so that needs to be
checked on the gmenu object either at load or display. This commit
does it at load, so consequently any unhidden category will show
all unique apps as newly installed/highlighted upon unhiding after
starting the session or applet with it hidden.

Thanks goes to @collinss for finding both the bug and the fix.

fixes: 0ed2544d7398d033a9