### PR TITLE
windows-quick-list applet: avoid fixed popup size

### DIFF
--- a/files/usr/share/cinnamon/applets/windows-quick-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/windows-quick-list@cinnamon.org/applet.js
@@ -11,7 +11,7 @@ const Clutter = imports.gi.Clutter;
 class WindowMenuItem extends PopupMenu.PopupBaseMenuItem {
     constructor(icon, label, params) {
         super(params);
-        this.box = new St.BoxLayout({ style_class: 'popup-combobox-item' });
+        this.box = new St.BoxLayout({ style_class: 'popup-combobox-item', style: 'padding: 0px;' });
         this.icon = icon;
 
         if (icon) {

--- a/files/usr/share/cinnamon/applets/windows-quick-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/windows-quick-list@cinnamon.org/applet.js
@@ -42,7 +42,6 @@ class CinnamonWindowsQuickListApplet extends Applet.IconApplet {
 
         this.scrollBox = new St.ScrollView({ x_fill: true, y_fill: false, y_align: St.Align.START });
         this.scrollBox.set_auto_scrolling(true);
-        this.scrollBox.set_height(400);
         this.mainContainer.add(this.scrollBox);
 
         this.windowsBox = new St.BoxLayout({ vertical:true });


### PR DESCRIPTION
Height of the the windows-quick-list applet popup is hardcoded to 400px, this forces ScrollView to show the scroll bar too early. After removing the hardcoded option, the popup will be dynamically resized to show all the opened windows until it will reach screen height, only then scroll bar will be shown.