### PR TITLE
cs_sound.py: Allow previewing the sound even when disabled

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_sound.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_sound.py
@@ -410,7 +410,6 @@ class Effect(GSettingsSoundFileChooser):
         sizeGroup.add_widget(self.content_widget)
 
         self.settings.bind(self.enabled_key, self.enabled_switch, "active", Gio.SettingsBindFlags.DEFAULT)
-        self.settings.bind(self.enabled_key, self.content_widget, "sensitive", Gio.SettingsBindFlags.DEFAULT)
 
 class SoundTest(Gtk.Dialog):
     def __init__(self, parent, stream):


### PR DESCRIPTION
It should be possible to try the sounds out without having to enable them to
see if you actually want to use them.

Closes https://github.com/linuxmint/cinnamon/issues/8187