### PR TITLE
fix issue #9546

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1302,6 +1302,8 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
     }
 
     _initial_cat_selection (start_index) {
+        if(this.lastSelectedCategory !== null) //if a category is already selected
+            return;
         let n = this._applicationsButtons.length;
         for (let i = start_index; i < n; i++) {
             this._applicationsButtons[i].actor.show();


### PR DESCRIPTION
This PR fixes issue #9546

The problem was that the `_initial_cat_selection` function can be executed after a category is selected due to being called asynchronously, and there was no check if it _is_ running after a category has been selected.