### PR TITLE
python 3.8: fix all flake8 F632 errors

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-desktop-editor/cinnamon-desktop-editor.py
+++ b/files/usr/share/cinnamon/cinnamon-desktop-editor/cinnamon-desktop-editor.py
@@ -194,7 +194,7 @@ class LauncherEditor(ItemEditor):
     def resync_validity(self, *args):
         name_text = self.builder.get_object('name-entry').get_text().strip()
         exec_text = self.builder.get_object('exec-entry').get_text().strip()
-        name_valid = name_text is not ""
+        name_valid = name_text != ""
         exec_valid = self.validate_exec_line(exec_text)
         self.sync_widgets(name_valid, exec_valid)
 
@@ -236,7 +236,7 @@ class DirectoryEditor(ItemEditor):
 
     def resync_validity(self, *args):
         name_text = self.builder.get_object('name-entry').get_text().strip()
-        valid = (name_text is not "")
+        valid = (name_text != "")
         self.builder.get_object('ok').set_sensitive(valid)
 
     def load(self):
@@ -281,7 +281,7 @@ class CinnamonLauncherEditor(ItemEditor):
     def resync_validity(self, *args):
         name_text = self.builder.get_object('name-entry').get_text().strip()
         exec_text = self.builder.get_object('exec-entry').get_text().strip()
-        name_valid = name_text is not ""
+        name_valid = name_text != ""
         exec_valid = self.validate_exec_line(exec_text)
         self.sync_widgets(name_valid, exec_valid)
 

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/ChooserButtonWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/ChooserButtonWidgets.py
@@ -331,13 +331,13 @@ class TimeChooserButton(Gtk.Button):
     def __init__(self, follow_current=False, time=None, show_seconds='default'):
         super(TimeChooserButton, self).__init__()
 
-        if show_seconds is 'default':
+        if show_seconds == 'default':
             self.show_seconds_override_default = False
         else:
             self.show_seconds_override_default = True
-            if show_seconds is 'true':
+            if show_seconds == 'true':
                 self.show_seconds = True
-            elif show_seconds is 'false':
+            elif show_seconds == 'false':
                 self.show_seconds = False
             else:
                 raise ValueError('Invalid argument: show_seconds must be default, true, or false')

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py
@@ -239,7 +239,7 @@ class JSONSettingsRevealer(Gtk.Revealer):
                 break
 
         if self.key is None:
-            if key[:1] is '!':
+            if key[:1] == '!':
                 self.invert = True
                 self.key = key[1:]
             else:

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_keyboard.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_keyboard.py
@@ -419,7 +419,7 @@ class Module:
             categories, iter = tree.get_selection().get_selected()
             if iter:
                 category = categories[iter][2]
-                if category.int_name is not "custom":
+                if category.int_name != "custom":
                     for keybinding in category.keybindings:
                         self.kb_store.append((keybinding.label, keybinding))
                 else:
@@ -428,7 +428,7 @@ class Module:
 
     def loadCustoms(self):
         for category in self.main_store:
-            if category.int_name is "custom":
+            if category.int_name == "custom":
                 category.clear()
 
         parent = Gio.Settings.new(CUSTOM_KEYS_PARENT_SCHEMA)
@@ -443,7 +443,7 @@ class Module:
                                          schema.get_strv("binding"))
             self.kb_store.append((custom_kb.label, custom_kb))
             for category in self.main_store:
-                if category.int_name is "custom":
+                if category.int_name == "custom":
                     category.add(custom_kb)
 
     def onKeyBindingChanged(self, tree):
@@ -453,7 +453,7 @@ class Module:
             if iter:
                 keybinding = keybindings[iter][1]
                 for entry in keybinding.entries:
-                    if entry is not "_invalid_":
+                    if entry != "_invalid_":
                         self.entry_store.append((entry,))
                 self.remove_custom_button.set_property('sensitive', isinstance(keybinding, CustomKeyBinding))
 
@@ -536,7 +536,7 @@ class Module:
         new_schema.set_strv("binding", ())
         i = 0
         for cat in self.cat_store:
-            if cat[2].int_name is "custom":
+            if cat[2].int_name == "custom":
                 self.cat_tree.set_cursor(str(i), self.cat_tree.get_column(0), False)
             i += 1
         i = 0
@@ -574,7 +574,7 @@ class Module:
 
         i = 0
         for cat in self.cat_store:
-            if cat[2].int_name is "custom":
+            if cat[2].int_name == "custom":
                 self.cat_tree.set_cursor(str(i), self.cat_tree.get_column(0), False)
             i += 1
 
@@ -600,7 +600,7 @@ class Module:
 
                 i = 0
                 for cat in self.cat_store:
-                    if cat[2].int_name is "custom":
+                    if cat[2].int_name == "custom":
                         self.cat_tree.set_cursor(str(i), self.cat_tree.get_column(0), False)
                     i += 1
                 i = 0
@@ -691,7 +691,7 @@ class KeyBinding():
     def writeSettings(self):
         array = []
         for entry in self.entries:
-            if entry is not "":
+            if entry != "":
                 array.append(entry)
         self.settings.set_strv(self.key, array)
 
@@ -731,7 +731,7 @@ class CustomKeyBinding():
 
         array = []
         for entry in self.entries:
-            if entry is not "":
+            if entry != "":
                 array.append(entry)
         settings.set_strv("binding", array)
 
@@ -777,6 +777,5 @@ class AddCustomDialog(Gtk.Dialog):
         self.command_entry.set_text(path)
 
     def onEntriesChanged(self, widget):
-        ok_enabled = self.name_entry.get_text().strip() is not "" and self.command_entry.get_text().strip() is not ""
+        ok_enabled = self.name_entry.get_text().strip() != "" and self.command_entry.get_text().strip() != ""
         self.set_response_sensitive(Gtk.ResponseType.OK, ok_enabled)
-        

--- a/files/usr/share/cinnamon/cinnamon-slideshow/cinnamon-slideshow.py
+++ b/files/usr/share/cinnamon/cinnamon-slideshow/cinnamon-slideshow.py
@@ -118,7 +118,7 @@ class CinnamonSlideshow(dbus.service.Object):
         def on_next_file_complete(obj, res, user_data=all_files):
             files = obj.next_files_finish(res)
             file_list = all_files
-            if len(files) is not 0:
+            if len(files) != 0:
                 file_list = file_list.extend(files)
                 enumerator.next_files_async(100, GLib.PRIORITY_LOW, None, on_next_file_complete, None)
             else:


### PR DESCRIPTION
In https://bugs.python.org/issue34850 using `is` with a literal became a SyntaxWarning at runtime. It was always wrong, and abused implementation details of CPython, but now it also tells ordinary users about it.
Loudly.