### PR TITLE
grouped-window-list: Add FLASH_MAX_COUNT constant

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -14,6 +14,7 @@ const {createStore} = imports.misc.state;
 const {AppMenuButtonRightClickMenu, HoverMenuController, AppThumbnailHoverMenu} = require('./menus');
 const {
     FLASH_INTERVAL,
+    FLASH_MAX_COUNT,
     MAX_BUTTON_WIDTH,
     BUTTON_BOX_ANIMATION_TIME,
     RESERVE_KEYS,
@@ -328,7 +329,7 @@ class AppGroup {
 
         this.actor.remove_style_pseudo_class('active');
         this.actor.add_style_class_name('grouped-window-list-item-demands-attention');
-        if (counter < 4) {
+        if (counter < FLASH_MAX_COUNT) {
             setTimeout(() => {
                 if (this.actor && this.actor.has_style_class_name('grouped-window-list-item-demands-attention')) {
                     this.actor.remove_style_class_name('grouped-window-list-item-demands-attention');

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/constants.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/constants.js
@@ -10,6 +10,7 @@ const constants = {
     BUTTON_BOX_ANIMATION_TIME: 0.15,
     MAX_BUTTON_WIDTH: 150, // Pixels
     FLASH_INTERVAL: 500,
+    FLASH_MAX_COUNT: 4,
     RESERVE_KEYS: ['willUnmount'],
     ICON_NAMES: {
         area_shot: 'screenshot-area',


### PR DESCRIPTION
This way the amount of flashes is not hardcoded in the UI code anymore.

If this were to be merged, should I do the same for the `window-list` applet?