### PR TITLE
Solve a deprecation warning in an if statement

### DIFF
--- a/src/cinnamon-generic-container.c
+++ b/src/cinnamon-generic-container.c
@@ -273,7 +273,7 @@ cinnamon_generic_container_get_paint_volume (ClutterActor *self,
         {
           const ClutterPaintVolume *child_volume;
 
-          if (!CLUTTER_ACTOR_IS_VISIBLE (child))
+          if (!clutter_actor_is_visible (child))
             continue;
 
           if (cinnamon_generic_container_get_skip_paint (CINNAMON_GENERIC_CONTAINER  (self), child))


### PR DESCRIPTION
Build thinks it should be lowercase.

It also complains about pre-processor symbols which I'll look into-I think it's tab formatting.