### PR TITLE
Add `Activate, then cycle` to grouped window list

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -750,7 +750,24 @@ class AppGroup {
                 return;
             }
             if (this.state.settings.leftClickAction === 3 && nWindows > 1) {
-                this.state.trigger('cycleWindows', null, this.actor._delegate);
+                let foundActive = false;
+                for (let i = 0, len = nWindows; i < len; i++) {
+                    if (
+                        this.groupState.lastFocused &&
+                        this.groupState.metaWindows[i] === this.groupState.lastFocused
+                    ) {
+                        if (this.groupState.metaWindows[i].appears_focused) {
+                            this.state.trigger("cycleWindows", null, this.actor._delegate);
+                        } else {
+                            handleMinimizeToggle(this.groupState.metaWindows[i]);
+                        }
+                        foundActive = true;
+                        break;
+                    }
+                }
+                if (!foundActive) {
+                    handleMinimizeToggle(this.groupState.metaWindows[0]);
+                }
                 return;
             }
             if (this.hoverMenu) this.hoverMenu.shouldOpen = false;


### PR DESCRIPTION
Hi, I feel that the `cycle` option in the `grouped window list` applet should activate the application (if it doesn't have focus) on first click, then cycle the windows on subsequent clicks. However, since some people may depend on the current workflow, I've added it as an option: `Activate, then cycle`.

My rationale for this mode is as follows.  The current `switch windows` works like this:
* Say I've got two Firefox windows, 1 and 2, and a Terminal window. 
* I'm working in Firefox window __1__, then I need to do something in terminal, so I click its icon.
* Terminal activates, all is well. I need to go back to firefox, so I click its icon.
* Firefox __2__ comes to the front, and I'm confused, why am I seeing a different window suddenly?

For this reason I feel that the first click should active, but then you can quickly cycle windows by clicking again.

I realise some people may feel strongly about this, so please let me know your thoughts!

Edit: you can quickly try this by using the renamed extension I made: https://github.com/Epskampie/grouped-window-list-epskampie