### PR TITLE
cinnamon-util.c: Fix icon fetching for known folders

### DIFF
--- a/src/cinnamon-util.c
+++ b/src/cinnamon-util.c
@@ -203,17 +203,23 @@ cinnamon_util_get_icon_for_uri_known_folders (const char *uri)
 
   path = g_filename_from_uri (uri, NULL, NULL);
 
-  len = strlen (path);
-  if (path[len] == '/')
-    path[len] = '\0';
+  if (!path)
+    return NULL;
 
   if (strcmp (path, "/") == 0)
     icon = "drive-harddisk";
-  else if (strcmp (path, g_get_home_dir ()) == 0)
-    icon = "user-home";
-  else if (strcmp (path, g_get_user_special_dir (G_USER_DIRECTORY_DESKTOP))
-      == 0)
-    icon = "user-desktop";
+  else {
+    if (g_str_has_suffix (path, "/")) {
+      len = strlen (path);
+      path[len - 1] = '\0';
+    }
+
+    if (strcmp (path, g_get_home_dir ()) == 0)
+      icon = "user-home";
+    else if (strcmp (path, g_get_user_special_dir (G_USER_DIRECTORY_DESKTOP))
+        == 0)
+      icon = "user-desktop";
+  }
 
   g_free (path);
 


### PR DESCRIPTION
This fixes 2 things:
- Trailing slashes never got deleted
- the variable path could be NULL, in which case the rest would be superfluous