### PR TITLE
extension.js: Remove multicore-sys-monitor@ccadeptic23 from knownCinnamon4Conflicts list

### DIFF
--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -29,7 +29,6 @@ var knownCinnamon4Conflicts = [
     'turbonote@iksws.com.b',
     'vnstat@linuxmint.com',
     'netusagemonitor@pdcurtis',
-    'multicore-sys-monitor@ccadeptic23',
     // Desklets
     'netusage@30yavash.com',
     'simple-system-monitor@ariel'


### PR DESCRIPTION
This applet doesn't use old `import.gi.NMClient` since Cinnamon 4.0, so it should be removed from the knownCinnamon4Conflicts list.