### PR TITLE
[WIP] Some adjustments for the new version of cmenu

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/appUtils.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/appUtils.js
@@ -74,12 +74,11 @@ function getApps() {
             let dir = iter.get_directory();
             if (dir.get_is_nodisplay())
                 continue;
-            if (loadDirectory(dir, dir, apps))
+            if (loadDirectory(dir, apps))
                 dirs.push(dir);
         }
     }
 
-    dirs.sort(dirSort);
     let sortedApps = Array.from(apps.entries()).sort(appSort);
 
     return [sortedApps, dirs];
@@ -87,7 +86,7 @@ function getApps() {
 
 // load all apps and their categories from a cmenu directory
 // into 'apps' Map
-function loadDirectory(dir, top_dir, apps) {
+function loadDirectory(dir, apps) {
     let iter = dir.iter();
     let has_entries = false;
     let nextType;
@@ -102,9 +101,7 @@ function loadDirectory(dir, top_dir, apps) {
             if (apps.has(app))
                 apps.get(app).push(dir.get_menu_id());
             else
-                apps.set(app, [top_dir.get_menu_id()]);
-        } else if (nextType == CMenu.TreeItemType.DIRECTORY) {
-            has_entries = loadDirectory(iter.get_directory(), top_dir, apps);
+                apps.set(app, [dir.get_menu_id()]);
         }
     }
     return has_entries;

--- a/files/usr/share/cinnamon/cinnamon-menu-editor/cme/MainWindow.py
+++ b/files/usr/share/cinnamon/cinnamon-menu-editor/cme/MainWindow.py
@@ -19,7 +19,7 @@
 
 import gi
 gi.require_version('Gtk', '3.0')
-gi.require_version('CMenu', '3.0')
+gi.require_version('CMenu', '4.0')
 from gi.repository import Gtk, GObject, Gio, GdkPixbuf, Gdk, CMenu, GLib
 import cgi
 import os
@@ -115,19 +115,6 @@ class MainWindow(object):
                     if isinstance (item[3], CMenu.TreeDirectory) and item[3].get_desktop_file_path() and update_type == CMenu.TreeItemType.DIRECTORY:
                         if os.path.split(item[3].get_desktop_file_path())[1] == item_id:
                             found = True
-                if isinstance(item[3], CMenu.TreeSeparator):
-                    if not isinstance(item_id, tuple):
-                        #we may not skip the increment via "continue"
-                        i += 1
-                        continue
-                    #separators have no id, have to find them manually
-                    #probably won't work with two separators together
-                    if (item_id[0] - 1,) == (i,):
-                        found = True
-                    elif (item_id[0] + 1,) == (i,):
-                        found = True
-                    elif (item_id[0],) == (i,):
-                        found = True
                 if found:
                     item_tree.get_selection().select_path((i,))
                     self.on_item_tree_cursor_changed(item_tree)
@@ -191,10 +178,7 @@ class MainWindow(object):
             cell.set_property("surface", wrapper.surface)
 
     def _cell_data_toggle_func(self, tree_column, renderer, model, treeiter, data=None):
-        if isinstance(model[treeiter][3], CMenu.TreeSeparator):
-            renderer.set_property('visible', False)
-        else:
-            renderer.set_property('visible', True)
+        renderer.set_property('visible', True)
 
     def loadMenus(self):
         self.menu_store.clear()
@@ -392,8 +376,6 @@ class MainWindow(object):
 
     def on_item_tree_show_toggled(self, cell, path):
         item = self.item_store[path][3]
-        if isinstance(item, CMenu.TreeSeparator):
-            return
         if self.item_store[path][0]:
             self.editor.setVisible(item, False)
         else:
@@ -411,10 +393,6 @@ class MainWindow(object):
         item = items[iter][3]
         self.tree.get_object('edit_delete').set_sensitive(True)
         self.tree.get_object('delete_button').set_sensitive(True)
-
-        can_edit = not isinstance(item, CMenu.TreeSeparator)
-        self.tree.get_object('edit_properties').set_sensitive(can_edit)
-        self.tree.get_object('properties_button').set_sensitive(can_edit)
 
         can_cut_copy = not isinstance(item, CMenu.TreeDirectory)
         self.tree.get_object('cut_button').set_sensitive(can_cut_copy)

--- a/files/usr/share/cinnamon/cinnamon-menu-editor/cme/MenuEditor.py
+++ b/files/usr/share/cinnamon/cinnamon-menu-editor/cme/MenuEditor.py
@@ -126,12 +126,6 @@ class MenuEditor(object):
                 item = item_iter.get_directory()
             elif item_type == CMenu.TreeItemType.ENTRY:
                 item = item_iter.get_entry()
-            elif item_type == CMenu.TreeItemType.HEADER:
-                item = item_iter.get_header()
-            elif item_type == CMenu.TreeItemType.ALIAS:
-                item = item_iter.get_alias()
-            elif item_type == CMenu.TreeItemType.SEPARATOR:
-                item = item_iter.get_separator()
             if item:
                 contents.append(item)
             item_type = item_iter.next()
@@ -146,12 +140,6 @@ class MenuEditor(object):
                 item = item_iter.get_entry()
             elif item_type == CMenu.TreeItemType.DIRECTORY:
                 item = item_iter.get_directory()
-            elif item_type == CMenu.TreeItemType.HEADER:
-                item = item_iter.get_header()
-            elif item_type == CMenu.TreeItemType.ALIAS:
-                item = item_iter.get_alias()
-            elif item_type == CMenu.TreeItemType.SEPARATOR:
-                item = item_iter.get_separator()
             yield (item, self.isVisible(item))
             item_type = item_iter.next()
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -239,7 +239,7 @@ libcinnamon_la_LIBADD = $(CINNAMON_LIBS) $(MUFFIN_LIBS) $(libcinnamon_libadd)
 libcinnamon_la_CPPFLAGS = $(MUFFIN_CFLAGS) $(cinnamon_cflags)
 
 Cinnamon-0.1.gir: libcinnamon.la St-1.0.gir
-Cinnamon_0_1_gir_INCLUDES = Clutter-0 ClutterX11-0 CoglPango-0 Cogl-0 Meta-Muffin.0 Soup-2.4 CMenu-3.0 NM-1.0
+Cinnamon_0_1_gir_INCLUDES = Clutter-0 ClutterX11-0 CoglPango-0 Cogl-0 Meta-Muffin.0 Soup-2.4 CMenu-4.0 NM-1.0
 Cinnamon_0_1_gir_CFLAGS = $(libcinnamon_la_CPPFLAGS) -I $(srcdir)
 Cinnamon_0_1_gir_LIBS = libcinnamon.la
 Cinnamon_0_1_gir_FILES = $(libcinnamon_la_gir_sources)

--- a/src/cinnamon-app-private.h
+++ b/src/cinnamon-app-private.h
@@ -12,9 +12,9 @@ G_BEGIN_DECLS
 
 CinnamonApp* _cinnamon_app_new_for_window (MetaWindow *window);
 
-CinnamonApp* _cinnamon_app_new (GMenuTreeEntry *entry);
+CinnamonApp* _cinnamon_app_new (CMenuTreeEntry *entry);
 
-void _cinnamon_app_set_entry (CinnamonApp *app, GMenuTreeEntry *entry);
+void _cinnamon_app_set_entry (CinnamonApp *app, CMenuTreeEntry *entry);
 
 void _cinnamon_app_handle_startup_sequence (CinnamonApp *app, SnStartupSequence *sequence);
 

--- a/src/cinnamon-app-system.h
+++ b/src/cinnamon-app-system.h
@@ -5,8 +5,8 @@
 #include <gio/gio.h>
 #include <clutter/clutter.h>
 #include <meta/window.h>
-#define GMENU_I_KNOW_THIS_IS_UNSTABLE
-#include <gmenu-tree.h>
+#define CMENU_I_KNOW_THIS_IS_UNSTABLE
+#include <cmenu-tree.h>
 
 #include "cinnamon-app.h"
 
@@ -39,7 +39,7 @@ struct _CinnamonAppSystemClass
 GType           cinnamon_app_system_get_type    (void) G_GNUC_CONST;
 CinnamonAppSystem *cinnamon_app_system_get_default (void);
 
-GMenuTree      *cinnamon_app_system_get_tree                     (CinnamonAppSystem *system);
+CMenuTree      *cinnamon_app_system_get_tree                     (CinnamonAppSystem *system);
 
 CinnamonApp       *cinnamon_app_system_lookup_app                   (CinnamonAppSystem  *system,
                                                                const char      *id);

--- a/src/cinnamon-app.c
+++ b/src/cinnamon-app.c
@@ -37,7 +37,7 @@ typedef struct {
  * SECTION:cinnamon-app
  * @short_description: Object representing an application
  *
- * This object wraps a #GMenuTreeEntry, providing methods and signals
+ * This object wraps a #CMenuTreeEntry, providing methods and signals
  * primarily useful for running applications.
  */
 struct _CinnamonApp
@@ -50,7 +50,7 @@ struct _CinnamonApp
 
   CinnamonAppState state;
 
-  GMenuTreeEntry *entry; /* If NULL, this app is backed by one or more
+  CMenuTreeEntry *entry; /* If NULL, this app is backed by one or more
                           * MetaWindow.  For purposes of app title
                           * etc., we use the first window added,
                           * because it's most likely to be what we
@@ -109,7 +109,7 @@ const char *
 cinnamon_app_get_id (CinnamonApp *app)
 {
   if (app->entry)
-    return gmenu_tree_entry_get_desktop_file_id (app->entry);
+    return cmenu_tree_entry_get_desktop_file_id (app->entry);
   return app->window_id_string;
 }
 
@@ -789,7 +789,7 @@ _cinnamon_app_new_for_window (MetaWindow      *window)
 }
 
 CinnamonApp *
-_cinnamon_app_new (GMenuTreeEntry *info)
+_cinnamon_app_new (CMenuTreeEntry *info)
 {
   CinnamonApp *app;
 
@@ -802,9 +802,9 @@ _cinnamon_app_new (GMenuTreeEntry *info)
 
 void
 _cinnamon_app_set_entry (CinnamonApp       *app,
-                      GMenuTreeEntry *entry)
+                      CMenuTreeEntry *entry)
 {
-  g_clear_pointer (&app->entry, gmenu_tree_item_unref);
+  g_clear_pointer (&app->entry, cmenu_tree_item_unref);
   g_clear_object (&app->info);
 
   /* If our entry has changed, our name may have as well, so clear
@@ -812,11 +812,11 @@ _cinnamon_app_set_entry (CinnamonApp       *app,
   g_clear_pointer (&app->unique_name, g_free);
   app->hidden_as_duplicate = FALSE;
 
-  app->entry = gmenu_tree_item_ref (entry);
+  app->entry = cmenu_tree_item_ref (entry);
 
   if (entry != NULL)
     {
-      app->info = g_object_ref (gmenu_tree_entry_get_app_info (entry));
+      app->info = g_object_ref (cmenu_tree_entry_get_app_info (entry));
     }
 }
 
@@ -1151,9 +1151,9 @@ cinnamon_app_get_app_info (CinnamonApp *app)
  * cinnamon_app_get_tree_entry:
  * @app: a #CinnamonApp
  *
- * Returns: (transfer none): The #GMenuTreeEntry for this app, or %NULL if backed by a window
+ * Returns: (transfer none): The #CMenuTreeEntry for this app, or %NULL if backed by a window
  */
-GMenuTreeEntry *
+CMenuTreeEntry *
 cinnamon_app_get_tree_entry (CinnamonApp *app)
 {
   return app->entry;
@@ -1205,7 +1205,7 @@ cinnamon_app_dispose (GObject *object)
 
   if (app->entry)
     {
-      gmenu_tree_item_unref (app->entry);
+      cmenu_tree_item_unref (app->entry);
       app->entry = NULL;
     }
 

--- a/src/cinnamon-app.h
+++ b/src/cinnamon-app.h
@@ -5,8 +5,8 @@
 #include <clutter/clutter.h>
 #include <gio/gio.h>
 #include <meta/window.h>
-#define GMENU_I_KNOW_THIS_IS_UNSTABLE
-#include <gmenu-tree.h>
+#define CMENU_I_KNOW_THIS_IS_UNSTABLE
+#include <cmenu-tree.h>
 
 G_BEGIN_DECLS
 
@@ -36,7 +36,7 @@ typedef enum {
 GType cinnamon_app_get_type (void) G_GNUC_CONST;
 
 const char *cinnamon_app_get_id (CinnamonApp *app);
-GMenuTreeEntry *cinnamon_app_get_tree_entry (CinnamonApp *app);
+CMenuTreeEntry *cinnamon_app_get_tree_entry (CinnamonApp *app);
 GDesktopAppInfo *cinnamon_app_get_app_info (CinnamonApp *app);
 ClutterActor *cinnamon_app_create_icon_texture (CinnamonApp *app,
                                                 int          size);


### PR DESCRIPTION
The majority of these changes are due to the change in prefix from gmenu_* to cmenu_*, though support for inlining and separators were also removed since we don't use those in Cinnamon anyway. CMenu now also flattens the menu structure and performs a sort, so we don't need to do that in Cinnamon any more.

Requires https://github.com/linuxmint/cinnamon-menus/pull/29