### PR TITLE
Attempt to fix clipping issue with osdWindow.js

### DIFF
--- a/js/ui/osdWindow.js
+++ b/js/ui/osdWindow.js
@@ -12,7 +12,7 @@ const LEVEL_ANIMATION_TIME = 0.1;
 const FADE_TIME = 0.1;
 const HIDE_TIMEOUT = 1500;
 
-const OSD_SIZE = 110;
+const OSD_SIZE = 100;
 
 function convertGdkIndex(monitorIndex) {
     let screen = Gdk.Screen.get_default();
@@ -218,7 +218,7 @@ OsdWindow.prototype = {
                 this._osdBaseSize = null;
                 break;
             case "small":
-                this._sizeMultiplier = 0.7;
+                this._sizeMultiplier = 0.6;
                 this._osdBaseSize = Math.floor(OSD_SIZE * this._sizeMultiplier);
                 break;
             case "large":
@@ -226,7 +226,7 @@ OsdWindow.prototype = {
                 this._osdBaseSize = OSD_SIZE;
                 break;
             default:
-                this._sizeMultiplier = 0.85;
+                this._sizeMultiplier = 0.8;
                 this._osdBaseSize = Math.floor(OSD_SIZE * this._sizeMultiplier);
         }
 


### PR DESCRIPTION
https://github.com/linuxmint/cinnamon/issues/9758

I have literally zero idea what I am doing or how to code JavaScript, but my issue has been open more than 20 days with no response, so I am desperate at trying to get this resolved. I figure this is the only way to get someone to look at it?

This fixes the issue I described and also makes the Volume % font less blurry and more "crisp". There is some sort of issue with the OSD_SIZE and this._sizeMultiplier not playing nice with each other according to the previous values.