### PR TITLE
Documentation corrections

### DIFF
--- a/docs/reference/cinnamon-tutorials/documenting-source.xml
+++ b/docs/reference/cinnamon-tutorials/documenting-source.xml
@@ -145,7 +145,7 @@
         The type of a property specified will be automatically converted to a link to the documentation of that type, if available.
       </listitem>
       <listitem>
-        In the description of itmes, <code>@word</code> will be automatically converted to code format, ie. enclosed within <code>&lt;code&gt;</code> tags.
+        In the description of items, <code>@word</code> will be automatically converted to code format, ie. enclosed within <code>&lt;code&gt;</code> tags.
       </listitem>
       <listitem>
         In the description of items, <code>*text more text*</code> will be shown in italics and <code>**text more text**</code> will be shown in bold. Note that using <code>_underlines to highlight_</code> is not supported since the parser will confuse it with private variables.

--- a/docs/reference/cinnamon-tutorials/documenting-tutorial.xml
+++ b/docs/reference/cinnamon-tutorials/documenting-tutorial.xml
@@ -123,7 +123,7 @@
   &amp;lt;para&amp;gt;Lorem &amp;lt;code&amp;gt;ipsum&amp;lt;/code&amp;gt; dolor sit amet.&amp;lt;/para&amp;gt;
 &amp;lt;/section&amp;gt;&lt;/programlisting&gt;</programlisting>
 
-      <para>There are a few things to take note of. Firstly, the &lt; and &gt; items are escaped. Secondly, the contents of the <code>&lt;programlisting&gt;</code> is flushed to the left, regardless of the current indentation of the xml. This is since all whitepsace is rendered verbatim. Thirdly, the end <code>&lt;/programlisting tag&gt;</code> is put on the same row as the last line, or else an extra row will appear in the output.</para>
+      <para>There are a few things to take note of. Firstly, the &lt; and &gt; items are escaped. Secondly, the contents of the <code>&lt;programlisting&gt;</code> is flushed to the left, regardless of the current indentation of the xml. This is since all whitespace is rendered verbatim. Thirdly, the end <code>&lt;/programlisting tag&gt;</code> is put on the same row as the last line, or else an extra row will appear in the output.</para>
 
       <para>If you are intending to show code, you will want to do syntax highlighting. Doing so via the regular DocBook way is useless. Instead, you need some magic, namely enclosing your <code>&lt;programlisting&gt;</code> inside an <code>&lt;informalexample&gt;</code> tag, eg.</para>
       <programlisting>

--- a/docs/reference/cinnamon-tutorials/using-documentation.xml
+++ b/docs/reference/cinnamon-tutorials/using-documentation.xml
@@ -36,7 +36,7 @@
 
     <para>The <code>_init</code> function of each object is the constructor. So if you want to know what happens when you call <code>new Applet.Applet</code>, you look at the <code>_init</code> function of <code>Applet.Applet</code>. There usually isn't much helpful information apart form what each argument does.</para>
 
-    <para>Certain variables and functions are prepended with <code>_</code>, eg. <code>_showPanel</code>. These are private variables and functions which shouldn't be accessed normally, and is there purely for referencial purposes. It is generally not a good idea to use them in applets/desklets. Within Cinnamon itself, you may use them when necessary.</para>
+    <para>Certain variables and functions are prepended with <code>_</code>, eg. <code>_showPanel</code>. These are private variables and functions which shouldn't be accessed normally, and is there purely for referential purposes. It is generally not a good idea to use them in applets/desklets. Within Cinnamon itself, you may use them when necessary.</para>
 
     <para>Note that the <code>_init</code> is also a private function, and you also shouldn't call it directly (unless you are inheriting the object). It is implicitly called when you call the constructor (which technically can be totally unrelated to the <code>_init</code> function.</para>
 

--- a/docs/reference/cinnamon-tutorials/write-applet.xml
+++ b/docs/reference/cinnamon-tutorials/write-applet.xml
@@ -12,7 +12,7 @@
     <para>In this tutorial, we will go through the process of creating a simple applet to learn about the Applet API. Here we will create a Force Quit applet.</para>
 
     <para>
-      For those who are unfamiliar with “force-quitting”: When a window becomes unresponsive and doesn’t want to close, the most efficient way to force it to close is to kill its process. You could use the “<code>ps</code>” command to find its process ID and kill it with the “<code>kill</code>” command. Or alternatively you could run the “<code>xkill</code>” command, and simply click on the window you want to kill. And that’s exactly what our “Force Quit” applet is going to do... after you click on it, your mouse cursor will change into a window killer, which you’ll target at the window you want to get rid of :)
+      For those who are unfamiliar with “force-quitting”: When a window becomes unresponsive and doesn't want to close, the most efficient way to force it to close is to kill its process. You could use the “<code>ps</code>” command to find its process ID and kill it with the “<code>kill</code>” command. Or alternatively you could run the “<code>xkill</code>” command, and simply click on the window you want to kill. And that's exactly what our “Force Quit” applet is going to do... after you click on it, your mouse cursor will change into a window killer, which you’ll target at the window you want to get rid of :)
     </para>
 
   </sect2>

--- a/docs/reference/cinnamon-tutorials/xlet-settings-ref.xml
+++ b/docs/reference/cinnamon-tutorials/xlet-settings-ref.xml
@@ -241,22 +241,22 @@
   "section1" : {
     "type" : "section",
     "title" : "1st section",
-    "sections" : ["setting1", "setting2"]
+    "keys" : ["setting1", "setting2"]
   },
   "section2" : {
     "type" : "section",
     "title" : "2nd section",
-    "sections" : ["setting3", "setting4"]
+    "keys" : ["setting3", "setting4"]
   },
   "section3" : {
     "type" : "section",
     "title" : "3rd section",
-    "sections" : ["setting5", "setting6"]
+    "keys" : ["setting5", "setting6"]
   },
   "section4" : {
     "type" : "section",
     "title" : "4th section",
-    "sections" : ["setting7", "setting8"]
+    "keys" : ["setting7", "setting8"]
   }
 }</programlisting>
       </informalexample>
@@ -322,7 +322,7 @@
       </itemizedlist>
 
       <para>
-        This widget provides a list with columns, and rows which can be created, edited, deleted and reordered. The columns in the list are specified by the <code>columns</code> propery. All columns have the following properties:
+        This widget provides a list with columns, and rows which can be created, edited, deleted and reordered. The columns in the list are specified by the <code>columns</code> property. All columns have the following properties:
         <itemizedlist>
           <listitem><code>id</code>: a unique string for identifying the column</listitem>
           <listitem><code>title</code>: the title that will be displayed in the column header</listitem>
@@ -339,7 +339,7 @@
           <listitem><code>file</code>: this type stores data as a string. A <code>filechooser</code> is generated in the add/edit dialog. The default value for new entries is an empty string unless specified with the <code>default</code> property.</listitem>
           <listitem><code>integer</code>: this type stores data as an integer. A <code>spinbutton</code> is generated in the add/edit dialog. The default value for new entries is 0 unless specified with the <code>default</code> property.</listitem>
           <listitem><code>float</code>: this type stores data as a floating point number. A <code>spinbutton</code> is generated in the add/edit dialog. The default value for new entries is 0.0 unless specified with the <code>default</code> property.</listitem>
-          <listitem><code>boolean</code>: this type stores data as a bool. A <code>switch</code> is generated in the add/edit dialog. The default value for new entries is false unless specified with the <code>default</code> property.</listitem>
+          <listitem><code>boolean</code>: this type stores data as a boolean. A <code>switch</code> is generated in the add/edit dialog. The default value for new entries is false unless specified with the <code>default</code> property.</listitem>
         </itemizedlist>
       </para>
       <para>The values are stored as an array of objects where each object in the array corresponds to a row in the list, and each entry in the row object is a key:value pair where the key being the <code>column id</code> of the column to which the value corresponds.</para>
@@ -410,7 +410,7 @@
 
       <itemizedlist>
         <listitem>
-            <code>dependency: </code>Shows or hides the settings widget based on the value of another key in the settings-schema file. There are several possibl values for this option:
+            <code>dependency: </code>Shows or hides the settings widget based on the value of another key in the settings-schema file. There are several possible values for this option:
             <itemizedlist>
                 <listitem>The most common value for this option is simply the <code>key</code> of the setting you wish to depend on. This is most useful for depending on a boolean setting such as a switch. This will make your setting hide if the key you're depending on is false, and show it when the key is true.</listitem>
                 <listitem>If you wish to 'invert' the dependence you can precede the key with a <code>!</code>. This will make your setting hide if the key you're depending on is true, and show it when the key is false.</listitem>
@@ -436,7 +436,7 @@
 
       <para>Signals when <code>key</code> has changed in the configuration file. Use this in conjunction with <code>getValue</code> if you want to handle your own updating in a more traditional way (like gsettings).</para>
 
-      <para>The callback function will be called with three paramenters: <code>settingProvider, oldval, newval</code>, which are, respectively, the settings object (which you usually don't need), the original value and the updated value.</para>
+      <para>The callback function will be called with three parameters: <code>settingProvider, oldval, newval</code>, which are, respectively, the settings object (which you usually don't need), the original value and the updated value.</para>
     </sect3>
   </sect2>
 

--- a/docs/reference/cinnamon-tutorials/xlet-settings.xml
+++ b/docs/reference/cinnamon-tutorials/xlet-settings.xml
@@ -68,14 +68,14 @@
   <sect2>
     <title>Using the settings in your applet</title>
     <para>
-      Now that you have your settings defined in settings-schema.json, you will need to set up your applet to use them. The first thing you will need to do is import the settings library. To do so, sipmly place the following line with the other imports at the beginning of your file:
+      Now that you have your settings defined in settings-schema.json, you will need to set up your applet to use them. The first thing you will need to do is import the settings library. To do so, simply place the following line with the other imports at the beginning of your file:
     </para>
     <informalexample>
       <programlisting>
 const Settings = imports.ui.settings;</programlisting>
     </informalexample>
     <para>
-      Now you will need to initialize the settings provider. It is recommended that you do this early in the <code>_init</code> function of your applet, since you can’t use any of the settings until the provider is initialized. We do this by using the AppletSettings class as follows:
+      Now you will need to initialize the settings provider. It is recommended that you do this early in the <code>_init</code> function of your applet, since you can't use any of the settings until the provider is initialized. We do this by using the AppletSettings class as follows:
     </para>
     <informalexample>
       <programlisting>

--- a/docs/reference/cinnamon-tutorials/xlet-translating.xml
+++ b/docs/reference/cinnamon-tutorials/xlet-translating.xml
@@ -60,7 +60,7 @@
         Open a terminal in the directory where the <code>metadata.json</code> file is saved.
       </listitem>
       <listitem>
-        Type in the command <code>cinnamon-json-makepot --js po/yourApplet.pot</code>
+        Type in the command <code>cinnamon-xlet-makepot</code>
       </listitem>
     </itemizedlist>
     <para>
@@ -70,7 +70,7 @@
   <sect2>
     <title>Create a translation for the first time with the application Poedit</title>
     <para>
-      Install the programm "Poedit": <code>sudo apt install poedit</code>
+      Install the program "Poedit": <code>sudo apt install poedit</code>
     </para>
     <itemizedlist>
       <listitem>
@@ -108,7 +108,7 @@
         Open a terminal in the directory where the <code>metadata.json</code> file is saved.
       </listitem>
       <listitem>
-        Type in the command <code>cinnamon-json-makepot --js po/yourApplet.pot</code>
+        Type in the command <code>cinnamon-xlet-makepot</code>
       </listitem>
     </itemizedlist>
     <para>
@@ -145,7 +145,7 @@
         Open a terminal in the directory where the <code>metadata.json</code> file is saved.
       </listitem>
       <listitem>
-        Type in the command <code>cinnamon-json-makepot -i</code> to install the existing translations (i.e. the <code>.po</code> files)
+        Type in the command <code>cinnamon-xlet-makepot -i</code> to install the existing translations (i.e. the <code>.po</code> files)
       </listitem>
       <listitem>
         Restart Cinnamon: <code>CTRL+ALT+ESC</code>
@@ -159,7 +159,7 @@
         Open a terminal in the directory where the <code>metadata.json</code> file is saved.
       </listitem>
       <listitem>
-        Type in the command <code>cinnamon-json-makepot -r</code> to remove the installed translations.
+        Type in the command <code>cinnamon-xlet-makepot -r</code> to remove the installed translations.
       </listitem>
       <listitem>
         Restart Cinnamon: <code>CTRL+ALT+ESC</code>


### PR DESCRIPTION
- Corrected erroneous example for the layout key on setting-schemas.json files.
- Changed the examples using the `cinnamon-json-makepot` command in favor of using the `cinnamon-xlet-makepot` command. Mainly to avoid confusion since the `--js` CLI parameter has now an inverted meaning as it did before.
- Corrected other typos.