### PR TITLE
Display spaces instead of underscores in time zone selector

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_calendar.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_calendar.py
@@ -227,13 +227,14 @@ class TimeZoneSelector(SettingsWidget):
         for tz in pytz.common_timezones:
             try:
                 region, city = tz.split('/', maxsplit=1)
+                city_display_name = city.replace("_"," ")
             except:
                 continue
 
             if region not in self.region_map:
                 self.region_map[region] = Gtk.ListStore(str, str)
                 self.region_list.append([region, _(region)])
-            self.region_map[region].append([city, _(city)])
+            self.region_map[region].append([city, _(city_display_name)])
 
     def set_timezone(self, timezone):
         if timezone == "Etc/UTC":


### PR DESCRIPTION
The time zone selector displays names like New_York, Isle_of_Man and various others with underscores. While we should store values with underscores, the displayed name (in the absence of a translation, as these strings don't get imported into Launchpad at present) should have spaces.

Partial fix for #10057.