### PR TITLE
Add Edit menu item option when right clicking an app

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -375,6 +375,9 @@ class ApplicationContextMenuItem extends PopupMenu.PopupBaseMenuItem {
                     return false;
                 });
                 break;
+            case "edit_item":
+                Util.spawnCommandLine("cinnamon-desktop-editor -mlauncher -o " + this._appButton.app.get_app_info().get_filename());
+                break;
             case "add_to_desktop":
                 let file = Gio.file_new_for_path(this._appButton.app.get_app_info().get_filename());
                 let destFile = Gio.file_new_for_path(USER_DESKTOP_PATH+"/"+file.get_basename());
@@ -458,6 +461,9 @@ class GenericApplicationButton extends SimpleMenuItem {
         }
 
         menuItem = new ApplicationContextMenuItem(this, _("Add to panel"), "add_to_panel", "list-add");
+        menu.addMenuItem(menuItem);
+
+        menuItem = new ApplicationContextMenuItem(this, _("Edit"), "edit_item", "document-properties");
         menu.addMenuItem(menuItem);
 
         if (USER_DESKTOP_PATH){


### PR DESCRIPTION
Spawns cinnamon-desktop-editor

Less annoying than right clicking the menu -> configure... -> Menu -> open menu editor -> finding your app
Also puts it at parity with Mate and XFCE