### PR TITLE
cinnamon-app.c: Have cinnamon_app_get_id() return the app's lookup key for the CinnamonAppSystem app table.

### DIFF
--- a/src/cinnamon-app-private.h
+++ b/src/cinnamon-app-private.h
@@ -12,7 +12,7 @@ G_BEGIN_DECLS
 
 CinnamonApp* _cinnamon_app_new_for_window (MetaWindow *window);
 
-CinnamonApp* _cinnamon_app_new (GMenuTreeEntry *entry);
+CinnamonApp* _cinnamon_app_new (GMenuTreeEntry *entry, const gchar *lookup_id);
 
 void _cinnamon_app_set_entry (CinnamonApp *app, GMenuTreeEntry *entry);
 

--- a/src/cinnamon-app-system.c
+++ b/src/cinnamon-app-system.c
@@ -643,7 +643,7 @@ on_apps_tree_changed_cb (GMenuTree *tree,
       else
         {
           old_entry = NULL;
-          app = _cinnamon_app_new (entry);
+          app = _cinnamon_app_new (entry, id);
 
           DEBUG_RENAMING ("New app entry: '%s' with source '%s'\n",
                           _cinnamon_app_get_common_name (app),

--- a/src/cinnamon-app.c
+++ b/src/cinnamon-app.c
@@ -68,6 +68,7 @@ struct _CinnamonApp
 
   char *keywords;
   char *unique_name;
+  char *lookup_id;
 
   gboolean hidden_as_duplicate;
   gboolean is_flatpak;
@@ -114,7 +115,7 @@ cinnamon_app_get_id (CinnamonApp *app)
 {
   if (app->info)
   {
-    return g_app_info_get_id (G_APP_INFO (app->info));
+    return app->lookup_id;
   }
   return app->window_id_string;
 }
@@ -837,11 +838,14 @@ _cinnamon_app_new_for_window (MetaWindow      *window)
 }
 
 CinnamonApp *
-_cinnamon_app_new (GMenuTreeEntry *info)
+_cinnamon_app_new (GMenuTreeEntry *info,
+                   const gchar    *lookup_id)
 {
   CinnamonApp *app;
 
   app = g_object_new (CINNAMON_TYPE_APP, NULL);
+
+  app->lookup_id = g_strdup (lookup_id);
 
   _cinnamon_app_set_entry (app, info);
 
@@ -1337,6 +1341,7 @@ cinnamon_app_finalize (GObject *object)
   CinnamonApp *app = CINNAMON_APP (object);
 
   g_free (app->window_id_string);
+  g_free (app->lookup_id);
 
   G_OBJECT_CLASS(cinnamon_app_parent_class)->finalize (object);
 }


### PR DESCRIPTION
Some applets (menu, gwl and panel-launchers) want to use this id
for lookups at a later time. In the case of desktop files inside of
subfolders, cinnamon-menus prepends the parent path to the desktop
filename, and this is used as a key in CinnamonAppSys. This won't
match the id returned by g_app_info_get_id() causing app-sys lookups
to fail later on.

ref: https://github.com/linuxmint/mint20.1-beta/issues/40