### PR TITLE
xlet-settings.py: Take into account icon.svg prior to icon.png

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/xlet-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/xlet-settings.py
@@ -255,9 +255,13 @@ class MainWindow(object):
         if "icon" in self.xlet_meta:
             self.window.set_icon_name(self.xlet_meta["icon"])
         else:
-            icon_path = os.path.join(self.xlet_dir, "icon.png")
+            icon_path = os.path.join(self.xlet_dir, "icon.svg")
             if os.path.exists(icon_path):
                 self.window.set_icon_from_file(icon_path)
+            else:
+                icon_path = os.path.join(self.xlet_dir, "icon.png")
+                if os.path.exists(icon_path):
+                    self.window.set_icon_from_file(icon_path)
         self.window.set_title(translate(self.uuid, self.xlet_meta["name"]))
 
         def check_sizing(widget, data=None):


### PR DESCRIPTION
Until now, when viewing an applet's settings, the `icon.png` icon was displayed in the panel, which could contrast with the applet icon itself and confuse the user.

From now on, if an `icon.svg` icon exists then this one is displayed first.