### PR TITLE
Prevent panel settings menu from crashing when opening it

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_panel.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_panel.py
@@ -578,5 +578,5 @@ class PanelRange(Range, PanelWidgetBackend):
 
     def on_setting_changed(self, *args):
         value = self.get_value()
-        if value != int(self.bind_object.get_value()):
+        if value != None and value != int(self.bind_object.get_value()):
             self.bind_object.set_value(value)


### PR DESCRIPTION
Fixes #10551