### PR TITLE
[WIP] magnifier: Configurability and general improvements to user experience

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_accessibility.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_accessibility.py
@@ -134,8 +134,30 @@ class Module:
             else:
                 self.zoom_stack.set_visible_child_name("screen")
 
-            crosshair = GSettingsSwitch(_("Enable crosshair"), "org.cinnamon.desktop.a11y.magnifier", "show-cross-hairs")
-            settings.add_reveal_row(crosshair, "org.cinnamon.desktop.a11y.applications", "screen-magnifier-enabled")
+            widget = GSettingsSwitch(_("Enable crosshair"), "org.cinnamon.desktop.a11y.magnifier", "show-cross-hairs")
+            settings.add_reveal_row(widget, "org.cinnamon.desktop.a11y.applications", "screen-magnifier-enabled")
+
+            self.zoom_stack.add_named(widget, "crosshair")
+
+            spin = GSettingsSpinButton(_("Crosshair opacity"), "org.cinnamon.desktop.a11y.magnifier", "cross-hairs-opacity", None, 0.0, 1.0, step=0.1)
+            settings.add_reveal_row(spin, "org.cinnamon.desktop.a11y.applications", "screen-magnifier-enabled")
+
+            spin = GSettingsSpinButton(_("Crosshair thickness"), "org.cinnamon.desktop.a11y.magnifier", "cross-hairs-thickness", None, 1, 50, step=1)
+            settings.add_reveal_row(spin, "org.cinnamon.desktop.a11y.applications", "screen-magnifier-enabled")
+
+            crosshair_color_options = [["#ff0000", _("Red")],
+                                       ["#00ff00", _("Green")],
+                                       ["#0000ff", _("Blue")],
+                                       ["#ffff00", _("Yellow")],
+                                       ["#ff6700", _("Orange")],
+                                       ["#ff00ff", _("Pink")],
+                                       ["#a020f0", _("Purple")],
+                                       ["#ffffff", _("White")],
+                                       ["#000000", _("Black")]]
+            widget = GSettingsComboBox(_("Crosshair color"), "org.cinnamon.desktop.a11y.magnifier", "cross-hairs-color", crosshair_color_options)
+            settings.add_reveal_row(widget, "org.cinnamon.desktop.a11y.applications", "screen-magnifier-enabled")
+
+            self.zoom_stack.add_named(widget, "crosshair-color"
 
 #### Keyboard
 

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_accessibility.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_accessibility.py
@@ -84,7 +84,7 @@ class Module:
             spin = GSettingsSpinButton(_("Magnification"), "org.cinnamon.desktop.a11y.magnifier", "mag-factor", None, 1.0, 15.0, step=0.5)
             settings.add_reveal_row(spin, "org.cinnamon.desktop.a11y.applications", "screen-magnifier-enabled")
 
-            zoom_key_options = [["", _("Disabled")], ["<Alt>", "<Alt>"],["<Super>", "<Super>"],["<Control>", "<Control>"]]
+            zoom_key_options = [["", _("Disabled")], ["<Alt>", "<Alt>"],["<Super>", "<Super>"],["<Control>", "<Control>"], ["<Shift>", "<Shift>"]]
             widget = GSettingsComboBox(_("Mouse wheel modifier"), "org.cinnamon.desktop.wm.preferences", "mouse-button-zoom-modifier", zoom_key_options)
             widget.set_tooltip_text(_("While this modifier is pressed, mouse scrolling will increase or decrease zoom."))
             settings.add_reveal_row(widget, "org.cinnamon.desktop.a11y.applications", "screen-magnifier-enabled")

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_accessibility.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_accessibility.py
@@ -84,7 +84,7 @@ class Module:
             spin = GSettingsSpinButton(_("Magnification"), "org.cinnamon.desktop.a11y.magnifier", "mag-factor", None, 1.0, 15.0, step=0.5)
             settings.add_reveal_row(spin, "org.cinnamon.desktop.a11y.applications", "screen-magnifier-enabled")
 
-            zoom_key_options = [["", _("Disabled")], ["<Alt>", "<Alt>"],["<Super>", "<Super>"],["<Control>", "<Control>"], ["<Shift>", "<Shift>"]]
+            zoom_key_options = [["", _("Disabled")], ["<Alt>", "<Alt>"],["<Super>", "<Super>"],["<Control>", "<Control>"], ["<Shift_L>", "<Shift_L>"], ["<Shift_R>", "<Shift_R>"]]
             widget = GSettingsComboBox(_("Mouse wheel modifier"), "org.cinnamon.desktop.wm.preferences", "mouse-button-zoom-modifier", zoom_key_options)
             widget.set_tooltip_text(_("While this modifier is pressed, mouse scrolling will increase or decrease zoom."))
             settings.add_reveal_row(widget, "org.cinnamon.desktop.a11y.applications", "screen-magnifier-enabled")
@@ -133,6 +133,9 @@ class Module:
                 self.zoom_stack.set_visible_child_name("shape")
             else:
                 self.zoom_stack.set_visible_child_name("screen")
+
+            crosshair = GSettingsSwitch(_("Enable crosshair"), "org.cinnamon.desktop.a11y.magnifier", "show-cross-hairs")
+            settings.add_reveal_row(crosshair, "org.cinnamon.desktop.a11y.applications", "screen-magnifier-enabled")
 
 #### Keyboard
 

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_accessibility.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_accessibility.py
@@ -84,7 +84,7 @@ class Module:
             spin = GSettingsSpinButton(_("Magnification"), "org.cinnamon.desktop.a11y.magnifier", "mag-factor", None, 1.0, 15.0, step=0.5)
             settings.add_reveal_row(spin, "org.cinnamon.desktop.a11y.applications", "screen-magnifier-enabled")
 
-            zoom_key_options = [["", _("Disabled")], ["<Alt>", "<Alt>"],["<Super>", "<Super>"],["<Control>", "<Control>"], ["<Shift_L>", "<Shift_L>"], ["<Shift_R>", "<Shift_R>"]]
+            zoom_key_options = [["", _("Disabled")], ["<Alt>", "<Alt>"],["<Super>", "<Super>"],["<Control>", "<Control>"], ["<Shift>", "<Shift>"]]
             widget = GSettingsComboBox(_("Mouse wheel modifier"), "org.cinnamon.desktop.wm.preferences", "mouse-button-zoom-modifier", zoom_key_options)
             widget.set_tooltip_text(_("While this modifier is pressed, mouse scrolling will increase or decrease zoom."))
             settings.add_reveal_row(widget, "org.cinnamon.desktop.a11y.applications", "screen-magnifier-enabled")
@@ -137,8 +137,6 @@ class Module:
             widget = GSettingsSwitch(_("Enable crosshair"), "org.cinnamon.desktop.a11y.magnifier", "show-cross-hairs")
             settings.add_reveal_row(widget, "org.cinnamon.desktop.a11y.applications", "screen-magnifier-enabled")
 
-            self.zoom_stack.add_named(widget, "crosshair")
-
             spin = GSettingsSpinButton(_("Crosshair opacity"), "org.cinnamon.desktop.a11y.magnifier", "cross-hairs-opacity", None, 0.0, 1.0, step=0.1)
             settings.add_reveal_row(spin, "org.cinnamon.desktop.a11y.applications", "screen-magnifier-enabled")
 
@@ -156,8 +154,6 @@ class Module:
                                        ["#000000", _("Black")]]
             widget = GSettingsComboBox(_("Crosshair color"), "org.cinnamon.desktop.a11y.magnifier", "cross-hairs-color", crosshair_color_options)
             settings.add_reveal_row(widget, "org.cinnamon.desktop.a11y.applications", "screen-magnifier-enabled")
-
-            self.zoom_stack.add_named(widget, "crosshair-color"
 
 #### Keyboard
 

--- a/js/ui/magnifier.js
+++ b/js/ui/magnifier.js
@@ -994,6 +994,8 @@ ZoomRegion.prototype = {
      * @shape:      LensShape.SQUARE, LensShape.HORIZONTAL, LensShape.VERTICAL.
      */
     setLensShape: function(shape) {
+        //Destroy the current actors for style updates
+        this._destroyActors();
         switch (shape) {
             case LensShape.SQUARE:
                 this.setSquareLens();
@@ -1005,6 +1007,8 @@ ZoomRegion.prototype = {
                 this.setVerticalLens();
                 break;
         }
+        // Recreate actors
+        this._createActors();
     },
 
     /**
@@ -1076,7 +1080,13 @@ ZoomRegion.prototype = {
     _createActors: function() {
         global.reparentActor(global.top_window_group, Main.uiGroup);
         // The root actor for the zoom region
-        this._magView = new St.Bin({ style_class: 'magnifier-zoom-region', x_fill: true, y_fill: true });
+        // Only style the zoom region if it is not fullscreen
+        // we don't want borders when in fullscreen
+        if(!this._isFullScreen()){
+            this._magView = new St.Bin({ style_class: 'magnifier-zoom-region', x_fill: true, y_fill: true });
+        } else {
+            this._magView = new St.Bin({ x_fill: true, y_fill: true });
+        }
         global.stage.add_actor(this._magView);
 
         // hide the magnified region from CLUTTER_PICK_ALL


### PR DESCRIPTION
This PR adds configuration options for several magnifier features Cinnamon has retained from GNOME, but haven't been usable in the DE since. It also aims to improve the overall user experience of magnifier.

Changes to cinnamon-settings:

* Add additional settings for magnifier
  * Enable/Disable cross-hairs
  * Cross-hair opacity
  * Cross-hair thickness
  * Cross-hair color

Changes to magnifier.js:

 * No styling when lens is in fullscreen mode

I'll be adding more magnifier-specific things over the next couple of weeks. I'd be happy to receive some sort of mentorship to get more familiar with Cinnamons architecture.