### PR TITLE
Option to display non-critical notifications over full-screen apps

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_notifications.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_notifications.py
@@ -61,6 +61,9 @@ class Module:
 
         switch = GSettingsSwitch(_("Show notifications on the bottom side of the screen"), "org.cinnamon.desktop.notifications", "bottom-notifications")
         settings.add_reveal_row(switch, "org.cinnamon.desktop.notifications", "display-notifications")
+        
+        switch = GSettingsSwitch(_("Show non-critical notifications in fullscreen"), "org.cinnamon.desktop.notifications", "display-noncritical-in-fullscreen")
+        settings.add_reveal_row(switch, "org.cinnamon.desktop.notifications", "display-notifications")
 
         button = Button(_("Display a test notification"), self.send_test)
         settings.add_reveal_row(button, "org.cinnamon.desktop.notifications", "display-notifications")

--- a/js/ui/messageTray.js
+++ b/js/ui/messageTray.js
@@ -833,6 +833,7 @@ MessageTray.prototype = {
 		}
 		setting(this, this.settings, "_notificationsEnabled", "display-notifications");
         this.bottomPosition = this.settings.get_boolean("bottom-notifications");
+	setting(this, this.settings, "_nonCriticalDisplayFullscreen", "display-noncritical-in-fullscreen");
         this.settings.connect("changed::bottom-notifications", () => {
             this.bottomPosition = this.settings.get_boolean("bottom-notifications");
         });
@@ -1014,6 +1015,8 @@ MessageTray.prototype = {
             this._notification.actor._parent_container.remove_actor(this._notification.actor);
         }
 
+	let canShowNonCriticalInFullscreen = this._nonCriticalDisplayFullscreen;
+
         this._notificationBin.child = this._notification.actor;
         this._notificationBin.opacity = 0;
 
@@ -1041,7 +1044,7 @@ MessageTray.prototype = {
         if (!this._notification.silent || this._notification.urgency >= Urgency.HIGH) {
             Main.soundManager.play('notification');
         }
-        if (this._notification.urgency == Urgency.CRITICAL) {
+        if (this._notification.urgency == Urgency.CRITICAL || canShowNonCriticalInFullscreen) {
             Main.layoutManager._chrome.modifyActorParams(this._notificationBin, { visibleInFullscreen: true });
         } else {
             Main.layoutManager._chrome.modifyActorParams(this._notificationBin, { visibleInFullscreen: false });

--- a/js/ui/messageTray.js
+++ b/js/ui/messageTray.js
@@ -824,16 +824,16 @@ MessageTray.prototype = {
         this._sources = [];
         Main.layoutManager.addChrome(this._notificationBin);
 
-		// Settings
+        // Settings
         this.settings = new Gio.Settings({ schema_id: "org.cinnamon.desktop.notifications" })
-		function setting(self, source, camelCase, dashed) {
-			function updater() { self[camelCase] = source.get_boolean(dashed); }
-			source.connect('changed::'+dashed, updater);
-			updater();
-		}
-		setting(this, this.settings, "_notificationsEnabled", "display-notifications");
+        function setting(self, source, camelCase, dashed) {
+            function updater() { self[camelCase] = source.get_boolean(dashed); }
+            source.connect('changed::'+dashed, updater);
+            updater();
+        }
+        setting(this, this.settings, "_notificationsEnabled", "display-notifications");
         this.bottomPosition = this.settings.get_boolean("bottom-notifications");
-	setting(this, this.settings, "_nonCriticalDisplayFullscreen", "display-noncritical-in-fullscreen");
+        setting(this, this.settings, "_nonCriticalDisplayFullscreen", "display-noncritical-in-fullscreen");
         this.settings.connect("changed::bottom-notifications", () => {
             this.bottomPosition = this.settings.get_boolean("bottom-notifications");
         });
@@ -1015,7 +1015,7 @@ MessageTray.prototype = {
             this._notification.actor._parent_container.remove_actor(this._notification.actor);
         }
 
-	let canShowNonCriticalInFullscreen = this._nonCriticalDisplayFullscreen;
+    let canShowNonCriticalInFullscreen = this._nonCriticalDisplayFullscreen;
 
         this._notificationBin.child = this._notification.actor;
         this._notificationBin.opacity = 0;

--- a/js/ui/messageTray.js
+++ b/js/ui/messageTray.js
@@ -1015,7 +1015,7 @@ MessageTray.prototype = {
             this._notification.actor._parent_container.remove_actor(this._notification.actor);
         }
 
-    let canShowNonCriticalInFullscreen = this._nonCriticalDisplayFullscreen;
+        let canShowNonCriticalInFullscreen = this._nonCriticalDisplayFullscreen;
 
         this._notificationBin.child = this._notification.actor;
         this._notificationBin.opacity = 0;


### PR DESCRIPTION
#9529 

~~Seems okay here... this is probably not quite ready to merge yet though, because this change requires adding `display-noncritical-in-fullscreen` to `org.cinnamon.desktop.notifications`, and I could not for the life of me figure out how to programmatically add or update this in the cinnamon repo.~~

~~For testing I manually edited `/usr/share/glib-2.0/schemas/org.cinnamon.desktop.notifications.gschema.xml` to add the new key, and recompiled using `glib-compile-schemas`. If you'd like to merge then please make sure to update things on your end so the new key can be properly added.~~