### PR TITLE
Rename applets and desklets Add/Remove text to Enable/Disable

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_applets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_applets.py
@@ -51,8 +51,8 @@ class ManageAppletsPage(ManageSpicesPage):
     directories = [("%s/.local/share/cinnamon/applets") % GLib.get_home_dir(), "/usr/share/cinnamon/applets"]
     collection_type = "applet"
     installed_page_title = _("Installed applets")
-    instance_button_text = _("Add")
-    remove_button_text = _("Remove")
+    instance_button_text = _("Enable")
+    remove_button_text = _("Disable")
     uninstall_button_text = _("Uninstall")
     restore_button_text = _("Reset all")
 

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_desklets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_desklets.py
@@ -73,8 +73,8 @@ class ManageDeskletsPage(ManageSpicesPage):
     directories = [("%s/.local/share/cinnamon/desklets") % GLib.get_home_dir(), "/usr/share/cinnamon/desklets"]
     collection_type = "desklet"
     installed_page_title = _("Installed desklets")
-    instance_button_text = _("Add")
-    remove_button_text = _("Remove")
+    instance_button_text = _("Enable")
+    remove_button_text = _("Disable")
     uninstall_button_text = _("Uninstall")
     restore_button_text = _("Remove all")
 


### PR DESCRIPTION
To provide consistency with the extensions panel and to align the description with the interaction on what is actually being performed, the applets and desktlets "Add" and "Remove" text has been changed to "Enable" and "Disable".

| Applets Before (Add)   |      Applets After (Enable)     |
|:----------:|:-------------:|
| ![applets-add](https://user-images.githubusercontent.com/940113/93687127-f2885400-fa80-11ea-9fc8-943580e8dc57.png) | ![applets-enable](https://user-images.githubusercontent.com/940113/93687135-fc11bc00-fa80-11ea-90ba-166c62c2ec7b.png) |

| Applets Before (Remove)   |      Applets After (Disable)     |
|:----------:|:-------------:|
| ![applets-remove](https://user-images.githubusercontent.com/940113/93687162-31b6a500-fa81-11ea-9a8f-200351154693.png) | ![applets-disable](https://user-images.githubusercontent.com/940113/93687167-34b19580-fa81-11ea-985b-b8fa49d590bf.png) |


| Desklets Before (Add)   |      Desklets After (Enable)     |
|:----------:|:-------------:|
| ![desklets-add](https://user-images.githubusercontent.com/940113/93687191-6c204200-fa81-11ea-893d-3b8f242d0d1d.png) | ![desklets-enable](https://user-images.githubusercontent.com/940113/93687193-704c5f80-fa81-11ea-95ca-4919b06c7977.png) |

| Desklets Before (Remove)   |      Desklets After (Disable)     |
|:----------:|:-------------:|
| ![desklets-remove](https://user-images.githubusercontent.com/940113/93687239-b1dd0a80-fa81-11ea-9819-41bc4016d738.png) | ![desklets-disable](https://user-images.githubusercontent.com/940113/93687236-ad185680-fa81-11ea-8723-f570fd216ad8.png) |

