### PR TITLE
Deprecated Clutter keysyms migration

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1011,7 +1011,7 @@ class Menu extends Applet.AppletPopupMenu {
     }
 
     _onKeyPressEvent(actor, event) {
-        if (event.get_key_symbol() == Clutter.KEY_Escape) {
+        if (event.get_key_symbol() === Clutter.KEY_Escape) {
             this.close(false);
             return true;
         }

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -209,7 +209,7 @@ class SimpleMenuItem {
         if (this.activate &&
             (symbol === Clutter.KEY_space ||
              symbol === Clutter.KEY_Return ||
-             symbol === Clutter.KP_Enter)) {
+             symbol === Clutter.KEY_KP_Enter)) {
             this.activate();
             return Clutter.EVENT_STOP;
         }
@@ -1011,7 +1011,7 @@ class Menu extends Applet.AppletPopupMenu {
     }
 
     _onKeyPressEvent(actor, event) {
-        if (event.get_key_symbol() == Clutter.Escape) {
+        if (event.get_key_symbol() == Clutter.KEY_Escape) {
             this.close(false);
             return true;
         }
@@ -1440,8 +1440,8 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
     }
 
     _navigateContextMenu(button, symbol, ctrlKey) {
-        if (symbol === Clutter.KEY_Menu || symbol === Clutter.Escape ||
-            (ctrlKey && (symbol === Clutter.KEY_Return || symbol === Clutter.KP_Enter))) {
+        if (symbol === Clutter.KEY_Menu || symbol === Clutter.KEY_Escape ||
+            (ctrlKey && (symbol === Clutter.KEY_Return || symbol === Clutter.KEY_KP_Enter))) {
             this.toggleContextMenu(button);
             return;
         }
@@ -1471,7 +1471,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         }
 
         if (!this._activeContextMenuItem) {
-            if (symbol === Clutter.KEY_Return || symbol === Clutter.KP_Enter) {
+            if (symbol === Clutter.KEY_Return || symbol === Clutter.KEY_KP_Enter) {
                 button.activate();
             } else {
                 this._activeContextMenuItem = menuItems[goUp ? menuItemsLength - 1 : minIndex];
@@ -1479,7 +1479,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
             }
             return;
         } else if (this._activeContextMenuItem &&
-            (symbol === Clutter.KEY_Return || symbol === Clutter.KP_Enter)) {
+            (symbol === Clutter.KEY_Return || symbol === Clutter.KEY_KP_Enter)) {
             this._activeContextMenuItem.activate();
             this._activeContextMenuItem = null;
             return;
@@ -1536,17 +1536,17 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                 case Clutter.KEY_Up:
                 case Clutter.KEY_Down:
                 case Clutter.KEY_Return:
-                case Clutter.KP_Enter:
+                case Clutter.KEY_KP_Enter:
                 case Clutter.KEY_Menu:
                 case Clutter.KEY_Page_Up:
                 case Clutter.KEY_Page_Down:
-                case Clutter.Escape:
+                case Clutter.KEY_Escape:
                     this._navigateContextMenu(this._activeContextMenuParent, symbol, ctrlKey);
                     break;
                 case Clutter.KEY_Right:
                 case Clutter.KEY_Left:
-                case Clutter.Tab:
-                case Clutter.ISO_Left_Tab:
+                case Clutter.KEY_Tab:
+                case Clutter.KEY_ISO_Left_Tab:
                     continueNavigation = true;
                     break;
             }
@@ -1592,13 +1592,13 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                             (this._activeContainer === this.categoriesBox || this._activeContainer === null))
                     whichWay = "none";
                 break;
-            case Clutter.Tab:
+            case Clutter.KEY_Tab:
                 if (!this.searchActive)
                     whichWay = "right";
                 else
                     navigationKey = false;
                 break;
-            case Clutter.ISO_Left_Tab:
+            case Clutter.KEY_ISO_Left_Tab:
                 if (!this.searchActive)
                     whichWay = "left";
                 else
@@ -1856,7 +1856,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                 return false;
             index = item_actor.get_parent()._vis_iter.getAbsoluteIndexOfChild(item_actor);
         } else {
-            if ((this._activeContainer && this._activeContainer !== this.categoriesBox) && (symbol === Clutter.KEY_Return || symbol === Clutter.KP_Enter)) {
+            if ((this._activeContainer && this._activeContainer !== this.categoriesBox) && (symbol === Clutter.KEY_Return || symbol === Clutter.KEY_KP_Enter)) {
                 if (!ctrlKey) {
                     item_actor = this._activeContainer.get_child_at_index(this._selectedItemIndex);
                     item_actor._delegate.activate();
@@ -1869,7 +1869,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                 item_actor = this.applicationsBox.get_child_at_index(this._selectedItemIndex);
                 this.toggleContextMenu(item_actor._delegate);
                 return true;
-            } else if (!this.searchActive && this._activeContainer === this.favoritesBox && symbol === Clutter.Delete) {
+            } else if (!this.searchActive && this._activeContainer === this.favoritesBox && symbol === Clutter.KEY_Delete) {
                 item_actor = this.favoritesBox.get_child_at_index(this._selectedItemIndex);
                 if (item_actor._delegate instanceof FavoritesButton) {
                     let favorites = AppFavorites.getAppFavorites().getFavorites();
@@ -1900,18 +1900,18 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                 appFavorites.moveFavoriteToPos(id, favPos);
                 item_actor = this.favoritesBox.get_child_at_index(favPos);
                 this._scrollToButton(item_actor._delegate, this.favoritesScrollBox);
-            } else if (this.searchFilesystem && (this._fileFolderAccessActive || symbol === Clutter.slash)) {
-                if (symbol === Clutter.Return || symbol === Clutter.KP_Enter) {
+            } else if (this.searchFilesystem && (this._fileFolderAccessActive || symbol === Clutter.KEY_slash)) {
+                if (symbol === Clutter.KEY_Return || symbol === Clutter.KEY_KP_Enter) {
                     if (this._run(this.searchEntry.get_text())) {
                         this.menu.close();
                     }
                     return true;
                 }
-                if (symbol === Clutter.Escape) {
+                if (symbol === Clutter.KEY_Escape) {
                     this.searchEntry.set_text('');
                     this._fileFolderAccessActive = false;
                 }
-                if (symbol === Clutter.slash) {
+                if (symbol === Clutter.KEY_slash) {
                     // Need preload data before get completion. GFilenameCompleter load content of parent directory.
                     // Parent directory for /usr/include/ is /usr/. So need to add fake name('a').
                     let text = this.searchEntry.get_text().concat('/a');
@@ -1924,7 +1924,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
 
                     return false;
                 }
-                if (symbol === Clutter.Tab) {
+                if (symbol === Clutter.KEY_Tab) {
                     let text = actor.get_text();
                     let prefix;
                     if (!text.includes(' '))
@@ -1940,11 +1940,11 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                     }
                     return true;
                 }
-                if (symbol === Clutter.ISO_Left_Tab) {
+                if (symbol === Clutter.KEY_ISO_Left_Tab) {
                     return true;
                 }
                 return false;
-            } else if (symbol === Clutter.Tab || symbol === Clutter.ISO_Left_Tab) {
+            } else if (symbol === Clutter.KEY_Tab || symbol === Clutter.KEY_ISO_Left_Tab) {
                 return true;
             } else {
                 return false;

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -174,8 +174,8 @@ class VolumeSlider extends PopupMenu.PopupSliderMenuItem {
 
     _onKeyPressEvent(actor, event) {
         let key = event.get_key_symbol();
-        if (key == Clutter.KEY_Right || key == Clutter.KEY_Left) {
-            let delta = key == Clutter.KEY_Right ? VOLUME_ADJUSTMENT_STEP : -VOLUME_ADJUSTMENT_STEP;
+        if (key === Clutter.KEY_Right || key === Clutter.KEY_Left) {
+            let delta = key === Clutter.KEY_Right ? VOLUME_ADJUSTMENT_STEP : -VOLUME_ADJUSTMENT_STEP;
             this._value = Math.max(0, Math.min(this._value + delta/this.applet._volumeMax*this.applet._volumeNorm, 1));
             this._slider.queue_repaint();
             this.emit('value-changed', this._value);

--- a/js/misc/gridNavigator.js
+++ b/js/misc/gridNavigator.js
@@ -5,14 +5,14 @@ const Clutter = imports.gi.Clutter;
 function nextIndex(itemCount, numCols, currentIndex, symbol) {
     let result = -1;
     if (itemCount > 3 // grid navigation is not suited for a low item count
-        && (symbol === Clutter.Down || symbol === Clutter.Up))
+        && (symbol === Clutter.KEY_Down || symbol === Clutter.KEY_Up))
     {
         let numRows = Math.ceil(itemCount/numCols);
 
         let curRow = Math.floor(currentIndex/numCols);
         let curCol = currentIndex % numCols;
 
-        const rowDelta = symbol === Clutter.Down ? 1 : -1;
+        const rowDelta = symbol === Clutter.KEY_Down ? 1 : -1;
         let newIndex = (curRow + rowDelta) * numCols + curCol;
         if (rowDelta >= 0) { // down
             if (newIndex < itemCount) {
@@ -50,16 +50,16 @@ function nextIndex(itemCount, numCols, currentIndex, symbol) {
             return ((numRows - 1) * numCols) + curCol - 1;
         }
     }
-    else if (symbol === Clutter.Left || symbol === Clutter.Up) {
+    else if (symbol === Clutter.KEY_Left || symbol === Clutter.KEY_Up) {
         result = (currentIndex < 1 ? itemCount : currentIndex) - 1;
     }
-    else if (symbol === Clutter.Right || symbol === Clutter.Down) {
+    else if (symbol === Clutter.KEY_Right || symbol === Clutter.KEY_Down) {
         result = (currentIndex + 1) % itemCount;
     }
-    else if (symbol === Clutter.Home) {
+    else if (symbol === Clutter.KEY_Home) {
         result = 0;
     }
-    else if (symbol === Clutter.End) {
+    else if (symbol === Clutter.KEY_End) {
         result = itemCount - 1;
     }
     return result;

--- a/js/misc/history.js
+++ b/js/misc/history.js
@@ -93,10 +93,10 @@ HistoryManager.prototype = {
 
     _onEntryKeyPress: function(entry, event) {
         let symbol = event.get_key_symbol();
-        if (symbol == Clutter.KEY_Up) {
+        if (symbol === Clutter.KEY_Up) {
             this.prevItem(entry.get_text());
             return true;
-        } else if (symbol == Clutter.KEY_Down) {
+        } else if (symbol === Clutter.KEY_Down) {
             this.nextItem(entry.get_text());
             return true;
         }

--- a/js/ui/appSwitcher/appSwitcher.js
+++ b/js/ui/appSwitcher/appSwitcher.js
@@ -257,46 +257,46 @@ AppSwitcher.prototype = {
 
         // Switch workspace
         if (modifiers & Clutter.ModifierType.CONTROL_MASK &&
-           (symbol === Clutter.Right || symbol === Clutter.Left)) {
+           (symbol === Clutter.KEY_Right || symbol === Clutter.KEY_Left)) {
             if (this._switchWorkspace(symbol))
                 return true;
         }
 
         // Extra keys
         switch (symbol) {
-            case Clutter.Escape:
+            case Clutter.KEY_Escape:
                 // Esc -> Close switcher
                 this.destroy();
                 return true;
 
-            case Clutter.Return:
+            case Clutter.KEY_Return:
                 // Enter -> Select active window
                 this._activateSelected();
                 return true;
 
-            case Clutter.d:
-            case Clutter.D:
+            case Clutter.KEY_d:
+            case Clutter.KEY_D:
                 // D -> Show desktop
                 this._showDesktop();
                 return true;
 
-            case Clutter.q:
-            case Clutter.Q:
+            case Clutter.KEY_q:
+            case Clutter.KEY_Q:
                 // Q -> Close window
                 this._windows[this._currentIndex].delete(global.get_current_time());
                 this._checkDestroyedTimeoutId = Mainloop.timeout_add(CHECK_DESTROYED_TIMEOUT,
                         Lang.bind(this, this._checkDestroyed, this._windows[this._currentIndex]));
                 return true;
 
-            case Clutter.Right:
-            case Clutter.Down:
+            case Clutter.KEY_Right:
+            case Clutter.KEY_Down:
                 // Right/Down -> navigate to next preview
                 if(this._checkSwitchTime())
                     this._next();
                 return true;
 
-            case Clutter.Left:
-            case Clutter.Up:
+            case Clutter.KEY_Left:
+            case Clutter.KEY_Up:
                 // Left/Up -> navigate to previous preview
                 if(this._checkSwitchTime())
                     this._previous();
@@ -373,9 +373,9 @@ AppSwitcher.prototype = {
 
         let current = global.screen.get_active_workspace_index();
 
-        if (direction === Clutter.Left)
+        if (direction === Clutter.KEY_Left)
             Main.wm.actionMoveWorkspaceLeft();
-        else if (direction === Clutter.Right)
+        else if (direction === Clutter.KEY_Right)
             Main.wm.actionMoveWorkspaceRight();
         else
             return false;

--- a/js/ui/dnd.js
+++ b/js/ui/dnd.js
@@ -208,7 +208,7 @@ var _Draggable = new Lang.Class({
         // dragging and ignore all other key presses.
         } else if (event.type() == Clutter.EventType.KEY_PRESS && this._dragInProgress) {
             let symbol = event.get_key_symbol();
-            if (symbol == Clutter.Escape) {
+            if (symbol == Clutter.KEY_Escape) {
                 this._cancelDrag(event.get_time());
                 return true;
             }

--- a/js/ui/dnd.js
+++ b/js/ui/dnd.js
@@ -208,7 +208,7 @@ var _Draggable = new Lang.Class({
         // dragging and ignore all other key presses.
         } else if (event.type() == Clutter.EventType.KEY_PRESS && this._dragInProgress) {
             let symbol = event.get_key_symbol();
-            if (symbol == Clutter.KEY_Escape) {
+            if (symbol === Clutter.KEY_Escape) {
                 this._cancelDrag(event.get_time());
                 return true;
             }

--- a/js/ui/expo.js
+++ b/js/ui/expo.js
@@ -124,16 +124,16 @@ Expo.prototype = {
                         return true;
                     }
                     let symbol = event.get_key_symbol();
-                    if (symbol === Clutter.plus || symbol === Clutter.Insert) {
+                    if (symbol === Clutter.KEY_plus || symbol === Clutter.KEY_Insert) {
                         this._workspaceOperationPending = true;
                     }
                     let modifiers = Cinnamon.get_event_state(event);
-                    if ((symbol === Clutter.Delete && (modifiers & ctrlAltMask) !== ctrlAltMask)
-                        || symbol === Clutter.w && modifiers & Clutter.ModifierType.CONTROL_MASK)
+                    if ((symbol === Clutter.KEY_Delete && (modifiers & ctrlAltMask) !== ctrlAltMask)
+                        || symbol === Clutter.KEY_w && modifiers & Clutter.ModifierType.CONTROL_MASK)
                     {
                         this._workspaceOperationPending = true;
                     }
-                    if (symbol === Clutter.Escape) {
+                    if (symbol === Clutter.KEY_Escape) {
                         if (!this._workspaceOperationPending) {
                             this.hide();
                         }
@@ -147,7 +147,7 @@ Expo.prototype = {
             Lang.bind(this, function(actor, event) {
                 if (this._shown) {
                     let symbol = event.get_key_symbol();
-                    if (symbol === Clutter.plus || symbol === Clutter.Insert) {
+                    if (symbol === Clutter.KEY_plus || symbol === Clutter.KEY_Insert) {
                         if (this._workspaceOperationPending) {
                             this._workspaceOperationPending = false;
                             Main._addWorkspace();
@@ -155,8 +155,8 @@ Expo.prototype = {
                         return true;
                     }
                     let modifiers = Cinnamon.get_event_state(event);
-                    if ((symbol === Clutter.Delete && (modifiers & ctrlAltMask) !== ctrlAltMask)
-                        || symbol === Clutter.w && modifiers & Clutter.ModifierType.CONTROL_MASK)
+                    if ((symbol === Clutter.KEY_Delete && (modifiers & ctrlAltMask) !== ctrlAltMask)
+                        || symbol === Clutter.KEY_w && modifiers & Clutter.ModifierType.CONTROL_MASK)
                     {
                         if (this._workspaceOperationPending) {
                             this._workspaceOperationPending = false;

--- a/js/ui/expoThumbnail.js
+++ b/js/ui/expoThumbnail.js
@@ -484,8 +484,8 @@ ExpoWorkspaceThumbnail.prototype = {
     onTitleKeyPressEvent: function(actor, event) {
         this.undoTitleEdit = false;
         let symbol = event.get_key_symbol();
-        if (symbol === Clutter.Return || symbol === Clutter.Escape) {
-            if (symbol === Clutter.Escape) {
+        if (symbol === Clutter.KEY_Return || symbol === Clutter.KEY_Escape) {
+            if (symbol === Clutter.KEY_Escape) {
                 this.undoTitleEdit = true;
             }
             global.stage.set_key_focus(this.actor);
@@ -1135,18 +1135,18 @@ ExpoThumbnailsBox.prototype = {
         let modifiers = Cinnamon.get_event_state(event);
         let ctrlAltMask = Clutter.ModifierType.CONTROL_MASK | Clutter.ModifierType.MOD1_MASK;
         let symbol = event.get_key_symbol();
-        if (symbol === Clutter.Return || symbol === Clutter.KEY_space 
-            || symbol === Clutter.KP_Enter)
+        if (symbol === Clutter.KEY_Return || symbol === Clutter.KEY_space 
+            || symbol === Clutter.KEY_KP_Enter)
         {
             this.activateSelectedWorkspace();
             return true;
         }
-        if (symbol === Clutter.F2) {
+        if (symbol === Clutter.KEY_F2) {
             this.editWorkspaceTitle();
             return true;
         }
 
-        if ((symbol === Clutter.o || symbol === Clutter.O) && modifiers & Clutter.ModifierType.CONTROL_MASK) {
+        if ((symbol === Clutter.KEY_o || symbol === Clutter.KEY_O) && modifiers & Clutter.ModifierType.CONTROL_MASK) {
             this.toggleGlobalOverviewMode();
             return true;
         }
@@ -1184,7 +1184,7 @@ ExpoThumbnailsBox.prototype = {
                 // OK
             }
             else {
-                index = symbol - Clutter.KP_1; // convert Num-pad '1' to index 0, etc
+                index = symbol - Clutter.KEY_KP_1; // convert Num-pad '1' to index 0, etc
                 if (index < 0 || index > 9) {
                     return false; // not handled
                 }

--- a/js/ui/lookingGlass.js
+++ b/js/ui/lookingGlass.js
@@ -279,9 +279,9 @@ Inspector.prototype = {
     },
 
     _onCapturedEvent: function (actor, event) {
-        if (event.type() == Clutter.EventType.KEY_PRESS && (event.get_key_symbol() == Clutter.Control_L ||
-                                                            event.get_key_symbol() == Clutter.Control_R ||
-                                                            event.get_key_symbol() == Clutter.Pause)) {
+        if (event.type() == Clutter.EventType.KEY_PRESS && (event.get_key_symbol() == Clutter.KEY_Control_L ||
+                                                            event.get_key_symbol() == Clutter.KEY_Control_R ||
+                                                            event.get_key_symbol() == Clutter.KEY_Pause)) {
             this.passThroughEvents = !this.passThroughEvents;
             this._updatePassthroughText();
             return true;
@@ -336,7 +336,7 @@ Inspector.prototype = {
     },
 
     _onKeyPressEvent: function (actor, event) {
-        if (event.get_key_symbol() == Clutter.Escape)
+        if (event.get_key_symbol() == Clutter.KEY_Escape)
             this._close();
         return true;
     },

--- a/js/ui/lookingGlass.js
+++ b/js/ui/lookingGlass.js
@@ -279,9 +279,9 @@ Inspector.prototype = {
     },
 
     _onCapturedEvent: function (actor, event) {
-        if (event.type() == Clutter.EventType.KEY_PRESS && (event.get_key_symbol() == Clutter.KEY_Control_L ||
-                                                            event.get_key_symbol() == Clutter.KEY_Control_R ||
-                                                            event.get_key_symbol() == Clutter.KEY_Pause)) {
+        if (event.type() == Clutter.EventType.KEY_PRESS && (event.get_key_symbol() === Clutter.KEY_Control_L ||
+                                                            event.get_key_symbol() === Clutter.KEY_Control_R ||
+                                                            event.get_key_symbol() === Clutter.KEY_Pause)) {
             this.passThroughEvents = !this.passThroughEvents;
             this._updatePassthroughText();
             return true;
@@ -336,7 +336,7 @@ Inspector.prototype = {
     },
 
     _onKeyPressEvent: function (actor, event) {
-        if (event.get_key_symbol() == Clutter.KEY_Escape)
+        if (event.get_key_symbol() === Clutter.KEY_Escape)
             this._close();
         return true;
     },

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -1129,7 +1129,7 @@ function _stageEventHandler(actor, event) {
         return false;
 
     // This isn't a Meta.KeyBindingAction yet
-    if (symbol == Clutter.Super_L || symbol == Clutter.Super_R) {
+    if (symbol == Clutter.KEY_Super_L || symbol == Clutter.KEY_Super_R) {
         if (expo.visible) {
             expo.hide();
             return true;

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -1129,7 +1129,7 @@ function _stageEventHandler(actor, event) {
         return false;
 
     // This isn't a Meta.KeyBindingAction yet
-    if (symbol == Clutter.KEY_Super_L || symbol == Clutter.KEY_Super_R) {
+    if (symbol === Clutter.KEY_Super_L || symbol === Clutter.KEY_Super_R) {
         if (expo.visible) {
             expo.hide();
             return true;

--- a/js/ui/modalDialog.js
+++ b/js/ui/modalDialog.js
@@ -157,12 +157,12 @@ ModalDialog.prototype = {
      *     {
      *         label: _("Cancel"),
      *         action: Lang.bind(this, this.callback),
-     *         key: Clutter.Escape
+     *         key: Clutter.KEY_Escape
      *     },
      *     {
      *         label: _("OK"),
      *         action: Lang.bind(this, this.destroy),
-     *         key: Clutter.Return
+     *         key: Clutter.KEY_Return
      *     }
      * ]);
      * ```
@@ -243,7 +243,7 @@ ModalDialog.prototype = {
         let modifiers = Cinnamon.get_event_state(keyPressEvent);
         let ctrlAltMask = Clutter.ModifierType.CONTROL_MASK | Clutter.ModifierType.MOD1_MASK;
         let symbol = keyPressEvent.get_key_symbol();
-        if (symbol === Clutter.Escape && !(modifiers & ctrlAltMask)) {
+        if (symbol === Clutter.KEY_Escape && !(modifiers & ctrlAltMask)) {
             this.close();
             return;
         }

--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -157,7 +157,7 @@ var PopupBaseMenuItem = class PopupBaseMenuItem {
     _onKeyPressEvent(actor, event) {
         let symbol = event.get_key_symbol();
 
-        if (symbol == Clutter.KEY_space || symbol == Clutter.KEY_Return) {
+        if (symbol === Clutter.KEY_space || symbol === Clutter.KEY_Return) {
             this.activate(event);
             return true;
         }
@@ -581,7 +581,7 @@ var PopupAlternatingMenuItem = class PopupAlternatingMenuItem extends PopupBaseM
 
         let key = event.get_key_symbol();
 
-        if (key == Clutter.KEY_Alt_L || key == Clutter.KEY_Alt_R)
+        if (key === Clutter.KEY_Alt_L || key === Clutter.KEY_Alt_R)
             this._updateStateFromModifiers();
 
         return false;
@@ -791,8 +791,8 @@ var PopupSliderMenuItem = class PopupSliderMenuItem extends PopupBaseMenuItem {
 
     _onKeyPressEvent (actor, event) {
         let key = event.get_key_symbol();
-        if (key == Clutter.KEY_Right || key == Clutter.KEY_Left) {
-            let delta = key == Clutter.KEY_Right ? 0.1 : -0.1;
+        if (key === Clutter.KEY_Right || key === Clutter.KEY_Left) {
+            let delta = key === Clutter.KEY_Right ? 0.1 : -0.1;
             this._value = Math.max(0, Math.min(this._value + delta, 1));
             this._slider.queue_repaint();
             this.emit('value-changed', this._value);
@@ -2565,7 +2565,7 @@ var PopupMenu = class PopupMenu extends PopupMenuBase {
     }
 
     _onKeyPressEvent(actor, event) {
-        if (event.get_key_symbol() == Clutter.KEY_Escape) {
+        if (event.get_key_symbol() === Clutter.KEY_Escape) {
             this.close(true);
             return true;
         }
@@ -2793,7 +2793,7 @@ var PopupSubMenu = class PopupSubMenu extends PopupMenuBase {
     _onKeyPressEvent(actor, event) {
         // Move focus back to parent menu if the user types Left.
 
-        if (this.isOpen && event.get_key_symbol() == Clutter.KEY_Left) {
+        if (this.isOpen && event.get_key_symbol() === Clutter.KEY_Left) {
             this.sourceActor._delegate.setActive(true);
             this.close(true);
             return true;
@@ -2874,11 +2874,11 @@ var PopupSubMenuMenuItem = class PopupSubMenuMenuItem extends PopupBaseMenuItem 
     _onKeyPressEvent(actor, event) {
         let symbol = event.get_key_symbol();
 
-        if (symbol == Clutter.KEY_Right) {
+        if (symbol === Clutter.KEY_Right) {
             this.menu.open(true);
             this.menu.actor.navigate_focus(null, Gtk.DirectionType.DOWN, false);
             return true;
-        } else if (symbol == Clutter.KEY_Left && this.menu.isOpen) {
+        } else if (symbol === Clutter.KEY_Left && this.menu.isOpen) {
             this.menu.close();
             return true;
         }
@@ -2908,7 +2908,7 @@ var PopupComboMenu = class PopupComboMenu extends PopupMenuBase {
     }
 
     _onKeyPressEvent(actor, event) {
-        if (event.get_key_symbol() == Clutter.KEY_Escape) {
+        if (event.get_key_symbol() === Clutter.KEY_Escape) {
             this.close(true);
             return true;
         }

--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -2565,7 +2565,7 @@ var PopupMenu = class PopupMenu extends PopupMenuBase {
     }
 
     _onKeyPressEvent(actor, event) {
-        if (event.get_key_symbol() == Clutter.Escape) {
+        if (event.get_key_symbol() == Clutter.KEY_Escape) {
             this.close(true);
             return true;
         }
@@ -2908,7 +2908,7 @@ var PopupComboMenu = class PopupComboMenu extends PopupMenuBase {
     }
 
     _onKeyPressEvent(actor, event) {
-        if (event.get_key_symbol() == Clutter.Escape) {
+        if (event.get_key_symbol() == Clutter.KEY_Escape) {
             this.close(true);
             return true;
         }

--- a/js/ui/runDialog.js
+++ b/js/ui/runDialog.js
@@ -212,7 +212,7 @@ __proto__: ModalDialog.ModalDialog.prototype,
 
     _onKeyPress: function (o, e) {
         let symbol = e.get_key_symbol();
-        if (symbol == Clutter.KEY_Return || symbol == Clutter.KEY_KP_Enter) {
+        if (symbol === Clutter.KEY_Return || symbol === Clutter.KEY_KP_Enter) {
             if (o.get_text().trim() == "") {
                 return false;
             }
@@ -243,26 +243,26 @@ __proto__: ModalDialog.ModalDialog.prototype,
             }
             return true;
         }
-        if (symbol == Clutter.KEY_Escape || symbol == Clutter.KEY_Super_L || symbol == Clutter.KEY_Super_R) {
+        if (symbol === Clutter.KEY_Escape || symbol === Clutter.KEY_Super_L || symbol === Clutter.KEY_Super_R) {
             this.close();
             return true;
         }
-        if (symbol == Clutter.KEY_Tab) {
+        if (symbol === Clutter.KEY_Tab) {
             this._updateCompletions(NAVIGATE_TYPE_TAB);
             return true;
         }
 
         if (this._completionBox.visible) {
-            if (symbol == Clutter.KEY_Up) {
+            if (symbol === Clutter.KEY_Up) {
                 this._updateCompletions(NAVIGATE_TYPE_ARROW, UP);
                 return true;
-            } else if (symbol == Clutter.KEY_Down) {
+            } else if (symbol === Clutter.KEY_Down) {
                 this._updateCompletions(NAVIGATE_TYPE_ARROW, DOWN);
                 return true;
             }
         }
 
-        if (symbol == Clutter.KEY_BackSpace) {
+        if (symbol === Clutter.KEY_BackSpace) {
             this._completionSelected = 0;
             this._completionBox.hide();
             this._oldText = "";

--- a/js/ui/runDialog.js
+++ b/js/ui/runDialog.js
@@ -212,7 +212,7 @@ __proto__: ModalDialog.ModalDialog.prototype,
 
     _onKeyPress: function (o, e) {
         let symbol = e.get_key_symbol();
-        if (symbol == Clutter.Return || symbol == Clutter.KP_Enter) {
+        if (symbol == Clutter.KEY_Return || symbol == Clutter.KEY_KP_Enter) {
             if (o.get_text().trim() == "") {
                 return false;
             }
@@ -243,11 +243,11 @@ __proto__: ModalDialog.ModalDialog.prototype,
             }
             return true;
         }
-        if (symbol == Clutter.Escape || symbol == Clutter.Super_L || symbol == Clutter.Super_R) {
+        if (symbol == Clutter.KEY_Escape || symbol == Clutter.KEY_Super_L || symbol == Clutter.KEY_Super_R) {
             this.close();
             return true;
         }
-        if (symbol == Clutter.Tab) {
+        if (symbol == Clutter.KEY_Tab) {
             this._updateCompletions(NAVIGATE_TYPE_TAB);
             return true;
         }
@@ -262,7 +262,7 @@ __proto__: ModalDialog.ModalDialog.prototype,
             }
         }
 
-        if (symbol == Clutter.BackSpace) {
+        if (symbol == Clutter.KEY_BackSpace) {
             this._completionSelected = 0;
             this._completionBox.hide();
             this._oldText = "";

--- a/js/ui/slider.js
+++ b/js/ui/slider.js
@@ -187,8 +187,8 @@ Slider.prototype = {
 
     _onKeyPressEvent: function (actor, event) {
         let key = event.get_key_symbol();
-        if (key == Clutter.KEY_Right || key == Clutter.KEY_Left) {
-            let delta = key == Clutter.KEY_Right ? 0.1 : -0.1;
+        if (key === Clutter.KEY_Right || key === Clutter.KEY_Left) {
+            let delta = key === Clutter.KEY_Right ? 0.1 : -0.1;
             this._value = Math.max(0, Math.min(this._value + delta, 1));
             this.actor.queue_repaint();
             this.emit('value-changed', this._value);

--- a/js/ui/workspace.js
+++ b/js/ui/workspace.js
@@ -1295,13 +1295,13 @@ WindowContextMenu.prototype = {
 
     _onSourceKeyPress: function(actor, event) {
         let symbol = event.get_key_symbol();
-        if (symbol == Clutter.KEY_space || symbol == Clutter.KEY_Return) {
+        if (symbol === Clutter.KEY_space || symbol === Clutter.KEY_Return) {
             this.menu.toggle();
             return true;
-        } else if (symbol == Clutter.KEY_Escape && this.menu.isOpen) {
+        } else if (symbol === Clutter.KEY_Escape && this.menu.isOpen) {
             this.menu.close();
             return true;
-        } else if (symbol == Clutter.KEY_Down) {
+        } else if (symbol === Clutter.KEY_Down) {
             if (!this.menu.isOpen)
                 this.menu.toggle();
             this.menu.actor.navigate_focus(this.actor, Gtk.DirectionType.DOWN, false);

--- a/js/ui/workspace.js
+++ b/js/ui/workspace.js
@@ -1385,15 +1385,15 @@ Workspace.prototype = {
         // This relies on the fact that Clutter.ModifierType is the same as Gdk.ModifierType
         let action = global.display.get_keybinding_action(keycode, modifiers);
 
-        if ((symbol === Clutter.ISO_Left_Tab || symbol === Clutter.Tab)  && !(modifiers & ctrlAltMask)) {
-            let increment = symbol === Clutter.ISO_Left_Tab ? -1 : 1;
+        if ((symbol === Clutter.KEY_ISO_Left_Tab || symbol === Clutter.KEY_Tab)  && !(modifiers & ctrlAltMask)) {
+            let increment = symbol === Clutter.KEY_ISO_Left_Tab ? -1 : 1;
             this.selectNextNonEmptyMonitor(this.currentMonitorIndex, increment);
             return true;
         }
 
         let activeMonitor = this._monitors[this.currentMonitorIndex];
 
-        if ((symbol === Clutter.m  || symbol === Clutter.M || symbol === Clutter.KEY_space) &&
+        if ((symbol === Clutter.KEY_m  || symbol === Clutter.KEY_M || symbol === Clutter.KEY_space) &&
             (modifiers & Clutter.ModifierType.MOD1_MASK) && !(modifiers & Clutter.ModifierType.CONTROL_MASK))
         {
             activeMonitor.showMenuForSelectedWindow();
@@ -1401,17 +1401,17 @@ Workspace.prototype = {
         }
 
         if (action === Meta.KeyBindingAction.CLOSE ||
-            symbol === Clutter.w && modifiers & Clutter.ModifierType.CONTROL_MASK) {
+            symbol === Clutter.KEY_w && modifiers & Clutter.ModifierType.CONTROL_MASK) {
             activeMonitor.closeSelectedWindow();
             return true;
         }
 
-        if ((symbol === Clutter.m || symbol === Clutter.M) && modifiers & Clutter.ModifierType.CONTROL_MASK) {
+        if ((symbol === Clutter.KEY_m || symbol === Clutter.KEY_M) && modifiers & Clutter.ModifierType.CONTROL_MASK) {
             activeMonitor.moveSelectedWindowToNextMonitor();
             return true;
         }
 
-        if (symbol === Clutter.Return || symbol === Clutter.KEY_space || symbol === Clutter.KP_Enter) {
+        if (symbol === Clutter.KEY_Return || symbol === Clutter.KEY_space || symbol === Clutter.KEY_KP_Enter) {
             if (activeMonitor.activateSelectedWindow()) {
                 return true;
             }

--- a/js/ui/workspacesView.js
+++ b/js/ui/workspacesView.js
@@ -128,9 +128,9 @@ WorkspacesView.prototype = {
         let symbol = event.get_key_symbol();
 
         switch (symbol) {
-            case Clutter.Escape:
-            case Clutter.Super_L:
-            case Clutter.Super_R:
+            case Clutter.KEY_Escape:
+            case Clutter.KEY_Super_L:
+            case Clutter.KEY_Super_R:
                 Main.overview.hide();
                 return true;
             default:


### PR DESCRIPTION
# What

```c
/*
 * Compatibility version of clutter-keysyms.h.
 *
 * Since Clutter 1.4, the key symbol defines have been changed to have
 * a KEY_ prefix. This is a compatibility header that is included when
 * deprecated symbols are enabled. Consider porting to the new names
 * instead.
 */
```
**Source:** [deprecated/clutter-keysyms.h (muffin)](https://github.com/linuxmint/muffin/blob/9cbb7ea75d3855ee11a71c11e75000edc7c1ede7/clutter/clutter/deprecated/clutter-keysyms.h#L20-L27)

:fast_forward: This PR does this throughout the content of the Cinnamon repository, in an automated manner. :thumbsup:

# How

```c
#define CLUTTER_VoidSymbol 0xffffff CLUTTER_DEPRECATED_MACRO_FOR("Deprecated key symbol. Use CLUTTER_KEY_VoidSymbol instead.")
```
:arrow_right_hook: Above, an excerpt from [this long list](https://github.com/linuxmint/muffin/blob/9cbb7ea75d3855ee11a71c11e75000edc7c1ede7/clutter/clutter/deprecated/clutter-keysyms.h#L34-L2132).

`awk '{ print $2 }'` = `CLUTTER_VoidSymbol`
`awk '{ print $8 }'` = `CLUTTER_KEY_VoidSymbol`

Just need to replace `CLUTTER_` by `Clutter.` and we can then look for the first to replace it with the second.

＞ In each file, perform this action but for all entries in this list — using two different security mechanisms to ensure that only exact matches are replaced. Also, the case is preserved, to differentiate `Clutter.a` from `Clutter.A` for example.

# Remarks

:bulb: I've checked in an automated manner **all** other entries in this long list that **don't have** `CLUTTER_DEPRECATED_MACRO_FOR` as well but none are present in the case of Cinnamon <strong>(</strong>e.g. `Clutter.HomePage` and `Clutter.AudioPlay` — which also have their non-deprecated equivalent `Clutter.KEY_HomePage` and `Clutter.KEY_AudioPlay`, simply that not specified in the file but easily determinable according to the same pattern<strong>)</strong>.

:bulb: As a bonus, in a second full round (once the migration is done), I transform the few ` == Clutter.KEY_` found into ` === Clutter.KEY_`.
&nbsp;
&nbsp;

___
**Similar to:** https://github.com/GNOME/gnome-shell/commit/d3d165243c8457cc65e8864cee493f27fca15d59 ([source](https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/808/diffs?commit_id=d3d165243c8457cc65e8864cee493f27fca15d59))