### PR TITLE
meson: fix order-only dependency on generated headers

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -115,7 +115,7 @@ endif
 
 libcinnamon = library(
     'cinnamon',
-    [cinnamon_sources, non_gir, tray_sources],
+    [cinnamon_sources, non_gir, tray_sources, st_enum_types[1]],
     c_args: '-DG_LOG_DOMAIN="notification_area"',
     include_directories: [include_root, include_directories('st', 'tray')],
     install_rpath: join_paths(prefix, pkglibdir),

--- a/src/st/meson.build
+++ b/src/st/meson.build
@@ -134,10 +134,11 @@ st_gir_sources = [
     st_headers,
 ]
 
-st_gir_sources += gnome.mkenums_simple(
+st_enum_types = gnome.mkenums_simple(
     'st-enum-types',
     sources: st_headers,
 )
+st_gir_sources += st_enum_types
 
 st_sources = [
     st_gir_sources,


### PR DESCRIPTION
https://mesonbuild.com/FAQ.html#how-do-i-tell-meson-that-my-sources-use-generated-headers