### PR TITLE
Settings: add missing widget import

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py
@@ -2,7 +2,7 @@
 
 from gi.repository import Gio, GObject
 from xapp.SettingsWidgets import *
-from SettingsWidgets import SoundFileChooser, TweenChooser, EffectChooser, DateChooser, Keybinding
+from SettingsWidgets import SoundFileChooser, TweenChooser, EffectChooser, DateChooser, TimeChooser, Keybinding
 from xapp.GSettingsWidgets import CAN_BACKEND as px_can_backend
 from SettingsWidgets import CAN_BACKEND as c_can_backend
 from TreeListWidgets import List

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
@@ -11,12 +11,12 @@ from gi.repository import Gio, Gtk, GObject, GLib, XApp
 
 from xapp.SettingsWidgets import SettingsWidget, SettingsLabel
 from xapp.GSettingsWidgets import PXGSettingsBackend
-from ChooserButtonWidgets import DateChooserButton, TweenChooserButton, EffectChooserButton
+from ChooserButtonWidgets import DateChooserButton, TweenChooserButton, EffectChooserButton, TimeChooserButton
 from KeybindingWidgets import ButtonKeybinding
 
 settings_objects = {}
 
-CAN_BACKEND = ["SoundFileChooser", "TweenChooser", "EffectChooser", "DateChooser", "Keybinding"]
+CAN_BACKEND = ["SoundFileChooser", "TweenChooser", "EffectChooser", "DateChooser", "TimeChooser", "Keybinding"]
 
 class BinFileMonitor(GObject.GObject):
     __gsignals__ = {


### PR DESCRIPTION
So far this only affects the settings-example applet, but it will cause breakages if someone tries to use this in another applet.