### PR TITLE
Removed logic that was keeping icons around after window closed

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appList.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appList.js
@@ -279,7 +279,7 @@ class AppList {
             && !this.state.removingWindowFromWorkspaces) {
             // Abort the remove if the window is just changing workspaces, window
             // should always remain indexed on all workspaces while its mapped.
-            if (!metaWindow.showing_on_its_workspace()) return;
+            // if (!metaWindow.showing_on_its_workspace()) return;
             this.state.removingWindowFromWorkspaces = true;
             this.state.trigger('removeWindowFromAllWorkspaces', metaWindow);
             return;


### PR DESCRIPTION
This PR addresses #8779. 

This PR will need tested since the logic that was keeping the icons around is closely related to logic that is used when moving windows around from one workspace to another. I did some testing and things looked to still be working correctly. I'll remove the commented code once further testing has been established.