### PR TITLE
window-list: proper fix for incorrect flashing

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -741,7 +741,7 @@ class AppMenuButton {
     }
 
     getAttention() {
-        if (this._needsAttention || this._hasFocus())
+        if (this._needsAttention)
             return false;
 
         this._needsAttention = true;
@@ -750,13 +750,16 @@ class AppMenuButton {
     }
 
     _flashButton() {
-        if (!this._needsAttention || this._hasFocus())
+        if (!this._needsAttention)
             return;
 
         let counter = 0;
         let sc = "window-list-item-demands-attention";
 
         Mainloop.timeout_add(FLASH_INTERVAL, () => {
+            if (!this._needsAttention)
+                return false;
+
             if (this.actor.has_style_class_name(sc))
                 this.actor.remove_style_class_name(sc);
             else


### PR DESCRIPTION
I hate when I mess it up twice in a row :[ Third time's a charm...........?

The original implementation checked needsAttention every timeout
interval and this caught the case where a window demands attention
event is triggered by an activate event on an existing window. An
example of this could be a non-focused browser window being focused
as a user clicks a link in another application. In this case, with
the original implementation, the window starts flashing and stops
before the style even changes. It also handles the case where a
user clicks the window during the flash cycle.

This commit restores that behavior.

fixes/reverts: ec9b3fb1c1c03eaf27b893e0f2ffc29166b646c1