### PR TITLE
flake8: remove useless double or unneeded imports

### DIFF
--- a/docs/reference/cinnamon-js/gen_doc.py
+++ b/docs/reference/cinnamon-js/gen_doc.py
@@ -47,7 +47,6 @@
 
 import sys
 import os
-import xml.etree.ElementTree as ET
 import re
 from gen_lib import *
 

--- a/docs/search-providers-examples/trackerprovider@cinnamon.org/search_provider.py
+++ b/docs/search-providers-examples/trackerprovider@cinnamon.org/search_provider.py
@@ -1,6 +1,5 @@
 # -*- coding=utf-8 -*-
 
-import subprocess
 import sys
 import gettext
 import json

--- a/files/usr/share/cinnamon/cinnamon-desktop-editor/cinnamon-desktop-editor.py
+++ b/files/usr/share/cinnamon/cinnamon-desktop-editor/cinnamon-desktop-editor.py
@@ -12,8 +12,7 @@ from setproctitle import setproctitle
 import gi
 gi.require_version("Gtk", "3.0")
 gi.require_version("CMenu", "3.0")
-gi.require_version("XApp", "1.0")
-from gi.repository import GLib, Gtk, Gio, CMenu, GdkPixbuf, XApp
+from gi.repository import GLib, Gtk, Gio, CMenu
 
 sys.path.insert(0, '/usr/share/cinnamon/cinnamon-menu-editor')
 from cme import util

--- a/files/usr/share/cinnamon/cinnamon-menu-editor/cme/MainWindow.py
+++ b/files/usr/share/cinnamon/cinnamon-menu-editor/cme/MainWindow.py
@@ -20,12 +20,11 @@
 import gi
 gi.require_version('Gtk', '3.0')
 gi.require_version('CMenu', '3.0')
-from gi.repository import Gtk, GObject, Gio, GdkPixbuf, Gdk, CMenu, GLib
+from gi.repository import Gtk, GObject, Gdk, CMenu
 import html
 import os
 import gettext
 import subprocess
-import shutil
 
 from cme import config
 gettext.bindtextdomain(config.GETTEXT_PACKAGE, config.localedir)

--- a/files/usr/share/cinnamon/cinnamon-settings-users/cinnamon-settings-users.py
+++ b/files/usr/share/cinnamon/cinnamon-settings-users/cinnamon-settings-users.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 
 import os
-import sys
 import pwd
 import grp
 import gettext

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/ExtensionCore.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/ExtensionCore.py
@@ -1,23 +1,19 @@
 #!/usr/bin/python3
 
-import sys
 import os
 import re
-import json
 import html
 import subprocess
 import gettext
 from html.parser import HTMLParser
 import html.entities as entities
 
-import dbus
 import gi
 gi.require_version('Gtk', '3.0')
-from gi.repository import Gio, Gtk, GObject, Gdk, GdkPixbuf, Pango, GLib
+from gi.repository import Gio, Gtk, GdkPixbuf, GLib
 
-from xapp.SettingsWidgets import SettingsStack, SettingsPage, SettingsWidget, SettingsLabel
-from SettingsWidgets import SidePage
-from Spices import Spice_Harvester, ThreadedTaskManager
+from xapp.SettingsWidgets import SettingsPage, SettingsWidget, SettingsLabel
+from Spices import ThreadedTaskManager
 
 home = os.path.expanduser('~')
 
@@ -961,4 +957,3 @@ class DownloadSpicesPage(SettingsPage):
 
         infobar.set_revealed(False)
         self.search_entry.grab_focus()
-

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py
@@ -1,8 +1,7 @@
 #!/usr/bin/python3
 
-from gi.repository import Gio, GObject
+from gi.repository import Gio
 from xapp.SettingsWidgets import *
-from SettingsWidgets import SoundFileChooser, TweenChooser, EffectChooser, DateChooser, TimeChooser, Keybinding
 from xapp.GSettingsWidgets import CAN_BACKEND as px_can_backend
 from SettingsWidgets import CAN_BACKEND as c_can_backend
 from TreeListWidgets import List

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
@@ -6,8 +6,7 @@ import subprocess
 import dbus
 import gi
 gi.require_version('Gtk', '3.0')
-gi.require_version('CDesktopEnums', '3.0')
-from gi.repository import Gio, Gtk, GObject, GLib, XApp
+from gi.repository import Gio, Gtk, GObject, GLib
 
 from xapp.SettingsWidgets import SettingsWidget, SettingsLabel
 from xapp.GSettingsWidgets import PXGSettingsBackend

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 
 try:
-    import gettext
     from gi.repository import Gio, Gtk, GObject, Gdk, GdkPixbuf, GLib
     import tempfile
     import os

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/eyedropper.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/eyedropper.py
@@ -2,7 +2,7 @@
 
 import gi
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk, Gdk, GObject, GdkPixbuf
+from gi.repository import Gtk, Gdk, GObject
 from PIL import Image
 
 class EyeDropper(Gtk.HBox):

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/imtools.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/imtools.py
@@ -18,7 +18,6 @@
 import os
 from io import StringIO
 from itertools import cycle
-from urllib.request import urlopen
 from PIL import Image
 from PIL import ImageDraw
 from PIL import ImageEnhance

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_accessibility.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_accessibility.py
@@ -2,9 +2,8 @@
 
 import gi
 gi.require_version("Gtk", "3.0")
-gi.require_version('CDesktopEnums', '3.0')
 
-from gi.repository import Gtk, CDesktopEnums
+from gi.repository import Gtk
 from SettingsWidgets import SidePage, GSettingsDependencySwitch, DependencyCheckInstallButton, GSettingsSoundFileChooser
 from xapp.GSettingsWidgets import *
 

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_backgrounds.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_backgrounds.py
@@ -1,12 +1,10 @@
 #!/usr/bin/python3
 
-import sys
 import os
 import imtools
 import gettext
 import _thread as thread
 import subprocess
-import tempfile
 import locale
 import time
 import hashlib
@@ -18,9 +16,8 @@ from xml.etree import ElementTree
 from PIL import Image
 import gi
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gio, Gtk, GObject, Gdk, GdkPixbuf, Pango, GLib
+from gi.repository import Gio, Gtk, Gdk, GdkPixbuf, Pango, GLib
 
-import config
 from SettingsWidgets import SidePage
 from xapp.GSettingsWidgets import *
 

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_desktop.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_desktop.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python3
 
-from gi.repository import Gio
-
 import gi
 gi.require_version('Nemo', '3.0')
 

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_keyboard.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_keyboard.py
@@ -1,12 +1,11 @@
 #!/usr/bin/python3
 
-from gi.repository import Gio, Gtk, GObject, Gdk
 import html
 import gettext
 
 import gi
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gio, Gtk, GObject, Gdk
+from gi.repository import Gio, Gtk
 
 from KeybindingWidgets import CellRendererKeybinding
 from SettingsWidgets import SidePage

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_notifications.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_notifications.py
@@ -2,7 +2,7 @@
 
 import gi
 gi.require_version('Notify', '0.7')
-from gi.repository import GObject, Notify
+from gi.repository import Notify
 
 from SettingsWidgets import SidePage
 from xapp.GSettingsWidgets import *

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_panel.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_panel.py
@@ -5,7 +5,7 @@ import json
 import dbus
 import gi
 gi.require_version('Gtk', '3.0')
-from gi.repository import GLib, Gtk, Gdk
+from gi.repository import Gtk, Gdk
 
 from SettingsWidgets import SidePage
 from xapp.GSettingsWidgets import *

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_power.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_power.py
@@ -1,9 +1,8 @@
 #!/usr/bin/python3
 
 import gi
-gi.require_version('CinnamonDesktop', '3.0')
 gi.require_version('UPowerGlib', '1.0')
-from gi.repository import CinnamonDesktop, Gdk, UPowerGlib
+from gi.repository import UPowerGlib
 
 from SettingsWidgets import SidePage
 from xapp.GSettingsWidgets import *

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_screensaver.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_screensaver.py
@@ -1,13 +1,10 @@
 #!/usr/bin/python3
 
-import os, json, subprocess, re
-from xml.etree import ElementTree
-import gettext
-import signal
+import subprocess
 
 import gi
 gi.require_version('Gtk', '3.0')
-from gi.repository import Gtk, Gdk, GLib, Pango
+from gi.repository import Gtk
 
 from SettingsWidgets import SidePage
 from xapp.GSettingsWidgets import *

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_sound.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_sound.py
@@ -3,7 +3,7 @@
 import gi
 gi.require_version('Cvc', '1.0')
 gi.require_version('Gtk', '3.0')
-from gi.repository import GLib, Gtk, Gdk, Cvc, GdkPixbuf, Gio
+from gi.repository import Gtk, Cvc, GdkPixbuf, Gio
 from SettingsWidgets import SidePage, GSettingsSoundFileChooser
 from xapp.GSettingsWidgets import *
 import dbus

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_startup.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_startup.py
@@ -7,7 +7,7 @@ import shutil
 
 import gi
 gi.require_version('Gtk', '3.0')
-from gi.repository import Gio, Gtk, GObject, Gdk, GdkPixbuf, GLib, Pango
+from gi.repository import Gio, Gtk, Gdk, GdkPixbuf, GLib, Pango
 
 from SettingsWidgets import SidePage
 from xapp.GSettingsWidgets import *

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
@@ -2,7 +2,7 @@
 
 import os
 
-from gi.repository.Gtk import SizeGroup, SizeGroupMode
+from gi.repository import Gtk
 
 from xapp.GSettingsWidgets import *
 from CinnamonGtkSettings import CssRange, CssOverrideSwitch, GtkSettingsSwitch, PreviewWidget, Gtk2ScrollbarSizeEditor

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_windows.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_windows.py
@@ -2,7 +2,7 @@
 
 import gi
 gi.require_version('Gtk', '3.0')
-from gi.repository import Gio, Gtk, GObject, Gdk
+from gi.repository import Gio, Gtk
 
 from SettingsWidgets import SidePage
 from xapp.GSettingsWidgets import *

--- a/generate_additional_files.py
+++ b/generate_additional_files.py
@@ -2,7 +2,6 @@
 
 import os
 import gettext
-import sys
 from mintcommon import additionalfiles
 
 DOMAIN = "cinnamon"

--- a/utils/cinnamon-stap-monitor/cinnamon-stap-monitor.py
+++ b/utils/cinnamon-stap-monitor/cinnamon-stap-monitor.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python3
 
-import os
 import sys
 import signal
 signal.signal(signal.SIGINT, signal.SIG_DFL)
@@ -8,7 +7,7 @@ import _thread
 import gi
 gi.require_version('Gtk', '3.0')
 gi.require_version('Gdk', '3.0')
-from gi.repository import Gdk, Gtk, GObject, GLib, Pango, GdkPixbuf, Gio
+from gi.repository import Gdk, Gtk, GObject, GLib, Pango
 
 import time
 from datetime import timedelta


### PR DESCRIPTION
In one case, gi.require_version is supposed to be run before importing the namespace itself, so keep the second set of imports.

Clean up lots of other imports that aren't actually used.