### PR TITLE
Notification Source simplification

### DIFF
--- a/js/ui/notificationDaemon.js
+++ b/js/ui/notificationDaemon.js
@@ -645,37 +645,6 @@ Source.prototype = {
         this.notify(notification);
     },
 
-    handleSummaryClick: function() {
-        if (!this.trayIcon)
-            return false;
-
-        let event = Clutter.get_current_event();
-        if (event.type() != Clutter.EventType.BUTTON_RELEASE)
-            return false;
-
-        // Left clicks are passed through only where there aren't unacknowledged
-        // notifications, so it possible to open them in summary mode; right
-        // clicks are always forwarded, as the right click menu is not useful for
-        // tray icons
-        if (event.get_button() == 1 &&
-            this.notifications.length > 0)
-            return false;
-
-        if (Main.overview.visible) {
-            // We can't just connect to Main.overview's 'hidden' signal,
-            // because it's emitted *before* it calls popModal()...
-            let id = global.connect('notify::stage-input-mode', Lang.bind(this,
-                function () {
-                    global.disconnect(id);
-                    this.trayIcon.click(event);
-                }));
-            Main.overview.hide();
-        } else {
-            this.trayIcon.click(event);
-        }
-        return true;
-    },
-
     _getApp: function() {
         let app;
 


### PR DESCRIPTION
This removes a bunch of code related to the notification source's former usage as an actual actor on the panel in the old message tray implementation. We only use the icon generation and source tracking features of this prototype these days, so we don't need any of this wasted CPU time making a new actor for the summary label and such.

Works for me on the notification sources I know of, but could probably use some additional testing before merge just in case. This code was all in play before, just not used...so there is still possibility for breakage if I missed any vestiges.