### PR TITLE
Fallback regression fix and launcher preservation thru keybind restart

### DIFF
--- a/files/usr/bin/cinnamon-killer-daemon
+++ b/files/usr/bin/cinnamon-killer-daemon
@@ -50,7 +50,7 @@ class KillerDaemon:
 
     def restart_cinnamon(self, keystring, data):
         os.system("nemo -n &")  # restart nemo if it's not running already
-        os.system("cinnamon --replace &")  # restart Cinnamon whether it's running or not (can be handy in case of a DE freeze)
+        os.system("cinnamon-launcher &")  # restart Cinnamon whether it's running or not (can be handy in case of a DE freeze)
 
 
 if __name__ == '__main__':

--- a/files/usr/bin/cinnamon-launcher
+++ b/files/usr/bin/cinnamon-launcher
@@ -12,7 +12,7 @@ import psutil
 import threading
 import gi
 gi.require_version('Gtk', '3.0')  # noqa
-from gi.repository import Gtk, GObject, Gio
+from gi.repository import Gtk, GLib, Gio
 
 FALLBACK_COMMAND = "metacity"
 FALLBACK_ARGS = ("--replace",)
@@ -43,7 +43,7 @@ def async_function(func):
 # Used as a decorator to run things in the main loop, from another thread
 def idle_function(func):
     def wrapper(*args):
-        GObject.idle_add(func, *args)
+        GLib.idle_add(func, *args)
     return wrapper
 
 class Launcher():
@@ -81,11 +81,8 @@ class Launcher():
                     # Start the fallback window manager
                     os.execvp(FALLBACK_COMMAND, (FALLBACK_COMMAND,) + FALLBACK_ARGS)
                 else:
-                    if self.confirm_restart():
-                        # Kill the fallback panel
-                        os.system("killall %s" % panel_process_name)
-                        # Restart Cinnamon
-                        self.restart_cinnamon()
+                    self.confirm_restart()
+ 
         Gtk.main_quit()
 
     @async_function
@@ -142,8 +139,8 @@ class Launcher():
         if resp == Gtk.ResponseType.YES:
             if checkbutton.get_active():
                 os.environ["CINNAMON_TROUBLESHOOT"] = "1"
-            return(True)
-        return(False)
+            os.system("killall %s" % panel_process_name)
+            self.restart_cinnamon()
 
 if __name__ == "__main__":
     setproctitle("cinnamon-launcher")


### PR DESCRIPTION
This fixes a regression with the fallback code in `cinnamon-launcher` where after conversion to an idle function, the `confirm_restart` function no longer returned a boolean value, and so the code always functioned as if the user had clicked no. (`None` was the actual return value) To work around this, the conditional code was moved directly into `confirm_restart` so we don't have to worry about passing the value around at all.

It also changes cinnamon-killer-daemon to make sure it uses `cinnamon-launcher` instead of `cinnamon --replace` directly, so that the fallback and memory limiting behavior are preserved across restarts via the shortcut.

Finally, and least important, the usage of GObject.idle_add is converted to GLib.idle_add to avoid a deprecation warning.