### PR TITLE
Use all monitor(s) geometry to determine hot corner positions (linuxmint#7726)

### DIFF
--- a/js/ui/hotCorner.js
+++ b/js/ui/hotCorner.js
@@ -55,11 +55,14 @@ HotCornerManager.prototype = {
         return true;
     },
 
-    updatePosition: function(monitor) {
-        let left   = monitor.x;
-        let right  = monitor.x + monitor.width - 2;
-        let top    = monitor.y;
-        let bottom = monitor.y + monitor.height - 2;
+    updatePosition: function(...monitors) {
+        let left=0, right=0, top=0, bottom=0;
+        for (var monitor of monitors) {
+            left   = Math.min(left,   monitor.x);
+            right  = Math.max(right,  monitor.x + monitor.width - 2);
+            top    = Math.min(top,    monitor.y);
+            bottom = Math.max(bottom, monitor.y + monitor.height - 2);
+        }
 
         // Top Left: 0
         this.corners[0].actor.set_position(left, top);

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -145,7 +145,7 @@ LayoutManager.prototype = {
 
     _updateBoxes: function() {
         if (this.hotCornerManager)
-            this.hotCornerManager.updatePosition(this.primaryMonitor);
+            this.hotCornerManager.updatePosition(this.monitors);
         this._chrome._queueUpdateRegions();
     },
 


### PR DESCRIPTION
Fixes #7726

**Description:**

Avoids hard-to-trigger "corner" points between monitors on dual/multi-monitor setups by moving hot corner positions to the outer edge.

**Change Summary:**

- Updated the `HotCornerManager.updatePosition()` to (optionally) accept multiple monitors for use in determining hot corner positions.
- Updated `LayoutManager._updateBoxes()` to pass all connected monitors instead of just `primaryMonitor`.
