### PR TITLE
Added suspend to critical battery actions

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_power.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_power.py
@@ -621,6 +621,7 @@ def get_available_options(up_client):
     ]
 
     critical_options = [
+        ("suspend", _("Suspend")),
         ("shutdown", _("Shut down immediately")),
         ("hibernate", _("Hibernate")),
         ("nothing", _("Do nothing"))


### PR DESCRIPTION
This PR adds suspend as a critical battery action. Useful especially after configuring the critical battery percentage in dconf.