### PR TITLE
a11y applet: don't show "Screen reader" switch when gnome-orca isn't installed

### DIFF
--- a/files/usr/share/cinnamon/applets/a11y@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/a11y@cinnamon.org/applet.js
@@ -4,6 +4,7 @@ const Lang = imports.lang;
 const Applet = imports.ui.applet;
 const Main = imports.ui.main;
 const Gdk = imports.gi.Gdk;
+const GLib = imports.gi.GLib;
 
 const A11Y_SCHEMA = 'org.cinnamon.desktop.a11y.keyboard';
 const KEY_STICKY_KEYS_ENABLED = 'stickykeys-enable';
@@ -54,9 +55,11 @@ class CinnamonA11YApplet extends Applet.TextIconApplet {
             let textZoom = this._buildFontItem();
             this.menu.addMenuItem(textZoom);
 
-            let screenReader = this._buildItem(_("Screen Reader"), APPLICATIONS_SCHEMA,
-                                                                  'screen-reader-enabled');
-            this.menu.addMenuItem(screenReader);
+            if (GLib.file_test("/usr/bin/orca", GLib.FileTest.EXISTS)) {
+                let screenReader = this._buildItem(_("Screen Reader"), APPLICATIONS_SCHEMA,
+                                                                      'screen-reader-enabled');
+                this.menu.addMenuItem(screenReader);
+            }
 
             let screenKeyboard = this._buildItem(_("Screen Keyboard"), APPLICATIONS_SCHEMA,
                                                                        'screen-keyboard-enabled');


### PR DESCRIPTION
On "Accessibility" settings, if gnome-orca isn't installed the switch "Screen reader" disappears (the legend "install gnome-orca" is displayed), but on the accessibility applet it's still visible.

I don't know if this is the best way to verify that gnome-orca is installed, but it works.