### PR TITLE
Fix for desktop files in subfolders: use the desktop id generated in cinnamon-menus

### DIFF
--- a/src/cinnamon-app.c
+++ b/src/cinnamon-app.c
@@ -112,10 +112,8 @@ cinnamon_app_get_property (GObject    *gobject,
 const char *
 cinnamon_app_get_id (CinnamonApp *app)
 {
-  if (app->info)
-  {
-    return g_app_info_get_id (G_APP_INFO (app->info));
-  }
+  if (app->entry)
+    return gmenu_tree_entry_get_desktop_file_id (app->entry);
   return app->window_id_string;
 }
 


### PR DESCRIPTION
Some applets (menu, gwl and panel-launchers) want to use this id
for lookups at a later time. In the case of desktop files inside of
subfolders, cinnamon-menus prepends the parent path to the desktop
filename, and this is used as a key in CinnamonAppSys. This won't
match the id returned by g_app_info_get_id() causing app-sys lookups
to fail later on.