### PR TITLE
sound applet: fix empty artist

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -689,6 +689,8 @@ class Player extends PopupMenu.PopupMenuSection {
                 default:
                     this._artist = _("Unknown Artist");
             }
+            // make sure artist isn't empty
+            if (!this._artist) this._artist = _("Unknown Artist");
         }
         else
             this._artist = _("Unknown Artist");


### PR DESCRIPTION
Some players return an empty `as` artist array, which results in `_artist` being empty.