### PR TITLE
Add 2-second screensaver lock delay option

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_screensaver.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_screensaver.py
@@ -14,6 +14,7 @@ from xapp.GSettingsWidgets import *
 
 LOCK_DELAY_OPTIONS = [
     (0, _("Lock immediately")),
+    (2, _("2 seconds")),
     (15, _("15 seconds")),
     (30, _("30 seconds")),
     (60, _("1 minute")),


### PR DESCRIPTION
The pull request to add an input for the delay before locking (#7577) was not merged, so here's something else.

At the moment you can choose no lock delay or, at the minimum, a 15-second lock delay. The only situation I use the delayed locking feature for is when I notice immediately that the screensaver has kicked in and don't want it to go to the lock screen. In that situation, 15 seconds is far too long and 0 seconds is obviously too short, so there should be an option between them. This pull request adds a 2-second option.

What do you think?