### PR TITLE
Make cinnamon-settings a GApplication to accomodate webkit.

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
@@ -261,6 +261,7 @@ class MainWindow(Gtk.Application):
     # Create the UI
     def __init__(self):
         Gtk.Application.__init__(self,
+                                 application_id="org.cinnamon.Settings_%d" % os.getpid(),
                                  flags=Gio.ApplicationFlags.NON_UNIQUE | Gio.ApplicationFlags.HANDLES_OPEN)
         self.builder = Gtk.Builder()
         self.builder.set_translation_domain('cinnamon')  # let it translate!

--- a/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
@@ -166,7 +166,7 @@ def touch(fname, times=None):
         os.utime(fname, times)
 
 
-class MainWindow:
+class MainWindow(Gtk.Application):
     # Change pages
     def side_view_nav(self, side_view, path, cat):
         selected_items = side_view.get_selected_items()
@@ -260,6 +260,8 @@ class MainWindow:
 
     # Create the UI
     def __init__(self):
+        Gtk.Application.__init__(self,
+                                 flags=Gio.ApplicationFlags.NON_UNIQUE | Gio.ApplicationFlags.HANDLES_OPEN)
         self.builder = Gtk.Builder()
         self.builder.set_translation_domain('cinnamon')  # let it translate!
         self.builder.add_from_file(config.currentPath + "/cinnamon-settings.ui")
@@ -297,7 +299,7 @@ class MainWindow:
         self.search_entry.connect("changed", self.onSearchTextChanged)
         self.search_entry.connect("icon-press", self.onClearSearchBox)
 
-        self.window.connect("destroy", self.quit)
+        self.window.connect("destroy", self._quit)
 
         self.builder.connect_signals(self)
         self.unsortedSidePages = []
@@ -447,6 +449,13 @@ class MainWindow:
             self.window.connect("button-press-event", self.on_buttonpress)
 
             self.window.show()
+
+    # If there are no arguments, do_active() is called, otherwise do_open().
+    def do_activate(self):
+        self.hold()
+
+    def do_open(self, files, n_files, hint):
+        self.hold()
 
     def on_keypress(self, widget, event):
         grab = False
@@ -715,10 +724,9 @@ class MainWindow:
 
         self.current_sidepage = None
 
-    def quit(self, *args):
+    def _quit(self, *args):
         self.window.destroy()
-        Gtk.main_quit()
-
+        self.quit()
 
 if __name__ == "__main__":
     setproctitle("cinnamon-settings")
@@ -733,4 +741,4 @@ if __name__ == "__main__":
 
     window = MainWindow()
     signal.signal(signal.SIGINT, signal.SIG_DFL)
-    Gtk.main()
+    window.run(sys.argv)


### PR DESCRIPTION
GApplication is required for xdg-desktop-portal access in the WebKit sandbox.

https://forums.fedoraforum.org/showthread.php?327343-Gnome-Online-Accounts-Unusable-In-F35-Cinnamon-GUI-Consistently-Crashes-Vanishes