### PR TITLE
Closes #8956 - cinnamon-settings.py and ExtensionCore.py: now compatibles with Python 3.8

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/ExtensionCore.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/ExtensionCore.py
@@ -910,7 +910,7 @@ class DownloadSpicesPage(SettingsPage):
         updates_available = self.spices.get_n_updates()
         self.update_all_button.set_sensitive(updates_available)
         if updates_available > 0:
-            msg_text = _("Update all") + ' (' + ngettext("%d update available", "%d updates available", updates_available) % updates_available  + ')'
+            msg_text = _("Update all") + ' (' + gettext.ngettext("%d update available", "%d updates available", updates_available) % updates_available  + ')'
         else:
             msg_text = _("No updates available")
         self.update_all_button.set_tooltip_text(msg_text)

--- a/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
@@ -27,7 +27,7 @@ import proxygsettings
 import SettingsWidgets
 
 # i18n
-gettext.install("cinnamon", "/usr/share/locale", names="ngettext")
+gettext.install("cinnamon", "/usr/share/locale", names="gettext.ngettext")
 
 # Standard setting pages... this can be expanded to include applet dirs maybe?
 mod_files = glob.glob(config.currentPath + "/modules/*.py")
@@ -422,7 +422,7 @@ class MainWindow:
             # can consider it as a standalone app and give it its own
             # group.
             wm_class = "cinnamon-settings %s" % arg1
-            self.window.set_wmclass(wm_class, wm_class)
+            self.window.set_role(wm_class)
             self.button_back.hide()
             (iter, cat) = sidePagesIters[arg1]
             path = self.store[cat].get_path(iter)


### PR DESCRIPTION
(Python 3.8 is used on Arch with Cinnamon 4.2.4.)
Also replaces `self.window.set_wmclass(wm_class, wm_class)` by `self.window.set_role(wm_class)` to avoid the warning message "Gtk.Window.set_wmclass is deprecated" (https://developer.gnome.org/gtk3/stable/GtkWindow.html#gtk-window-set-wmclass).

Closes #8956. 