### PR TITLE
Make evolution-data-server integration optional

### DIFF
--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/eventView.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/eventView.js
@@ -301,7 +301,7 @@ class EventsManager {
     }
 
     start_events() {
-        if (this._calendar_server == null) {
+        if (this._calendar_server == null && Cinnamon.CalendarServerProxy) {
             Cinnamon.CalendarServerProxy.new_for_bus(
                 Gio.BusType.SESSION,
                 // Gio.DBusProxyFlags.NONE,

--- a/meson.build
+++ b/meson.build
@@ -179,6 +179,9 @@ install_subdir(
     strip_directory: true,
 )
 
-subdir('calendar-server')
+
+if get_option('build_calendar_server')
+    subdir('calendar-server')
+endif
 subdir('python3')
 subdir('install-scripts')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -13,6 +13,11 @@ option('build_recorder',
     value: true,
     description: 'Build the cinnamon recorder into source'
 )
+option('build_calendar_server',
+    type: 'boolean',
+    value: true,
+    description: 'Build the cinnamon EDS calendar server'
+)
 option('disable_networkmanager',
     type: 'boolean',
     value: false,

--- a/src/meson.build
+++ b/src/meson.build
@@ -3,12 +3,6 @@ subdir('hotplug-sniffer')
 
 include_src = include_directories('.')
 
-calendar_generated = gnome.gdbus_codegen('cinnamon-calendar',
-  sources: 'org.cinnamon.CalendarServer.xml',
-  interface_prefix: 'org.cinnamon.',
-  namespace: 'Cinnamon'
-)
-
 cinnamon_headers = [
     'cinnamon-app.h',
     'cinnamon-app-system.h',
@@ -59,9 +53,20 @@ cinnamon_sources = [
     'cinnamon-window-tracker.c',
     'cinnamon-wm.c',
     'cinnamon-xfixes-cursor.c',
-    cinnamon_headers,
-    calendar_generated
+    cinnamon_headers
 ]
+
+if get_option('build_calendar_server')
+    calendar_generated = gnome.gdbus_codegen('cinnamon-calendar',
+      sources: 'org.cinnamon.CalendarServer.xml',
+      interface_prefix: 'org.cinnamon.',
+      namespace: 'Cinnamon'
+    )
+
+    cinnamon_sources += [
+        calendar_generated
+    ]
+endif
 
 cinnamon_enum_types = gnome.mkenums_simple(
     'cinnamon-enum-types',


### PR DESCRIPTION
I worked on this as part of packaging Cinnamon for Gentoo.

This adds a build flag to optionally disable building the calendar server. This helps reduce dependency weight for users who don't use Evolution.

I'm not 100% sure of the JS change (I haven't worked with CJS/GI objects before), but it seems to work and I'm not seeing any obvious log warnings/errors.