### PR TITLE
cs_info: delay import of 'distro' module until it is used

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
@@ -7,7 +7,6 @@ import os
 import re
 import threading
 from json import loads
-import distro
 
 from SettingsWidgets import SidePage
 from xapp.GSettingsWidgets import *
@@ -104,6 +103,7 @@ def createSystemInfos():
         title = ' '.join(contents[:2]) or "Manjaro Linux"
         infos.append((_("Operating System"), title))
     else:
+        import distro
         s = '%s (%s)' % (' '.join(distro.linux_distribution()), arch)
         # Normalize spacing in distribution name
         s = re.sub(r'\s{2,}', ' ', s)
@@ -192,4 +192,3 @@ class Module:
             success = subproc.wait_check_finish(result)
         except GLib.Error as e:
             print("upload-system-info failed: %s" % e.message)
-


### PR DESCRIPTION
This third-party module isn't always used, as it's special-cased on some distros. By only importing it if it is actually used, we can reduce the likelihood of things going wrong, such as failure to have it installed.

#9171 added a new dependency without me noticing. But I can't help notice that my distro (and Mint itself) is one case where this codepath is never touched anyway, so the dependency is useless. I could of course add it, and for the current release will do so, but this commit would make overlooking a dependency, potentially less issueful, so why not?