### PR TITLE
I'm trying to fix two issues related to the GWL applet.

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appList.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appList.js
@@ -333,6 +333,8 @@ class AppList {
             // Abort the remove if the window is just changing workspaces, window
             // should always remain indexed on all workspaces while its mapped.
             // if (!metaWindow.showing_on_its_workspace()) return;
+            if ((!metaWindow.showing_on_its_workspace() && metaWindow.minimize())
+            || metaWindow.has_focus() && metaWorkspace.index() !== global.screen.get_active_workspace_index()) return;
             this.state.removingWindowFromWorkspaces = true;
             this.state.trigger('removeWindowFromAllWorkspaces', metaWindow);
             return;

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appList.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appList.js
@@ -50,6 +50,8 @@ class AppList {
 
         // Connect all the signals
         this.signals.connect(global.screen, 'window-workspace-changed', (...args) => this.windowWorkspaceChanged(...args));
+        // ugly hack: forces applet to refresh the list of all removed app instances in all workspaces
+        this.signals.connect(global.screen, 'window-removed', (...args) => this.windowRemoved(...args));        
         this.signals.connect(this.metaWorkspace, 'window-removed', (...args) => this.windowRemoved(...args));
         this.on_orientation_changed(null, true);
     }


### PR DESCRIPTION
1)  Does not clear icons for apps that were closed while they were minimized, related to #8779. 

2)  windows disappear while dragging when the arrow or numeric keys are used to switch workspaces, related to #9153.