### PR TITLE
Add additional information to the sound@cinnamon.org applet tooltip

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -1253,17 +1253,10 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
                 tooltips.push(this.player._name + " - " + _(this.player._playerStatus));
             }
             if (this.tooltipShowArtist) {
-<<<<<<< HEAD
                 tooltips.push(this.player._artist);
             }
             if (this.tooltipShowTitle) {
                 tooltips.push(this.player._title);
-=======
-                tooltips.push(this.player._artist);
-            }
-            if (this.tooltipShowTitle) {
-                tooltips.push(this.player._title);
->>>>>>> ff72891b23bc922b79c9357908e26d89d894f480
             }
         }
         if (tooltips.length == 0) {

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -896,8 +896,7 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
 
         this.settings.bind("tooltipShowVolume", "tooltipShowVolume", this.on_settings_changed);
         this.settings.bind("tooltipShowPlayer", "tooltipShowPlayer", this.on_settings_changed);
-        this.settings.bind("tooltipShowArtist", "tooltipShowArtist", this.on_settings_changed);
-        this.settings.bind("tooltipShowTitle", "tooltipShowTitle", this.on_settings_changed);
+        this.settings.bind("tooltipShowArtistTitle", "tooltipShowArtistTitle", this.on_settings_changed);
 
         this.menuManager = new PopupMenu.PopupMenuManager(this);
         this.menu = new Applet.AppletPopupMenu(this, orientation);
@@ -1252,11 +1251,13 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
             if (this.tooltipShowPlayer) {
                 tooltips.push(this.player._name + " - " + _(this.player._playerStatus));
             }
-            if (this.tooltipShowArtist) {
-                tooltips.push(this.player._artist);
-            }
-            if (this.tooltipShowTitle) {
-                tooltips.push(this.player._title);
+            if (this.tooltipShowArtistTitle) {
+                if (this.player._artist != _("Unknown Artist")) {
+                    tooltips.push(this.player._artist);
+                }
+                if (this._title != _("Unknown Title")) {
+                    tooltips.push(this.player._title);
+                }
             }
         }
         if (tooltips.length == 0) {

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -1260,9 +1260,6 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
                 }
             }
         }
-        if (tooltips.length == 0) {
-            tooltips.push(_("A Cinnamon applet to control sound and music"));
-        }
         this.set_applet_tooltip(tooltips.join("\n"));
     }
 

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/settings-schema.json
@@ -79,5 +79,29 @@
         "type" : "switch",
         "description" : "Hide system tray icons for compatible players",
         "default": true
+    },
+    "section3": {
+        "type": "section",
+        "description" : "Tooltip"
+    },
+    "tooltipShowVolume": {
+        "type": "switch",
+        "default": true,
+        "description": "Show volume in tooltip"
+    },
+    "tooltipShowPlayer": {
+        "type": "switch",
+        "default": true,
+        "description": "Show player in tooltip"
+    },
+    "tooltipShowArtist": {
+        "type": "switch",
+        "default": true,
+        "description": "Show song artist in tooltip"
+    },
+    "tooltipShowTitle": {
+        "type": "switch",
+        "default": true,
+        "description": "Show song title in tooltip"
     }
 }

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/settings-schema.json
@@ -91,12 +91,12 @@
     },
     "tooltipShowPlayer": {
         "type": "switch",
-        "default": true,
+        "default": false,
         "description": "Show player in tooltip"
     },
     "tooltipShowArtistTitle": {
         "type": "switch",
-        "default": true,
-        "description": "Show song artist/title in tooltip"
+        "default": false,
+        "description": "Show song artist and title in tooltip"
     }
 }

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/settings-schema.json
@@ -94,14 +94,9 @@
         "default": true,
         "description": "Show player in tooltip"
     },
-    "tooltipShowArtist": {
+    "tooltipShowArtistTitle": {
         "type": "switch",
         "default": true,
-        "description": "Show song artist in tooltip"
-    },
-    "tooltipShowTitle": {
-        "type": "switch",
-        "default": true,
-        "description": "Show song title in tooltip"
+        "description": "Show song artist/title in tooltip"
     }
 }


### PR DESCRIPTION
Currently the tooltip of the sound@cinnamon.org applet only shows the sound volume. Often I just want to check quickly, which track is playing. At the moment I have to click onto the icon to reveal this information. I don't want to have this information shown permanently in the panel, because it takes a lot of space.

This adds the following additional information to the tooltip:

    The player and its state.
    The artist.
    The title.

It is possible to configure what is actually added.

@mtwebster 