### PR TITLE
menu@cinnamon.org - allow end-user control of favorite, category and application icon sizes

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/settings-schema.json
@@ -25,7 +25,7 @@
         "menu-layout" : {
             "type" : "section",
             "title" : "Layout and content",
-            "keys" : ["show-category-icons", "show-application-icons", "favbox-show", "favbox-min-height", "show-places", "show-recents", "menu-editor-button"]
+            "keys" : ["show-category-icons", "category-icon-size", "show-application-icons", "application-icon-size", "favbox-show", "fav-icon-size", "favbox-min-height", "show-places", "show-recents", "menu-editor-button"]
         },
         "menu-behave" : {
             "type" : "section",
@@ -89,17 +89,50 @@
     "description" : "Show category icons",
     "tooltip" : "Choose whether or not to show icons on categories."
  },
+ "category-icon-size" : {
+    "type": "spinbutton",
+    "default" : 22,
+    "min" : 16,
+    "max" : 48,
+    "step" : 1,
+    "units" : "px",
+    "description" : "Categories icon size",
+    "dependency" : "show-category-icons",
+    "indent" : true
+ },
  "show-application-icons" : {
     "type" : "switch",
     "default" : true,
     "description" : "Show application icons",
     "tooltip" : "Choose whether or not to show icons on applications."
  },
+ "application-icon-size" : {
+    "type": "spinbutton",
+    "default" : 22,
+    "min" : 16,
+    "max" : 48,
+    "step" : 1,
+    "units" : "px",
+    "description" : "Applications icon size",
+    "dependency" : "show-application-icons",
+    "indent" : true
+ },
  "favbox-show" : {
     "type" : "switch",
     "default" : true,
     "description" : "Show favorites and session buttons",
     "tooltip" : "Choose whether or not to show the left pane of the menu."
+ },
+ "fav-icon-size" : {
+    "type": "spinbutton",
+    "default" : 32,
+    "min" : 16,
+    "max" : 64,
+    "step" : 1,
+    "units" : "px",
+    "description" : "Favorites icon size",
+    "dependency" : "favbox-show",
+    "indent" : true
  },
  "show-places" : {
     "type" : "switch",


### PR DESCRIPTION
Hi,

This removes the hardcoded icon sizes in-menu and allows the end user to configure in-menu icon sizes.

The 'magic' formula to resize favourites box icons was effectively obsoleted in any case when the option was added to control the minimum height of the favourites box and it was made scrollable several releases ago.

Application context menu icon sizes remain hardcoded - leave it like that?

I also had to hard code the Recents clear-items button icon-size as for reasons I couldn't work out the applet object wasn't recognised in the `refreshPlaces()` function where that button is added.
