### PR TITLE
sound applet: added processing base64 code for art url data

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -730,9 +730,30 @@ class Player extends PopupMenu.PopupMenuSection {
             if (this._trackCoverFile) {
                 let cover_path = "";
                 if (this._trackCoverFile.match(/^http/)) {
-                    if(!this._trackCoverFileTmp)
+                    if (!this._trackCoverFileTmp)
                         this._trackCoverFileTmp = Gio.file_new_tmp('XXXXXX.mediaplayer-cover')[0];
                     Util.spawn_async(['wget', this._trackCoverFile, '-O', this._trackCoverFileTmp.get_path()], () => this._onDownloadedCover());
+                }
+                else if (this._trackCoverFile.match(/data:image\/(png|jpeg);base64,/)) {
+                    if (!this._trackCoverFileTmp)
+                        this._trackCoverFileTmp = Gio.file_new_tmp('XXXXXX.mediaplayer-cover')[0];
+                    const cover_base64 = this._trackCoverFile.split(',')[1];
+                    const base64_decode = data => new Promise(resolve => resolve(GLib.base64_decode(data)));
+                    if (!cover_base64) {
+                        return;
+                    }
+                    base64_decode(cover_base64)
+                    .then(decoded => {
+                        this._trackCoverFileTmp.replace_contents(
+                            decoded,
+                            null,
+                            false,
+                            Gio.FileCreateFlags.REPLACE_DESTINATION,
+                            null
+                        );
+                        return this._trackCoverFileTmp.get_path();
+                    })
+                    .then(path => this._showCover(path));
                 }
                 else {
                     cover_path = decodeURIComponent(this._trackCoverFile);


### PR DESCRIPTION
In this PR I propose a new feature of sound applet for processing base64 data, that can arrived through d-bus in [artUrl](https://www.freedesktop.org/wiki/Specifications/mpris-spec/metadata/#mpris:arturl) property.  The KDE already has the feature like this.

<details><summary><b>Screenshot</b>:</summary>

![Screenshot](https://user-images.githubusercontent.com/54072529/126225486-49adad54-4563-44f7-b1fb-0df0dec35f36.png)
</details>