### PR TITLE
SettingsWidgets.py: remove duplicate IconChooser widget

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
@@ -16,7 +16,7 @@ from KeybindingWidgets import ButtonKeybinding
 
 settings_objects = {}
 
-CAN_BACKEND = ["SoundFileChooser", "IconChooser", "TweenChooser", "EffectChooser", "DateChooser", "Keybinding"]
+CAN_BACKEND = ["SoundFileChooser", "TweenChooser", "EffectChooser", "DateChooser", "Keybinding"]
 
 class BinFileMonitor(GObject.GObject):
     __gsignals__ = {
@@ -422,36 +422,6 @@ class SoundFileChooser(SettingsWidget):
 
     def connect_widget_handlers(self, *args):
         pass
-
-class IconChooser(SettingsWidget):
-    bind_prop = "icon"
-    bind_dir = Gio.SettingsBindFlags.DEFAULT
-
-    def __init__(self, label, default_icon=None, icon_categories=[], default_category=None, expand_width=False, size_group=None, dep_key=None, tooltip=""):
-        super(IconChooser, self).__init__(dep_key=dep_key)
-
-        self.label = SettingsLabel(label)
-
-        self.content_widget = XApp.IconChooserButton()
-        self.content_widget.set_icon_size(Gtk.IconSize.BUTTON)
-
-        dialog = self.content_widget.get_dialog()
-        if default_icon:
-            dialog.set_default_icon(default_icon)
-
-        for category in icon_categories:
-            dialog.add_custom_category(category['name'], category['icons'])
-
-        if default_category is not None:
-            self.content_widget.set_default_category(default_category)
-
-        self.pack_start(self.label, False, False, 0)
-        self.pack_end(self.content_widget, expand_width, expand_width, 0)
-
-        self.set_tooltip_text(tooltip)
-
-        if size_group:
-            self.add_to_size_group(size_group)
 
 class TweenChooser(SettingsWidget):
     bind_prop = "tween"


### PR DESCRIPTION
It we were already using the version that exists in python-xapp so it's dead code now