### PR TITLE
workspace-osd: Simplify and reuse the InfoOSD

### DIFF
--- a/data/org.cinnamon.gschema.xml.in
+++ b/data/org.cinnamon.gschema.xml.in
@@ -428,32 +428,6 @@
       </_description>
     </key>
     
-    <key type="i" name="workspace-osd-duration">
-      <default>400</default>
-      <_summary>Duration of Workspace OSD (in milliseconds)</_summary>
-      <_description>
-       Duration of the OSD (in milliseconds)    
-      </_description>
-    </key>
-    
-    <key type="i" name="workspace-osd-x">
-      <range min="5" max="95" />
-      <default>50</default>
-      <_summary>Workspace horizontal position (in percent of the monitor's width)</_summary>
-      <_description>
-       Workspace horizontal position (in percent of the monitor's width)   
-      </_description>
-    </key>
-    
-    <key type="i" name="workspace-osd-y">
-      <range min="5" max="95" />
-      <default>50</default>
-      <_summary>Workspace vertical position (in percent of the monitor's height)</_summary>
-      <_description>
-       Workspace vertical position (in percent of the monitor's height)
-      </_description>
-    </key>
-    
     <key name="workspace-osd-visible" type="b">
       <default>true</default>
       <_summary>Enable or disable the workspace OSD</_summary>

--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -859,6 +859,12 @@ StScrollBar StButton#vhandle:hover {
     text-align: center;
 }
 
+.workspace-osd {
+    color: #ffffff;
+    font-weight: bold;
+    font-size: 3em;
+}
+
 /* ===================================================================
  * Run dialog
  * ===================================================================*/
@@ -1734,17 +1740,6 @@ StScrollBar StButton#vhandle:hover {
  * Clock Desklet (desklet.js)
  * ===================================================================*/
 .clock-desklet-label {
-}
-
-/* ===================================================================
- * Workspace OSD
- * ===================================================================*/
-
-.workspace-osd {
-    color: #ffffff;
-    text-shadow: black 5px 5px 5px;
-    font-weight: bold;
-    font-size: 4em;
 }
 
 .expo-workspaces-name-entry {

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_workspaces.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_workspaces.py
@@ -21,36 +21,13 @@ class Module:
         if not self.loaded:
             print("Loading Workspaces module")
 
-            self.sidePage.stack = SettingsStack()
-            self.sidePage.add_widget(self.sidePage.stack)
-
-            # OSD
-
             page = SettingsPage()
+            self.sidePage.add_widget(page)
 
-            switch = GSettingsSwitch("", "org.cinnamon", "workspace-osd-visible")
-            switch.label.set_markup("<b>%s</b>" % _("Enable workspace OSD"))
-            switch.fill_row()
-            page.add(switch)
+            settings = page.add_section(_("Workspace Options"))
 
-            settings = page.add_reveal_section(_("On-Screen Display (OSD)"), "org.cinnamon", "workspace-osd-visible")
-
-            spin = GSettingsSpinButton(_("Workspace OSD duration"), "org.cinnamon", "workspace-osd-duration", mini=0, maxi=2000, step=50, page=400, units=_("milliseconds"))
-            settings.add_row(spin)
-
-            spin = GSettingsSpinButton(_("Workspace OSD horizontal position"), "org.cinnamon", "workspace-osd-x", mini=0, maxi=100, step=5, page=50, units=_("percent of the monitor's width"))
-            settings.add_row(spin)
-
-            spin = GSettingsSpinButton(_("Workspace OSD vertical position"), "org.cinnamon", "workspace-osd-y", mini=0, maxi=100, step=5, page=50, units=_("percent of the monitor's height"))
-            settings.add_row(spin)
-
-            self.sidePage.stack.add_titled(page, "osd", _("OSD"))
-
-            # Settings
-
-            page = SettingsPage()
-
-            settings = page.add_section(_("Miscellaneous Options"))
+            switch = GSettingsSwitch(_("Enable workspace OSD"), "org.cinnamon", "workspace-osd-visible")
+            settings.add_row(switch)
 
             switch = GSettingsSwitch(_("Allow cycling through workspaces"), "org.cinnamon.muffin", "workspace-cycle")
             settings.add_row(switch)
@@ -69,5 +46,3 @@ class Module:
 
             switch = GSettingsSwitch(_("Invert the left and right arrow key directions used to shift workspaces during a window drag"), "org.cinnamon.muffin", "invert-workspace-flip-direction")
             settings.add_row(switch)
-
-            self.sidePage.stack.add_titled(page, "settings", _("Settings"))


### PR DESCRIPTION
Remove all the custom placement settings and reuse the existing InfoOSD
dialog. Using the dialog with the background makes it much easier to read
against the open window backgrounds.