### PR TITLE
notifications applet: Add new setting "Don't show notification count in tray"

### DIFF
--- a/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
@@ -26,6 +26,7 @@ class CinnamonNotificationsApplet extends Applet.TextIconApplet {
         this.settings.bind("showEmptyTray", "showEmptyTray", this._show_hide_tray);
         this.settings.bind("keyOpen", "keyOpen", this._setKeybinding);
         this.settings.bind("keyClear", "keyClear", this._setKeybinding);
+        this.settings.bind("hideNotificationCount", "hideNotificationCount", this.update_list);
         this._setKeybinding();
 
         // Layout
@@ -196,6 +197,10 @@ class CinnamonNotificationsApplet extends Applet.TextIconApplet {
                 if (!this.showEmptyTray) {
                     this.actor.hide();
                 }
+            }
+            if (this.hideNotificationCount) {  // Don't show notification count
+                this.set_applet_label('');
+                this.clear_action.actor.hide();
             }
             this.menu_label.label.set_text(stringify(count));
             this._notificationbin.queue_relayout();

--- a/files/usr/share/cinnamon/applets/notifications@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/notifications@cinnamon.org/settings-schema.json
@@ -13,23 +13,28 @@
         "type": "section",
         "description": "Display"
     },
-    "showEmptyTray" : {
-        "type" : "switch",
-        "default" : false,
-        "description" : "Show empty tray",
-        "tooltip" : "Check this to show the tray even when there are no new notifications."
+    "showEmptyTray": {
+        "type": "switch",
+        "default": false,
+        "description": "Show empty tray",
+        "tooltip": "Check this to show the tray even when there are no new notifications."
     },
-        "section3": {
+    "hideNotificationCount": {
+        "type": "switch",
+        "default": false,
+        "description": "Don't show notification count in tray"
+    },
+    "section3": {
         "type": "section",
         "description": "Keyboard shortcuts"
     },
-        "keyOpen": {
+    "keyOpen": {
         "type": "keybinding",
         "description": "Show notifications",
         "default": "<Super>n",
         "tooltip" : "Set keybinding(s) to show the notification popup menu."
     },
-        "keyClear": {
+    "keyClear": {
         "type": "keybinding",
         "description": "Clear notifications",
         "default": "<Shift><Super>c",


### PR DESCRIPTION
RFC to add a setting that always hides notification count (useful when panel is vertical).

Needs translations for string "Don't show notification count in tray".