### PR TITLE
meson: fix order-only dependency on generated headers for cinnamon-en…

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -54,10 +54,12 @@ cinnamon_sources = [
     cinnamon_headers,
 ]
 
-cinnamon_sources += gnome.mkenums_simple(
+cinnamon_enum_types = gnome.mkenums_simple(
     'cinnamon-enum-types',
     sources: cinnamon_headers,
 )
+
+cinnamon_sources += cinnamon_enum_types
 
 tray_headers = [
     'tray/na-tray-child.h',


### PR DESCRIPTION
…um-types-h

This is a follow-up for https://github.com/linuxmint/cinnamon/pull/9725