### PR TITLE
GWL: Fix thumbnail preview issue when window fade-out setting is non-zero

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -732,7 +732,7 @@ class AppGroup {
                 } else {
                     this.hoverMenu.open();
                 }
-                if (this.state.overlayPreview) {
+                if (this.state.lastOverlayPreview) {
                     this.hoverMenu.appThumbnails[0].destroyOverlayPreview();
                     this.hoverMenu.close(true);
                 }

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -204,7 +204,7 @@ class GroupedWindowListApplet extends Applet.Applet {
             willUnmount: false,
             settings: {},
             homeDir: GLib.get_home_dir(),
-            overlayPreview: null,
+            lastOverlayPreview: null,
             lastCycled: -1,
             lastTitleDisplay: null,
             scrollActive: false,

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
@@ -528,9 +528,7 @@ class WindowThumbnail {
         this.state = params.state;
         this.stateConnectId = this.state.connect({
             scrollActive: () => {
-                if (this.state.overlayPreview) {
-                    this.destroyOverlayPreview();
-                }
+                this.destroyOverlayPreview();
             },
             thumbnailCloseButtonOffset: ({thumbnailCloseButtonOffset}) => {
                 this.button.style = CLOSED_BUTTON_STYLE + `position: ${thumbnailCloseButtonOffset}px -2px;`;
@@ -637,9 +635,7 @@ class WindowThumbnail {
             && (!this.lastEnterActor
                 || (this.lastEnterActor.indexOf('StButton') === -1)
                     && this.lastEnterActor.indexOf('ClutterClone') === -1)) {
-            if (this.state.overlayPreview) {
-                this.destroyOverlayPreview();
-            }
+            this.destroyOverlayPreview();
             this.hoverPeek(this.state.settings.peekOpacity);
         }
         this.lastEnterActor = actorString;
@@ -688,7 +684,6 @@ class WindowThumbnail {
     handleCloseClick() {
         this.onLeave();
         this.stopClick = true;
-        this.hoverPeek(OPACITY_OPAQUE);
 
         this.metaWindow.delete(global.get_current_time());
         if (!this.groupState.metaWindows || this.groupState.metaWindows.length <= 1) {
@@ -836,7 +831,6 @@ class WindowThumbnail {
 
     hoverPeek(opacity) {
         if (!this.state.settings.enablePeek
-            || this.state.overlayPreview
             || this.state.scrollActive
             || (this.metaWindowActor && this.metaWindowActor.is_finalized())) {
             return;
@@ -845,37 +839,41 @@ class WindowThumbnail {
             this.metaWindowActor = this.metaWindow.get_compositor_private();
         }
         this.state.set({
-            overlayPreview: new Clutter.Clone({
+            lastOverlayPreview: new Clutter.Clone({
                 source: this.metaWindowActor.get_texture(),
                 opacity: 0
             })
         });
         let [x, y] = this.metaWindowActor.get_position();
-        this.state.overlayPreview.set_position(x, y);
-        global.overlay_group.add_child(this.state.overlayPreview);
-        global.overlay_group.set_child_above_sibling(this.state.overlayPreview, null);
-        setOpacity(this.state.settings.peekTimeIn, this.state.overlayPreview, opacity);
+        this.state.lastOverlayPreview.set_position(x, y);
+        global.overlay_group.add_child(this.state.lastOverlayPreview);
+        global.overlay_group.set_child_above_sibling(this.state.lastOverlayPreview, null);
+        setOpacity(this.state.settings.peekTimeIn, this.state.lastOverlayPreview, opacity);
     }
 
     destroyOverlayPreview() {
-        if (!this.state.overlayPreview) return;
+        if (!this.state.lastOverlayPreview) return;
 
         if (this.state.settings.peekTimeOut) {
+            let currOverlayPreview = this.state.lastOverlayPreview;
             setOpacity(
                 this.state.settings.peekTimeOut,
-                this.state.overlayPreview,
+                currOverlayPreview,
                 0,
-                () => this._destroyOverlayPreview()
+                () => this._destroyOverlayPreview(currOverlayPreview)
             );
         } else {
-            this._destroyOverlayPreview();
+            this._destroyOverlayPreview(this.state.lastOverlayPreview);
         }
     }
 
-    _destroyOverlayPreview() {
-        global.overlay_group.remove_child(this.state.overlayPreview);
-        this.state.overlayPreview.destroy();
-        this.state.set({overlayPreview: null});
+    _destroyOverlayPreview(overlayPreview) {
+        global.overlay_group.remove_child(overlayPreview);
+        overlayPreview.destroy();
+
+        if(overlayPreview === this.state.lastOverlayPreview) {
+            this.state.set({lastOverlayPreview: null});
+        }
     }
 
     destroy() {


### PR DESCRIPTION
In order to have fade-out animations, multiple preview overlays are needed at the same time.
The existing code did not handle this, instead not creating a new overlay and not showing a window preview if an existing overlay was fading out.

I did not find any existing issues that were reported about this.
I also did some related code cleanup.