### PR TITLE
calendar: Fix missing prefix in bindir path for D-Bus service

### DIFF
--- a/calendar-server/meson.build
+++ b/calendar-server/meson.build
@@ -12,7 +12,7 @@ launcher = configure_file(
 )
 
 service_conf = configuration_data()
-service_conf.set('BINDIR', bindir)
+service_conf.set('BINDIR', join_paths(prefix, bindir))
 
 launcher = configure_file(
     input: 'org.cinnamon.CalendarServer.service.in',

--- a/calendar-server/org.cinnamon.CalendarServer.service.in
+++ b/calendar-server/org.cinnamon.CalendarServer.service.in
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=org.cinnamon.CalendarServer
-Exec=/@BINDIR@/cinnamon-calendar-server
+Exec=@BINDIR@/cinnamon-calendar-server


### PR DESCRIPTION
Hi, the D-Bus service file for cinnamon-calendar-server doesn't currently respect any install prefix other than `/`. While any prefix *is* respected when installing the corresponding binaries (with them ending up in the correct locations), the service file does not reflect this at all and thus potentially points to an invalid location. In such cases, opening the calendar applet only results in the following D-Bus error:
```
Activated service 'org.cinnamon.CalendarServer' failed: Failed to execute program org.cinnamon.CalendarServer: No such file or directory
```

This patch prepends the used prefix to the `BINDIR` variable that is used for replacement in the service file.