### PR TITLE
Replace deprecated gvfs-bin calls with gio-tool

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -118,7 +118,6 @@ Depends:
  gettext,
  gir1.2-cinnamondesktop-3.0,
  gir1.2-meta-muffin-0.0,
- gvfs-bin,
  gir1.2-timezonemap-1.0,
  xdg-utils,
  python3-xapp,

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -515,7 +515,7 @@ class TransientButton extends SimpleMenuItem {
         } else {
             // Try anyway, even though we probably shouldn't.
             try {
-                Util.spawn(['gvfs-open', this.file.get_uri()]);
+                Util.spawn(['gio', 'open', this.file.get_uri()]);
             } catch (e) {
                 global.logError("No handler available to open " + this.file.get_uri());
             }

--- a/js/ui/messageTray.js
+++ b/js/ui/messageTray.js
@@ -134,7 +134,7 @@ URLHighlighter.prototype = {
                     return true;
                 } catch (e) {
                     // TODO: remove this after gnome 3 release
-                    Util.spawn(['gvfs-open', url]);
+                    Util.spawn(['gio', 'open', url]);
                     return true;
                 }
             }

--- a/js/ui/search.js
+++ b/js/ui/search.js
@@ -298,7 +298,7 @@ OpenSearchSystem.prototype = {
         } catch (e) {
             // TODO: remove this after glib will be removed from moduleset
             // In the default build gio is in our prefix but gvfs is not
-            Util.spawn(['gvfs-open', url])
+            Util.spawn(['gio', 'open', url])
         }
 
         Main.overview.hide();


### PR DESCRIPTION
Maximiliano Curia patch from debian packages, used from cinnamon 4.0 packages.
As reported by Simon McVittie in
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=877738, in the next debian
version the deprecated gvfs-bin will be removed.

This patch remove also gvfs-bin from deps, libglib2.0-bin is already present and
used.