### PR TITLE
menu@cinnamon.org: a fix for jumpiness bug

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1233,6 +1233,12 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
 
             this.lastSelectedCategory = null;
 
+            /* This is a workaround to prevent selectedAppBox from changing height when no height value is set
+             * in the .css style and thus causing the menu above to jump up and down. This has no effect when a
+             * height value is set in the .css style as get_preferred_height() returns this value in this case*/
+            this.selectedAppBox.set_height(-1); //unset previously set height
+            this.selectedAppBox.set_height(this.selectedAppBox.get_preferred_height(-1)[1]);
+            
             let n = Math.min(this._applicationsButtons.length,
                              INITIAL_BUTTON_LOAD);
             for (let i = 0; i < n; i++) {
@@ -2471,11 +2477,6 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         this.mainBox._delegate = null;
 
         this.selectedAppBox = new St.BoxLayout({ style_class: 'menu-selected-app-box', vertical: true });
-
-        if (this.selectedAppBox.peek_theme_node() == null ||
-            this.selectedAppBox.get_theme_node().get_length('height') == 0)
-            this.selectedAppBox.set_height(30 * global.ui_scale);
-
         this.selectedAppTitle = new St.Label({ style_class: 'menu-selected-app-title', text: "" });
         this.selectedAppBox.add_actor(this.selectedAppTitle);
         this.selectedAppDescription = new St.Label({ style_class: 'menu-selected-app-description', text: "" });


### PR DESCRIPTION
The current fix ([here](https://github.com/linuxmint/cinnamon/commit/08742aa68838f95c1de419c146f096d4c1a387d3)) to prevent "jumpiness" [#3144](https://github.com/linuxmint/cinnamon/issues/3144) when different scripts are used works by always setting the selectedAppBox height to 30px as get_theme_node().get_length('height') always returns 0 and get_theme_node().get_height() returns -1 (due to the style not yet having been initialised) meaning that selectedAppBox height is always set to 30px regardless of any height set in the .css file. 

This fix sets the height to an appropriate height if no height value exists in the .css file. If a height is set in the .css, get_preferred_height() returns this value.

~~Ideally~~, this fix would be used whenever the style-changed signal is received in case the style is changed after applet initialisation. But this signal is not currently connected in the app so using it each time the menu is opened seems like a good alternative.

The line this.selectedAppBox.set_height(-1); is necessary to unset the previously set_height(). 