### PR TITLE
removable-drives applet: use drive-removable-media icon

### DIFF
--- a/files/usr/share/cinnamon/applets/removable-drives@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/removable-drives@cinnamon.org/applet.js
@@ -41,7 +41,7 @@ class CinnamonRemovableDrivesApplet extends Applet.IconApplet {
     constructor(orientation, panel_height, instance_id) {
         super(orientation, panel_height, instance_id);
 
-        this.set_applet_icon_symbolic_name("drive-harddisk");
+        this.set_applet_icon_symbolic_name("drive-removable-media");
         this.set_applet_tooltip(_("Removable drives"));
 
         global.settings.connect('changed::' + PANEL_EDIT_MODE_KEY, Lang.bind(this, this._onPanelEditModeChanged));


### PR DESCRIPTION
Before:
![screenshot-cinnamon-2021-01-01-193446](https://user-images.githubusercontent.com/8415124/103444513-21f65180-4c69-11eb-8f02-474cd5d9180f.png)

After (together with https://github.com/linuxmint/mint-y-icons/pull/279):
![screenshot-cinnamon-2021-01-01-193356](https://user-images.githubusercontent.com/8415124/103444524-320e3100-4c69-11eb-99db-77d2be7519a0.png)
