### PR TITLE
looking glass ClutterActor inspection and WindowList fix + cleanups

### DIFF
--- a/js/ui/lookingGlass.js
+++ b/js/ui/lookingGlass.js
@@ -38,6 +38,9 @@ var commandHeader = 'const Clutter = imports.gi.Clutter; ' +
 
 const HISTORY_KEY = 'looking-glass-history';
 
+// these properties throw an error even trying to use typeof on them
+const KEY_BLACKLIST = ['get_abs_allocation_vertices', 'get_allocation_vertices'];
+
 /* fake types for special cases:
  *  -"array": objects that pass Array.isArray() and should only show enumerable properties
  *  -"boxedproto": boxed prototypes throw an error on property access
@@ -114,8 +117,12 @@ function getObjKeysInfo(obj) {
 
 
     return Array.from(keys).map((k) => {
-        let [t, v] = getObjInfo(obj[k]);
-        return { name: k.toString(), type: t, value: v, shortValue: "" };
+        if (!KEY_BLACKLIST.includes(k)) {
+            let [t, v] = getObjInfo(obj[k]);
+            return { name: k.toString(), type: t, value: v, shortValue: "" };
+        } else {
+            return { name: k.toString(), type: '[inacessible]', value: '[inacessible]', shortValue: "" }; 
+        }
     });
 }
 

--- a/js/ui/lookingGlass.js
+++ b/js/ui/lookingGlass.js
@@ -6,7 +6,6 @@ const Cogl = imports.gi.Cogl;
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
-const Lang = imports.lang;
 const Meta = imports.gi.Meta;
 const Signals = imports.signals;
 const St = imports.gi.St;
@@ -25,7 +24,6 @@ var commandHeader = 'const Clutter = imports.gi.Clutter; ' +
                     'const Meta = imports.gi.Meta; ' +
                     'const Cinnamon = imports.gi.Cinnamon; ' +
                     'const Main = imports.ui.main; ' +
-                    'const Lang = imports.lang; ' +
                     'const Tweener = imports.ui.tweener; ' +
                     /* Utility functions...we should probably be able to use these
                      * in Cinnamon core code too. */
@@ -33,9 +31,9 @@ var commandHeader = 'const Clutter = imports.gi.Clutter; ' +
                     'const color = function(pixel) { let c= new Clutter.Color(); c.from_pixel(pixel); return c; }; ' +
                     /* Special lookingGlass functions */
                     'const it = Main.lookingGlass.getIt(); ' +
-                    'const a = Lang.bind(Main.lookingGlass, Main.lookingGlass.getWindowApp); '+
-                    'const w = Lang.bind(Main.lookingGlass, Main.lookingGlass.getWindow); '+
-                    'const r = Lang.bind(Main.lookingGlass, Main.lookingGlass.getResult); ';
+                    'const a = Main.lookingGlass.getWindowApp.bind(Main.lookingGlass); '+
+                    'const w = Main.lookingGlass.getWindow.bind(Main.lookingGlass); '+
+                    'const r = Main.lookingGlass.getResult.bind(Main.lookingGlass); ';
 
 /* delay/aggregation period for window list updates. without a delay, the window
  * still exists in the get_window_actor() immediately after 'MetaWindow::unmanaged',
@@ -144,12 +142,8 @@ function tryEval(js) {
     return out;
 }
 
-function WindowList() {
-    this._init();
-}
-
-WindowList.prototype = {
-    _init : function () {
+class WindowList {
+    constructor() {
         this.lastId = 0;
         this.latestWindowList = [];
         this.delayedUpdateId = 0;
@@ -157,9 +151,9 @@ WindowList.prototype = {
         let tracker = Cinnamon.WindowTracker.get_default();
         global.display.connect('window-created', () => { this._queueDelayedUpdate() });
         tracker.connect('window-app-changed', () => { this._queueDelayedUpdate() });
-    },
+    }
 
-    getWindowById: function(id) {
+    getWindowById(id) {
         let windows = global.get_window_actors();
         for (let i = 0; i < windows.length; i++) {
             let metaWindow = windows[i].metaWindow;
@@ -167,9 +161,9 @@ WindowList.prototype = {
                 return metaWindow;
         }
         return null;
-    },
+    }
 
-    _queueDelayedUpdate: function() {
+    _queueDelayedUpdate() {
         if (this.delayedUpdateId)
             Mainloop.source_remove(this.delayedUpdateId);
 
@@ -178,9 +172,9 @@ WindowList.prototype = {
             this._updateWindowList();
             return false;
         });
-    },
+    }
 
-    _updateWindowList: function() {
+    _updateWindowList() {
         let windows = global.get_window_actors();
         let tracker = Cinnamon.WindowTracker.get_default();
 
@@ -232,7 +226,6 @@ WindowList.prototype = {
             Main.createLookingGlass().emitWindowListUpdate();
     }
 };
-Signals.addSignalMethods(WindowList.prototype);
 
 function addBorderPaintHook(actor) {
     let signalId = actor.connect_after('paint',
@@ -258,15 +251,11 @@ function addBorderPaintHook(actor) {
     return signalId;
 }
 
-function Inspector() {
-    this._init();
-}
-
-Inspector.prototype = {
-    _init: function() {
+class Inspector {
+    constructor() {
         let container = new Cinnamon.GenericContainer({ width: 0,
-                                                     height: 0 });
-        container.connect('allocate', Lang.bind(this, this._allocate));
+                                                        height: 0 });
+        container.connect('allocate', (...args) => { this._allocate(...args) });
         Main.uiGroup.add_actor(container);
 
         let eventHandler = new St.BoxLayout({ name: 'LookingGlassDialog',
@@ -282,8 +271,8 @@ Inspector.prototype = {
 
         this._borderPaintTarget = null;
         this._borderPaintId = null;
-        eventHandler.connect('destroy', Lang.bind(this, this._onDestroy));
-        this._capturedEventId = global.stage.connect('captured-event', Lang.bind(this, this._onCapturedEvent));
+        eventHandler.connect('destroy', () => { this._onDestroy() });
+        this._capturedEventId = global.stage.connect('captured-event', (...args) => { this._onCapturedEvent(...args) });
 
         // this._target is the actor currently shown by the inspector.
         // this._pointerTarget is the actor directly under the pointer.
@@ -294,16 +283,16 @@ Inspector.prototype = {
         this._pointerTarget = null;
         this.passThroughEvents = false;
         this._updatePassthroughText();
-    },
+    }
 
-    _updatePassthroughText: function() {
+    _updatePassthroughText() {
         if (this.passThroughEvents)
             this._passThroughText.text = '(Press Pause or Control to disable event pass through)';
         else
             this._passThroughText.text = '(Press Pause or Control to enable event pass through)';
-    },
+    }
 
-    _onCapturedEvent: function (actor, event) {
+    _onCapturedEvent(actor, event) {
         if (event.type() == Clutter.EventType.KEY_PRESS && (event.get_key_symbol() === Clutter.KEY_Control_L ||
                                                             event.get_key_symbol() === Clutter.KEY_Control_R ||
                                                             event.get_key_symbol() === Clutter.KEY_Pause)) {
@@ -327,9 +316,9 @@ Inspector.prototype = {
             default:
                 return true;
         }
-    },
+    }
 
-    _allocate: function(actor, box, flags) {
+    _allocate(actor, box, flags) {
         if (!this._eventHandler)
             return;
 
@@ -344,38 +333,38 @@ Inspector.prototype = {
         childBox.y1 = primary.y + Math.floor((primary.height - natHeight) / 2);
         childBox.y2 = childBox.y1 + natHeight;
         this._eventHandler.allocate(childBox, flags);
-    },
+    }
 
-    _close: function() {
+    _close() {
         global.stage.disconnect(this._capturedEventId);
         Main.popModal(this._eventHandler);
 
         this._eventHandler.destroy();
         this._eventHandler = null;
         this.emit('closed');
-    },
+    }
 
-    _onDestroy: function() {
+    _onDestroy() {
         if (this._borderPaintTarget != null)
             this._borderPaintTarget.disconnect(this._borderPaintId);
-    },
+    }
 
-    _onKeyPressEvent: function (actor, event) {
+    _onKeyPressEvent(actor, event) {
         if (event.get_key_symbol() === Clutter.KEY_Escape)
             this._close();
         return true;
-    },
+    }
 
-    _onButtonPressEvent: function (actor, event) {
+    _onButtonPressEvent(actor, event) {
         if (this._target) {
             let [stageX, stageY] = event.get_coords();
             this.emit('target', this._target, stageX, stageY);
         }
         this._close();
         return true;
-    },
+    }
 
-    _onScrollEvent: function (actor, event) {
+    _onScrollEvent(actor, event) {
         switch (event.get_scroll_direction()) {
             case Clutter.ScrollDirection.UP:
                 // select parent
@@ -407,14 +396,14 @@ Inspector.prototype = {
                 break;
         }
         return true;
-    },
+    }
 
-    _onMotionEvent: function (actor, event) {
+    _onMotionEvent(actor, event) {
         this._update(event);
         return true;
-    },
+    }
 
-    _update: function(event) {
+    _update(event) {
         let [stageX, stageY] = event.get_coords();
         let target = global.stage.get_actor_at_pos(Clutter.PickMode.ALL,
                                                    stageX,
@@ -436,7 +425,6 @@ Inspector.prototype = {
         }
     }
 };
-
 Signals.addSignalMethods(Inspector.prototype);
 
 
@@ -505,17 +493,13 @@ const lgIFace =
 
 const proxy = Gio.DBusProxy.makeProxyWrapper(dbusIFace);
 
-function Melange() {
-    this._init.apply(this, arguments);
-}
-
-Melange.prototype = {
-    _init: function() {
+var Melange = class {
+    constructor() {
         this.proxy = null;
         this._it = null;
         this._open = false;
         this._settings = new Gio.Settings({schema_id: "org.cinnamon.desktop.keybindings"});
-        this._settings.connect("changed::looking-glass-keybinding", Lang.bind(this, this._update_keybinding));
+        this._settings.connect("changed::looking-glass-keybinding", () => { this._update_keybinding() });
         this._update_keybinding();
 
         this._results = [];
@@ -528,41 +512,35 @@ Melange.prototype = {
         this._dbusImpl.export(Gio.DBus.session, '/org/Cinnamon/LookingGlass');
 
         Gio.DBus.session.own_name('org.Cinnamon.LookingGlass', Gio.BusNameOwnerFlags.REPLACE, null, null);
-    },
+    }
 
-    _update_keybinding: function() {
+    _update_keybinding() {
         let kb = this._settings.get_strv("looking-glass-keybinding");
-        Main.keybindingManager.addHotKeyArray("looking-glass-toggle", kb, Lang.bind(this, this._key_callback));
-    },
+        Main.keybindingManager.addHotKeyArray("looking-glass-toggle", kb, () => { this.open() });
+    }
 
-    _key_callback: function() {
-        this.open();
-    },
-
-    ensureProxy: function() {
+    ensureProxy() {
         if (!this.proxy)
             this.proxy = new proxy(Gio.DBus.session, 'org.Cinnamon.Melange', '/org/Cinnamon/Melange');
-    },
+    }
 
-    open: function() {
+    open() {
         this.ensureProxy()
         this.proxy.showRemote();
         this.updateVisible();
-    },
+    }
 
-    close: function() {
+    close() {
         this.ensureProxy()
         this.proxy.hideRemote();
         this.updateVisible();
-    },
+    }
 
-    updateVisible: function() {
-        this.proxy.getVisibleRemote(Lang.bind(this, function(visible) {
-            this._open = visible;
-        }));
-    },
+    updateVisible() {
+        this.proxy.getVisibleRemote((visible) => { this._open = visible });
+    }
 
-    _pushResult: function(command, obj, tooltip) {
+    _pushResult(command, obj, tooltip) {
         let index = this._results.length;
         let result = {"o": obj, "index": index};
         let [type, value] = getObjInfo(obj);
@@ -571,37 +549,37 @@ Melange.prototype = {
 
         this._results.push(result);
         this._it = obj;
-    },
+    }
 
-    inspect: function(path) {
+    inspect(path) {
         let fullCmd = commandHeader + path;
         let result = tryEval(fullCmd);
         return getObjKeysInfo(result);
-    },
+    }
 
-    getIt: function () {
+    getIt() {
         return this._it;
-    },
+    }
 
-    getResult: function(idx) {
+    getResult(idx) {
         return this._results[idx].o;
-    },
+    }
 
-    getWindow: function(idx) {
+    getWindow(idx) {
         return this._windowList.getWindowById(idx);
-    },
+    }
 
-    getWindowApp: function(idx) {
+    getWindowApp(idx) {
         let metaWindow = this._windowList.getWindowById(idx)
         if (metaWindow) {
             let tracker = Cinnamon.WindowTracker.get_default();
             return tracker.get_window_app(metaWindow);
         }
         return null;
-    },
+    }
 
     // DBus function
-    Eval: function(command) {
+    Eval(command) {
         this._history.addItem(command);
 
         let fullCmd = commandHeader + command;
@@ -613,36 +591,36 @@ Melange.prototype = {
         let tooltip = _("Execution time (ms): ") + (ts2 - ts) / 1000;
 
         this._pushResult(command, resultObj, tooltip);
-    },
+    }
 
     // DBus function
-    GetResults: function() {
+    GetResults() {
         return [true, this.rawResults];
-    },
+    }
 
     // DBus function
-    AddResult: function(path) {
+    AddResult(path) {
         let fullCmd = commandHeader + path;
         this._pushResult(path, tryEval(fullCmd), "");
-    },
+    }
 
     // DBus function
-    GetErrorStack: function() {
+    GetErrorStack() {
         return [true, Main._errorLogStack];
-    },
+    }
 
     // DBus function
-    GetMemoryInfo: function() {
+    GetMemoryInfo() {
         return null;
-    },
+    }
 
     // DBus function
-    FullGc: function() {
+    FullGc() {
         System.gc();
-    },
+    }
 
     // DBus function
-    Inspect: function(path) {
+    Inspect(path) {
         try {
             let result = this.inspect(path);
             return [true, result];
@@ -650,36 +628,34 @@ Melange.prototype = {
             global.logError('Error inspecting path: ' + path, e);
             return [false, []];
         }
-    },
+    }
 
     // DBus function
-    GetLatestWindowList: function() {
+    GetLatestWindowList() {
         try {
             return [true, this._windowList.latestWindowList];
         } catch (e) {
             global.logError('Error getting latest window list', e);
             return [false, []];
         }
-    },
+    }
 
     // DBus function
-    StartInspector: function() {
+    StartInspector() {
         try {
             let inspector = new Inspector();
-            inspector.connect('target', Lang.bind(this, function(i, target, stageX, stageY) {
+            inspector.connect('target', (i, target, stageX, stageY) => {
                 let name = '<inspect x:' + stageX + ' y:' + stageY + '>';
                 this._pushResult(name, target, "Inspected actor");
-            }));
-            inspector.connect('closed', Lang.bind(this, function() {
-                this.emitInspectorDone();
-            }));
+            });
+            inspector.connect('closed', () => { this.emitInspectorDone() });
         } catch (e) {
             global.logError('Error starting inspector', e);
         }
-    },
+    }
 
     // DBus function
-    GetExtensionList: function() {
+    GetExtensionList() {
         try {
             let extensionList = Array(Extension.extensions.length);
             for (let i = 0; i < extensionList.length; i++) {
@@ -705,30 +681,30 @@ Melange.prototype = {
             global.logError('Error getting the extension list', e);
             return [false, []];
         }
-    },
+    }
 
     // DBus function
-    ReloadExtension: function(uuid, type) {
+    ReloadExtension(uuid, type) {
         Extension.reloadExtension(uuid, Extension.Type[type]);
-    },
+    }
 
-    emitLogUpdate: function() {
+    emitLogUpdate() {
         this._dbusImpl.emit_signal('LogUpdate', null);
-    },
+    }
 
-    emitWindowListUpdate: function() {
+    emitWindowListUpdate() {
         this._dbusImpl.emit_signal('WindowListUpdate', null);
-    },
+    }
 
-    emitResultUpdate: function() {
+    emitResultUpdate() {
         this._dbusImpl.emit_signal('ResultUpdate', null);
-    },
+    }
 
-    emitInspectorDone: function() {
+    emitInspectorDone() {
         this._dbusImpl.emit_signal('InspectorDone', null);
-    },
+    }
 
-    emitExtensionListUpdate: function() {
+    emitExtensionListUpdate() {
         this._dbusImpl.emit_signal('ExtensionListUpdate', null);
-    },
+    }
 }


### PR DESCRIPTION
For some reason, the `ClutterActor` vertex functions[1] now throw an error[2] on any access of the property. Previously, I'm guessing before the most recent CJS rebase, the functions would only throw an error when trying to use them, but now it's any time they are even touched. I don't know why this is, but I've just blacklisted those functions from being described via melange's object inspector.

This also fixes a long standing issue with the Window List inside Melange where windows will not properly be removed from the list after they are closed. For some reason the `MetaWindowActor` is still listed by `global.get_window_actors()` immediately after the `MetaWindow` emits `MetaWindow::unmanaged`. To work around this, I've made all calls to update the window list instead queue an update after 200ms, which should also help to aggregate multiple consecutive window operations and may improve performance in some cases like a "Close All" operation on a set of windows.

A final change included here modernizes the objects to ES6 class syntax and removes all usage of the CJS `Lang` module, using arrow functions and a few basic bound functions instead.

[1] `clutter_actor_get_abs_allocation_vertices`, `clutter_actor_get_allocation_vertices`
[2]  `Error: Unsupported type array for argument verts with (out caller-allocates)`