### PR TITLE
menu@cinnamon.org: alternative fix for jumpiness bug.

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1231,6 +1231,9 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
 
             this.lastSelectedCategory = null;
 
+            this.selectedAppBox.set_height(-1); //unset previously set height
+            this.selectedAppBox.set_height(this.selectedAppBox.get_preferred_height(-1)[1]);
+
             let n = Math.min(this._applicationsButtons.length,
                              INITIAL_BUTTON_LOAD);
             for (let i = 0; i < n; i++) {
@@ -2466,11 +2469,6 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         this.mainBox._delegate = null;
 
         this.selectedAppBox = new St.BoxLayout({ style_class: 'menu-selected-app-box', vertical: true });
-
-        if (this.selectedAppBox.peek_theme_node() == null ||
-            this.selectedAppBox.get_theme_node().get_length('height') == 0)
-            this.selectedAppBox.set_height(30 * global.ui_scale);
-
         this.selectedAppTitle = new St.Label({ style_class: 'menu-selected-app-title', text: "" });
         this.selectedAppBox.add_actor(this.selectedAppTitle);
         this.selectedAppDescription = new St.Label({ style_class: 'menu-selected-app-description', text: "" });


### PR DESCRIPTION
The current fix ([here](https://github.com/linuxmint/cinnamon/commit/08742aa68838f95c1de419c146f096d4c1a387d3)) to prevent "jumpiness" [#3144](https://github.com/linuxmint/cinnamon/issues/3144) when different scripts are used works by always setting the selectedAppBox height to 30 as get_theme_node().get_length('height') always seems to return 0 and get_theme_node().get_height() returns -1 meaning that selectedAppBox height is always set to 30. Also, fixing the selectedAppBox height upon applet initialization means that when the cinnamon theme, text scaling factor or user interface scaling are changed, the fixed height of selectedAppBox doesn't change until the applet is restarted. There's also the problem that setting the height of selectedAppBox in cinnamon theme files (.menu-selected-app-box) takes no account of text scaling factor so this should not be a preferred method anyway.

This alternative fix fixes these problems by setting the height to get_preferred_height() every time the menu is opened. Although strangely, when the menu is first opened after a change (eg. text scaling factor,) nothing happens until after the menu is opened for a second time. I don't know why this is. The line this.selectedAppBox.set_height(-1); is necessary to unset the previously set height. This means that the height setting in the theme css file is effectively ignored which I guess is a good thing because this setting was most likely only used as a fix for this bug anyway and would otherwise be a problem.