### PR TITLE
hotplug-sniffer: drop volatile

### DIFF
--- a/src/hotplug-sniffer/hotplug-sniffer.c
+++ b/src/hotplug-sniffer/hotplug-sniffer.c
@@ -276,7 +276,7 @@ print_debug (const gchar *format, ...)
   GTimeVal now;
   time_t now_t;
   struct tm broken_down;
-  static volatile gsize once_init_value = 0;
+  static size_t once_init_value = 0;
   static gboolean show_debug = FALSE;
   static guint pid = 0;
 


### PR DESCRIPTION
(https://github.com/GNOME/gnome-shell/commit/4dfc53cade812e3b63205620fa13e31955e72763)