### PR TITLE
[WIP] calendar@cinnamon.org: full time (with seconds) on top of the calendar

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -586,6 +586,10 @@ StScrollBar StButton#vhandle:hover {
     color: #cccccc;
     font-weight: bold;
 }
+.datemenu-time-label {
+  font-size: 200%;
+  padding-bottom: 0;
+}
 .calendar-day-base {
     text-align: center;
     width: 2.4em;

--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
@@ -145,7 +145,7 @@ class CinnamonCalendarApplet extends Applet.TextApplet {
         if (this.use_custom_format) {
             if (!this.clock.get_clock_for_format(this.custom_format)) {
                 global.logError("Calendar applet: bad time format string - check your string.");
-                this.clock.set_format_string("~CLOCK FORMAT ERROR~ %l:%M %p");
+                this._labelFormat = "~CLOCK FORMAT ERROR~ %l:%M %p";
             } else {
                 this._labelFormat = this.custom_format;
             }

--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
@@ -128,17 +128,17 @@ class CinnamonCalendarApplet extends Applet.TextApplet {
         let show_seconds = this.desktop_settings.get_boolean("clock-show-seconds");
 
         if (use_24h) {
-           this.clock.set_format_string(_("%H:%M:%S"));
-           this._labelFormat = "%H:%M";
+            this.clock.set_format_string(_("%H:%M:%S"));
+            this._labelFormat = "%H:%M";
         } else {
-           this.clock.set_format_string(_("%l:%M:%S"));
-           this._labelFormat = "%l:%M";
+            this.clock.set_format_string(_("%l:%M:%S"));
+            this._labelFormat = "%l:%M";
         }
         if (show_seconds) {
-           this._labelFormat += ":%S";
+            this._labelFormat += ":%S";
         }
         if (in_vertical_panel) {
-           this._labelFormat = this._labelFormat.replace(/:/g,"%n");
+            this._labelFormat = this._labelFormat.replace(/:/g, "%n");
         }
         this._labelFormat = _(this._labelFormat);
 

--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
@@ -138,22 +138,23 @@ class CinnamonCalendarApplet extends Applet.TextApplet {
            this._labelFormat += ":%S";
         }
         if (in_vertical_panel) {
-           this._labelFormat = this._labelFormat.replace(/:/g,"%n")
+           this._labelFormat = this._labelFormat.replace(/:/g,"%n");
         }
-        this._labelFormat = _(this._labelFormat)
+        this._labelFormat = _(this._labelFormat);
 
         if (this.use_custom_format) {
             if (!this.clock.get_clock_for_format(this.custom_format)) {
                 global.logError("Calendar applet: bad time format string - check your string.");
                 this.clock.set_format_string("~CLOCK FORMAT ERROR~ %l:%M %p");
+            } else {
+                this._labelFormat = this.custom_format;
             }
-        } else {
-            this._labelFormat = this.custom_format;
         }
     }
 
     _updateClockAndDate() {
         let timeFormatted = this.clock.get_clock();
+        timeFormatted = timeFormatted.capitalize();
         this._time.set_text(timeFormatted);
 
         let label_string = this.clock.get_clock_for_format(this._labelFormat);

--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
@@ -145,7 +145,7 @@ class CinnamonCalendarApplet extends Applet.TextApplet {
                 this._labelFormat += _(":%S");
             }
             if (in_vertical_panel) {
-                this._labelFormat = this._labelFormat.replace(/:/g,"%n")
+                this._labelFormat = this._labelFormat.replace(/:/g, "%n")
             }
         }
     }

--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
@@ -87,8 +87,6 @@ class CinnamonCalendarApplet extends Applet.TextApplet {
 
             this.clock_notify_id = 0;
 
-            this.clock.set_format_string("%X");
-
             // https://bugzilla.gnome.org/show_bug.cgi?id=655129
             this._upClient = new UPowerGlib.Client();
             try {
@@ -126,6 +124,23 @@ class CinnamonCalendarApplet extends Applet.TextApplet {
 
     _updateFormatString() {
         let in_vertical_panel = (this.orientation == St.Side.LEFT || this.orientation == St.Side.RIGHT);
+        let use_24h = this.desktop_settings.get_boolean("clock-use-24h");
+        let show_seconds = this.desktop_settings.get_boolean("clock-show-seconds");
+
+        if (use_24h) {
+           this.clock.set_format_string(_("%H:%M:%S"));
+           this._labelFormat = "%H:%M";
+        } else {
+           this.clock.set_format_string(_("%l:%M:%S"));
+           this._labelFormat = "%l:%M";
+        }
+        if (show_seconds) {
+           this._labelFormat += ":%S";
+        }
+        if (in_vertical_panel) {
+           this._labelFormat = this._labelFormat.replace(/:/g,"%n")
+        }
+        this._labelFormat = _(this._labelFormat)
 
         if (this.use_custom_format) {
             if (!this.clock.get_clock_for_format(this.custom_format)) {
@@ -133,20 +148,7 @@ class CinnamonCalendarApplet extends Applet.TextApplet {
                 this.clock.set_format_string("~CLOCK FORMAT ERROR~ %l:%M %p");
             }
         } else {
-            let use_24h = this.desktop_settings.get_boolean("clock-use-24h");
-            let show_seconds = this.desktop_settings.get_boolean("clock-show-seconds");
-
-            if (use_24h) {
-                this._labelFormat = _("%H:%M");
-            } else {
-                this._labelFormat = _("%l:%M");
-            }
-            if (show_seconds) {
-                this._labelFormat += _(":%S");
-            }
-            if (in_vertical_panel) {
-                this._labelFormat = this._labelFormat.replace(/:/g, "%n")
-            }
+            this._labelFormat = this.custom_format;
         }
     }
 
@@ -155,6 +157,9 @@ class CinnamonCalendarApplet extends Applet.TextApplet {
         this._time.set_text(timeFormatted);
 
         let label_string = this.clock.get_clock_for_format(this._labelFormat);
+        if (!this.use_custom_format) {
+            label_string = label_string.capitalize();
+        }
 
         this.set_applet_label(label_string);
 


### PR DESCRIPTION
Hi,

It might be more efficient from space utilization to display time without seconds in the task bar. Though, it is occasionally useful to have a full time with seconds. For comparison, all versions of Windows have these: older versions had an analog clock with the second hand, and the new versions have a digital clock with seconds.

This pull request addresses this need adding the full time on top of the calendar applet.

Cheers!