### PR TITLE
Fix memory leaks on error paths

### DIFF
--- a/src/cinnamon-perf-log.c
+++ b/src/cinnamon-perf-log.c
@@ -874,7 +874,8 @@ replay_to_json (gint64      time,
                 gpointer    user_data)
 {
   ReplayToJsonClosure *closure = user_data;
-  char *event_str;
+  char *event_str = NULL;
+  gboolean rc;
 
   if (closure->error != NULL)
     return;
@@ -923,7 +924,9 @@ replay_to_json (gint64      time,
       g_assert_not_reached ();
     }
 
-  if (!write_string (closure->out, event_str, &closure->error))
+  rc = write_string (closure->out, event_str, &closure->error);
+  g_free (event_str);
+  if (!rc)
       return;
 }
 

--- a/src/cinnamon-recorder.c
+++ b/src/cinnamon-recorder.c
@@ -1281,6 +1281,7 @@ recorder_open_outfile (CinnamonRecorder *recorder)
                   break;
                 default:
                   g_warning ("Unknown escape %%%c in filename", *p);
+                  g_string_free (filename, TRUE);
                   goto out;
                 }
 

--- a/src/hotplug-sniffer/hotplug-sniffer.c
+++ b/src/hotplug-sniffer/hotplug-sniffer.c
@@ -128,9 +128,9 @@ sniff_async_ready_cb (GObject *source,
 
   g_dbus_method_invocation_return_value (data->invocation,
                                          g_variant_new ("(^as)", types));
-  g_strfreev (types);
 
  out:
+  g_strfreev (types);
   invocation_data_free (data);
   ensure_autoquit_on ();
 }

--- a/src/st/croco/cr-parser.c
+++ b/src/st/croco/cr-parser.c
@@ -1850,6 +1850,7 @@ cr_parser_parse_simple_selector (CRParser * a_this, CRSimpleSel ** a_sel)
                                 found_sel = TRUE;
                         } else {
                                 status = CR_PARSING_ERROR;
+                                cr_pseudo_destroy (pseudo);
                                 goto error;
                         }
 
@@ -1867,7 +1868,8 @@ cr_parser_parse_simple_selector (CRParser * a_this, CRSimpleSel ** a_sel)
                                         cr_additional_sel_append
                                         (add_sel_list, add_sel);
                                 status = CR_OK;
-                        }
+                        } else
+                                cr_pseudo_destroy (pseudo);
                 } else {
                         status = cr_tknzr_unget_token
                                 (PRIVATE (a_this)->tknzr, token);

--- a/src/st/croco/cr-statement.c
+++ b/src/st/croco/cr-statement.c
@@ -874,8 +874,10 @@ cr_statement_import_rule_to_string (CRStatement const *a_this,
                                                 str);
                         g_free (str);
                         str = NULL ;
-                } else          /*there is no url, so no import rule, get out! */
+                } else {        /*there is no url, so no import rule, get out! */
+                        g_string_free (stringue, TRUE);
                         return NULL;
+                }
 
                 if (a_this->kind.import_rule->media_list) {
                         GList const *cur = NULL;
@@ -1291,6 +1293,7 @@ cr_statement_new_at_media_rule (CRStyleSheet * a_sheet,
                         cr_utils_trace_info ("Bad parameter a_rulesets. "
                                              "It should be a list of "
                                              "correct ruleset statement only !");
+                        g_free (result);
                         goto error;
                 }
                 cur->kind.ruleset->parent_media_rule = result;

--- a/src/st/croco/cr-term.c
+++ b/src/st/croco/cr-term.c
@@ -484,8 +484,10 @@ cr_term_one_to_string (CRTerm const * a_this)
 
         if ((a_this->content.str == NULL)
             && (a_this->content.num == NULL)
-            && (a_this->content.rgb == NULL))
+            && (a_this->content.rgb == NULL)) {
+                g_string_free (str_buf, TRUE);
                 return NULL ;
+        }
 
         switch (a_this->the_operator) {
         case DIVIDE:
@@ -560,9 +562,9 @@ cr_term_one_to_string (CRTerm const * a_this)
                                 }
 
                                 g_string_append_printf (str_buf, ")");
-                                g_free (content);
-                                content = NULL;
                         }
+                        g_free (content);
+                        content = NULL;
                 }
 
                 break;


### PR DESCRIPTION
This patch fixes a number of memory leaks found by static analysis. In a
couple places the free'ing was at the wrong scope and didn't free in the
error path.