### PR TITLE
cinnamon-settings-users: Don't hold when user creates an existant user.

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings-users/cinnamon-settings-users.py
+++ b/files/usr/share/cinnamon/cinnamon-settings-users/cinnamon-settings-users.py
@@ -392,6 +392,15 @@ class NewUserDialog(Gtk.Dialog):
         except Exception as detail:
             print(detail)
 
+    def user_exists(self, user_name):
+        users = AccountsService.UserManager.get_default().list_users()
+
+        for user in users:
+            if user.get_user_name() == user_name:
+                return True
+
+        return False
+
     def _on_info_changed(self, widget):
         fullname = self.realname_entry.get_text()
         username = self.username_entry.get_text()
@@ -399,6 +408,10 @@ class NewUserDialog(Gtk.Dialog):
         if re.search('[^a-z0-9_.-]', username):
             self.username_entry.set_icon_from_icon_name(Gtk.EntryIconPosition.SECONDARY, "dialog-warning-symbolic")
             self.username_entry.set_icon_tooltip_text(Gtk.EntryIconPosition.SECONDARY, _("Invalid username"))
+            valid = False
+        elif self.user_exists(username):
+            self.username_entry.set_icon_from_icon_name(Gtk.EntryIconPosition.SECONDARY, "dialog-warning-symbolic")
+            self.username_entry.set_icon_tooltip_text(Gtk.EntryIconPosition.SECONDARY, _("A user with the name '" + username + "' already exists."))
             valid = False
         else:
             self.username_entry.set_icon_from_icon_name(Gtk.EntryIconPosition.SECONDARY, None)


### PR DESCRIPTION
This catches the AccountsService error for USER_EXISTS. Everything has 
to be moved to try/except because without it, it can lead to some 
unstability.

Fixes #9494

Extra Notes: For some reason using in or == doesn't work but __eq__ does. Making a new dialog can cause some unstability, and the *whole* try/except has to be moved because we don't want an undefined reference with the new_user variable. Believe me I got frustrated trying this.

I know this isn't the *best* but it's something for systems that want to make a Stable Release Update for this fix. Let me know if you want me to change anything