### PR TITLE
cinnamon-file-dialog: Import GTK properly

### DIFF
--- a/files/usr/bin/cinnamon-file-dialog
+++ b/files/usr/bin/cinnamon-file-dialog
@@ -11,6 +11,8 @@ import sys
 from setproctitle import setproctitle
 setproctitle("cinnamon-file-dialog")
 
+import gi
+gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 
 cancelButton = (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)


### PR DESCRIPTION
(and specify a version properly).

Was monkeying around and I found:
```
/usr/bin/cinnamon-file-dialog:14: PyGIWarning: Gtk was imported without specifying a version first. Use gi.require_version('Gtk', '3.0') before import to ensure that the right version gets loaded.
  from gi.repository import Gtk
```
I did figure out why it really did fail (because I didn't specify a number) but this should've been imported anyways.