### PR TITLE
Fix "shutdown" typos

### DIFF
--- a/cinnamon.pot
+++ b/cinnamon.pot
@@ -801,7 +801,7 @@ msgid "Quit"
 msgstr ""
 
 #: files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js:2334
-msgid "Shutdown the computer"
+msgid "Shut down the computer"
 msgstr ""
 
 #: files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js:2393

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -2331,7 +2331,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         //Shutdown button
         button = new SystemButton(this, "system-shutdown",
                                   _("Quit"),
-                                  _("Shutdown the computer"));
+                                  _("Shut down the computer"));
 
         button.activate = () => {
             this.menu.close();

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_power.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_power.py
@@ -11,7 +11,7 @@ from xapp.GSettingsWidgets import *
 POWER_BUTTON_OPTIONS = [
     ("blank", _("Lock the screen")),
     ("suspend", _("Suspend")),
-    ("shutdown", _("Shutdown immediately")),
+    ("shutdown", _("Shut down immediately")),
     ("hibernate", _("Hibernate")),
     ("interactive", _("Ask what to do")),
     ("nothing", _("Do nothing"))
@@ -606,7 +606,7 @@ def get_available_options(up_client):
 
     lid_options = [
         ("suspend", _("Suspend")),
-        ("shutdown", _("Shutdown immediately")),
+        ("shutdown", _("Shut down immediately")),
         ("hibernate", _("Hibernate")),
         ("blank", _("Lock Screen")),
         ("nothing", _("Do nothing"))
@@ -615,14 +615,14 @@ def get_available_options(up_client):
     button_power_options = [
         ("blank", _("Lock Screen")),
         ("suspend", _("Suspend")),
-        ("shutdown", _("Shutdown immediately")),
+        ("shutdown", _("Shut down immediately")),
         ("hibernate", _("Hibernate")),
         ("interactive", _("Ask")),
         ("nothing", _("Do nothing"))
     ]
 
     critical_options = [
-        ("shutdown", _("Shutdown immediately")),
+        ("shutdown", _("Shut down immediately")),
         ("hibernate", _("Hibernate")),
         ("nothing", _("Do nothing"))
     ]


### PR DESCRIPTION
Fix some "shutdown" uses from incorrect noun form "shutdown" to correct verb form "shut down".