### PR TITLE
XApp status applet: Fix apps being reactive after loading in panel-edit-mode

### DIFF
--- a/files/usr/share/cinnamon/applets/xapp-status@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/xapp-status@cinnamon.org/applet.js
@@ -26,7 +26,7 @@ class XAppStatusIcon {
 
         this.actor = new St.BoxLayout({
             style_class: "applet-box",
-            reactive: true,
+            reactive: !global.settings.get_boolean('panel-edit-mode'),
             track_hover: true,
             // The systray use a layout manager, we need to fill the space of the actor
             // or otherwise the menu will be displayed inside the panel.


### PR DESCRIPTION
Fixed the applet's apps being reactive when loaded in panel-edit-mode (ex. after moving the applet while editing panel)