### PR TITLE
network applet: Indicate on the panel icon when there is no internet access

### DIFF
--- a/js/misc/util.js
+++ b/js/misc/util.js
@@ -754,3 +754,31 @@ function getGObjectPropertyValues(obj, r = 0) {
     }
     return jsRepresentation;
 }
+
+function version_exceeds(version, min_version) {
+    let our_version = version.split(".");
+    let cmp_version = min_version.split(".");
+    let i;
+
+    for (i = 0; i < our_version.length && i < cmp_version.length; i++) {
+        let our_part = parseInt(our_version[i]);
+        let cmp_part = parseInt(cmp_version[i]);
+
+        if (isNaN(our_part) || isNaN(cmp_part)) {
+            return false;
+        }
+
+        if (our_part < cmp_part) {
+            return false;
+        } else
+        if (our_part > cmp_part) {
+            return true;
+        }
+    }
+
+    if (our_version.length < cmp_version.length) {
+        return false;
+    } else {
+        return true;
+    }
+}


### PR DESCRIPTION
Perform a periodic connectivity check to indicate
on the panel when there is no internet (global) access.

Due to a bug in libnm, this uses a dbus to communicate directly
with org.freedesktop.NetworkManager for libnm versions before
1.28.0. For newer versions, the NM.Client api is used.

Since the check can take some time - potentially more than the
periodic update interval, we don't start a new check before
receiving a reply from the previous one.

fixes #9927 