### PR TITLE
[WIP] various: Fix hidpi change detection.

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1175,6 +1175,8 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         this._updateKeybinding();
 
         Main.themeManager.connect("theme-set", Lang.bind(this, this._updateIconAndLabel));
+        global.connect('scale-changed', () => this.queueRefresh(REFRESH_ALL_MASK));
+
         this._updateIconAndLabel();
 
         this._searchInactiveIcon = new St.Icon({ style_class: 'menu-search-entry-icon',

--- a/files/usr/share/cinnamon/applets/xapp-status@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/xapp-status@cinnamon.org/applet.js
@@ -307,6 +307,7 @@ class CinnamonXAppStatusApplet extends Applet.Applet {
         this.signalManager.connect(this.monitor, "icon-removed", this.onMonitorIconRemoved, this);
 
         this.signalManager.connect(Gtk.IconTheme.get_default(), 'changed', this.on_icon_theme_changed, this);
+        this.signalManager.connect(global, 'scale-changed', this.on_scale_changed, this);
         this.signalManager.connect(global.settings, 'changed::panel-edit-mode', this.on_panel_edit_mode_changed, this);
 
         this.signalManager.connect(Main.systrayManager, "changed", this.onSystrayRolesChanged, this);
@@ -471,6 +472,10 @@ class CinnamonXAppStatusApplet extends Applet.Applet {
     }
 
     on_icon_theme_changed() {
+        this.refreshIcons();
+    }
+
+    on_scale_changed() {
         this.refreshIcons();
     }
 

--- a/src/st/st-texture-cache.c
+++ b/src/st/st-texture-cache.c
@@ -145,10 +145,9 @@ on_icon_theme_changed (GtkIconTheme   *icon_theme,
   g_signal_emit (cache, signals[ICON_THEME_CHANGED], 0);
 }
 
-static void
-update_scale_factor (gpointer data)
+void
+st_texture_cache_update_scale_factor (StTextureCache *cache)
 {
-  StTextureCache *cache = ST_TEXTURE_CACHE (data);
   GdkScreen *screen;
   guint new_scale;
   GValue value = G_VALUE_INIT;
@@ -166,9 +165,8 @@ update_scale_factor (gpointer data)
   if (new_scale != cache->priv->scale)
     {
       cache->priv->scale = new_scale;
+      on_icon_theme_changed (cache->priv->icon_theme, cache);
     }
-
-  on_icon_theme_changed (cache->priv->icon_theme, cache);
 }
 
 static void
@@ -193,10 +191,7 @@ st_texture_cache_init (StTextureCache *self)
   self->priv->file_monitors = g_hash_table_new_full (g_str_hash, g_str_equal,
                                                      g_object_unref, g_object_unref);
 
-  g_signal_connect_swapped (gtk_settings_get_default (), "notify::gtk-xft-dpi",
-                            G_CALLBACK (update_scale_factor), self);
-
-  update_scale_factor (self);
+  st_texture_cache_update_scale_factor (self);
 }
 
 static void
@@ -211,10 +206,6 @@ st_texture_cache_dispose (GObject *object)
                                             self);
       self->priv->icon_theme = NULL;
     }
-
-  g_signal_handlers_disconnect_by_func (gtk_settings_get_default (),
-                                        (gpointer) update_scale_factor,
-                                        self);
 
   g_clear_pointer (&self->priv->keyed_cache, g_hash_table_destroy);
   g_clear_pointer (&self->priv->keyed_surface_cache, g_hash_table_destroy);

--- a/src/st/st-texture-cache.h
+++ b/src/st/st-texture-cache.h
@@ -68,6 +68,8 @@ GType st_texture_cache_get_type (void) G_GNUC_CONST;
 
 StTextureCache* st_texture_cache_get_default (void);
 
+void st_texture_cache_update_scale_factor (StTextureCache *cache);
+
 ClutterActor *
 st_texture_cache_load_sliced_image (StTextureCache *cache,
                                     const gchar    *path,


### PR DESCRIPTION
This was broken with fractional scaling - we have traditionally
equated the changing of Xft.dpi to mean the scale changed, so we
could update our ui (cinnamon runs in 1x always, but we scale our
elements to match the global scale).

When fractional scaling is disabled (switched off thru the gui),
these old methods are fine - changes to the global scale affect
the dpi as well.

With it enabled, however, the following differences manifest:
- The global scale becomes only the base scale factor from which
  the fractional scale will be achieved.
- Only changes to the fractional value will affect the Xft.dpi
  value; changing the global scale does not.

Unfortunately cinnamon (as well as some apps in certain situations)
need to know what the global scale is, and when it changes, so the
dpi is no longer a reliable value to monitor.

This uses the primary GdkMonitor to listen for changes to its
scale-factor property and notify the appropriate parties when it
changes.