### PR TITLE
Add setting to disable Q key in Alt-Tab switcher

### DIFF
--- a/data/org.cinnamon.gschema.xml
+++ b/data/org.cinnamon.gschema.xml
@@ -513,6 +513,11 @@
       <default>false</default>
       <summary>Show all windows from all workspaces</summary>
     </key>
+    
+    <key type="b" name="alttab-close-with-q">
+      <default>true</default>
+      <summary>Close the selected window with Q</summary>
+    </key>
 
     <key name="bring-windows-to-current-workspace" type="b">
       <default>false</default>

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_windows.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_windows.py
@@ -149,3 +149,6 @@ class Module:
 
             widget = GSettingsSwitch(_("Show windows from all workspaces"), "org.cinnamon", "alttab-switcher-show-all-workspaces")
             settings.add_row(widget)
+            
+            widget = GSettingsSwitch(_("Close the selected window with Q"), "org.cinnamon", "alttab-close-with-q")
+            settings.add_row(widget)

--- a/js/ui/appSwitcher/appSwitcher.js
+++ b/js/ui/appSwitcher/appSwitcher.js
@@ -284,9 +284,11 @@ AppSwitcher.prototype = {
             case Clutter.KEY_q:
             case Clutter.KEY_Q:
                 // Q -> Close window
-                this._windows[this._currentIndex].delete(global.get_current_time());
-                this._checkDestroyedTimeoutId = Mainloop.timeout_add(CHECK_DESTROYED_TIMEOUT,
-                        Lang.bind(this, this._checkDestroyed, this._windows[this._currentIndex]));
+                if (global.settings.get_boolean("alttab-close-with-q") ?? true) {
+                    this._windows[this._currentIndex].delete(global.get_current_time());
+                    this._checkDestroyedTimeoutId = Mainloop.timeout_add(CHECK_DESTROYED_TIMEOUT,
+                            Lang.bind(this, this._checkDestroyed, this._windows[this._currentIndex]));
+                }
                 return true;
 
             case Clutter.KEY_Right:


### PR DESCRIPTION
Fixes #9787

The new setting allows disabling the feature in the Alt-Tab switcher which closes the currently selected window.

Such a setting is only added for this key/action (and not the other actions `_keyPressEvent()`) because it's the only destructive action.