### PR TITLE
[removable-drives@cinnamon] Close the menu when the eject button is activated

### DIFF
--- a/files/usr/share/cinnamon/applets/removable-drives@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/removable-drives@cinnamon.org/applet.js
@@ -9,10 +9,11 @@ const PopupMenu = imports.ui.popupMenu;
 const PANEL_EDIT_MODE_KEY = "panel-edit-mode";
 
 class DriveMenuItem extends PopupMenu.PopupBaseMenuItem {
-    constructor(place) {
+    constructor(place, applet) {
         super();
 
         this.place = place;
+        this.applet = applet;
 
         this.label = new St.Label({ text: place.name });
         this.addActor(this.label);
@@ -26,6 +27,7 @@ class DriveMenuItem extends PopupMenu.PopupBaseMenuItem {
     }
 
     _eject() {
+        this.applet.menu.toggle();
         this.place.remove();
     }
 
@@ -84,7 +86,7 @@ class CinnamonRemovableDrivesApplet extends Applet.IconApplet {
         let any = false;
         for (let i = 0; i < mounts.length; i++) {
             if (mounts[i].isRemovable()) {
-                this._contentSection.addMenuItem(new DriveMenuItem(mounts[i]));
+                this._contentSection.addMenuItem(new DriveMenuItem(mounts[i], this));
                 any = true;
             }
         }


### PR DESCRIPTION
Until now, any action closed the menu of this applet, except the "unmount" action.

This PR is made so that the menu of this applet does not remain open after the user has clicked on the unmount button.