### PR TITLE
Attempt to fix parallel build

### DIFF
--- a/src/st/meson.build
+++ b/src/st/meson.build
@@ -189,6 +189,7 @@ libst = library(
 st_dep = declare_dependency(
     include_directories: include_directories('.', 'croco'),
     dependencies: libst_deps,
+    sources: st_enum_types[1],
     link_with: libst,
     link_args: ['-Wl,-Bsymbolic', '-Wl,-z,relro', '-Wl,-z,now'],
 )


### PR DESCRIPTION
Uncovered while building with samurai [0] but can probably also
happen with ninja eventually.

In file included from ../src/main.c:25:
In file included from ../src/cinnamon-global-private.h:28:
In file included from src/st/st.h:7:
../src/st/st-box-layout-child.h:24:10: fatal error: 'st-enum-types.h' file not found
 #include "st-enum-types.h"
         ^~~~~~~~~~~~~~~~~

[0] https://github.com/michaelforney/samurai