### PR TITLE
meson girs: Export gir names as a package

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -183,6 +183,7 @@ cinnamon_gir = gnome.generate_gir(
     dependencies: libcinnamon_deps,
     identifier_prefix: 'Cinnamon',
     symbol_prefix: 'cinnamon',
+    export_packages: 'cinnamon',
     includes: cinnamon_gir_includes,
     install: true,
     install_dir_typelib: pkglibdir,

--- a/src/st/meson.build
+++ b/src/st/meson.build
@@ -209,6 +209,7 @@ st_gir = gnome.generate_gir(
     dependencies: libst_deps,
     identifier_prefix: 'St',
     symbol_prefix: 'st',
+    export_packages: 'st',
     includes: st_gir_includes,
     install: true,
     install_dir_typelib: pkglibdir,


### PR DESCRIPTION
Fixes an issue with the package tag in the gir not being generated.

See https://github.com/linuxmint/xapp/commit/e40a44c