### PR TITLE
Sound applet: close the menu when a player is launched

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -834,11 +834,11 @@ class MediaPlayerLauncher extends PopupMenu.PopupBaseMenuItem {
         this.addActor(this.label);
         this._icon = app.create_icon_texture(ICON_SIZE);
         this.addActor(this._icon, { expand: false });
+        this.connect("activate", (event) => this._onActivate(event).get_time());
     }
 
-    //note: shadows base method and prevents "activate" emission
-    activate(event, keepMenu) {
-        this._app.activate_full(-1, event.get_time());
+    _onActivate(time) {
+        this._app.activate_full(-1, time);
     }
 }
 


### PR DESCRIPTION
This fixes a regression in 93e85cd055bd6f7bddbb734255774e73e6167121. The intention presumably was to avoid emitting a signal unnecessarily, but the 'activate' signal is used by the menu structure to know when to close the menu, so we really do need to use it.