### PR TITLE
Spotify fixed the album art issue

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -711,9 +711,6 @@ class Player extends PopupMenu.PopupMenuSection {
         let change = false;
         if (metadata["mpris:artUrl"]) {
             let artUrl = metadata["mpris:artUrl"].unpack();
-            if ( this._name.toLowerCase() === "spotify" ) {
-                artUrl = artUrl.replace("open.spotify.com", "i.scdn.co");
-            }
             if (this._trackCoverFile != artUrl) {
                 this._trackCoverFile = artUrl;
                 change = true;


### PR DESCRIPTION
Spotify now fixed the album art issue. I commented out the artUrl.replace() line and album art now shows in the sound applet.

Here's proof that it works now:

![image](https://user-images.githubusercontent.com/51266541/139581455-4993abe6-5101-4beb-8276-53433d8d3753.png)

![image](https://user-images.githubusercontent.com/51266541/139581468-b55f0121-c9be-4a32-89a9-d95511f86d30.png)
