### PR TITLE
Makefile.am: simplify libcinnamon's dependendies

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -227,11 +227,6 @@ libcinnamon_libadd =		\
 	$(CINNAMON_LIBS)	\
 	libst-1.0.la       	\
 	libtray.la \
-	$(libdir)/muffin/libmuffin-clutter-0.so \
-	$(libdir)/muffin/libmuffin-cogl-0.so \
-	$(libdir)/muffin/libmuffin-cogl-pango-0.so \
-	$(libdir)/muffin/libmuffin-cogl-path-0.so \
-	$(MUFFIN_LIBS)
 	$(NULL)
 
 libcinnamon_la_LDFLAGS = $(WARN_LDFLAGS) -avoid-version -L$(libdir)/muffin


### PR DESCRIPTION
All of libmuffin-* will be detected and substituted into CINNAMON_LIBS
during configure stage by PKG_CHECK_MODULES(CINNAMON).

List them again is redundant, and we will run into trouble on cross
compiling.

Simplify the Makefile.am by removing it.

This will also fix the broken cross build.
See: https://github.com/void-linux/void-packages/pull/18826