### PR TITLE
Add mic mute keyboard shortcut option

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_keyboard.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_keyboard.py
@@ -176,6 +176,7 @@ KEYBINDINGS = [
     [_("Volume mute"), MEDIA_KEYS_SCHEMA, "volume-mute", "media"],
     [_("Volume down"), MEDIA_KEYS_SCHEMA, "volume-down", "media"],
     [_("Volume up"), MEDIA_KEYS_SCHEMA, "volume-up", "media"],
+    [_("Mic mute"), MEDIA_KEYS_SCHEMA, "mic-mute", "media"],
     [_("Launch media player"), MEDIA_KEYS_SCHEMA, "media", "media"],
     [_("Play"), MEDIA_KEYS_SCHEMA, "play", "media"],
     [_("Pause playback"), MEDIA_KEYS_SCHEMA, "pause", "media"],


### PR DESCRIPTION
This allows a keyboard shortcut to be configured for "Mic mute". Adding this and configuring a key already seems to make toggle muting the default input/mic to work for me.

Partly fixes https://github.com/linuxmint/cinnamon/issues/9310
