### PR TITLE
cinnamon-settings: Remove ~/.local and /usr/local from python's module search paths.

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/util.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/util.py
@@ -1,0 +1,13 @@
+#!/usr/bin/python3
+
+def strip_syspath_locals():
+    import sys
+    import os
+
+    new_path = []
+    for path in sys.path:
+        if path.startswith(("/usr/local", os.path.expanduser("~/.local"))):
+            continue
+        new_path.append(path)
+
+    sys.path = new_path

--- a/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
@@ -3,6 +3,9 @@
 import getopt
 import sys
 
+from bin import util
+util.strip_syspath_locals()
+
 import os
 import glob
 import gettext

--- a/files/usr/share/cinnamon/cinnamon-settings/xlet-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/xlet-settings.py
@@ -1,5 +1,9 @@
 #!/usr/bin/python3
 import getopt
+
+from bin import util
+util.strip_syspath_locals()
+
 import gi
 gi.require_version('Gtk', '3.0')
 gi.require_version('XApp', '1.0')


### PR DESCRIPTION
Ref: #10195