### PR TITLE
"KEY_KP_Enter" as an alternative to "KEY_Return" everywhere

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
@@ -1130,7 +1130,7 @@ class AppThumbnailHoverMenu extends PopupMenu.PopupMenu {
             } else {
                 index = this.appThumbnails.length - 1;
             }
-        } else if (symbol === Clutter.KEY_Return && entered) {
+        } else if ((symbol === Clutter.KEY_Return || symbol === Clutter.KEY_KP_Enter) && entered) {
             this.appThumbnails[i].connectToWindow(null, 1);
         } else if (symbol === closeArg) {
             this.appThumbnails[i].onLeave();

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1858,7 +1858,8 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                 return false;
             index = item_actor.get_parent()._vis_iter.getAbsoluteIndexOfChild(item_actor);
         } else {
-            if ((this._activeContainer && this._activeContainer !== this.categoriesBox) && (symbol === Clutter.KEY_Return || symbol === Clutter.KEY_KP_Enter)) {
+            if ((this._activeContainer && this._activeContainer !== this.categoriesBox) &&
+                (symbol === Clutter.KEY_Return || symbol === Clutter.KEY_KP_Enter)) {
                 if (!ctrlKey) {
                     item_actor = this._activeContainer.get_child_at_index(this._selectedItemIndex);
                     item_actor._delegate.activate();

--- a/js/ui/appSwitcher/appSwitcher.js
+++ b/js/ui/appSwitcher/appSwitcher.js
@@ -270,6 +270,7 @@ AppSwitcher.prototype = {
                 return true;
 
             case Clutter.KEY_Return:
+            case Clutter.KEY_KP_Enter:
                 // Enter -> Select active window
                 this._activateSelected();
                 return true;

--- a/js/ui/expoThumbnail.js
+++ b/js/ui/expoThumbnail.js
@@ -484,7 +484,9 @@ ExpoWorkspaceThumbnail.prototype = {
     onTitleKeyPressEvent: function(actor, event) {
         this.undoTitleEdit = false;
         let symbol = event.get_key_symbol();
-        if (symbol === Clutter.KEY_Return || symbol === Clutter.KEY_Escape) {
+        if (symbol === Clutter.KEY_Return ||
+            symbol === Clutter.KEY_KP_Enter ||
+            symbol === Clutter.KEY_Escape) {
             if (symbol === Clutter.KEY_Escape) {
                 this.undoTitleEdit = true;
             }
@@ -1135,8 +1137,9 @@ ExpoThumbnailsBox.prototype = {
         let modifiers = Cinnamon.get_event_state(event);
         let ctrlAltMask = Clutter.ModifierType.CONTROL_MASK | Clutter.ModifierType.MOD1_MASK;
         let symbol = event.get_key_symbol();
-        if (symbol === Clutter.KEY_Return || symbol === Clutter.KEY_space 
-            || symbol === Clutter.KEY_KP_Enter)
+        if (symbol === Clutter.KEY_Return ||
+            symbol === Clutter.KEY_KP_Enter ||
+            symbol === Clutter.KEY_space)
         {
             this.activateSelectedWorkspace();
             return true;

--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -157,7 +157,9 @@ var PopupBaseMenuItem = class PopupBaseMenuItem {
     _onKeyPressEvent(actor, event) {
         let symbol = event.get_key_symbol();
 
-        if (symbol === Clutter.KEY_space || symbol === Clutter.KEY_Return) {
+        if (symbol === Clutter.KEY_space ||
+            symbol === Clutter.KEY_Return ||
+            symbol === Clutter.KEY_KP_Enter) {
             this.activate(event);
             return true;
         }

--- a/js/ui/workspace.js
+++ b/js/ui/workspace.js
@@ -1295,7 +1295,9 @@ WindowContextMenu.prototype = {
 
     _onSourceKeyPress: function(actor, event) {
         let symbol = event.get_key_symbol();
-        if (symbol === Clutter.KEY_space || symbol === Clutter.KEY_Return) {
+        if (symbol === Clutter.KEY_space ||
+            symbol === Clutter.KEY_Return ||
+            symbol === Clutter.KEY_KP_Enter) {
             this.menu.toggle();
             return true;
         } else if (symbol === Clutter.KEY_Escape && this.menu.isOpen) {
@@ -1411,7 +1413,9 @@ Workspace.prototype = {
             return true;
         }
 
-        if (symbol === Clutter.KEY_Return || symbol === Clutter.KEY_space || symbol === Clutter.KEY_KP_Enter) {
+        if (symbol === Clutter.KEY_Return ||
+            symbol === Clutter.KEY_KP_Enter ||
+            symbol === Clutter.KEY_space) {
             if (activeMonitor.activateSelectedWindow()) {
                 return true;
             }

--- a/src/st/st-button.c
+++ b/src/st/st-button.c
@@ -207,7 +207,8 @@ st_button_key_press (ClutterActor    *actor,
   if (button->priv->button_mask & ST_BUTTON_ONE)
     {
       if (event->keyval == CLUTTER_KEY_space ||
-          event->keyval == CLUTTER_KEY_Return)
+          event->keyval == CLUTTER_KEY_Return ||
+          event->keyval == CLUTTER_KEY_KP_Enter)
         {
           st_button_press (button, ST_BUTTON_ONE);
           return TRUE;
@@ -226,7 +227,8 @@ st_button_key_release (ClutterActor    *actor,
   if (button->priv->button_mask & ST_BUTTON_ONE)
     {
       if (event->keyval == CLUTTER_KEY_space ||
-          event->keyval == CLUTTER_KEY_Return)
+          event->keyval == CLUTTER_KEY_Return ||
+          event->keyval == CLUTTER_KEY_KP_Enter)
         {
           gboolean is_click;
 


### PR DESCRIPTION
### This:

- adds "KEY_KP_Enter" _(numpad Enter key)_ as an alternative to "KEY_Return" _(Enter key)_ everywhere.

#### Examples

- In Alt+Tab;
- In the context menu of the Cinnamon panel;
- etc.
&nbsp;
___
![KEY_Return_and_KEY_KP_Enter](https://user-images.githubusercontent.com/4764956/95903031-e8165d00-0d95-11eb-8e81-543f7aa78a78.jpg)