### PR TITLE
[sound@cinnamon.org] Slider tooltip: Display entire stream name when its length <= 20 characters

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -425,7 +425,7 @@ class StreamMenuSection extends PopupMenu.PopupMenuSection {
         }
 
         // Trim stream name
-        if(name.length > 16) {
+        if(name.length > 20) {
             name = name.substring(0, 16) + "... ";
         }
 


### PR DESCRIPTION
With old code, a stream name (in slider tooltip) containing 17, 18, 19 or 20 characters was replaced by a string containing 20 characters, losing useful info.

For example, the string `ALSA plug-in [mocp]` (19 chars) was replaced with `ALSA plug-in [mo... ` (20 chars).

This commit fixes that.