### PR TITLE
Add libexecdir to meson

### DIFF
--- a/debian/cinnamon.install
+++ b/debian/cinnamon.install
@@ -1,5 +1,6 @@
 usr/bin
 usr/lib
+usr/libexec
 usr/share/applications
 usr/share/dbus-1
 usr/share/man

--- a/debian/rules
+++ b/debian/rules
@@ -15,6 +15,7 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
 override_dh_auto_configure:
 	dh_auto_configure -- \
+		--libexecdir=/usr/libexec/cinnamon \
 		-D docs=true \
 		-D deprecated_warnings=false
 

--- a/src/hotplug-sniffer/meson.build
+++ b/src/hotplug-sniffer/meson.build
@@ -20,11 +20,11 @@ executable(
     include_directories: include_root,
     dependencies: sniffer_deps,
     install: true,
-    install_dir: pkglibdir,
+    install_dir: libexecdir,
 )
 
 sniffer_conf = configuration_data()
-sniffer_conf.set('pkglibexecdir', join_paths(prefix, pkglibdir))
+sniffer_conf.set('pkglibexecdir', join_paths(prefix, libexecdir))
 
 configure_file(
     input: 'org.Cinnamon.HotplugSniffer.service.in',

--- a/src/meson.build
+++ b/src/meson.build
@@ -137,7 +137,7 @@ executable(
     include_directories: include_root,
     dependencies: [config_h, gtk],
     install: true,
-    install_dir: pkglibdir,
+    install_dir: libexecdir,
 )
 
 js_tester = executable(


### PR DESCRIPTION
Fedora and other distro's use libexec for

/usr/libexec/cinnamon/cinnamon-hotplug-sniffer
/usr/libexec/cinnamon/cinnamon-perf-helper