### PR TITLE
[WIP] Allow expiration of critical notification

### DIFF
--- a/js/ui/messageTray.js
+++ b/js/ui/messageTray.js
@@ -879,7 +879,6 @@ MessageTray.prototype = {
         let notificationsPending = this._notificationQueue.length > 0 && (!this._busy || notificationUrgent);
 
         let notificationExpired = (this._notificationTimeoutId == 0 &&
-                !(this._notification && this._notification.urgency == Urgency.CRITICAL) &&
                 !this._locked
             ) || this._notificationRemoved;
         let canShowNotification = notificationsPending && this._notificationsEnabled;


### PR DESCRIPTION
This fixed the issue #9378 which is still present on latest Cinnamon version.

Old behavior was keeping the critical notification displayed even is a notification applet is provided.
The new behavior is keeping the critical notification displayed for 10s, then if a notification applet is provided, then notification is moved into it and is hidden, else the notification stay displayed as before.