### PR TITLE
modalDialog: Quiet an ES6 warning

### DIFF
--- a/js/ui/modalDialog.js
+++ b/js/ui/modalDialog.js
@@ -19,9 +19,10 @@ const Tweener = imports.ui.tweener;
 
 const Gettext = imports.gettext;
 
-const OPEN_AND_CLOSE_TIME = 0.1;
 const FADE_IN_BUTTONS_TIME = 0.33;
 const FADE_OUT_DIALOG_TIME = 1.0;
+
+var OPEN_AND_CLOSE_TIME = 0.1;
 
 var State = {
     OPENED: 0,


### PR DESCRIPTION
We now access OPEN_AND_CLOSE_TIME outside of modalDialog.js so we need to
declare this with var instead of const