### PR TITLE
cs_backgrounds.py: Remove "screenshot" from the keywords

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_backgrounds.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_backgrounds.py
@@ -165,7 +165,7 @@ class Module:
     comment = _("Change your desktop's background")
 
     def __init__(self, content_box):
-        keywords = _("background, picture, screenshot, slideshow")
+        keywords = _("background, picture, slideshow")
         self.sidePage = SidePage(_("Backgrounds"), "cs-backgrounds", keywords, content_box, module=self)
 
     def on_module_selected(self):


### PR DESCRIPTION
It causes it to be the first item listed in the cinnamon menu when you open
and search for screenshot and it's hardly ever going to be what you actually
want.