### PR TITLE
Remove build dependency on dbus-glib

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -75,7 +75,7 @@ STARTUP_NOTIFICATION_MIN_VERSION=0.11
 
 # Collect more than 20 libraries for a prize!
 PKG_CHECK_MODULES(CINNAMON, gio-2.0 >= $GIO_MIN_VERSION
-                               gio-unix-2.0 dbus-glib-1 libxml-2.0
+                               gio-unix-2.0 dbus-1 libxml-2.0
                                gtk+-3.0 >= $GTK_MIN_VERSION
                                libmuffin >= $MUFFIN_MIN_VERSION
                                cjs-1.0 >= $GJS_MIN_VERSION
@@ -123,7 +123,7 @@ CFLAGS=$saved_CFLAGS
 LIBS=$saved_LIBS
 
 PKG_CHECK_MODULES(ST, muffin-cogl-path-0 muffin-clutter-0 gtk+-3.0 libcroco-0.6 >= 0.6.2 cinnamon-desktop >= 2.4.0 x11)
-PKG_CHECK_MODULES(GDMUSER, dbus-glib-1 gtk+-3.0)
+PKG_CHECK_MODULES(GDMUSER, gtk+-3.0)
 PKG_CHECK_MODULES(TRAY, muffin-clutter-0 gtk+-3.0)
 PKG_CHECK_MODULES(DESKTOP_SCHEMAS, cinnamon-desktop >= 2.4.0)
 

--- a/configure.ac
+++ b/configure.ac
@@ -123,9 +123,7 @@ CFLAGS=$saved_CFLAGS
 LIBS=$saved_LIBS
 
 PKG_CHECK_MODULES(ST, muffin-cogl-path-0 muffin-clutter-0 gtk+-3.0 libcroco-0.6 >= 0.6.2 cinnamon-desktop >= 2.4.0 x11)
-PKG_CHECK_MODULES(GDMUSER, gtk+-3.0)
 PKG_CHECK_MODULES(TRAY, muffin-clutter-0 gtk+-3.0)
-PKG_CHECK_MODULES(DESKTOP_SCHEMAS, cinnamon-desktop >= 2.4.0)
 
 MUFFIN_GIR_DIR=`$PKG_CONFIG --variable=girdir libmuffin`
 MUFFIN_TYPELIB_DIR=`$PKG_CONFIG --variable=typelibdir libmuffin`

--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,7 @@ Build-Depends:
  libcinnamon-menu-3-dev,
  libcjs-dev (>= 3.8),
  libcroco3-dev (>= 0.6.2),
- libdbus-glib-1-dev,
+ libdbus-1-dev,
  libgirepository1.0-dev (>= 1.29.15),
  libgl1-mesa-dev,
  libglib2.0-dev (>= 2.25.11),

--- a/src/main.c
+++ b/src/main.c
@@ -10,7 +10,7 @@
 
 #include <clutter/clutter.h>
 #include <clutter/x11/clutter-x11.h>
-#include <dbus/dbus-glib.h>
+#include <dbus/dbus-shared.h>
 #include <gdk/gdk.h>
 #include <gdk/gdkx.h>
 #include <gtk/gtk.h>


### PR DESCRIPTION
It's not actually used, but it pulls in a dependency on dbus itself, and the dbus-glib header is used to grab some constants from a dbus provided header. There's no reason to proxy this through dbus-glib.

Also clean up some PKG_CHECK_MODULES I noticed at the same time.

@Fantu relevant to your discussion about using it in cinnamon-settings-daemon, it needs to be cleaned up in a few other places before cinnamon-settings-daemon dropping it will mean much. Also https://github.com/linuxmint/cinnamon-control-center/pull/235