### PR TITLE
Fix warning about using var for module exports in screenshot.js

### DIFF
--- a/js/ui/screenshot.js
+++ b/js/ui/screenshot.js
@@ -72,7 +72,7 @@ const ScreenshotIface =
  * The callback argument is unused.
  */
 
-class ScreenshotService {
+var ScreenshotService = class ScreenshotService {
     constructor() {
         this._dbusImpl = Gio.DBusExportedObject.wrapJSObject(ScreenshotIface, this);
         this._dbusImpl.export(Gio.DBus.session, '/org/gnome/Shell/Screenshot');


### PR DESCRIPTION
Fix the following warning:

> (cinnamon:2349): Cjs-WARNING **: 23:44:58.421: Some code accessed the property 'ScreenshotService' on the module 'screenshot'. That property was defined with 'let' or 'const' inside the module. This was previously supported, but is not correct according to the ES6 standard. Any symbols to be exported from a module must be defined with 'var'. The property access will work as previously for the time being, but please fix your code anyway.