### PR TITLE
workspace-switcher applet: New option: "Reverse scrolling direction"

### DIFF
--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
@@ -271,6 +271,7 @@ class CinnamonWorkspaceSwitcher extends Applet.Applet {
 
         this.settings = new Settings.AppletSettings(this, metadata.uuid, instance_id);
         this.settings.bind("display-type", "display_type", this.queueCreateButtons);
+        this.settings.bind("reverse-scrolling", "reverse_scrolling");
 
         this.actor.connect('scroll-event', this.hook.bind(this));
 
@@ -364,8 +365,11 @@ class CinnamonWorkspaceSwitcher extends Applet.Applet {
         if ((now - this._last_switch) > MIN_SWITCH_INTERVAL_MS ||
             direction !== this._last_switch_direction) {
 
-            if (direction == 0) Main.wm.actionMoveWorkspaceLeft();
-            else if (direction == 1) Main.wm.actionMoveWorkspaceRight();
+            // XOR used to determine the effective direction
+            if ((direction == 0) != this.reverse_scrolling)
+                Main.wm.actionMoveWorkspaceLeft();
+            else
+                Main.wm.actionMoveWorkspaceRight();
 
             this._last_switch = now;
             this._last_switch_direction = direction;

--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
@@ -270,7 +270,7 @@ class CinnamonWorkspaceSwitcher extends Applet.Applet {
             this._focusWindow = global.display.focus_window.get_compositor_private();
 
         this.settings = new Settings.AppletSettings(this, metadata.uuid, instance_id);
-        this.settings.bind("display_type", "display_type", this.queueCreateButtons);
+        this.settings.bind("display-type", "display_type", this.queueCreateButtons);
 
         this.actor.connect('scroll-event', this.hook.bind(this));
 

--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/settings-schema.json
@@ -1,10 +1,10 @@
 {
-    "display_type": {
+    "display-type": {
         "type": "combobox",
+        "default": "visual",
         "description": "Type of display",
         "tooltip": "Note that the visual representation will only work if your panel is large enough to display it properly, otherwise the simple style will be used.",
-        "default": "visual",
-        "options" : {
+        "options": {
             "A visual representation of the workspaces": "visual",
             "Simple buttons": "buttons"
         }

--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/settings-schema.json
@@ -8,5 +8,11 @@
             "A visual representation of the workspaces": "visual",
             "Simple buttons": "buttons"
         }
+    },
+    "reverse-scrolling": {
+        "type": "switch",
+        "default": false,
+        "description": "Reverse scrolling direction",
+        "tooltip": "Reverse the direction of the scroll in the workspace list."
     }
 }


### PR DESCRIPTION
### This:

- adds a new option called **Reverse scrolling direction** in the "workspace-switcher" applet _(option is off by default)_.

# Screenshot

<details>
<summary>View me ...</summary>
&nbsp;

![Screenshot from 2020-09-25 19-13-43](https://user-images.githubusercontent.com/4764956/94296643-72bc2700-ff63-11ea-8291-b636940178f6.png)
</details>

# Context

<details>
<summary>Read me ...</summary>
&nbsp;

![logitech-m705](https://user-images.githubusercontent.com/4764956/94269559-1fd07880-ff3f-11ea-8204-0fd192c78546.jpg)

On my mouse (a Logitech M705 as above), I hold the side button visible on the right side of this image and scroll down to go to the left workspace and up to go to the right workspace _(using a customized version of [this script](https://www.linuxquestions.org/questions/linux-desktop-74/%5Bxbindkeys%5D-advanced-mouse-binds-4175428297/#post4786821))_.

The goal, achieved with this PR, is to have the same behavior when I scroll on the "workspace-switcher" applet (without holding the additional button there).
</details>

# Additional information

<details>
<summary>Read me ...</summary>
&nbsp;

&nbsp;
**applet.js:**
- XOR used, like [here](https://github.com/linuxmint/cinnamon/blob/18f24baf6b80ac7e4c9cf2b0c1bd928280e1d125/files/usr/share/cinnamon/applets/window-list%40cinnamon.org/applet.js#L426).

**settings-schema.json:**
- Option called `reverse-scrolling`, like [here](https://github.com/linuxmint/cinnamon/blob/18f24baf6b80ac7e4c9cf2b0c1bd928280e1d125/files/usr/share/cinnamon/applets/window-list%40cinnamon.org/settings-schema.json#L21).

- Description set to "Reverse scrolling direction", like [here](https://github.com/linuxmint/cinnamon/search?q=%22Reverse+scrolling+direction%22).
&nbsp;

Regarding this last point, in adequacy with the [source code](https://github.com/linuxmint/cinnamon/blob/18f24baf6b80ac7e4c9cf2b0c1bd928280e1d125/files/usr/share/cinnamon/applets/workspace-switcher%40cinnamon.org/applet.js#L362-L363), use of a more generic formulation than one restricted to mice only (see [touchpad virtual scrolling](https://support.lenovo.com/us/en/solutions/HT062562)).

![b82079738bd6480eb63f4f0dace5125d](https://user-images.githubusercontent.com/4764956/94297781-591bdf00-ff65-11ea-9177-453c7f7d25cf.jpg)
:arrow_right_hook: _Touchpad virtual scrolling_.
&nbsp;
</details>

# :heavy_plus_sign: About the commit "Standardization"

<details>
<summary>Read me ...</summary>

### This mainly fixes this exception (`display_type` &nbsp;:arrow_right: &nbsp;`display-type`) …

```bash
$ cd /usr/share/cinnamon/applets

$ grep -P '".*[_].*"\s*:\s*{' */settings-schema.json
sound@cinnamon.org/settings-schema.json:    "_knownPlayers": {
workspace-switcher@cinnamon.org/settings-schema.json:    "display_type": {
```

```bash
$ cd /usr/share/cinnamon/applets

$ grep -P '".*[-].*"\s*:\s*{' */settings-schema.json
calendar@cinnamon.org/settings-schema.json:    "show-week-numbers" : {
calendar@cinnamon.org/settings-schema.json:    "use-custom-format" : {
calendar@cinnamon.org/settings-schema.json:    "custom-format" : {
calendar@cinnamon.org/settings-schema.json:    "format-button" : {
expo@cinnamon.org/settings-schema.json:    "activate-on-hover": {
grouped-window-list@cinnamon.org/settings-schema.json:  "number-display": {
grouped-window-list@cinnamon.org/settings-schema.json:  "title-display": {
grouped-window-list@cinnamon.org/settings-schema.json:  "scroll-behavior": {
grouped-window-list@cinnamon.org/settings-schema.json:  "left-click-action": {
grouped-window-list@cinnamon.org/settings-schema.json:  "middle-click-action": {
grouped-window-list@cinnamon.org/settings-schema.json:  "pinned-apps": {
grouped-window-list@cinnamon.org/settings-schema.json:  "group-apps": {
grouped-window-list@cinnamon.org/settings-schema.json:  "show-all-workspaces": {
grouped-window-list@cinnamon.org/settings-schema.json:  "enable-app-button-dragging": {
grouped-window-list@cinnamon.org/settings-schema.json:  "launcher-animation-effect": {
grouped-window-list@cinnamon.org/settings-schema.json:  "show-apps-order-hotkey": {
grouped-window-list@cinnamon.org/settings-schema.json:  "show-apps-order-timeout": {
grouped-window-list@cinnamon.org/settings-schema.json:  "thumbnail-timeout": {
grouped-window-list@cinnamon.org/settings-schema.json:  "thumbnail-size": {
grouped-window-list@cinnamon.org/settings-schema.json:  "thumbnail-scroll-behavior": {
grouped-window-list@cinnamon.org/settings-schema.json:  "show-thumbnails": {
grouped-window-list@cinnamon.org/settings-schema.json:  "animate-thumbnails": {
grouped-window-list@cinnamon.org/settings-schema.json:  "vertical-thumbnails": {
grouped-window-list@cinnamon.org/settings-schema.json:  "sort-thumbnails": {
grouped-window-list@cinnamon.org/settings-schema.json:  "highlight-last-focused-thumbnail": {
grouped-window-list@cinnamon.org/settings-schema.json:  "onclick-thumbnails": {
grouped-window-list@cinnamon.org/settings-schema.json:  "show-recent": {
grouped-window-list@cinnamon.org/settings-schema.json:  "autostart-menu-item": {
grouped-window-list@cinnamon.org/settings-schema.json:  "launch-new-instance-menu-item": {
grouped-window-list@cinnamon.org/settings-schema.json:  "monitor-move-all-windows": {
grouped-window-list@cinnamon.org/settings-schema.json:  "enable-hover-peek": {
grouped-window-list@cinnamon.org/settings-schema.json:  "hover-peek-time-in": {
grouped-window-list@cinnamon.org/settings-schema.json:  "hover-peek-time-out": {
grouped-window-list@cinnamon.org/settings-schema.json:  "hover-peek-opacity": {
menu@cinnamon.org/settings-schema.json:        "panel-appear" : {
menu@cinnamon.org/settings-schema.json:        "panel-behave" : {
menu@cinnamon.org/settings-schema.json:        "menu-layout" : {
menu@cinnamon.org/settings-schema.json:        "menu-behave" : {
menu@cinnamon.org/settings-schema.json: "overlay-key" : {
menu@cinnamon.org/settings-schema.json: "menu-custom" : {
menu@cinnamon.org/settings-schema.json: "menu-icon" : {
menu@cinnamon.org/settings-schema.json: "menu-label" : {
menu@cinnamon.org/settings-schema.json: "favbox-min-height" : {
menu@cinnamon.org/settings-schema.json: "show-category-icons" : {
menu@cinnamon.org/settings-schema.json: "show-application-icons" : {
menu@cinnamon.org/settings-schema.json: "favbox-show" : {
menu@cinnamon.org/settings-schema.json: "show-places" : {
menu@cinnamon.org/settings-schema.json: "show-recents" : {
menu@cinnamon.org/settings-schema.json:"enable-autoscroll" : {
menu@cinnamon.org/settings-schema.json:"search-filesystem" : {
menu@cinnamon.org/settings-schema.json:"activate-on-hover" : {
menu@cinnamon.org/settings-schema.json: "hover-delay" : {
menu@cinnamon.org/settings-schema.json: "enable-animation" : {
menu@cinnamon.org/settings-schema.json:  "menu-editor-button" : {
panel-launchers@cinnamon.org/settings-schema.json:    "allow-dragging": {
printers@cinnamon.org/settings-schema.json:    "show-icon": {
scale@cinnamon.org/settings-schema.json: "activate-on-hover": {
settings-example@cinnamon.org/settings-schema.json:    "label-info" : {
settings-example@cinnamon.org/settings-schema.json:    "icon-name": {
settings-example@cinnamon.org/settings-schema.json:    "spinner-number" : {
settings-example@cinnamon.org/settings-schema.json:    "combo-selection" : {
settings-example@cinnamon.org/settings-schema.json:    "scale-demo" : {
settings-example@cinnamon.org/settings-schema.json:    "use-custom-label" : {
settings-example@cinnamon.org/settings-schema.json:    "custom-label" : {
settings-example@cinnamon.org/settings-schema.json:    "tween-function" : {
settings-example@cinnamon.org/settings-schema.json:    "effect-style" : {
settings-example@cinnamon.org/settings-schema.json:    "demo-button" : {
settings-example@cinnamon.org/settings-schema.json:    "signal-test" : {
settings-example@cinnamon.org/settings-schema.json:    "keybinding-test" : {
settings-example@cinnamon.org/settings-schema.json:    "file-select" : {
settings-example@cinnamon.org/settings-schema.json:    "directory-select" : {
settings-example@cinnamon.org/settings-schema.json:    "sound-select" : {
settings-example@cinnamon.org/settings-schema.json:    "font-select" : {
settings-example@cinnamon.org/settings-schema.json:    "long-text" : {
settings-example@cinnamon.org/settings-schema.json:    "date-select" : {
settings-example@cinnamon.org/settings-schema.json:    "time-select" : {
settings-example@cinnamon.org/settings-schema.json:    "show-deps-section" : {
settings-example@cinnamon.org/settings-schema.json:    "deps-info" : {
settings-example@cinnamon.org/settings-schema.json:    "dep-combo" : {
settings-example@cinnamon.org/settings-schema.json:    "dep-combo-info1" : {
settings-example@cinnamon.org/settings-schema.json:    "dep-combo-info2" : {
settings-example@cinnamon.org/settings-schema.json:    "dep-spin" : {
settings-example@cinnamon.org/settings-schema.json:    "dep-spin-info1" : {
settings-example@cinnamon.org/settings-schema.json:    "dep-spin-info2" : {
settings-example@cinnamon.org/settings-schema.json:    "custom-widget": {
show-desktop@cinnamon.org/settings-schema.json: "peek-at-desktop" : {
show-desktop@cinnamon.org/settings-schema.json:  "peek-blur" : {
show-desktop@cinnamon.org/settings-schema.json: "peek-delay" : {
show-desktop@cinnamon.org/settings-schema.json: "peek-opacity": {
user@cinnamon.org/settings-schema.json: "display-name" : {
window-list@cinnamon.org/settings-schema.json:  "show-all-workspaces" : {
window-list@cinnamon.org/settings-schema.json:  "enable-alerts" : {
window-list@cinnamon.org/settings-schema.json:  "enable-scrolling" : {
window-list@cinnamon.org/settings-schema.json:  "reverse-scrolling" : {
window-list@cinnamon.org/settings-schema.json:  "left-click-minimize": {
window-list@cinnamon.org/settings-schema.json:  "middle-click-close": {
window-list@cinnamon.org/settings-schema.json:  "buttons-use-entire-space": {
window-list@cinnamon.org/settings-schema.json:  "window-preview": {
window-list@cinnamon.org/settings-schema.json:  "window-preview-show-label": {
window-list@cinnamon.org/settings-schema.json:  "window-preview-scale": {
```

:memo: If the user changed this value before this modification, he will have to change it again due to this option name change.
&nbsp;

### … and puts the option `default` in second position because it's more frequent (based on real applets):

```bash
$ cd /usr/share/cinnamon/applets

$ grep '"type"' */settings-schema.json -A1 | grep -v '"type"' | grep -v "\-\-" | grep -F -v "settings-example@cinnamon.org" | grep default | wc -l
80
==> Number of occurrences where the option immediately following the option "type" is "default".

$ grep '"type"' */settings-schema.json -A1 | grep -v '"type"' | grep -v "\-\-" | grep -F -v "settings-example@cinnamon.org" | grep -v default | wc -l
35
==> Number of occurrences where the option immediately following the option "type" is not "default".
```
</details>