### PR TITLE
menu applet: search for words inbetween

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -2807,7 +2807,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
 
     _matchNames(buttons, pattern){
         let ret = [];
-        let regexpPattern = new RegExp("\\b" + Util.escapeRegExp(pattern));
+        let regexpPattern = new RegExp(Util.escapeRegExp(pattern));
 
         for (let i = 0; i < buttons.length; i++) {
             if (buttons[i].type == "recent-clear") {
@@ -2830,7 +2830,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
             return [];
 
         let apps = [];
-        let regexpPattern = new RegExp("\\b" + Util.escapeRegExp(pattern));
+        let regexpPattern = new RegExp(Util.escapeRegExp(pattern));
 
         for (let i in this._applicationsButtons) {
             let button = this._applicationsButtons[i];


### PR DESCRIPTION
The search function does a search only at the beginning of a word.
E.g. search for "Manager" does find "Update Manager", but searching for
"date" does not find "Update Manager" or a better example, searching for
"office" does not find "LibreOffice".

This commit (magic trick from mtwebster) removes the restriction to the beginning of a word.