### PR TITLE
[removable-drives@cinnamon.org] Closes #5377

### DIFF
--- a/files/usr/share/cinnamon/applets/removable-drives@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/removable-drives@cinnamon.org/applet.js
@@ -9,6 +9,9 @@ const MessageTray = imports.ui.messageTray;
 const PANEL_EDIT_MODE_KEY = "panel-edit-mode";
 
 const translated_id = (s1, s2) => {
+    if (s2 === "") {
+        return s1
+    }
     // In some languages, parentheses are replaced by other characters.
     return _("%s (%s)").format(s1, s2)
 }
@@ -19,7 +22,10 @@ class DriveMenuItem extends PopupMenu.PopupBaseMenuItem {
 
         this.place = place;
 
-        let unixDevice = place._mount.get_drive().get_identifier('unix-device');
+        let unixDevice = "";
+        if (place._mount.get_drive() !== null) {
+            unixDevice = place._mount.get_drive().get_identifier('unix-device');
+        }
         this.label = new St.Label({ text: translated_id(place.name, unixDevice) });
         this.addActor(this.label);
 
@@ -101,8 +107,12 @@ class CinnamonRemovableDrivesApplet extends Applet.IconApplet {
             if (mounts[i].isRemovable()) {
                 this._contentSection.addMenuItem(new DriveMenuItem(mounts[i]));
                 name = mounts[i].name.toString();
-                driveName = mounts[i]._mount.get_drive().get_name().toString();
-                unixDevice = mounts[i]._mount.get_drive().get_identifier('unix-device').toString();
+                driveName = name.toString();
+                unixDevice = "";
+                if (mounts[i]._mount.get_drive() !== null) {
+                    driveName = mounts[i]._mount.get_drive().get_name().toString();
+                    unixDevice = mounts[i]._mount.get_drive().get_identifier('unix-device').toString();
+                }
                 uId = translated_id(name, unixDevice);
                 this._labels.push(uId);
                 if (!this._oldMounts.has(uId)) {

--- a/files/usr/share/cinnamon/applets/removable-drives@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/removable-drives@cinnamon.org/applet.js
@@ -55,8 +55,8 @@ class CinnamonRemovableDrivesApplet extends Applet.IconApplet {
         this.menuManager.addMenu(this.menu);
 
         this._oldMounts = new Map();
-        this._oldLabels = new Array();
-        this._labels = new Array();
+        this._oldLabels = [];
+        this._labels = [];
         this._contentSection = new PopupMenu.PopupMenuSection();
         this.menu.addMenuItem(this._contentSection);
 
@@ -89,7 +89,7 @@ class CinnamonRemovableDrivesApplet extends Applet.IconApplet {
     _update() {
         this._contentSection.removeAll();
 
-        this._labels = new Array();
+        this._labels = [];
         let mounts = Main.placesManager.getMounts();
         let any = false;
         let name;
@@ -127,7 +127,7 @@ class CinnamonRemovableDrivesApplet extends Applet.IconApplet {
                 notification.setTransient(true);
                 notification.setUrgency(MessageTray.Urgency.NORMAL);
                 source.notify(notification);
-                }
+            }
         }
         this._oldLabels = this._labels.slice();
         this.actor.visible = any;

--- a/files/usr/share/cinnamon/applets/removable-drives@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/removable-drives@cinnamon.org/applet.js
@@ -1,12 +1,17 @@
-const Lang = imports.lang;
 const St = imports.gi.St;
 const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
 const Applet = imports.ui.applet;
 const Main = imports.ui.main;
 const PopupMenu = imports.ui.popupMenu;
+const MessageTray = imports.ui.messageTray;
 
 const PANEL_EDIT_MODE_KEY = "panel-edit-mode";
+
+const translated_id = (s1, s2) => {
+    // In some languages, parentheses are replaced by other characters.
+    return _("%s (%s)").format(s1, s2)
+}
 
 class DriveMenuItem extends PopupMenu.PopupBaseMenuItem {
     constructor(place) {
@@ -14,14 +19,15 @@ class DriveMenuItem extends PopupMenu.PopupBaseMenuItem {
 
         this.place = place;
 
-        this.label = new St.Label({ text: place.name });
+        let unixDevice = place._mount.get_drive().get_identifier('unix-device');
+        this.label = new St.Label({ text: translated_id(place.name, unixDevice) });
         this.addActor(this.label);
 
         let ejectIcon = new St.Icon({ icon_name: 'media-eject',
                       icon_type: St.IconType.SYMBOLIC,
-                      style_class: 'popup-menu-icon ' });
+                      style_class: 'popup-menu-icon' });
         let ejectButton = new St.Button({ child: ejectIcon });
-        ejectButton.connect('clicked', Lang.bind(this, this._eject));
+        ejectButton.connect('clicked', () => this._eject());
         this.addActor(ejectButton);
     }
 
@@ -42,12 +48,15 @@ class CinnamonRemovableDrivesApplet extends Applet.IconApplet {
         this.set_applet_icon_symbolic_name("drive-harddisk");
         this.set_applet_tooltip(_("Removable drives"));
 
-        global.settings.connect('changed::' + PANEL_EDIT_MODE_KEY, Lang.bind(this, this._onPanelEditModeChanged));
+        global.settings.connect('changed::' + PANEL_EDIT_MODE_KEY, () => this._onPanelEditModeChanged());
 
         this.menuManager = new PopupMenu.PopupMenuManager(this);
         this.menu = new Applet.AppletPopupMenu(this, orientation);
         this.menuManager.addMenu(this.menu);
 
+        this._oldMounts = new Map();
+        this._oldLabels = new Array();
+        this._labels = new Array();
         this._contentSection = new PopupMenu.PopupMenuSection();
         this.menu.addMenuItem(this._contentSection);
 
@@ -60,7 +69,7 @@ class CinnamonRemovableDrivesApplet extends Applet.IconApplet {
             Gio.app_info_launch_default_for_uri(homeUri, null);
         });
 
-        Main.placesManager.connect('mounts-updated', Lang.bind(this, this._update));
+        Main.placesManager.connect('mounts-updated', () => this._update());
         this._onPanelEditModeChanged();
     }
 
@@ -80,15 +89,47 @@ class CinnamonRemovableDrivesApplet extends Applet.IconApplet {
     _update() {
         this._contentSection.removeAll();
 
+        this._labels = new Array();
         let mounts = Main.placesManager.getMounts();
         let any = false;
+        let name;
+        let driveName;  // Ex: USB Flash Drive
+        let unixDevice; // Ex: /dev/sdc
+        let uId; // unique Id
+
         for (let i = 0; i < mounts.length; i++) {
             if (mounts[i].isRemovable()) {
                 this._contentSection.addMenuItem(new DriveMenuItem(mounts[i]));
+                name = mounts[i].name.toString();
+                driveName = mounts[i]._mount.get_drive().get_name().toString();
+                unixDevice = mounts[i]._mount.get_drive().get_identifier('unix-device').toString();
+                uId = translated_id(name, unixDevice);
+                this._labels.push(uId);
+                if (!this._oldMounts.has(uId)) {
+                    this._oldMounts.set(uId, translated_id(driveName, unixDevice));
+                }
                 any = true;
             }
         }
 
+        for (let old of this._oldLabels) {
+            if (!this._labels.includes(old.toString())) {
+                uId = this._oldMounts.get(old.toString());
+                this._oldMounts.delete(old.toString());
+
+                let source = new MessageTray.SystemNotificationSource();
+                Main.messageTray.add(source);
+                let notification = new MessageTray.Notification(
+                    source,
+                    _("%s can be safely unplugged").format(uId),
+                    _("Device can be removed")
+                );
+                notification.setTransient(true);
+                notification.setUrgency(MessageTray.Urgency.NORMAL);
+                source.notify(notification);
+                }
+        }
+        this._oldLabels = this._labels.slice();
         this.actor.visible = any;
     }
 }


### PR DESCRIPTION
This PR closes #5377.

Now, when a drive is unmounted and can be unplugged, a notification is sent.

Also, it replaces all the calls to Lang.bind() by arrow functions.

EDIT: `ci/circleci: lmde3` errors come from the `main.c` file, not from this `applet.js` script.
~~EDIT2: Work In Progress~~