### PR TITLE
[calendar applet] make new date strings translatable

### DIFF
--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
@@ -15,8 +15,8 @@ const Main = imports.ui.main;
 const Separator = imports.ui.separator;
 
 const DAY_FORMAT = CinnamonDesktop.WallClock.lctime_format("cinnamon", "%A");
-const DATE_FORMAT_SHORT = CinnamonDesktop.WallClock.lctime_format("cinnamon", "%B %-e, %Y");
-const DATE_FORMAT_FULL = CinnamonDesktop.WallClock.lctime_format("cinnamon", "%A, %B %-e, %Y");
+const DATE_FORMAT_SHORT = CinnamonDesktop.WallClock.lctime_format("cinnamon", _("%B %-e, %Y"));
+const DATE_FORMAT_FULL = CinnamonDesktop.WallClock.lctime_format("cinnamon", _("%A, %B %-e, %Y"));
 
 class CinnamonCalendarApplet extends Applet.TextApplet {
     constructor(orientation, panel_height, instance_id) {

--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/eventView.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/eventView.js
@@ -23,7 +23,7 @@ const STATUS_NO_CALENDARS = 1;
 const STATUS_HAS_CALENDARS = 2;
 
 // TODO: this is duplicated from applet.js
-const DATE_FORMAT_FULL = CinnamonDesktop.WallClock.lctime_format("cinnamon", "%A, %B %-e, %Y");
+const DATE_FORMAT_FULL = CinnamonDesktop.WallClock.lctime_format("cinnamon", _("%A, %B %-e, %Y"));
 const DAY_FORMAT = CinnamonDesktop.WallClock.lctime_format("cinnamon", "%A");
 
 function locale_cap(str) {


### PR DESCRIPTION
This makes the new date format strings translatable, so that they can be picked up when makepot is run again.