### PR TITLE
xapp status applet: update the tooltip text immediately

### DIFF
--- a/files/usr/share/cinnamon/applets/xapp-status@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/xapp-status@cinnamon.org/applet.js
@@ -152,6 +152,8 @@ class XAppStatusIcon {
         else {
             this.tooltipText = "";
         }
+
+        this.applet.set_applet_tooltip(this.tooltipText, true);
     }
 
     setLabel(label) {


### PR DESCRIPTION
Previously, the tooltip wasn't updated until the next time it was shown, meaning that if the value changed while the tooltip was already visible, it would continue to display the outdated text until the mouse was moved away and then back again. This could be a problem in situations where the user scrolls on the icon to change a value (eg. volume) which is displayed in the tooltip.