### PR TITLE
menu applet: fix broken search, if no recent documents

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -2810,7 +2810,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         let regexpPattern = new RegExp(Util.escapeRegExp(pattern));
 
         for (let i = 0; i < buttons.length; i++) {
-            if (buttons[i].type == "recent-clear") {
+            if (buttons[i].type == "recent-clear" || buttons[i].type == "no-recent") {
                 continue;
             }
             let res = buttons[i].searchStrings[0].match(regexpPattern);


### PR DESCRIPTION
If "Show recent documents" is activated, but there are no recent
documents, the search doesn't work at all.