### PR TITLE
Revert the incorrect and problematic addition of overlinking in Cinnamon-0.1.gir

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -240,9 +240,6 @@ libcinnamon_la_CPPFLAGS = $(MUFFIN_CFLAGS) $(cinnamon_cflags)
 
 Cinnamon-0.1.gir: libcinnamon.la St-1.0.gir
 Cinnamon_0_1_gir_INCLUDES = Clutter-0 ClutterX11-0 CoglPango-0 Cogl-0 Meta-Muffin.0 Soup-2.4 CMenu-3.0
-if HAVE_NETWORKMANAGER
-Cinnamon_0_1_gir_INCLUDES += NM-1.0
-endif HAVE_NETWORKMANAGER
 Cinnamon_0_1_gir_CFLAGS = $(libcinnamon_la_CPPFLAGS) -I $(srcdir)
 Cinnamon_0_1_gir_LIBS = libcinnamon.la
 Cinnamon_0_1_gir_FILES = $(libcinnamon_la_gir_sources)


### PR DESCRIPTION
This was explicitly removed in commit 237fa0090516e60d03aaea313c5671e6a78f8e3f but then re-added in commit e289a971610b4530622e4b35fea5af6958f5356b

Fixes regression in #8617