### PR TITLE
grouped-window-list@cinnamon.org: Listen to MetaDisplay's window-created signal for adding new windows.

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appList.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appList.js
@@ -49,7 +49,6 @@ class AppList {
         this.lastFocusedApp = null;
 
         // Connect all the signals
-        this.signals.connect(this.metaWorkspace, 'window-added', (...args) => this.windowAdded(...args));
         this.signals.connect(this.metaWorkspace, 'window-removed', (...args) => this.windowRemoved(...args));
         this.on_orientation_changed(null, true);
     }

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -316,6 +316,7 @@ class GroupedWindowListApplet extends Applet.Applet {
         this.signals.connect(global.screen, 'window-skip-taskbar-changed', (...args) => this.onWindowSkipTaskbarChanged(...args));
         this.signals.connect(global.display, 'window-marked-urgent', (...args) => this.updateAttentionState(...args));
         this.signals.connect(global.display, 'window-demands-attention', (...args) => this.updateAttentionState(...args));
+        this.signals.connect(global.display, 'window-created', (...args) => this.onWindowCreated(...args));
         this.signals.connect(global.settings, 'changed::panel-edit-mode', (...args) => this.on_panel_edit_mode_changed(...args));
         this.signals.connect(Main.overview, 'showing', (...args) => this.onOverviewShow(...args));
         this.signals.connect(Main.overview, 'hiding', (...args) => this.onOverviewHide(...args));
@@ -534,6 +535,12 @@ class GroupedWindowListApplet extends Applet.Applet {
     updateAttentionState(display, window) {
         each(this.appLists, (workspace) => {
             workspace.updateAttentionState(display, window);
+        });
+    }
+
+    onWindowCreated(display, window) {
+        each(this.appLists, (workspace) => {
+            workspace.windowAdded(window.get_workspace(), window);
         });
     }
 

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
@@ -912,11 +912,10 @@ class AppThumbnailHoverMenu extends PopupMenu.PopupMenu {
             },
             addThumbnailToMenu: (win) => {
                 if (this.isOpen) {
-                    this.close(true);
                     this.addThumbnail(win);
-                    this.open(true);
                     return;
                 }
+
                 this.queuedWindows.push(win);
             },
             removeThumbnailFromMenu: (win) => {


### PR DESCRIPTION
MetaWorkspace:window-added is sent very early in the construction of a new
window - before the compositor even knows about it, which ends up with cinnamon
frequently adding a window with no actor yet (to clone for thumbnails).

The display signal is sent at the very end of meta_window_new_with_attrs() so
should be more reliable to provide a fully developed window.

If a window is created using the ctr-click method on the app's panel item,
the framing around the new thumb is corrupted at first, if animation is enabled.
Removing the hide/show when adding a new window in this manner avoids this issue,
and has the added benefit of the entire thumbnail group re-centering itself with
its panel item automatically.