### PR TITLE
Add a memory limit mechanism to Cinnamon

### DIFF
--- a/data/org.cinnamon.gschema.xml
+++ b/data/org.cinnamon.gschema.xml
@@ -589,6 +589,7 @@
     <child name="keyboard" schema="org.cinnamon.keyboard"/>
     <child name="desklets" schema="org.cinnamon.desklets" />
     <child name="sounds" schema="org.cinnamon.sounds" />
+    <child name="launcher" schema="org.cinnamon.launcher" />
 
     <key name="enable-vfade" type="b">
       <default>true</default>
@@ -1007,6 +1008,28 @@
   </schema>
 
   <schema id="org.cinnamon.invalid-schema" path="/org/cinnamon/invalid-schema/">
+  </schema>
+
+  <schema id="org.cinnamon.launcher" path="/org/cinnamon/launcher/">
+
+    <key name="memory-limit-enabled" type="b">
+      <default>true</default>
+      <summary>Whether to restart Cinnamon when it reachs the memory limit</summary>
+      <description></description>
+    </key>
+
+    <key name="memory-limit" type="i">
+      <default>2048</default>
+      <summary>Memory limit (in MB)</summary>
+      <description></description>
+    </key>
+
+    <key name="check-frequency" type="i">
+      <default>300</default>
+      <summary>Time between each checks (in seconds)</summary>
+      <description></description>
+    </key>
+
   </schema>
 
 </schemalist>

--- a/files/usr/bin/cinnamon-launcher
+++ b/files/usr/bin/cinnamon-launcher
@@ -46,32 +46,6 @@ def idle_function(func):
         GObject.idle_add(func, *args)
     return wrapper
 
-def confirm_restart():
-    d = Gtk.MessageDialog(title=None, parent=None, flags=0, message_type=Gtk.MessageType.WARNING)
-    d.add_buttons(_("No"),  Gtk.ResponseType.NO,
-                  _("Yes"), Gtk.ResponseType.YES)
-    d.set_keep_above(True)
-    d.set_position(Gtk.WindowPosition.CENTER)
-    d.set_title(_("Cinnamon just crashed"))
-    box = d.get_content_area()
-    checkbutton = Gtk.CheckButton(label=_("Disable downloaded applets, desklets and extensions"))
-    d.set_markup("<span size='large'><b>%s</b></span>\n\n%s\n\n%s\n\n" %
-            (
-                _("You are currently running in fallback mode."),
-                _("If you suspect the source of the crash is a local extension, applet or desklet, you can disable downloaded add-ons using the checkbox below."),
-                _("Do you want to restart Cinnamon?"),
-            ))
-    box.set_border_width(20)
-    box.add(checkbutton)
-    checkbutton.show_all()
-    resp = d.run()
-    d.destroy()
-    if resp == Gtk.ResponseType.YES:
-        if checkbutton.get_active():
-            os.environ["CINNAMON_TROUBLESHOOT"] = "1"
-        return(True)
-    return(False)
-
 class Launcher():
 
     def __init__(self):
@@ -107,7 +81,7 @@ class Launcher():
                     # Start the fallback window manager
                     os.execvp(FALLBACK_COMMAND, (FALLBACK_COMMAND,) + FALLBACK_ARGS)
                 else:
-                    if confirm_restart():
+                    if self.confirm_restart():
                         # Kill the fallback panel
                         os.system("killall %s" % panel_process_name)
                         # Restart Cinnamon
@@ -143,6 +117,33 @@ class Launcher():
             os.mkdir(directory)
         with open(os.path.join(directory, "restarts.log"), "a") as log_file:
             print(string, file=log_file)
+
+    @idle_function
+    def confirm_restart(self):
+        d = Gtk.MessageDialog(title=None, parent=None, flags=0, message_type=Gtk.MessageType.WARNING)
+        d.add_buttons(_("No"),  Gtk.ResponseType.NO,
+                      _("Yes"), Gtk.ResponseType.YES)
+        d.set_keep_above(True)
+        d.set_position(Gtk.WindowPosition.CENTER)
+        d.set_title(_("Cinnamon just crashed"))
+        box = d.get_content_area()
+        checkbutton = Gtk.CheckButton(label=_("Disable downloaded applets, desklets and extensions"))
+        d.set_markup("<span size='large'><b>%s</b></span>\n\n%s\n\n%s\n\n" %
+                (
+                    _("You are currently running in fallback mode."),
+                    _("If you suspect the source of the crash is a local extension, applet or desklet, you can disable downloaded add-ons using the checkbox below."),
+                    _("Do you want to restart Cinnamon?"),
+                ))
+        box.set_border_width(20)
+        box.add(checkbutton)
+        checkbutton.show_all()
+        resp = d.run()
+        d.destroy()
+        if resp == Gtk.ResponseType.YES:
+            if checkbutton.get_active():
+                os.environ["CINNAMON_TROUBLESHOOT"] = "1"
+            return(True)
+        return(False)
 
 if __name__ == "__main__":
     setproctitle("cinnamon-launcher")

--- a/files/usr/bin/cinnamon-launcher
+++ b/files/usr/bin/cinnamon-launcher
@@ -125,9 +125,9 @@ class Launcher():
                 if not process.is_running():
                     break
                 memory = ((process.memory_full_info().rss - process.memory_full_info().shared) / 1024 ** 2)
-                print("Checking memory... %d" % memory)
                 if memory > limit:
                     print ("Memory threshold reached: %d" % memory)
+                    self.log_kill(memory, limit, delay)
                     self.killed = True
                     process.kill()
                     break
@@ -136,9 +136,14 @@ class Launcher():
         Gtk.main_quit()
         os.execvp(sys.argv[0], (sys.argv[0], "--replace"))
 
+    def log_kill(self, memory, limit, delay):
+        directory = os.path.expanduser("~/.cinnamon")
+        string = "%s - Usage: %d MB - Limit: %d MB - Freq: %s sec" % (time.strftime("%Y.%m.%d %H:%M:%S"), memory, limit, delay)
+        if not os.path.exists(directory):
+            os.mkdir(directory)
+        with open(os.path.join(directory, "restarts.log"), "a") as log_file:
+            print(string, file=log_file)
+
 if __name__ == "__main__":
     setproctitle("cinnamon-launcher")
     Launcher()
-
-# make it log kills
-# let people see logs

--- a/files/usr/bin/cinnamon-launcher
+++ b/files/usr/bin/cinnamon-launcher
@@ -5,12 +5,14 @@
 
 import os
 import sys
+import time
 import gettext
 from setproctitle import setproctitle
-
+import psutil
+import threading
 import gi
 gi.require_version('Gtk', '3.0')  # noqa
-from gi.repository import Gtk
+from gi.repository import Gtk, GObject, Gio
 
 FALLBACK_COMMAND = "metacity"
 FALLBACK_ARGS = ("--replace",)
@@ -29,6 +31,20 @@ elif os.path.exists("/usr/bin/tint2"):
     panel_process_name = "tint2"
     panel_cmd = "killall tint2; tint2 &"
 
+# Used as a decorator to run things in the background
+def async_function(func):
+    def wrapper(*args, **kwargs):
+        thread = threading.Thread(target=func, args=args, kwargs=kwargs)
+        thread.daemon = True
+        thread.start()
+        return thread
+    return wrapper
+
+# Used as a decorator to run things in the main loop, from another thread
+def idle_function(func):
+    def wrapper(*args):
+        GObject.idle_add(func, *args)
+    return wrapper
 
 def confirm_restart():
     d = Gtk.MessageDialog(title=None, parent=None, flags=0, message_type=Gtk.MessageType.WARNING)
@@ -56,23 +72,73 @@ def confirm_restart():
         return(True)
     return(False)
 
+class Launcher():
+
+    def __init__(self):
+        self.cinnamon_pid = os.fork()
+        if self.cinnamon_pid == 0:
+            os.execvp("cinnamon", ("cinnamon", "--replace", ) + tuple(sys.argv[1:]))
+        else:
+            self.settings = Gio.Settings(schema="org.cinnamon.launcher")
+            self.settings.connect("changed::memory-limit-enabled", self.on_settings_changed)
+            self.killed = False
+            if self.settings.get_boolean("memory-limit-enabled"):
+                print("Cinnamon memory limit enabled: %d MB" % self.settings.get_int("memory-limit"))
+                self.monitor_memory()
+                self.wait_for_process()
+            Gtk.main()
+
+    def on_settings_changed(self, settings, key):
+        print("Memory profiler status changed, restarting Cinnamon.")
+        self.restart_cinnamon()
+
+    @async_function
+    def wait_for_process(self):
+        exit_status = os.waitpid(self.cinnamon_pid, 0)[1]
+        if exit_status != 0:
+            if self.killed:
+                # Restart Cinnamon
+                self.restart_cinnamon()
+            else:
+                if os.fork() == 0:
+                    # Start the fallback panel
+                    if panel_cmd is not None:
+                        os.system(panel_cmd)
+                    # Start the fallback window manager
+                    os.execvp(FALLBACK_COMMAND, (FALLBACK_COMMAND,) + FALLBACK_ARGS)
+                else:
+                    if confirm_restart():
+                        # Kill the fallback panel
+                        os.system("killall %s" % panel_process_name)
+                        # Restart Cinnamon
+                        self.restart_cinnamon()
+        Gtk.main_quit()
+
+    @async_function
+    def monitor_memory(self):
+        if psutil.pid_exists(self.cinnamon_pid):
+            process = psutil.Process(self.cinnamon_pid)
+            while True:
+                delay = self.settings.get_int("check-frequency")
+                limit = self.settings.get_int("memory-limit")
+                time.sleep(delay)
+                if not process.is_running():
+                    break
+                memory = ((process.memory_full_info().rss - process.memory_full_info().shared) / 1024 ** 2)
+                print("Checking memory... %d" % memory)
+                if memory > limit:
+                    print ("Memory threshold reached: %d" % memory)
+                    self.killed = True
+                    process.kill()
+                    break
+
+    def restart_cinnamon(self):
+        Gtk.main_quit()
+        os.execvp(sys.argv[0], (sys.argv[0], "--replace"))
+
 if __name__ == "__main__":
     setproctitle("cinnamon-launcher")
-    cinnamon_pid = os.fork()
-    if cinnamon_pid == 0:
-        os.execvp("cinnamon", ("cinnamon", "--replace", ) + tuple(sys.argv[1:]))
-    else:
-        exit_status = os.waitpid(cinnamon_pid, 0)[1]
-        if exit_status != 0:
-            if os.fork() == 0:
-                # Start the fallback panel
-                if panel_cmd is not None:
-                    os.system(panel_cmd)
-                # Start the fallback window manager
-                os.execvp(FALLBACK_COMMAND, (FALLBACK_COMMAND,) + FALLBACK_ARGS)
-            else:
-                if confirm_restart():
-                    # Kill the fallback panel
-                    os.system("killall %s" % panel_process_name)
-                    # Restart Cinnamon
-                    os.execvp(sys.argv[0], (sys.argv[0], "--replace"))
+    Launcher()
+
+# make it log kills
+# let people see logs

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_general.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_general.py
@@ -40,3 +40,14 @@ class Module:
 
             spin = GSettingsSpinButton(_("Timer delay"), "org.cinnamon.SessionManager", "quit-time-delay", _("seconds"), 0, 36000, 1, 60)
             settings.add_reveal_row(spin, "org.cinnamon.SessionManager", "quit-delay-toggle")
+
+            settings = page.add_section(_("Memory limit"))
+
+            switch = GSettingsSwitch(_("Restart Cinnamon when it uses too much memory"), "org.cinnamon.launcher", "memory-limit-enabled")
+            settings.add_row(switch)
+
+            spin = GSettingsSpinButton(_("Memory limit"), "org.cinnamon.launcher", "memory-limit", _("MB"), 1024, 36000, 1, 100)
+            settings.add_reveal_row(spin, "org.cinnamon.launcher", "memory-limit-enabled")
+
+            spin = GSettingsSpinButton(_("Check frequency"), "org.cinnamon.launcher", "check-frequency", _("seconds"), 1, 86400, 1, 60)
+            settings.add_reveal_row(spin, "org.cinnamon.launcher", "memory-limit-enabled")

--- a/js/ui/cinnamonDBus.js
+++ b/js/ui/cinnamonDBus.js
@@ -77,6 +77,9 @@ const CinnamonIface =
                 <arg type="s" direction="in" /> \
             </method> \
             <method name="induceSegfault" /> \
+            <method name="leakMemory"> \
+                <arg type="i" direction="in" name="mb" /> \
+            </method> \
             <method name="switchWorkspaceRight" /> \
             <method name="switchWorkspaceLeft" /> \
             <method name="switchWorkspaceUp" /> \
@@ -363,6 +366,10 @@ CinnamonDBus.prototype = {
 
     induceSegfault: function() {
         global.segfault();
+    },
+
+    leakMemory: function(mb) {
+        global.alloc_leak(mb);
     },
 
     switchWorkspaceLeft: function() {

--- a/src/cinnamon-global.c
+++ b/src/cinnamon-global.c
@@ -1635,3 +1635,33 @@ cinnamon_global_segfault (CinnamonGlobal *global)
   int *ptr = NULL;
   g_strdup_printf ("%d", *ptr);
 }
+
+/**
+ * cinnamon_global_alloc_leak:
+ * @global: the #CinnamonGlobal
+ * @mb: How many mb to leak
+ *
+ * Request mb megabytes allocated. This is just for debugging.
+ */
+void
+cinnamon_global_alloc_leak (CinnamonGlobal *global, gint mb)
+{
+    gint i;
+    gchar x;
+
+    for (i = 0; i < mb * 1024; i++)
+    {
+        gchar *ptr = g_strdup_printf ("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                                      "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                                      "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                                      "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                                      "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                                      "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                                      "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                                      "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                                      "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                                      "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                                      "xxxxxxxxxxxxxxxxxxxxxxxx"
+        );
+    }
+}

--- a/src/cinnamon-global.h
+++ b/src/cinnamon-global.h
@@ -128,6 +128,8 @@ void     cinnamon_global_shutdown                  (void);
 void     cinnamon_global_reexec_self               (CinnamonGlobal  *global);
 
 void     cinnamon_global_segfault                  (CinnamonGlobal  *global);
+void     cinnamon_global_alloc_leak                (CinnamonGlobal  *global,
+                                                    gint             mb);
 
 G_END_DECLS
 


### PR DESCRIPTION
Check the memory used by Cinnamon at regular intervals. Restart Cinnamon when the memory reaches an unacceptable limit.

Rationale: Some memory leaks are hard to detect or identify (whether that's because they only happen on certain hardware or in certain niche use cases or whether that's because they're very small and have an imperceptible effect when monitored during a short period of time). Sometimes we don't even know if issues reporting leaks we can't reproduce are still relevant. Yet people still sometimes do report abnormal RAM usage, particularly as the result of using 3rd party spices or after leaving the computer idle for a long period of time. This PR provides a workaround by monitoring the RAM usage and restarting Cinnamon if it reaches a certain threshold.

![image](https://user-images.githubusercontent.com/1138515/107764399-11390100-6d28-11eb-9c11-0a8ccb635180.png)

Using the General section of the System Settings, the memory limit can be enabled/disabled. It's value can be configured and so can the frequency of the memory checks.

Cinnamon restarts are logged in ~/.cinnamon/restarts.log.