### PR TITLE
Make building the reference documentation optional

### DIFF
--- a/docs/reference/meson.build
+++ b/docs/reference/meson.build
@@ -1,13 +1,15 @@
-version_conf = configuration_data()
-version_conf.set('VERSION', version)
+if get_option('docs')
+    version_conf = configuration_data()
+    version_conf.set('VERSION', version)
 
-configure_file(
-    input: 'version.xml.in',
-    output: 'version.xml',
-    configuration: version_conf,
-)
+    configure_file(
+        input: 'version.xml.in',
+        output: 'version.xml',
+        configuration: version_conf,
+    )
 
-subdir('cinnamon')
-subdir('cinnamon-js')
-subdir('cinnamon-tutorials')
-subdir('st')
+    subdir('cinnamon')
+    subdir('cinnamon-js')
+    subdir('cinnamon-tutorials')
+    subdir('st')
+endif


### PR DESCRIPTION
This makes building the reference documentation optional to prevent root ownership in the build folder when building and installing without package management.
The meson option is already available but unused. The corresponding debian rule is also already present.