### PR TITLE
St: Make the theme follow the default font

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -3,7 +3,6 @@
  * ... contains a few cinnamon specific styles (rare occurrences)
  * ###################################################################*/
 stage {
-    font-family: sans, sans-serif;
 }
 .cinnamon-link {
     color: #0000ff;

--- a/src/Makefile-st.am
+++ b/src/Makefile-st.am
@@ -68,6 +68,7 @@ st_source_h =					\
 	st/st-scrollable.h			\
 	st/st-scroll-bar.h			\
 	st/st-scroll-view.h			\
+	st/st-settings.h            \
 	st/st-shadow.h				\
 	st/st-table.h				\
 	st/st-table-child.h			\
@@ -125,6 +126,7 @@ st_source_c =					\
 	st/st-scrollable.c			\
 	st/st-scroll-bar.c			\
 	st/st-scroll-view.c			\
+	st/st-settings.c            \
 	st/st-shadow.c				\
 	st/st-table.c				\
 	st/st-table-child.c			\

--- a/src/st/st-settings.c
+++ b/src/st/st-settings.c
@@ -1,0 +1,143 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+/*
+ * st-settings.c: Global settings
+ *
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU Lesser General Public License,
+ * version 2.1, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <gio/gio.h>
+
+#include "st-settings.h"
+
+#define KEY_FONT_NAME "font-name"
+
+enum {
+    PROP_0,
+    PROP_FONT_NAME,
+    N_PROPS
+};
+
+GParamSpec *props[N_PROPS] = { 0 };
+
+struct _StSettings
+{
+  GObject parent_object;
+  GSettings *interface_settings;
+
+  gchar *font_name;
+};
+
+G_DEFINE_TYPE (StSettings, st_settings, G_TYPE_OBJECT)
+
+static void
+st_settings_finalize (GObject *object)
+{
+  StSettings *settings = ST_SETTINGS (object);
+
+  g_object_unref (settings->interface_settings);
+  g_free (settings->font_name);
+
+  G_OBJECT_CLASS (st_settings_parent_class)->finalize (object);
+}
+
+static void
+st_settings_set_property (GObject      *object,
+                          guint         prop_id,
+                          const GValue *value,
+                          GParamSpec   *pspec)
+{
+  G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+}
+
+static void
+st_settings_get_property (GObject    *object,
+                          guint       prop_id,
+                          GValue     *value,
+                          GParamSpec *pspec)
+{
+  StSettings *settings = ST_SETTINGS (object);
+
+  switch (prop_id)
+    {
+    case PROP_FONT_NAME:
+      g_value_set_string (value, settings->font_name);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+st_settings_class_init (StSettingsClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->finalize = st_settings_finalize;
+  object_class->set_property = st_settings_set_property;
+  object_class->get_property = st_settings_get_property;
+
+  props[PROP_FONT_NAME] = g_param_spec_string ("font-name",
+                                               "font name",
+                                               "font name",
+                                               "",
+                                               G_PARAM_READABLE);
+
+  g_object_class_install_properties (object_class, N_PROPS, props);
+}
+
+static void
+on_interface_settings_changed (GSettings   *g_settings,
+                               const gchar *key,
+                               StSettings  *settings)
+{
+  if (g_str_equal (key, KEY_FONT_NAME))
+    {
+      g_free (settings->font_name);
+      settings->font_name = g_settings_get_string (g_settings, key);
+      g_object_notify_by_pspec (G_OBJECT (settings), props[PROP_FONT_NAME]);
+    }
+}
+
+static void
+st_settings_init (StSettings *settings)
+{
+  settings->interface_settings = g_settings_new ("org.cinnamon.desktop.interface");
+  g_signal_connect (settings->interface_settings, "changed",
+                    G_CALLBACK (on_interface_settings_changed), settings);
+
+  settings->font_name = g_settings_get_string (settings->interface_settings, KEY_FONT_NAME);
+}
+
+/**
+ * st_settings_get:
+ *
+ * Gets the #StSettings
+ *
+ * Returns: (transfer none): a settings object
+ **/
+StSettings *
+st_settings_get (void)
+{
+  static StSettings *settings = NULL;
+
+  if (!settings)
+    settings = g_object_new (ST_TYPE_SETTINGS, NULL);
+
+  return settings;
+}

--- a/src/st/st-settings.h
+++ b/src/st/st-settings.h
@@ -1,0 +1,38 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+/*
+ * st-settings.h: Global settings
+ *
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU Lesser General Public License,
+ * version 2.1, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#if !defined(ST_H_INSIDE) && !defined(ST_COMPILATION)
+#error "Only <st/st.h> can be included directly.h"
+#endif
+
+#ifndef __ST_SETTINGS_H__
+#define __ST_SETTINGS_H__
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define ST_TYPE_SETTINGS (st_settings_get_type ())
+G_DECLARE_FINAL_TYPE (StSettings, st_settings, ST, SETTINGS, GObject)
+
+StSettings * st_settings_get (void);
+
+G_END_DECLS
+
+#endif /* __ST_SETTINGS_H__ */

--- a/src/st/st-theme-context.c
+++ b/src/st/st-theme-context.c
@@ -21,6 +21,7 @@
 
 #include <config.h>
 
+#include "st-settings.h"
 #include "st-texture-cache.h"
 #include "st-theme.h"
 #include "st-theme-context.h"
@@ -42,8 +43,6 @@ struct _StThemeContextClass {
   GObjectClass parent_class;
 };
 
-#define DEFAULT_FONT "sans-serif 10"
-
 enum
 {
   PROP_0,
@@ -61,6 +60,10 @@ static guint signals[LAST_SIGNAL] = { 0, };
 
 G_DEFINE_TYPE (StThemeContext, st_theme_context, G_TYPE_OBJECT);
 
+static PangoFontDescription *get_interface_font_description (void);
+static void on_font_name_changed (StSettings     *settings,
+                                  GParamSpec     *pspec,
+                                  StThemeContext *context);
 static void on_icon_theme_changed (StTextureCache *cache,
                                    StThemeContext *context);
 
@@ -80,6 +83,9 @@ st_theme_context_finalize (GObject *object)
 {
   StThemeContext *context = ST_THEME_CONTEXT (object);
 
+  g_signal_handlers_disconnect_by_func (st_settings_get (),
+                                        (gpointer) on_font_name_changed,
+                                        context);
   g_signal_handlers_disconnect_by_func (st_texture_cache_get_default (),
                                        (gpointer) on_icon_theme_changed,
                                        context);
@@ -134,8 +140,12 @@ st_theme_context_class_init (StThemeContextClass *klass)
 static void
 st_theme_context_init (StThemeContext *context)
 {
-  context->font = pango_font_description_from_string (DEFAULT_FONT);
+  context->font = get_interface_font_description ();
 
+  g_signal_connect (st_settings_get (),
+                    "notify::font-name",
+                    G_CALLBACK (on_font_name_changed),
+                    context);
   g_signal_connect (st_texture_cache_get_default (),
                     "icon-theme-changed",
                     G_CALLBACK (on_icon_theme_changed),
@@ -217,6 +227,16 @@ st_theme_context_new (void)
   return context;
 }
 
+static PangoFontDescription *
+get_interface_font_description (void)
+{
+  StSettings *settings = st_settings_get ();
+  g_autofree char *font_name = NULL;
+
+  g_object_get (settings, "font-name", &font_name, NULL);
+  return pango_font_description_from_string (font_name);
+}
+
 static void
 on_stage_destroy (ClutterStage *stage)
 {
@@ -237,6 +257,17 @@ st_theme_context_changed (StThemeContext *context)
 
   if (old_root)
     g_object_unref (old_root);
+}
+
+static void
+on_font_name_changed (StSettings     *settings,
+                      GParamSpec     *pspect,
+                      StThemeContext *context)
+{
+  PangoFontDescription *font_desc = get_interface_font_description ();
+  st_theme_context_set_font (context, font_desc);
+
+  pango_font_description_free (font_desc);
 }
 
 static gboolean


### PR DESCRIPTION
This will allow cinnamon themed elements to use the default font set in the
settings. It can still be overridden in the themes css.

* Add a st-settings object to track the font changes
* Use the interface settings instead of a default font in the theme context
* Stop setting a font-family in the default theme

Based on work in gnome shell by Florian Mullner and Carlos Garnacho