### PR TITLE
[sound@cinnamon.org] Display volume tooltip while scrolling with the mouse wheel (applet.js)

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -168,6 +168,7 @@ class VolumeSlider extends PopupMenu.PopupSliderMenuItem {
         }
 
         this._slider.queue_repaint();
+        this.tooltip.show();
         this.emit('value-changed', this._value);
     }
 
@@ -1106,6 +1107,8 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
                 this._players[this._activePlayer]._mediaServerPlayer.NextRemote();
             }
         }
+
+        this.tooltip.show();
 
         this._notifyVolumeChange(this._output);
     }


### PR DESCRIPTION
This PR updates `applet.js` to displays the volume level on the `sound@cinnamon.org` applet while scrolling with the mouse wheel.