### PR TITLE
Grouped Window List applet: Added option to hide the open window indicator on unfocused windows

### DIFF
--- a/cinnamon.pot
+++ b/cinnamon.pot
@@ -6644,6 +6644,11 @@ msgstr ""
 msgid "Enable app button dragging"
 msgstr ""
 
+#. grouped-window-list@cinnamon.org->settings-schema.json->hide-indicator-on-unfocused-
+#. windows->description
+msgid "Hide the open window indicator on unfocused windows"
+msgstr ""
+
 #. grouped-window-list@cinnamon.org->settings-schema.json->launcher-animation-
 #. effect->description
 msgid "Launcher animation"

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -205,7 +205,9 @@ class AppGroup {
     }
 
     on_orientation_changed(fromInit) {
-        this.actor.set_style_class_name('grouped-window-list-item-box');
+        let windowClass = this.state.settings.hideIndicatorUnfocused ? 'window-list-item-box' : 'grouped-window-list-item-box';
+        this.actor.set_style_class_name(windowClass);
+
         if (this.state.orientation === St.Side.TOP) {
             this.actor.add_style_class_name('top');
         } else if (this.state.orientation === St.Side.BOTTOM) {
@@ -589,7 +591,7 @@ class AppGroup {
         } else {
             this.actor.remove_style_pseudo_class('focus');
         }
-        if (metaWindows.length > 0) {
+        if (metaWindows.length > 0 && !this.state.settings.hideIndicatorUnfocused) {
             this.actor.add_style_pseudo_class('active');
         }
         this.resetHoverStatus();

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -311,6 +311,7 @@ class GroupedWindowListApplet extends Applet.Applet {
         let settingsProps = [
             {key: 'group-apps', value: 'groupApps', cb: this.refreshCurrentAppList},
             {key: 'enable-app-button-dragging', value: 'enableDragging', cb: this.draggableSettingChanged},
+            {key: 'hide-indicator-on-unfocused-windows', value: 'hideIndicatorUnfocused', cb: null},
             {key: 'launcher-animation-effect', value: 'launcherAnimationEffect', cb: null},
             {key: 'pinned-apps', value: 'pinnedApps', cb: null},
             {key: 'middle-click-action', value: 'middleClickAction', cb: null},

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/settings-schema.json
@@ -41,7 +41,8 @@
         "launcher-animation-effect",
         "number-display",
         "pinned-apps",
-        "enable-app-button-dragging"
+        "enable-app-button-dragging",
+        "hide-indicator-on-unfocused-windows"
       ]
     },
     "hotKeysSection": {
@@ -154,6 +155,11 @@
     "type": "checkbox",
     "default": true,
     "description": "Enable app button dragging"
+  },
+  "hide-indicator-on-unfocused-windows": {
+    "type": "checkbox",
+    "default": false,
+    "description": "Hide the open window indicator on unfocused windows"
   },
   "launcher-animation-effect": {
     "type": "combobox",


### PR DESCRIPTION
I added the option to hide the open window indicator. This can be useful when button labels are enabled and indicating which applications are open ends up being redundant.

Example:

- Normal behavior: https://gfycat.com/ifr/foolhardydigitalclumber?hd=1

- Indicator hidden: https://gfycat.com/ifr/unfithelpfulflies?hd=1