### PR TITLE
menu applet: Added option to display panel when the menu is opened

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1083,6 +1083,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         this.settings.bind("search-filesystem", "searchFilesystem");
         this.contextMenu = null;
         this.lastSelectedCategory = null;
+        this.settings.bind("force-show-panel", "forceShowPanel");
 
         // We shouldn't need to call refreshAll() here... since we get a "icon-theme-changed" signal when CSD starts.
         // The reason we do is in case the Cinnamon icon theme is the same as the one specificed in GTK itself (in .config)
@@ -1251,6 +1252,10 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
             this._allAppsCategoryButton.actor.style_class = "menu-category-button-selected";
 
             Mainloop.idle_add(Lang.bind(this, this._initial_cat_selection, n));
+
+            if (this.forceShowPanel) {
+                this.panel.peekPanel();
+            }
         } else {
             this.actor.remove_style_pseudo_class('active');
             if (this.searchActive) {

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/settings-schema.json
@@ -30,7 +30,7 @@
         "menu-behave" : {
             "type" : "section",
             "title" : "Behavior",
-            "keys" : ["enable-autoscroll", "search-filesystem"]
+            "keys" : ["enable-autoscroll", "search-filesystem", "force-show-panel"]
         }
     },
  "overlay-key" : {
@@ -157,6 +157,12 @@
     "default" : false,
     "description": "Enable filesystem path entry in search box",
     "tooltip": "Allows path entry in the menu search box."
+ },
+ "force-show-panel" : {
+    "type" : "switch",
+    "default" : false,
+    "description": "Force panel visible when opening the menu",
+    "tooltip": "Opening the menu will also show the main panel (which may be auto-hidden)."
  },
 "activate-on-hover" : {
     "type" : "switch",


### PR DESCRIPTION
A small bit of functionality I have been missing from my previous OS where opening the menu (using the Super key) would cause the main-panel/task-bar to also be shown if it was hidden. Allowing the time, open apps, etc. to be displayed without having to mouse-over the panel.