### PR TITLE
Window button layout setting: improve rtl handling

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_windows.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_windows.py
@@ -35,8 +35,12 @@ class Module:
             settings = page.add_section(_("Buttons"))
 
             button_options = []
-            button_options.append([":minimize,maximize,close", _("Right")])
-            button_options.append(["close,maximize,minimize:", _("Left")])
+            if Gtk.Widget.get_default_direction() == Gtk.TextDirection.RTL:
+                button_options.append([":minimize,maximize,close", _("Left")])
+                button_options.append(["close,maximize,minimize:", _("Right")])
+            else:
+                button_options.append([":minimize,maximize,close", _("Right")])
+                button_options.append(["close,maximize,minimize:", _("Left")])
             button_options.append([":close", _("Gnome")])
             button_options.append(["close:minimize,maximize", _("Classic Mac")])
 


### PR DESCRIPTION
Relpace `right` and `left` lables when on an rtl layout.
I would like some feedback as to whether using a label multiple times can affect translation handling (e.g. create two entries to translate).