### PR TITLE
Improve integration of flatpak apps for side-by-side installations

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appList.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appList.js
@@ -150,27 +150,12 @@ class AppList {
         }, 2000)
     }
 
-    // Gets a list of every app on the current workspace
-    getSpecialApps() {
-        this.specialApps = [];
-        let apps = Gio.app_info_get_all();
-
-        for (let i = 0, len = apps.length; i < len; i++) {
-            let wmClass = apps[i].get_startup_wm_class();
-            if (wmClass) {
-                let id = apps[i].get_id();
-                this.specialApps.push({id, wmClass});
-            }
-        }
-    }
-
     refreshList() {
         for (let i = 0, len = this.appList.length; i < len; i++) {
             this.appList[i].destroy();
             this.appList[i] = null;
         }
         this.appList = [];
-        this.getSpecialApps();
         this.loadFavorites();
         this.refreshApps();
     }
@@ -250,13 +235,7 @@ class AppList {
         // If it does, then we don't need to do anything.  If not, we need to
         // create an app group.
         if (!app) {
-            app = this.state.trigger('getAppFromWMClass', this.specialApps, metaWindow);
-        }
-        if (!app) {
-            let tracker = this.state.trigger('getTracker');
-            if (tracker) {
-                app = tracker.get_window_app(metaWindow);
-            }
+            app = this.state.trigger('getAppFromWindow', metaWindow);
         }
         if (!app
             || (!isFavoriteApp

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -222,7 +222,7 @@ class GroupedWindowListApplet extends Applet.Applet {
             getPanelIconSize: () => this.getPanelIconSize(),
             getPanelMonitor: () => this.panel ? Main.layoutManager.monitors[this.panel.monitorIndex] : null,
             getAppSystem: () => Cinnamon.AppSystem.get_default(),
-            getAppFromWMClass: (specialApps, metaWindow) => this.getAppFromWMClass(specialApps, metaWindow),
+            getAppFromWindow: (metaWindow) => this.getAppFromWindow(metaWindow),
             getTracker: () => this.tracker,
             addWindowToAllWorkspaces: (win, app, isFavoriteApp) => {
                 each(this.appLists, function(appList) {
@@ -615,20 +615,19 @@ class GroupedWindowListApplet extends Applet.Applet {
         this.state.set({lastTitleDisplay: titleDisplay});
     }
 
-    getAppFromWMClass(specialApps, metaWindow) {
-        let startupClass = (wmClass) => {
-            let app = null;
-            for (let i = 0, len = specialApps.length; i < len; i++) {
-                if (specialApps[i].wmClass === wmClass) {
-                    app = this.appSystem.lookup_app(specialApps[i].id);
-                    if (app) {
-                        app.wmClass = wmClass;
-                    }
-                }
-            }
-            return app;
-        };
-        return startupClass(metaWindow.get_wm_class_instance());
+    getAppFromWindow(metaWindow) {
+        let tracker = this.state.trigger('getTracker');
+        if (!tracker) {
+          return null;
+        }
+        let app = tracker.get_window_app(metaWindow);
+        if (!app) {
+          app = tracker.get_app_from_pid(metaWindow.get_pid());
+        }
+        if (!app) {
+          app = tracker.get_app_from_pid(metaWindow.get_client_pid());
+        }
+        return app;
     }
 
     getCurrentAppList() {

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -363,7 +363,7 @@ class ApplicationContextMenuItem extends PopupMenu.PopupBaseMenuItem {
                 break;
             case "add_to_desktop":
                 let file = Gio.file_new_for_path(this._appButton.app.get_app_info().get_filename());
-                let destFile = Gio.file_new_for_path(USER_DESKTOP_PATH+"/"+this._appButton.app.get_id());
+                let destFile = Gio.file_new_for_path(USER_DESKTOP_PATH+"/"+file.get_basename());
                 try{
                     file.copy(destFile, 0, null, function(){});
                     FileUtils.changeModeGFile(destFile, 755);

--- a/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
@@ -3,6 +3,7 @@ const AppletManager = imports.ui.appletManager;
 const Clutter = imports.gi.Clutter;
 const St = imports.gi.St;
 const Cinnamon = imports.gi.Cinnamon;
+const CMenu = imports.gi.CMenu;
 const Lang = imports.lang;
 const Gio = imports.gi.Gio;
 const PopupMenu = imports.ui.popupMenu;
@@ -578,7 +579,7 @@ class CinnamonPanelLaunchersApplet extends Applet.Applet {
         let app = appSys.lookup_app(path);
         let appinfo = null;
         if (!app) {
-            appinfo = Gio.DesktopAppInfo.new_from_filename(CUSTOM_LAUNCHERS_PATH+"/"+path);
+            appinfo = CMenu.DesktopAppInfo.new_from_filename(CUSTOM_LAUNCHERS_PATH+"/"+path);
             if (!appinfo) {
                 global.logWarning(`Failed to add launcher from path: ${path}`);
                 return null;

--- a/files/usr/share/cinnamon/desklets/launcher@cinnamon.org/desklet.js
+++ b/files/usr/share/cinnamon/desklets/launcher@cinnamon.org/desklet.js
@@ -1,5 +1,6 @@
 //-*- indent-tabs-mode: nil-*-
 const Cinnamon = imports.gi.Cinnamon;
+const CMenu = imports.gi.CMenu;
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 const Lang = imports.lang;
@@ -48,7 +49,7 @@ class CinnamonLauncherDesklet extends Desklet.Desklet {
                 desktopFile = settingsList[i].split(':')[1];
                 app = appSys.lookup_app(desktopFile);
                 if (!app) {
-                    app = Gio.DesktopAppInfo.new_from_filename(CUSTOM_LAUNCHERS_PATH + desktopFile);
+                    app = CMenu.DesktopAppInfo.new_from_filename(CUSTOM_LAUNCHERS_PATH + desktopFile);
                 }
                 return app;
             }

--- a/src/cinnamon-app-system.c
+++ b/src/cinnamon-app-system.c
@@ -7,6 +7,8 @@
 
 #include <gio/gio.h>
 #include <glib/gi18n.h>
+#define GMENU_I_KNOW_THIS_IS_UNSTABLE
+#include <gmenu-desktopappinfo.h>
 
 #include "cinnamon-app-private.h"
 #include "cinnamon-window-tracker-private.h"
@@ -52,6 +54,7 @@ struct _CinnamonAppSystemPrivate {
   GHashTable *running_apps;
   GHashTable *id_to_app;
   GHashTable *startup_wm_class_to_app;
+  GHashTable *flatpak_id_to_app;
 
   GSList *known_vendor_prefixes;
 };
@@ -131,6 +134,9 @@ cinnamon_app_system_init (CinnamonAppSystem *self)
                                                          NULL,
                                                          (GDestroyNotify)g_object_unref);
 
+  priv->flatpak_id_to_app = g_hash_table_new_full (g_str_hash, g_str_equal,
+                                                         NULL,
+                                                         (GDestroyNotify)g_object_unref);
 /* According to desktop spec, since our menu file is called 'cinnamon-applications', our
  * merged menu folders need to be called 'cinnamon-applications-merged'.  We'll setup the folder
  * 'applications-merged' if it doesn't exist yet, and a symlink pointing to it in the
@@ -158,6 +164,7 @@ cinnamon_app_system_finalize (GObject *object)
   g_hash_table_destroy (priv->running_apps);
   g_hash_table_destroy (priv->id_to_app);
   g_hash_table_destroy (priv->startup_wm_class_to_app);
+  g_hash_table_destroy (priv->flatpak_id_to_app);
   g_slist_free_full (priv->known_vendor_prefixes, g_free);
   priv->known_vendor_prefixes = NULL;
 
@@ -319,13 +326,12 @@ rename_app (CinnamonApp *app,
 {
   RenameAppData *data;
   const gchar *common_name;
-  gchar *unique_name, *basename, *dirname, *capitalized_exec;
+  gchar *unique_name, *basename, *capitalized_exec;
   guint i;
 
   data = (RenameAppData *) user_data;
 
   common_name = data->key;
-  dirname = g_path_get_dirname (_cinnamon_app_get_desktop_path (app));
 
   if (_cinnamon_app_get_unique_name (app) != NULL)
     {
@@ -336,7 +342,7 @@ rename_app (CinnamonApp *app,
       return;
     }
 
-  if (g_strstr_len (dirname, -1, "flatpak"))
+  if (cinnamon_app_get_is_flatpak (app))
     {
       unique_name = g_strdup_printf ("%s (Flatpak)",
                                      common_name);
@@ -347,8 +353,6 @@ rename_app (CinnamonApp *app,
 
       _cinnamon_app_set_unique_name (app, unique_name);
     }
-
-  g_free (dirname);
 
   if (flatpak_iteration)
     {
@@ -492,16 +496,17 @@ get_flattened_entries_recurse (GMenuTreeDirectory *dir,
         case GMENU_TREE_ITEM_ENTRY:
           {
             GMenuTreeEntry *entry;
+            GMenuDesktopAppInfo *info;
             item = entry = gmenu_tree_iter_get_entry (iter);
+            info = gmenu_tree_entry_get_app_info (entry);
             /* Key is owned by entry */
 
-            if (gmenu_tree_entry_get_app_info (entry) == NULL)
+            if (info == NULL)
               {
                 break;
               }
-
             g_hash_table_replace (entry_set,
-                                  (char*)gmenu_tree_entry_get_desktop_file_id (entry),
+                                  (char *) gmenu_tree_entry_get_desktop_file_id (entry),
                                   gmenu_tree_item_ref (entry));
           }
           break;
@@ -590,9 +595,8 @@ on_apps_tree_changed_cb (GMenuTree *tree,
       char *prefix;
       CinnamonApp *app;
 
-      GDesktopAppInfo *info;
+      GMenuDesktopAppInfo *info;
       const char *startup_wm_class;
-
       prefix = get_prefix_for_entry (entry);
 
       if (prefix != NULL
@@ -616,7 +620,7 @@ on_apps_tree_changed_cb (GMenuTree *tree,
 
 #if DEBUG_APPSYS_RENAMING
           if (g_strcmp0 (_cinnamon_app_get_desktop_path (app),
-                         g_desktop_app_info_get_filename (gmenu_tree_entry_get_app_info (entry))) == 0)
+                         gmenu_desktopappinfo_get_filename (gmenu_tree_entry_get_app_info (entry))) == 0)
             {
               DEBUG_RENAMING ("Existing match found for app: '%s'.  Source unchanged ('%s')\n",
                               _cinnamon_app_get_common_name (app),
@@ -628,7 +632,7 @@ on_apps_tree_changed_cb (GMenuTree *tree,
               DEBUG_RENAMING ("Existing match found for app: '%s'.  Source is changing from '%s' to '%s'\n",
                               _cinnamon_app_get_common_name (app),
                               _cinnamon_app_get_desktop_path (app),
-                              g_desktop_app_info_get_filename (gmenu_tree_entry_get_app_info (entry)));
+                              gmenu_desktopappinfo_get_filename (gmenu_tree_entry_get_app_info (entry)));
             }
 #endif
 
@@ -646,22 +650,27 @@ on_apps_tree_changed_cb (GMenuTree *tree,
                           _cinnamon_app_get_desktop_path (app));
 
         }
-      /* Note that "id" is owned by app->entry.  Since we're always
+      /* Note that "id" and "flatpak_app_id" are owned by app->entry.  Since we're always
        * setting a new entry, even if the app already exists in the
-       * hash table we need to replace the key so that the new id
-       * string is pointed to.
+       * hash tables we need to replace the keys so that the new id and flatpak app id
+       * string are pointed to.
        */
       g_hash_table_replace (self->priv->id_to_app, (char*)id, app);
+
+      if (cinnamon_app_get_is_flatpak (app))
+      {
+        g_hash_table_replace (self->priv->flatpak_id_to_app, (char*)cinnamon_app_get_flatpak_app_id (app), g_object_ref (app));
+      }
       // if (!gmenu_tree_entry_get_is_nodisplay_recurse (entry))
       //    g_hash_table_replace (self->priv->visible_id_to_app, (char*)id, app);
 
       if (old_entry)
         {
-          GDesktopAppInfo *old_info;
+          GMenuDesktopAppInfo *old_info;
           const gchar *old_startup_wm_class;
 
           old_info = gmenu_tree_entry_get_app_info (old_entry);
-          old_startup_wm_class = g_desktop_app_info_get_startup_wm_class (old_info);
+          old_startup_wm_class = gmenu_desktopappinfo_get_startup_wm_class (old_info);
 
           if (old_startup_wm_class)
             g_hash_table_remove (self->priv->startup_wm_class_to_app, old_startup_wm_class);
@@ -670,7 +679,7 @@ on_apps_tree_changed_cb (GMenuTree *tree,
       info = cinnamon_app_get_app_info (app);
       if (info)
         {
-          startup_wm_class = g_desktop_app_info_get_startup_wm_class (info);
+          startup_wm_class = gmenu_desktopappinfo_get_startup_wm_class (info);
           if (startup_wm_class)
             g_hash_table_replace (self->priv->startup_wm_class_to_app,
                                   (char*)startup_wm_class, g_object_ref (app));
@@ -830,6 +839,18 @@ lookup_heuristic_basename (CinnamonAppSystem *system,
 }
 
 gchar *
+strip_flatpak_suffix (gchar *wm_class)
+{
+  char *result;
+    if (g_str_has_suffix (wm_class, GMENU_DESKTOPAPPINFO_FLATPAK_SUFFIX)) {
+            result = g_strndup (wm_class, strlen (wm_class) - strlen (GMENU_DESKTOPAPPINFO_FLATPAK_SUFFIX));
+    } else {
+        result = g_strdup (wm_class);
+    }
+    return result;
+}
+
+gchar *
 strip_extension (gchar *wm_class)
 {
     char *result;
@@ -841,6 +862,8 @@ strip_extension (gchar *wm_class)
     }
     return result;
 }
+
+
 
 /**
  * cinnamon_app_system_lookup_desktop_wmclass:
@@ -857,25 +880,36 @@ cinnamon_app_system_lookup_desktop_wmclass (CinnamonAppSystem *system,
                                             const char        *wmclass)
 {
   char *canonicalized;
+  char *after_flatpak_strip;
   char *desktop_file;
   char *stripped_name;
+  gboolean is_flatpak;
   CinnamonApp *app;
 
   if (wmclass == NULL)
     return NULL;
 
+  is_flatpak = g_str_has_suffix (wmclass, GMENU_DESKTOPAPPINFO_FLATPAK_SUFFIX);
+
   canonicalized = g_ascii_strdown (wmclass, -1);
 
-  stripped_name = strip_extension(canonicalized);
+  after_flatpak_strip = strip_flatpak_suffix (canonicalized);
+
+  stripped_name = strip_extension(after_flatpak_strip);
 
   /* This handles "Fedora Eclipse", probably others.
    * Note g_strdelimit is modify-in-place. */
   g_strdelimit (stripped_name, " ", '-');
 
-  desktop_file = g_strconcat (stripped_name, ".desktop", NULL);
-
+  if (is_flatpak)
+  {
+    desktop_file = g_strconcat (stripped_name, ".desktop", GMENU_DESKTOPAPPINFO_FLATPAK_SUFFIX, NULL);
+  } else {
+    desktop_file = g_strconcat (stripped_name, ".desktop", NULL);
+  }
   app = lookup_heuristic_basename (system, desktop_file);
 
+  g_free (after_flatpak_strip);
   g_free (canonicalized);
   g_free (stripped_name);
   g_free (desktop_file);
@@ -904,6 +938,23 @@ cinnamon_app_system_lookup_startup_wmclass (CinnamonAppSystem *system,
 }
 
 /**
+ * cinnamon_app_system_lookup_flatpak_app_id:
+ *
+ * Find a #CinnamonApp corresponding to a flatpak app id.
+ *
+ * Return value: (transfer none): The #CinnamonApp for app_id, or %NULL if none
+ */
+CinnamonApp *
+cinnamon_app_system_lookup_flatpak_app_id (CinnamonAppSystem *system,
+                                           const char        *app_id)
+{
+  if (app_id == NULL)
+    return NULL;
+
+  return g_hash_table_lookup (system->priv->flatpak_id_to_app, app_id);
+}
+
+/**
  * cinnamon_app_system_get_all:
  * @system:
  *
@@ -921,7 +972,7 @@ cinnamon_app_system_get_all (CinnamonAppSystem  *self)
     {
       CinnamonApp *app = value;
 
-      if (!g_desktop_app_info_get_nodisplay (cinnamon_app_get_app_info (app)))
+      if (!gmenu_desktopappinfo_get_nodisplay (cinnamon_app_get_app_info (app)))
         result = g_slist_prepend (result, app);
     }
   return result;

--- a/src/cinnamon-app-system.h
+++ b/src/cinnamon-app-system.h
@@ -47,7 +47,8 @@ CinnamonApp       *cinnamon_app_system_lookup_startup_wmclass       (CinnamonApp
                                                                      const char     *wmclass);
 CinnamonApp       *cinnamon_app_system_lookup_desktop_wmclass       (CinnamonAppSystem *system,
                                                                      const char     *wmclass);
-
+CinnamonApp       *cinnamon_app_system_lookup_flatpak_app_id (CinnamonAppSystem *system,
+                                                              const char        *app_id);
 
 GSList         *cinnamon_app_system_get_all                   (CinnamonAppSystem  *system);
 

--- a/src/cinnamon-app.h
+++ b/src/cinnamon-app.h
@@ -7,6 +7,7 @@
 #include <meta/window.h>
 #define GMENU_I_KNOW_THIS_IS_UNSTABLE
 #include <gmenu-tree.h>
+#include <gmenu-desktopappinfo.h>
 
 G_BEGIN_DECLS
 
@@ -37,7 +38,7 @@ GType cinnamon_app_get_type (void) G_GNUC_CONST;
 
 const char *cinnamon_app_get_id (CinnamonApp *app);
 GMenuTreeEntry *cinnamon_app_get_tree_entry (CinnamonApp *app);
-GDesktopAppInfo *cinnamon_app_get_app_info (CinnamonApp *app);
+GMenuDesktopAppInfo *cinnamon_app_get_app_info (CinnamonApp *app);
 ClutterActor *cinnamon_app_create_icon_texture (CinnamonApp *app,
                                                 int          size);
 ClutterActor *cinnamon_app_create_icon_texture_for_window (CinnamonApp   *app,
@@ -88,6 +89,10 @@ gboolean cinnamon_app_launch_offloaded (CinnamonApp     *app,
                            int           workspace,
                            char        **startup_id,
                            GError      **error);
+
+gboolean cinnamon_app_get_is_flatpak (CinnamonApp *app);
+const char * cinnamon_app_get_flatpak_app_id (CinnamonApp *app);
+
 G_END_DECLS
 
 #endif /* __CINNAMON_APP_H__ */

--- a/src/cinnamon-window-tracker.c
+++ b/src/cinnamon-window-tracker.c
@@ -344,6 +344,85 @@ get_app_from_window_pid (CinnamonWindowTracker  *tracker,
   return result;
 }
 
+static CinnamonApp *
+get_app_for_flatpak_window (MetaWindow *window)
+{
+  CinnamonAppSystem *appsys;
+  CinnamonApp *app = NULL;
+  CinnamonApp *result = NULL;
+  gchar *info_filename;
+  GFile *file;
+  int pid = meta_window_get_client_pid (window);
+
+  g_return_val_if_fail (pid > 0, NULL);
+
+  info_filename = g_strdup_printf ("/proc/%u/root/.flatpak-info", pid);
+  file = g_file_new_for_path (info_filename);
+
+  if (g_file_query_exists (file, NULL)) {
+    gchar *wm_class;
+    gchar *wm_instance;
+    GKeyFile *keyfile;
+
+    appsys = cinnamon_app_system_get_default ();
+
+    keyfile = g_key_file_new ();
+    if (g_key_file_load_from_file (keyfile, info_filename, G_KEY_FILE_NONE, NULL))
+    {
+      gchar *app_id;
+      app_id = g_key_file_get_string (keyfile, "Application", "name", NULL);
+      app = cinnamon_app_system_lookup_flatpak_app_id (appsys, app_id);
+
+      if (app != NULL) {
+        result = g_object_ref (app);
+      }
+    }
+    g_key_file_unref (keyfile);
+
+    wm_instance = g_strconcat(meta_window_get_wm_class_instance (window), GMENU_DESKTOPAPPINFO_FLATPAK_SUFFIX, NULL);
+    wm_class = g_strconcat(meta_window_get_wm_class (window), GMENU_DESKTOPAPPINFO_FLATPAK_SUFFIX, NULL);
+
+    if (result == NULL) {
+      app = cinnamon_app_system_lookup_startup_wmclass (appsys, wm_instance);
+      if (app != NULL) {
+        result = g_object_ref (app);
+      }
+    }
+
+    /* then try a match from WM_CLASS to StartupWMClass */
+    if (result == NULL) {
+      app = cinnamon_app_system_lookup_startup_wmclass (appsys, wm_class);
+      if (app != NULL) {
+        result = g_object_ref (app);
+      }
+    }
+
+    /* then try a match from WM_CLASS (instance part) to .desktop */
+    if (result == NULL) {
+      app = cinnamon_app_system_lookup_desktop_wmclass (appsys, wm_instance);
+      if (app != NULL) {
+        result = g_object_ref (app);
+      }
+    }
+
+    /* finally, try a match from WM_CLASS to .desktop */
+    if (result == NULL) {
+      app = cinnamon_app_system_lookup_desktop_wmclass (appsys, wm_class);
+      if (app != NULL) {
+        result = g_object_ref (app);
+      }
+    }
+
+    g_free (wm_instance);
+    g_free (wm_class);
+  }
+
+  g_free (info_filename);
+  g_object_unref(file);
+
+  return result;
+}
+
 /**
  * get_app_for_window:
  *
@@ -376,6 +455,11 @@ get_app_for_window (CinnamonWindowTracker    *tracker,
 
   if (meta_window_is_remote (window))
     return _cinnamon_app_new_for_window (window);
+
+  /* Check if the window was launched from a sandboxed app, e.g. Flatpak */
+  result = get_app_for_flatpak_window (window);
+  if (result != NULL)
+    return result;
 
   /* Check if the window has a GApplication ID attached; this is
    * canonical if it does


### PR DESCRIPTION
Some flatpak apps don't care about making sure that side-by-side installation to versions from distribution repositories can be done cleanly.

This improves the way flatpak apps are integrated into Cinnamon by adding the suffix ":flatpak" to their
dekstop file id and to their StartupWMClass. This allows us to integrate them side-by-side with their distribution counterparts,
mainly for the menu, but also for pinning them in Grouped Window List and adding them to the panel-launchers applet.

This replaces https://github.com/linuxmint/cinnamon/pull/8701
This depends on https://github.com/linuxmint/cinnamon-menus/pull/39