### PR TITLE
Add confirmation dialog when removing a panel

### DIFF
--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -1593,7 +1593,11 @@ PanelContextMenu.prototype = {
 
         let menuItem = new PopupMenu.PopupIconMenuItem(_("Remove"), "list-remove", St.IconType.SYMBOLIC);  // submenu item remove panel
         menuItem.activate = Lang.bind(menu, function() {
-            Main.panelManager.removePanel(panelId);
+            let confirm = new ModalDialog.ConfirmDialog(_("Are you sure you want to remove this panel?\n\n"),
+                    function() {
+                        Main.panelManager.removePanel(panelId);
+                    });
+            confirm.open();
         });
         menu.addMenuItem(menuItem);
 

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -1593,7 +1593,7 @@ PanelContextMenu.prototype = {
 
         let menuItem = new PopupMenu.PopupIconMenuItem(_("Remove"), "list-remove", St.IconType.SYMBOLIC);  // submenu item remove panel
         menuItem.activate = Lang.bind(menu, function() {
-            let confirm = new ModalDialog.ConfirmDialog(_("Are you sure you want to remove this panel?\n\n"),
+            let confirm = new ModalDialog.ConfirmDialog(_("Are you sure you want to remove this panel?"),
                     function() {
                         Main.panelManager.removePanel(panelId);
                     });


### PR DESCRIPTION
fixes #10337

Although a panel can be recovered, this is not straightforward for a novice especially if it's your last remaining panel and it's easy to accidentally click on the wrong menu item and instantly delete your panel, I've done it myself. If you google "accidentally deleted cinnamon panel" you'll find lots of posts where people are asking how to recover their panel so this seems to be a not uncommon problem. I think just a confirmation dialog is the way to go.