### PR TITLE
grouped-window-list applet: Add new setting 'App button icon scaling factor'

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -223,6 +223,11 @@ class GroupedWindowListApplet extends Applet.Applet {
             getPanel: () => (this.panel ? this.panel : null),
             getPanelHeight: () => this._panelHeight,
             getPanelIconSize: () => this.getPanelIconSize(),
+
+            //TODO: FIXME: redefinition below is very dirty, but i don't know how to do this properly
+            getPanelIconSize: () => this.getPanelIconSize() * 
+                (this.state.settings.scalingFactor ? (this.state.settings.scalingFactor / 100) : 1),
+                
             getPanelMonitor: () => this.panel ? Main.layoutManager.monitors[this.panel.monitorIndex] : null,
             getAppSystem: () => Cinnamon.AppSystem.get_default(),
             getAppFromWindow: (metaWindow) => this.getAppFromWindow(metaWindow),

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/settings-schema.json
@@ -41,7 +41,8 @@
         "launcher-animation-effect",
         "number-display",
         "pinned-apps",
-        "enable-app-button-dragging"
+        "enable-app-button-dragging",
+        "app-button-scaling-factor"
       ]
     },
     "hotKeysSection": {
@@ -139,6 +140,15 @@
   "pinned-apps": {
     "type": "generic",
     "default": ["firefox.desktop", "org.gnome.Terminal.desktop", "nemo.desktop"]
+  },
+  "app-button-scaling-factor": {
+    "type": "spinbutton",
+    "default": 100,
+    "min": 20,
+    "max": 200,
+    "step": 1,
+    "units": "percent",
+    "description": "App button icon scaling factor"
   },
   "group-apps": {
     "type": "checkbox",


### PR DESCRIPTION
This is a dirty way to add a setting that changes program icon size in Grouped Window List applet. Although it's dirty, all works as expected, but it's a little unsupportable.

This setting is useful (at least for me), for example, when panel height is something about 50px, but 48/50px program icons looks (subjectively) too big and 32px - too small.

Needs translation for string "App button icon scaling factor".