### PR TITLE
Proper fix for builds with networkmanager disabled.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -49,7 +49,8 @@ xml = dependency('libxml-2.0')
 
 has_nm = not get_option('disable_networkmanager')
 if has_nm
-    libnm = dependency('libnm')
+    # only ever used in *.js via gi import
+    dependency('libnm')
 endif
 
 # on some systems we need to find the math lib to make sure it builds

--- a/src/meson.build
+++ b/src/meson.build
@@ -94,12 +94,6 @@ libcinnamon_deps = [
     xml,
 ]
 
-if not get_option('disable_networkmanager')
-    libcinnamon_deps += [
-        libnm,
-    ]
-endif
-
 non_gir = []
 if get_option('build_recorder')
     cinnamon_sources += [


### PR DESCRIPTION
We've never linked to libnm, merely checked if it existed. During the meson port, this somehow found its way into being over-linked into cinnamon itself, resulting in #9727, which was improperly fixed in #9729 by only performing the over-linking if networkmanager is enabled.

Nevertheless, it remains overlinking. Remove it entirely, and comment the dependency() call to document why we're looking for it but not trying to link it to anything.