### PR TITLE
GWL: Don't force the "New Window" option to show

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -339,7 +339,6 @@ class GroupedWindowListApplet extends Applet.Applet {
             {key: 'scroll-behavior', value: 'scrollBehavior', cb: null},
             {key: 'show-recent', value: 'showRecent', cb: null},
             {key: 'autostart-menu-item', value: 'autoStart', cb: null},
-            {key: 'launch-new-instance-menu-item', value: 'launchNewInstance', cb: null},
             {key: 'monitor-move-all-windows', value: 'monitorMoveAllWindows', cb: null},
             {key: 'show-all-workspaces', value: 'showAllWorkspaces', cb: this.refreshAllAppLists}
         ];

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
@@ -274,14 +274,6 @@ class AppMenuButtonRightClickMenu extends Applet.AppletPopupMenu {
                 }
                 this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
             }
-            if (this.state.settings.launchNewInstance && (!actions || actions.length === 0) && !isWindowBacked) {
-                item = createMenuItem({label: _('New Window'), icon: 'window-new'});
-                this.signals.connect(item, 'activate', () => this.groupState.trigger('launchNewInstance'));
-                this.addMenuItem(item);
-                if (!actions || actions.length === 0) {
-                    this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-                }
-            }
         }, () => {
             if (isWindowBacked) {
                 this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/settings-schema.json
@@ -85,7 +85,6 @@
       "keys": [
         "show-recent",
         "autostart-menu-item",
-        "launch-new-instance-menu-item",
         "monitor-move-all-windows"
       ]
     }
@@ -255,12 +254,6 @@
     "type": "checkbox",
     "default": false,
     "description": "Show autostart option"
-  },
-  "launch-new-instance-menu-item": {
-    "type": "checkbox",
-    "default": true,
-    "description": "Show new window option",
-    "tooltip": "Shows the \"New Window\" option in an app's context menu if it doesn't already have one from the app's own action menu items."
   },
   "monitor-move-all-windows": {
     "type": "checkbox",


### PR DESCRIPTION
Do this by removing the option from the GWL settings. This is forcing that
menu item to show even for applications that only support launching a
single instance like Bulky. The menu entry will still show for applications
that properly support this action in their desktop file.