### PR TITLE
TreeListWidgets: 'show-buttons' new option

### DIFF
--- a/docs/reference/cinnamon-tutorials/xlet-settings-ref.xml
+++ b/docs/reference/cinnamon-tutorials/xlet-settings-ref.xml
@@ -318,6 +318,7 @@
         <listitem><code>description</code>: (optional) String to describe the setting</listitem>
         <listitem><code>columns</code>: Array of objects specifying the columns in the list widget</listitem>
         <listitem><code>default</code>: default value</listitem>
+        <listitem><code>show-buttons</code>: (optional) Whether to show the action buttons below the list (<code>true</code> by default)</listitem>
       </itemizedlist>
 
       <para>

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py
@@ -31,7 +31,8 @@ JSON_SETTINGS_PROPERTIES_MAP = {
     "default_icon"     : "default_icon",
     "icon_categories"  : "icon_categories",
     "default_category" : "default_category",
-    "show-seconds"     : "show_seconds"
+    "show-seconds"     : "show_seconds",
+    "show-buttons"     : "show_buttons"
 }
 
 OPERATIONS = ['<=', '>=', '<', '>', '!=', '=']

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/TreeListWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/TreeListWidgets.py
@@ -100,7 +100,8 @@ def list_edit_factory(options):
 class List(SettingsWidget):
     bind_dir = None
 
-    def __init__(self, label=None, columns=None, height=200, size_group=None, dep_key=None, tooltip=""):
+    def __init__(self, label=None, columns=None, height=200, size_group=None, \
+                 dep_key=None, tooltip="", show_buttons=True):
         super(List, self).__init__(dep_key=dep_key)
         self.columns = columns
 
@@ -161,46 +162,49 @@ class List(SettingsWidget):
 
             if 'align' in column_def:
                 renderer.set_alignment(column_def['align'], 0.5)
+                column.set_alignment(column_def['align'])
 
             column.set_resizable(True)
             self.content_widget.append_column(column)
         self.model = Gtk.ListStore(*types)
         self.content_widget.set_model(self.model)
 
-        button_toolbar = Gtk.Toolbar()
-        button_toolbar.set_icon_size(1)
-        Gtk.StyleContext.add_class(Gtk.Widget.get_style_context(button_toolbar), "inline-toolbar")
-        self.pack_start(button_toolbar, False, False, 0)
+        if show_buttons:
+            button_toolbar = Gtk.Toolbar()
+            button_toolbar.set_icon_size(1)
+            Gtk.StyleContext.add_class(Gtk.Widget.get_style_context(button_toolbar), \
+                                       "inline-toolbar")
+            self.pack_start(button_toolbar, False, False, 0)
 
-        self.add_button = Gtk.ToolButton(None, None)
-        self.add_button.set_icon_name("list-add-symbolic")
-        self.add_button.set_tooltip_text(_("Add new entry"))
-        self.add_button.connect("clicked", self.add_item)
-        self.remove_button = Gtk.ToolButton(None, None)
-        self.remove_button.set_icon_name("list-remove-symbolic")
-        self.remove_button.set_tooltip_text(_("Remove selected entry"))
-        self.remove_button.connect("clicked", self.remove_item)
-        self.remove_button.set_sensitive(False)
-        self.edit_button = Gtk.ToolButton(None, None)
-        self.edit_button.set_icon_name("list-edit-symbolic")
-        self.edit_button.set_tooltip_text(_("Edit selected entry"))
-        self.edit_button.connect("clicked", self.edit_item)
-        self.edit_button.set_sensitive(False)
-        self.move_up_button = Gtk.ToolButton(None, None)
-        self.move_up_button.set_icon_name("go-up-symbolic")
-        self.move_up_button.set_tooltip_text(_("Move selected entry up"))
-        self.move_up_button.connect("clicked", self.move_item_up)
-        self.move_up_button.set_sensitive(False)
-        self.move_down_button = Gtk.ToolButton(None, None)
-        self.move_down_button.set_icon_name("go-down-symbolic")
-        self.move_down_button.set_tooltip_text(_("Move selected entry down"))
-        self.move_down_button.connect("clicked", self.move_item_down)
-        self.move_down_button.set_sensitive(False)
-        button_toolbar.insert(self.add_button, 0)
-        button_toolbar.insert(self.remove_button, 1)
-        button_toolbar.insert(self.edit_button, 2)
-        button_toolbar.insert(self.move_up_button, 3)
-        button_toolbar.insert(self.move_down_button, 4)
+            self.add_button = Gtk.ToolButton(None, None)
+            self.add_button.set_icon_name("list-add-symbolic")
+            self.add_button.set_tooltip_text(_("Add new entry"))
+            self.add_button.connect("clicked", self.add_item)
+            self.remove_button = Gtk.ToolButton(None, None)
+            self.remove_button.set_icon_name("list-remove-symbolic")
+            self.remove_button.set_tooltip_text(_("Remove selected entry"))
+            self.remove_button.connect("clicked", self.remove_item)
+            self.remove_button.set_sensitive(False)
+            self.edit_button = Gtk.ToolButton(None, None)
+            self.edit_button.set_icon_name("list-edit-symbolic")
+            self.edit_button.set_tooltip_text(_("Edit selected entry"))
+            self.edit_button.connect("clicked", self.edit_item)
+            self.edit_button.set_sensitive(False)
+            self.move_up_button = Gtk.ToolButton(None, None)
+            self.move_up_button.set_icon_name("go-up-symbolic")
+            self.move_up_button.set_tooltip_text(_("Move selected entry up"))
+            self.move_up_button.connect("clicked", self.move_item_up)
+            self.move_up_button.set_sensitive(False)
+            self.move_down_button = Gtk.ToolButton(None, None)
+            self.move_down_button.set_icon_name("go-down-symbolic")
+            self.move_down_button.set_tooltip_text(_("Move selected entry down"))
+            self.move_down_button.connect("clicked", self.move_item_down)
+            self.move_down_button.set_sensitive(False)
+            button_toolbar.insert(self.add_button, 0)
+            button_toolbar.insert(self.remove_button, 1)
+            button_toolbar.insert(self.edit_button, 2)
+            button_toolbar.insert(self.move_up_button, 3)
+            button_toolbar.insert(self.move_down_button, 4)
 
         self.content_widget.get_selection().connect("changed", self.update_button_sensitivity)
         self.content_widget.set_activate_on_single_click(False)


### PR DESCRIPTION
Add a new option to TreeListWidgets: `show-buttons`, a boolean to choose whether show the action buttons below the list.
The default value of `show-buttons` is `true`.

Example of use:

In settings-schema.json:
```
"temp_sensors": {
    "type": "list",
    "columns": [
      {
        "id": "sensor",
        "title": "Sensor",
        "type": "string"
      },
      {
        "id": "show_in_panel",
        "title": "Show in panel",
        "align": 0.5,
        "type": "boolean"
      },
      {
        "id": "show_in_tooltip",
        "title": "Show in tooltip",
        "align": 0.5,
        "type": "boolean"
      }
    ],
    "default": [],
    "show-buttons": false
  },
```

Result:
![image](https://user-images.githubusercontent.com/33965039/91862435-394b1100-ec6e-11ea-99ef-56ade6c04234.png)

Without this option, or if this option is set to `true`, the action buttons are shown below the list:
![image](https://user-images.githubusercontent.com/33965039/91863555-867bb280-ec6f-11ea-891e-31f3deece13f.png)
