### PR TITLE
Remove encoding=None

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py
@@ -150,7 +150,7 @@ class JSONSettingsHandler(object):
         raw_data = file.read()
         file.close()
         try:
-            settings = json.loads(raw_data, encoding=None, object_pairs_hook=collections.OrderedDict)
+            settings = json.loads(raw_data, object_pairs_hook=collections.OrderedDict)
         except:
             raise Exception("Failed to parse settings JSON data for file %s" % (self.filepath))
         return settings


### PR DESCRIPTION
Deprecated since version 3.1, will be removed in version 3.9: encoding keyword argument.

https://docs.python.org/3.8/library/json.html#json.loads