### PR TITLE
cs_windows: Fix the button layout when placing icons on the right

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_windows.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_windows.py
@@ -36,7 +36,7 @@ class Module:
 
             button_options = []
             button_options.append([":minimize,maximize,close", _("Right")])
-            button_options.append(["close,minimize,maximize:", _("Left")])
+            button_options.append(["close,maximize,minimize:", _("Left")])
             button_options.append([":close", _("Gnome")])
             button_options.append(["close:minimize,maximize", _("Classic Mac")])
 


### PR DESCRIPTION
These should mirror the layout of having them on the left

Fixes: https://github.com/linuxmint/cinnamon/issues/9522