### PR TITLE
fix lmde4 build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -18,5 +18,9 @@ override_dh_auto_configure:
 		-D docs=true \
 		-D deprecated_warnings=false
 
+# workaround for fix lmde4 build
+override_dh_dwz:
+
+
 override_dh_strip:
 	dh_strip --dbg-package=cinnamon-dbg


### PR DESCRIPTION
Actually lmde4 build fails, workaround it disabling dh_dwz, was added by default
in compat 12. Probably the issue is an unexpected case in dh_strip with old
manual debug packages used by cinnamon (instead
https://wiki.debian.org/AutomaticDebugPackages)