### PR TITLE
Change method of making "Clear list" label bold..

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -2569,8 +2569,8 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                                                     type: 'recent-clear',
                                                     styleClass: 'menu-application-button' });
             button.addIcon(22, 'edit-clear', null, true);
-            button.addLabel("", 'menu-application-button-label');
-            button.label.clutter_text.set_markup("<b>"+button.name+"</b>");
+            button.addLabel(button.name, 'menu-application-button-label');
+            button.label.set_style('font-weight: bold;');
             button.activate = () => {
                 this.menu.close();
                 (new Gtk.RecentManager()).purge_items();


### PR DESCRIPTION
..in menu applet to avoid label sometimes being ellipsized.

Ellipsizing goes away after changing text size but comes back after restarting cinnamon. This seems to fix it.

Changes:
![Screenshot1](https://user-images.githubusercontent.com/58893963/123505373-9fb67b00-d656-11eb-9878-42f6f2f21e08.png)
to:
![Screenshot2](https://user-images.githubusercontent.com/58893963/123505376-a80eb600-d656-11eb-9364-2b1e2715ef7f.png)
