### PR TITLE
[muffin-5.2-test] Add libmuffin-dev to build-dep

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -24,7 +24,7 @@ Build-Depends:
  libgtk-3-dev (>= 3.9.12),
  libgudev-1.0-dev,
  libjson-glib-dev (>= 0.13.2),
- libmuffin0 (>= 3.8),
+ libmuffin-dev (>= 5.2),
  libnm-dev (>= 1.6) [linux-any],
  libnma-dev [linux-any],
  libpolkit-agent-1-dev (>= 0.100),


### PR DESCRIPTION
Add libmuffin-dev to build-dep for muffin-5.2-test branch