### PR TITLE
Fix search in Hebrew

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -2807,7 +2807,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
 
     _matchNames(buttons, pattern){
         let ret = [];
-        let regexpPattern = new RegExp("\\b" + Util.escapeRegExp(pattern));
+        let regexpPattern = new RegExp("(?:^|\\s|;|,|.)" + Util.escapeRegExp(pattern));
 
         for (let i = 0; i < buttons.length; i++) {
             if (buttons[i].type == "recent-clear") {
@@ -2830,7 +2830,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
             return [];
 
         let apps = [];
-        let regexpPattern = new RegExp("\\b" + Util.escapeRegExp(pattern));
+        let regexpPattern = new RegExp("(?:^|\\s|;|,|.)" + Util.escapeRegExp(pattern));
 
         for (let i in this._applicationsButtons) {
             let button = this._applicationsButtons[i];


### PR DESCRIPTION
Fixes issue #9591;
Replaced the `\b` expression in the regexes with `(?:^|\s|;|,|.)` to add support for non-Latin languages.
As specified [here](https://javascript.info/regexp-boundary), the `\b` expression does not support non-Latin alphabets.
`(?:^|\s|;|,|.)` is meant to check for search query at the start of the string, after every whitespace (space, newline, etc), and after `;`, `,` and `.`.