### PR TITLE
Window list: Add toggle for window labels on/off

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -739,7 +739,7 @@ class AppMenuButton {
     }
 
     updateLabelVisible() {
-        if (this._applet.orientation == St.Side.TOP || this._applet.orientation == St.Side.BOTTOM) {
+        if (this._applet.showLabelPanel) {
             this._label.show();
             this.labelVisible = true;
         } else {
@@ -1018,6 +1018,7 @@ class CinnamonWindowListApplet extends Applet.Applet {
         this.settings.bind("left-click-minimize", "leftClickMinimize");
         this.settings.bind("middle-click-close", "middleClickClose");
         this.settings.bind("buttons-use-entire-space", "buttonsUseEntireSpace", this._refreshAllItems);
+        this.settings.bind("panel-show-label", "showLabelPanel", this._updateLabels);
         this.settings.bind("window-preview", "usePreview", this._onPreviewChanged);
         this.settings.bind("window-preview-show-label", "showLabel", this._onPreviewChanged);
         this.settings.bind("window-preview-scale", "previewScale", this._onPreviewChanged);
@@ -1226,6 +1227,11 @@ class CinnamonWindowListApplet extends Applet.Applet {
         for (let window of this._windows) {
             window.setDisplayTitle();
         }
+    }
+    
+    _updateLabels() {
+        for (let window of this._windows)
+            window.updateLabelVisible();
     }
 
     _updateWatchedMonitors() {

--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/settings-schema.json
@@ -43,6 +43,11 @@
       "default": false,
       "description": "Window buttons can have different sizes and use the entire space available"
   },
+  "panel-show-label": {
+      "type": "switch",
+      "default": true,
+      "description": "Show window labels next to icons"
+  },
   "window-preview": {
       "type": "switch",
       "default": true,


### PR DESCRIPTION
Currently, window labels are completely disabled for vertical panels with the window list applet. I've added a toggle to the preferences menu to "Show window labels next to icons," and this is enabled by default. For vertical panels, this allows users to show the window labels (same as the default behavior for a horizontal panel). Users can still disable this setting if they prefer the cleaner look of only icons/no labels for both horizontal or vertical panels.

(2nd PR since I messed up the first one)