### PR TITLE
grouped-window-list@cinnamon.org: Support disabling super+number

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -317,6 +317,7 @@ class GroupedWindowListApplet extends Applet.Applet {
             {key: 'left-click-action', value: 'leftClickAction', cb: null},
             {key: 'show-apps-order-hotkey', value: 'showAppsOrderHotkey', cb: this.bindAppKeys},
             {key: 'show-apps-order-timeout', value: 'showAppsOrderTimeout', cb: null},
+            {key: 'super-num-hotkeys', value: 'SuperNumHotkeys', cb: this.bindAppKeys},
             {key: 'cycleMenusHotkey', value: 'cycleMenusHotkey', cb: this.bindAppKeys},
             {key: 'enable-hover-peek', value: 'enablePeek', cb: null},
             {key: 'onclick-thumbnails', value: 'onClickThumbs', cb: null},
@@ -444,7 +445,10 @@ class GroupedWindowListApplet extends Applet.Applet {
         this.unbindAppKeys();
 
         for (let i = 1; i < 10; i++) {
-            this.bindAppKey(i);
+            if (this.state.settings.SuperNumHotkeys) {
+                this.bindAppKey(i);
+            }
+            this.bindNewAppKey(i);
         }
         Main.keybindingManager.addHotKey('launch-show-apps-order', this.state.settings.showAppsOrderHotkey, () =>
             this.showAppsOrder()
@@ -465,6 +469,9 @@ class GroupedWindowListApplet extends Applet.Applet {
 
     bindAppKey(i) {
         Main.keybindingManager.addHotKey('launch-app-key-' + i, '<Super>' + i, () => this.onAppKeyPress(i));
+    }
+
+    bindNewAppKey(i) {
         Main.keybindingManager.addHotKey('launch-new-app-key-' + i, '<Super><Shift>' + i, () =>
             this.onNewAppKeyPress(i)
         );

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/settings-schema.json
@@ -50,7 +50,8 @@
       "keys": [
         "cycleMenusHotkey",
         "show-apps-order-hotkey",
-        "show-apps-order-timeout"
+        "show-apps-order-timeout",
+        "super-num-hotkeys"
       ]
     },
     "thumbnailsSection": {
@@ -182,6 +183,11 @@
     "step": 10,
     "units": "milliseconds",
     "description": "Duration of the apps order display on hotkey press"
+  },
+  "super-num-hotkeys": {
+    "type": "checkbox",
+    "default": true,
+    "description": "Enable Super+<number> shortcut to switch/open apps"
   },
   "thumbnail-timeout": {
     "dependency": "!onclick-thumbnails",


### PR DESCRIPTION
Add configuration option for disabling `<Super> + number` hotkeys. Useful in cases when super+number is used for switching workspaces.