### PR TITLE
Pimp the sound@cinnamon.org applet tooltip

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -894,6 +894,11 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
         
         this.settings.bind("keyOpen", "keyOpen", this._setKeybinding);
 
+        this.settings.bind("tooltipShowVolume", "tooltipShowVolume", this.on_settings_changed);
+        this.settings.bind("tooltipShowPlayer", "tooltipShowPlayer", this.on_settings_changed);
+        this.settings.bind("tooltipShowArtist", "tooltipShowArtist", this.on_settings_changed);
+        this.settings.bind("tooltipShowTitle", "tooltipShowTitle", this.on_settings_changed);
+
         this.menuManager = new PopupMenu.PopupMenuManager(this);
         this.menu = new Applet.AppletPopupMenu(this, orientation);
         this.menuManager.addMenu(this.menu);
@@ -1230,10 +1235,34 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
     }
 
     setAppletTextIcon(player, icon) {
+        this.player = player;
         if (player && player._owner != this._activePlayer)
             return;
         this.setAppletIcon(player, icon);
         this.setAppletText(player);
+        this.setAppletTooltip();
+    }
+
+    setAppletTooltip() {
+        let tooltips = [];
+        if (this.tooltipShowVolume) {
+            tooltips.push(_("Volume") + ": " + this.volume);
+        }
+        if (this.player && this.player._owner == this._activePlayer) {
+            if (this.tooltipShowPlayer) {
+                tooltips.push(this.player._name + " - " + _(this.player._playerStatus));
+            }
+            if (this.tooltipShowArtist) {
+                tooltips.push(_("𝅘𝅥𝅯🎩") + ": " + this.player._artist);
+            }
+            if (this.tooltipShowTitle) {
+                tooltips.push(_("🎶") + ": " + this.player._title);
+            }
+        }
+        if (tooltips.length == 0) {
+            tooltips.push(_("A Cinnamon applet to control sound and music"));
+        }
+        this.set_applet_tooltip(tooltips.join("\n"));
     }
 
     _isInstance(busName) {
@@ -1447,7 +1476,8 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
     _outputValuesChanged(actor, iconName, percentage) {
         this.setIcon(iconName, "output");
         this.mute_out_switch.setIconSymbolicName(iconName);
-        this.set_applet_tooltip(_("Volume") + ": " + percentage);
+        this.volume = percentage;
+        this.setAppletTooltip();
     }
 
     _inputValuesChanged(actor, iconName) {

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/settings-schema.json
@@ -79,5 +79,29 @@
         "type" : "switch",
         "description" : "Hide system tray icons for compatible players",
         "default": true
+    },
+    "section3": {
+        "type": "section",
+        "description" : "Tooltip"
+    },
+    "tooltipShowVolume": {
+        "type": "switch",
+        "default": true,
+        "description": "Show volume in tooltip"
+    },
+    "tooltipShowPlayer": {
+        "type": "switch",
+        "default": true,
+        "description": "Show player in tooltip"
+    },
+    "tooltipShowArtist": {
+        "type": "switch",
+        "default": true,
+        "description": "Show song artist in tooltip"
+    },
+    "tooltipShowTitle": {
+        "type": "switch",
+        "default": true,
+        "description": "Show song title in tooltip"
     }
 }


### PR DESCRIPTION
Currently the tooltip of the sound@cinnamon.org applet only shows the sound volume. Often I just want to check quickly, which track is playing. At the moment I have to click onto the icon to reveal this information. I don't want to have this information shown permanently in the panel, because it takes a lot of space.

This adds the following additional information to the tooltip:
- The player and its state.
- The artist.
- The title.

It is possible to configure what is actually added.