### PR TITLE
If statement appears to serve no purpose

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -2466,11 +2466,6 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         this.mainBox._delegate = null;
 
         this.selectedAppBox = new St.BoxLayout({ style_class: 'menu-selected-app-box', vertical: true });
-
-        if (this.selectedAppBox.peek_theme_node() == null ||
-            this.selectedAppBox.get_theme_node().get_length('height') == 0)
-            this.selectedAppBox.set_height(30 * global.ui_scale);
-
         this.selectedAppTitle = new St.Label({ style_class: 'menu-selected-app-title', text: "" });
         this.selectedAppBox.add_actor(this.selectedAppTitle);
         this.selectedAppDescription = new St.Label({ style_class: 'menu-selected-app-description', text: "" });


### PR DESCRIPTION
This is my first attempt to make a change to someone else's code so feel free to give me feedback.
These 3 lines don't seem to have a purpose that I can see and I've checked at least 10 popular themes and they all work fine without them. Also, they appear to cause a bug: If the style value "height:" is set in the node of the css theme file, it makes no difference anyway, the height value is set to 30 regardless (I'm not sure way this is.) So If the text size (set in the css file) is too large, it disappears of the bottom - this is how I discovered the bug.