### PR TITLE
meson: Fix build when network manager is disabled

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -84,7 +84,6 @@ libcinnamon_deps = [
     gio_unix,
     gl,
     gtk,
-    libnm,
     muffin,
     pango,
     polkit,
@@ -94,6 +93,12 @@ libcinnamon_deps = [
     xfixes,
     xml,
 ]
+
+if not get_option('disable_networkmanager')
+    libcinnamon_deps += [
+        libnm,
+    ]
+endif
 
 non_gir = []
 if get_option('build_recorder')


### PR DESCRIPTION
It's optional but we need to account for that in the libcinnamon dependencies
as well.

Fixes: https://github.com/linuxmint/cinnamon/issues/9727