### PR TITLE
xlet-about-dialog: fix spices translations

### DIFF
--- a/files/usr/bin/xlet-about-dialog
+++ b/files/usr/bin/xlet-about-dialog
@@ -15,6 +15,8 @@ usage : xlet-about-dialog applets/desklets/extensions uuid
 
 gettext.install('cinnamon', '/usr/share/locale')
 
+home = os.path.expanduser('~')
+
 class AboutDialog(Gtk.AboutDialog):
     def __init__(self, metadata, stype):
         super(AboutDialog, self).__init__()
@@ -36,7 +38,7 @@ class AboutDialog(Gtk.AboutDialog):
 
         comments = self._(self.metadata['description'])
         if 'comments' in self.metadata:
-            comments += '\n' + self.metadata['comments']
+            comments += '\n\n' + self._(self.metadata['comments'])
         self.props.comments = comments
 
         s_id = self.get_spices_id()
@@ -47,7 +49,7 @@ class AboutDialog(Gtk.AboutDialog):
         if 'contributors' in self.metadata:
             self.props.authors = self.metadata['contributors'].split(',')
 
-        self.props.program_name = '%s (%s)' % (self.metadata['name'], self.metadata['uuid'])
+        self.props.program_name = '%s (%s)' % (self._(self.metadata['name']), self.metadata['uuid'])
 
         self.connect('response', self.close)
         self.show()
@@ -69,6 +71,7 @@ class AboutDialog(Gtk.AboutDialog):
 
 
     def _(self, msg):
+        gettext.bindtextdomain(self.metadata['uuid'], home + '/.local/share/locale')
         translation = gettext.dgettext(self.metadata['uuid'], msg)
         # try with cinnamon domain if the xlet domain doesn't work
         if translation == msg:
@@ -78,7 +81,7 @@ class AboutDialog(Gtk.AboutDialog):
 
     def get_spices_id(self):
         try:
-            cache_path = os.path.join(os.path.expanduser('~'), '.cinnamon', 'spices.cache', self.stype[0:-1], 'index.json')
+            cache_path = os.path.join(home, '.cinnamon', 'spices.cache', self.stype[0:-1], 'index.json')
             if os.path.exists(cache_path):
                 with open(cache_path, 'r') as cache_file:
                     index_cache = json.load(cache_file)
@@ -100,7 +103,7 @@ if __name__ == "__main__":
 
     suffix = 'share/cinnamon/%s/%s' % (xlet_type, uuid)
     prefixes = [
-        os.path.join(os.path.expanduser('~'), '.local'),
+        os.path.join(home, '.local'),
         '/usr'
     ]
 

--- a/makepot
+++ b/makepot
@@ -7,7 +7,7 @@ xgettext --language=C --keyword=_ --keyword=N_ --output=cinnamon.pot src/*.c src
 find files/usr/share/cinnamon -name "*.ui.h" -exec xgettext --language=C --keyword=_ --keyword=N_ --output=cinnamon.pot --join-existing {} \;
 
 xgettext --language=JavaScript --keyword=_ --keyword=N_ --output=cinnamon.pot --join-existing --from-code=UTF-8 js/*/*.js files/usr/share/cinnamon/*/*/*.js
-xgettext -c --language=Python --keyword=_ --output=cinnamon.pot --join-existing generate_additional_files.py files/usr/share/cinnamon/*/*.py files/usr/share/cinnamon/*/*/*.py files/usr/bin/cinnamon-launcher
+xgettext -c --language=Python --keyword=_ --output=cinnamon.pot --join-existing generate_additional_files.py files/usr/share/cinnamon/*/*.py files/usr/share/cinnamon/*/*/*.py files/usr/bin/cinnamon-launcher files/usr/bin/xlet-about-dialog
 files/usr/bin/cinnamon-xlet-makepot -j -p -o cinnamon.pot files/usr/share/cinnamon/applets/
 files/usr/bin/cinnamon-xlet-makepot -j -p -o cinnamon.pot files/usr/share/cinnamon/desklets/
 


### PR DESCRIPTION
this fixes a regression of the about dialog of non-builtin applets not being translated