### PR TITLE
[WIP] Added proper scaling of grouped window list's window buttons. (Fixing issue #9320)

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -449,7 +449,11 @@ class AppGroup {
             return;
         }
 
-        let width = MAX_BUTTON_WIDTH * global.ui_scale;
+        let iconNaturalSize = this.iconBox.get_preferred_width(forHeight);
+        let labelNaturalSize = this.label.get_preferred_width(forHeight);
+
+        let width = Math.min(iconNaturalSize + labelNaturalSize, 
+                                MAX_BUTTON_WIDTH * global.ui_scale);
 
         this.labelVisible = true;
         if (this.label.text == null) {
@@ -480,9 +484,6 @@ class AppGroup {
         if (!this.label || this.label.is_finalized() || !this.label.realized) return;
 
         this.label.set_text('');
-        this.labelVisible = false;
-        this.label.width = 1;
-        this.label.hide();
     }
 
     onEnter() {

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -449,8 +449,8 @@ class AppGroup {
             return;
         }
 
-        let iconNaturalSize = this.iconBox.get_preferred_width(forHeight);
-        let labelNaturalSize = this.label.get_preferred_width(forHeight);
+        let iconNaturalSize = this.iconBox.get_preferred_width();
+        let labelNaturalSize = this.label.get_preferred_width();
 
         let width = Math.min(iconNaturalSize + labelNaturalSize, 
                                 MAX_BUTTON_WIDTH * global.ui_scale);


### PR DESCRIPTION
Issue described in #9320 has been fixed. Window buttons will now always be as long as the text of the window name. Previously, such behaviour would only occur when the DE is restarted with Alt+F2 and "r" as the input command and only for pre-existing window buttons.