### PR TITLE
remove _hook from applet.js

### DIFF
--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -173,7 +173,6 @@ var Applet = class Applet {
 
         this.instance_id = instance_id; // Needed by appletSettings
         this._uuid = null;      // Defined in gsettings, set by Cinnamon.
-        this._hook = null;      // Defined in metadata.json, set by appletManager
         this._meta = null;      // set by appletManager
         this._dragging = false;
         this._draggable = DND.makeDraggable(this.actor);


### PR DESCRIPTION
this param isn't used anywhere since 9 years: https://github.com/linuxmint/cinnamon/commit/1c0c12014b54af946f987b158d2858d62817dabb#diff-689b36b65982d3aa71863ab8941da57b10a5a6bfb2e68d004673f820102f2514L101