### PR TITLE
systray manager: make all role comparisons lower case

### DIFF
--- a/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
@@ -118,7 +118,7 @@ class CinnamonSystrayApplet extends Applet.Applet {
         try {
             let hiddenIcons = Main.systrayManager.getRoles();
 
-            if (hiddenIcons.indexOf(role) != -1 ) {
+            if (hiddenIcons.indexOf(role.toLowerCase()) != -1 ) {
                 // We've got an applet for that
                 global.log("Hiding systray: " + role);
                 return;

--- a/files/usr/share/cinnamon/applets/xapp-status@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/xapp-status@cinnamon.org/applet.js
@@ -419,7 +419,7 @@ class CinnamonXAppStatusApplet extends Applet.Applet {
     shouldIgnoreStatusIcon(icon_proxy) {
         let hiddenIcons = Main.systrayManager.getRoles();
 
-        let name = icon_proxy.name;
+        let name = icon_proxy.name.toLowerCase();
 
         if (hiddenIcons.indexOf(name) != -1 ) {
             return true;

--- a/js/ui/systray.js
+++ b/js/ui/systray.js
@@ -9,21 +9,21 @@ SystrayManager.prototype = {
     _init: function() {
         this._roles = [];
     },
-    
+
     registerRole: function(role, id) {
-        this._roles.push({role: role, id: id});
+        this._roles.push({role: role.toLowerCase(), id: id});
         this.emit("changed");
     },
-    
+
     unregisterRole: function(role, id) {
         for (let i = this._roles.length - 1; i >= 0; i--) {
-            if (this._roles[i].id == id && this._roles[i].role == role) {
+            if (this._roles[i].id == id && this._roles[i].role == role.toLowerCase()) {
                 this._roles.splice(i, 1);
             }
         }
         this.emit("changed");
     },
-    
+
     unregisterId: function(id) {
         for (let i = this._roles.length - 1; i >= 0; i--) {
             if (this._roles[i].id == id) {
@@ -32,13 +32,13 @@ SystrayManager.prototype = {
         }
         this.emit("changed");
     },
-    
+
     getRoles: function(id) {
         let roles = [];
         for (let i = 0; i < this._roles.length; i++) {
             roles.push(this._roles[i].role);
         }
-        
+
         return roles;
     }
 }


### PR DESCRIPTION
This specifically fixes an issue where the sound applet registers `rhythmbox` but the xapp status applet gets `Rhythmbox`, but it could also serve to prevent other such issues in the future.