### PR TITLE
cinnamon-settings: Fix missing backgrounds issue

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_backgrounds.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_backgrounds.py
@@ -794,7 +794,7 @@ class ThreadedIconView(Gtk.IconView):
                     if backgroundNode.tag == "static":
                         for staticNode in backgroundNode:
                             if staticNode.tag == "file":
-                                if staticNode[-1].tag == "size":
+                                if len(staticNode) > 0 and staticNode[-1].tag == "size":
                                     return staticNode[-1].text
                                 return staticNode.text
             print("Could not find filename in %s" % filename)


### PR DESCRIPTION
The python script `cs_backgrounds.py` was failing because an array was
not checked to be empty before being indexed.

Fixes #5586