### PR TITLE
[sound@cinnamon.org] Update applet.js - Further fixes #6243

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -1361,7 +1361,9 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
                 let menuItem = new MediaPlayerLauncher(playerApp, this._launchPlayerItem.menu);
                 this._launchPlayerItem.menu.addMenuItem(menuItem);
             }
-        } else {
+        }
+
+        if (!this.playerControl || !availablePlayers.length) {
             this._launchPlayerItem.actor.hide();
         }
     }


### PR DESCRIPTION
When the Control Players setting is off, the Launch player menu item disappears, as it should. The problem is that the Launch player menu item will reappear after cinnamon is reloaded, either manually or from a restart/at next boot. This fixes it so that the Launch player menu item correctly stays hidden.