### PR TITLE
Notification applet: fix icon incorrectly getting hidden in panel-edit-mode

### DIFF
--- a/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
@@ -218,10 +218,12 @@ class CinnamonNotificationsApplet extends Applet.TextIconApplet {
     }
 
     _show_hide_tray() { // Show or hide the notification tray.
-        if (this.notifications.length || this.showEmptyTray) {
-            this.actor.show();
-        } else {
-            this.actor.hide();
+        if(!global.settings.get_boolean(PANEL_EDIT_MODE_KEY)) {
+            if (this.notifications.length || this.showEmptyTray) {
+                this.actor.show();
+            } else {
+                this.actor.hide();
+            }
         }
     }
 


### PR DESCRIPTION
Fixed the notifications icon getting hidden when toggling the show-empty-tray setting, despite being in panel-edit-mode.

