### PR TITLE
Fix menu-editor with python-3.10

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-menu-editor/cme/util.py
+++ b/files/usr/share/cinnamon/cinnamon-menu-editor/cme/util.py
@@ -19,7 +19,11 @@
 import os
 import xml.dom.minidom
 import uuid
-from collections import Sequence
+import sys
+if sys.version_info[:2] >= (3, 8):
+    from collections.abc import Sequence
+else:
+    from collections import Sequence
 from gi.repository import Gtk, GdkPixbuf, CMenu, GLib, Gdk
 
 DESKTOP_GROUP = GLib.KEY_FILE_DESKTOP_GROUP


### PR DESCRIPTION
Fix https://bugzilla.redhat.com/show_bug.cgi?id=2010737

```
  File "/usr/share/cinnamon/cinnamon-menu-editor/cme/util.py", line 22, in <module>
    from collections import Sequence
ImportError: cannot import name 'Sequence' from 'collections' (/usr/lib64/python3.10/collections/__init__.py)
```