### PR TITLE
Fix workspace OSD

### DIFF
--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -960,6 +960,8 @@ var WindowManager = class WindowManager {
                         transition: 'linear',
                         onComplete: () => osd.destroy()
                     });
+                } else {
+                    osd.destroy();
                 }
             }
         }


### PR DESCRIPTION
the osd does not get destroyed and lingers after switching workspaces, when window effects is disabled.

Regression caused by 041ac072e77431cbe5ea1fb23611d8c4f6fde08c