### PR TITLE
GWL: Fix issue 10401; Update AppGroup icon every time a new window is added

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -903,6 +903,10 @@ class AppGroup {
                 metaWindows.push(metaWindow);
                 if (this.hoverMenu) trigger('addThumbnailToMenu', metaWindow);
             }
+
+            // update icon using recent window for cases when the first window of an app doesn't have an icon. e.g: VirtualBox VM
+            this.setIcon(metaWindow)
+
             this.calcWindowNumber();
             this.onFocusChange();
         }


### PR DESCRIPTION
GWL: Update AppGroup icon every time a new window is added to it, to account for cases when the first window of an app doesn't have an icon.
e.g: VirtualBox VM