### PR TITLE
Include shift key as magnifier shortcut

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_accessibility.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_accessibility.py
@@ -84,7 +84,7 @@ class Module:
             spin = GSettingsSpinButton(_("Magnification"), "org.cinnamon.desktop.a11y.magnifier", "mag-factor", None, 1.0, 15.0, step=0.5)
             settings.add_reveal_row(spin, "org.cinnamon.desktop.a11y.applications", "screen-magnifier-enabled")
 
-            zoom_key_options = [["", _("Disabled")], ["<Alt>", "<Alt>"],["<Super>", "<Super>"],["<Control>", "<Control>"]]
+            zoom_key_options = [["", _("Disabled")], ["<Alt>", "<Alt>"],["<Super>", "<Super>"],["<Control>", "<Control>"], ["<Shift>", "<Shift>"]]
             widget = GSettingsComboBox(_("Mouse wheel modifier"), "org.cinnamon.desktop.wm.preferences", "mouse-button-zoom-modifier", zoom_key_options)
             widget.set_tooltip_text(_("While this modifier is pressed, mouse scrolling will increase or decrease zoom."))
             settings.add_reveal_row(widget, "org.cinnamon.desktop.a11y.applications", "screen-magnifier-enabled")


### PR DESCRIPTION
This pull request adds the Shift key as an option for mouse wheel magnification hotkeys to cinnamon-settings. In the current situation, this works a lot better than the other options because blink/chromium-based UIs (including cinnamon itself) would react to scrolling even though a hotkey was pressed and the magnifier was active. This is not the case with the Shift key.

Shift is the hotkey for horizontal mouse wheel scrolling, though, so it will interfere with that. But seeing that horizontal scrolling is less common in UIs, it is a suitable workaround for most users and applications. In cinnamon UIs, zooming while holding shift is not possible - it will just scroll vertically. From a usability perspective, this is more likely to be understood.

This issue was first described in #8549 and I've already proposed this workaround there.