### PR TITLE
[WIP] window-list applet: use the hotkeys to quick switch between windows

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -109,7 +109,7 @@ class WindowPreview extends Tooltips.TooltipBase {
         if (this._windowActor) {
             return this._windowActor;
         } else {
-            log("metaWindow has no actor!");
+            global.log("[window-list] metaWindow has no actor!");
             return null;
         }
     }
@@ -260,6 +260,7 @@ class AppMenuButton {
             reactive: true,
             can_focus: true,
             track_hover: true });
+        this.actor.metaWindow = metaWindow;
 
         this._applet = applet;
         this.metaWindow = metaWindow;
@@ -521,6 +522,22 @@ class AppMenuButton {
             title = "||"+ title;
         }
 
+        if (this._applet.displayWinNumbers) {
+            let button_actors_list = this._applet.manager_container.get_children();
+            if (button_actors_list) {
+                let index = 0;
+                for (let button_actor of button_actors_list) {
+                    if (button_actor.visible) {
+                        index++;
+                    }
+                    if (button_actor == this.actor) {
+                        title = `[${index}] ${title}`;
+                        break;
+                    }
+                }
+            }
+        }
+
         this._label.set_text(title);
     }
 
@@ -718,6 +735,10 @@ class AppMenuButton {
             }
 
             this._label.allocate(childBox, flags);
+        }
+
+        if (this._applet.displayWinNumbers) {
+            this._applet._reTitleItems();
         }
 
         if (!this.progressOverlay.visible) {
@@ -1014,10 +1035,17 @@ class CinnamonWindowListApplet extends Applet.Applet {
         this.settings.bind("reverse-scrolling", "reverseScroll");
         this.settings.bind("left-click-minimize", "leftClickMinimize");
         this.settings.bind("middle-click-close", "middleClickClose");
+
         this.settings.bind("buttons-use-entire-space", "buttonsUseEntireSpace", this._refreshAllItems);
         this.settings.bind("window-preview", "usePreview", this._onPreviewChanged);
         this.settings.bind("window-preview-show-label", "showLabel", this._onPreviewChanged);
         this.settings.bind("window-preview-scale", "previewScale", this._onPreviewChanged);
+        this.settings.bind("display-win-numbers", "displayWinNumbers", this._reTitleItems);
+
+        this.settings.bind("use-hotkeys", "useHotkeys", this.enableHotkeys);
+        for (let i = 1; i <= 10; i++) {
+            this.settings.bind(`hotkey-win-${i}`, `hotkeyWin_${i}`, this.enableHotkeys);
+        }
 
         this.signals.connect(global.screen, 'window-added', this._onWindowAddedAsync, this);
         this.signals.connect(global.screen, 'window-monitor-changed', this._onWindowMonitorChanged, this);
@@ -1033,6 +1061,8 @@ class CinnamonWindowListApplet extends Applet.Applet {
 
         this.on_orientation_changed(orientation);
         this._updateAttentionGrabber();
+
+        this.enableHotkeys();
     }
 
     on_applet_added_to_panel(userEnabled) {
@@ -1041,6 +1071,7 @@ class CinnamonWindowListApplet extends Applet.Applet {
     }
 
     on_applet_removed_from_panel() {
+        this.disableHotkeys();
         this.signals.disconnectAllSignals();
         this.settings.finalize();
     }
@@ -1143,6 +1174,10 @@ class CinnamonWindowListApplet extends Applet.Applet {
 
     _onWindowWorkspaceChanged(screen, metaWindow, metaWorkspace) {
         this._refreshItemByMetaWindow(metaWindow);
+
+        if (this.displayWinNumbers) {
+            this._reTitleItems();
+        }
     }
 
     _onWindowAppChanged(tracker, metaWindow) {
@@ -1297,6 +1332,10 @@ class CinnamonWindowListApplet extends Applet.Applet {
                 }
             }
         }
+
+        if (this.displayWinNumbers) {
+            this._reTitleItems();
+        }
     }
 
     _removeWindow(metaWindow) {
@@ -1307,6 +1346,10 @@ class CinnamonWindowListApplet extends Applet.Applet {
                 this._windows[i].destroy();
                 this._windows.splice(i, 1);
             }
+        }
+
+        if (this.displayWinNumbers) {
+            this._reTitleItems();
         }
     }
 
@@ -1348,7 +1391,6 @@ class CinnamonWindowListApplet extends Applet.Applet {
             this.manager_container.set_child_at_index(this._dragPlaceholder.actor,
                                                          this._dragPlaceholderPos);
         }
-
         return DND.DragMotionResult.MOVE_DROP;
     }
 
@@ -1386,6 +1428,49 @@ class CinnamonWindowListApplet extends Applet.Applet {
         if (this._tooltipErodeTimer) {
             Mainloop.source_remove(this._tooltipErodeTimer);
             this._tooltipErodeTimer = null;
+        }
+    }
+
+    enableHotkeys() {
+        this.disableHotkeys();
+
+        if (this.useHotkeys) {
+            for (let i = 1; i <= 10; i++) {
+                try {
+                    let [hk_1st_ten, hk_2nd_ten] = this[`hotkeyWin_${i}`].split("::");
+                    if (hk_1st_ten) {
+                        Main.keybindingManager.addHotKey(`winlistSwitchToWin_${i}`, hk_1st_ten, () => this.switchToWinNum(i));
+                    }
+                    if (hk_2nd_ten) {
+                        Main.keybindingManager.addHotKey(`winlistSwitchToWin_${i + 10}`, hk_2nd_ten, () => this.switchToWinNum(i + 10));
+                    }
+                } catch(err) {
+                    this.useHotkeys = false;
+                    global.log(`[window-list] exception at hotkeys registration: ${err.message}`);
+                }
+            }
+        }
+    }
+
+    disableHotkeys() {
+        for (let i = 1; i <= 20; i++) {
+            Main.keybindingManager.removeHotKey(`winlistSwitchToWin_${i}`);
+        }
+    }
+
+    switchToWinNum(window_num) {
+        let button_actors_list = this.manager_container.get_children();
+        if (button_actors_list) {
+            let index = 0;
+            for (let button_actor of button_actors_list) {
+                if (button_actor.visible) {
+                    index++;
+                }
+                if (index == window_num) {
+                    button_actor.metaWindow.activate(global.get_current_time());
+                    break;
+                }
+            }
         }
     }
 }

--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/settings-schema.json
@@ -65,5 +65,69 @@
           "Largest": 1.5
       },
       "dependency": "window-preview"
+  },
+  "display-win-numbers": {
+    "type" : "checkbox",
+    "default" : true,
+    "description": "Show the number in a window button title"
+  },
+  "section3": {
+    "type": "section",
+    "description": "Hotkeys"
+  },
+  "use-hotkeys" : {
+    "type" : "checkbox",
+    "default" : false,
+    "description": "Switch to a window by the number"
+  },
+  "hotkey-win-1": {
+    "type" : "keybinding",
+    "default" : "<Super>1::<Shift><Super>1",
+    "description" : "Window 1 / Window 11"
+  },
+  "hotkey-win-2": {
+    "type" : "keybinding",
+    "default" : "<Super>2::<Shift><Super>2",
+    "description" : "Window 2 / Window 12"
+  },
+  "hotkey-win-3": {
+    "type" : "keybinding",
+    "default" : "<Super>3::<Shift><Super>3",
+    "description" : "Window 3 / Window 13"
+  },
+  "hotkey-win-4": {
+    "type" : "keybinding",
+    "default" : "<Super>4::<Shift><Super>4",
+    "description" : "Window 4 / Window 14"
+  },
+  "hotkey-win-5": {
+    "type" : "keybinding",
+    "default" : "<Super>5::<Shift><Super>5",
+    "description" : "Window 5 / Window 15"
+  },
+  "hotkey-win-6": {
+    "type" : "keybinding",
+    "default" : "<Super>6::<Shift><Super>6",
+    "description" : "Window 6 / Window 16"
+  },
+  "hotkey-win-7": {
+    "type" : "keybinding",
+    "default" : "<Super>7::<Shift><Super>7",
+    "description" : "Window 7 / Window 17"
+  },
+  "hotkey-win-8": {
+    "type" : "keybinding",
+    "default" : "<Super>8::<Shift><Super>8",
+    "description" : "Window 8 / Window 18"
+  },
+  "hotkey-win-9": {
+    "type" : "keybinding",
+    "default" : "<Super>9::<Shift><Super>9",
+    "description" : "Window 9 / Window 19"
+  },
+  "hotkey-win-10": {
+    "type" : "keybinding",
+    "default" : "<Super>0::<Shift><Super>0",
+    "description" : "Window 10 / Window 20"
   }
 }


### PR DESCRIPTION
Add hot keys to switch between windows by its number.

By default these shortcuts is used:
 - Super+N - for windows with numbers 1..10
 - Super+Shift+N - for windows with numbers 11..20

Hotkeys is fully customizable. This feature can be disabled/enabled.
Code is simple and stable - tested around two months with various
versions of cinnamon.