### PR TITLE
build: unbreak with meson >= 0.60.2

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -196,7 +196,7 @@ cinnamon_gir = gnome.generate_gir(
     includes: cinnamon_gir_includes,
     install: true,
     install_dir_typelib: pkglibdir,
-    install_dir_gir: false,
+    install_dir_gir: [false],
     extra_args: [
         '-DST_COMPILATION',
         '--quiet',

--- a/src/st/meson.build
+++ b/src/st/meson.build
@@ -213,7 +213,7 @@ st_gir = gnome.generate_gir(
     includes: st_gir_includes,
     install: true,
     install_dir_typelib: pkglibdir,
-    install_dir_gir: false,
+    install_dir_gir: [false],
     extra_args: [
         '-DST_COMPILATION',
         '--quiet',


### PR DESCRIPTION
Regressed by [meson@5cc166a66](https://github.com/mesonbuild/meson/commit/5cc166a667ff). Similar to https://github.com/linuxmint/cjs/pull/98. From [error log](http://www.ipv6proxy.net/go.php?u=http://package22.nyi.freebsd.org/data/130amd64-default-foo/2021-11-28_09h10m20s/logs/cinnamon-4.8.6_1.log):
```python
$ meson setup _build
[...]
src/st/meson.build:204:0: ERROR: "install_dir" must be specified when installing a target
```

**EDIT**: `lmde4` bustage on CircleCI looks unrelated:
```
The following packages have unmet dependencies:
 cinnamon : Depends: gir1.2-ecal-2.0 but it is not installable
E: Unable to correct problems, you have held broken packages.
[...]
dpkg: dependency problems prevent configuration of cinnamon-common:
 cinnamon-common depends on gir1.2-timezonemap-1.0; however:
  Package gir1.2-timezonemap-1.0 is not installed.
[...]
dpkg: error processing package cinnamon (--install):
 dependency problems - leaving unconfigured
dpkg: dependency problems prevent configuration of cinnamon-dbg:
 cinnamon-dbg depends on cinnamon (= 5.2.1); however:
  Package cinnamon is not configured yet.

dpkg: error processing package cinnamon-dbg (--install):
 dependency problems - leaving unconfigured
[...]
Errors were encountered while processing:
 cinnamon-common
 cinnamon
 cinnamon-dbg
ERROR: 'sudo apt install --yes --allow-downgrades ../*.deb || sudo dpkg -i ../*.deb' exited with return code 256
```

