### PR TITLE
[applets][feature] window-list applet: add hotkeys to switch to a window by its number

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/settings-schema.json
@@ -65,5 +65,69 @@
           "Largest": 1.5
       },
       "dependency": "window-preview"
+  },
+  "display-win-numbers": {
+    "type" : "checkbox",
+    "default" : true,
+    "description": "Show the number in a window button title"
+  },
+  "section3": {
+    "type": "section",
+    "description": "Hotkeys"
+  },
+  "use-hotkeys" : {
+    "type" : "checkbox",
+    "default" : false,
+    "description": "Switch to a window by the number"
+  },
+  "hotkey-win-1": {
+    "type" : "keybinding",
+    "default" : "<Super>1::<Shift><Super>1",
+    "description" : "Window 1 / Window 11"
+  },
+  "hotkey-win-2": {
+    "type" : "keybinding",
+    "default" : "<Super>2::<Shift><Super>2",
+    "description" : "Window 2 / Window 12"
+  },
+  "hotkey-win-3": {
+    "type" : "keybinding",
+    "default" : "<Super>3::<Shift><Super>3",
+    "description" : "Window 3 / Window 13"
+  },
+  "hotkey-win-4": {
+    "type" : "keybinding",
+    "default" : "<Super>4::<Shift><Super>4",
+    "description" : "Window 4 / Window 14"
+  },
+  "hotkey-win-5": {
+    "type" : "keybinding",
+    "default" : "<Super>5::<Shift><Super>5",
+    "description" : "Window 5 / Window 15"
+  },
+  "hotkey-win-6": {
+    "type" : "keybinding",
+    "default" : "<Super>6::<Shift><Super>6",
+    "description" : "Window 6 / Window 16"
+  },
+  "hotkey-win-7": {
+    "type" : "keybinding",
+    "default" : "<Super>7::<Shift><Super>7",
+    "description" : "Window 7 / Window 17"
+  },
+  "hotkey-win-8": {
+    "type" : "keybinding",
+    "default" : "<Super>8::<Shift><Super>8",
+    "description" : "Window 8 / Window 18"
+  },
+  "hotkey-win-9": {
+    "type" : "keybinding",
+    "default" : "<Super>9::<Shift><Super>9",
+    "description" : "Window 9 / Window 19"
+  },
+  "hotkey-win-10": {
+    "type" : "keybinding",
+    "default" : "<Super>0::<Shift><Super>0",
+    "description" : "Window 10 / Window 20"
   }
 }


### PR DESCRIPTION
Another round to improve the code for this functionality.

1. Add hotkeys to switch to a window by its number. Default configuration
is Super+N for windows 1..10 and Super+Shift+N for windows 11..20. A user
can customize the hotkeys in the applet settins. This functionality can be
disabled/enabled via the applet settings.

2. Display a window number in the window button title. This functionality
also can be enabled and disabled by a user.