### PR TITLE
cinnamon-settings: Add standalone module for software-properties-gtk

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
@@ -88,6 +88,7 @@ STANDALONE_MODULES = [
     [_("Software Sources"),              "pkexec mintsources",                  "cs-sources",            "admin",          _("ppa, repository, package, source, download")],
     [_("Package Management"),            "dnfdragora",                          "cs-sources",            "admin",          _("update, install, repository, package, source, download")],
     [_("Package Management"),            "yumex-dnf",                           "cs-sources",            "admin",          _("update, install, repository, package, source, download")],
+    [_("Software & Updates"),            "software-properties-gtk",             "software-properties-gtk", "admin",        _("update, install, repository, package, source, download")],
     [_("Users and Groups"),              "cinnamon-settings-users",             "cs-user-accounts",      "admin",          _("user, users, account, accounts, group, groups, password")],
     [_("Bluetooth"),                     "blueberry",                           "cs-bluetooth",          "hardware",       _("bluetooth, dongle, transfer, mobile")],
     [_("Blueman"),                       "blueman-manager",                     "cs-bluetooth",          "hardware",       _("bluetooth, dongle, transfer, mobile")],


### PR DESCRIPTION
-------
(No extended commit description)

It's in Ubuntu (come on, let's not bias against distros here) and can actually technically probably be found in others.

If you want I can push over a little bit to make the code more nicer.

I was thinking of having a specific Ubuntu module for Livepatch but that's something for another day and I need to think about it with other Ubuntu devs first (in things like MATE)