### PR TITLE
fix regression in ExtensionCore not working when updates are available

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
@@ -27,7 +27,7 @@ import proxygsettings
 import SettingsWidgets
 
 # i18n
-gettext.install("cinnamon", "/usr/share/locale", names="ngettext")
+gettext.install("cinnamon", "/usr/share/locale", names=["ngettext"])
 
 # Standard setting pages... this can be expanded to include applet dirs maybe?
 mod_files = glob.glob(config.currentPath + "/modules/*.py")


### PR DESCRIPTION
In commit 6ac295a62556f22b755b17dee29d17d6721fa361, Settings>Applets>Download gained the ability to display the number of available updates, using an ngettext-translated message. However, it has never worked since ngettext was never imported in the file in question, so it simply raised a traceback.

In the same commit, `gettext.install()` was taught to declare `names="ngettext"`, but as per the python documentation, the `names=` argument requires a sequence (of one or more aliases to declare in the global namespace), not a string. So it tried to check if it could install the gettext functions: `{'x', 't', 'e', 'g'}`, which was wrong.

The fix is to either import `ngettext` directly, so it can be used as-is, or globally install `ngettext` by passing it as a one-item list to the `gettext.install()` function. I've done the latter.