### PR TITLE
Fix a couple typos in latest code

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_sound.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_sound.py
@@ -54,7 +54,7 @@ class SoundBox(Gtk.Box):
 
         label = Gtk.Label()
         label.set_markup("<b>%s</b>" % title)
-        label.set_x_align(0.0)
+        label.set_xalign(0.0)
         self.add(label)
 
         frame = Gtk.Frame()

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_sound.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_sound.py
@@ -54,7 +54,7 @@ class SoundBox(Gtk.Box):
 
         label = Gtk.Label()
         label.set_markup("<b>%s</b>" % title)
-        label.set_xalign(0.0)
+        label.set_x_align(0.0)
         self.add(label)
 
         frame = Gtk.Frame()

--- a/js/ui/accessibility.js
+++ b/js/ui/accessibility.js
@@ -121,6 +121,7 @@ A11yHandler.prototype = {
             switch (this.event_flash_type) {
                 case CDesktopEnums.VisualBellType.FULLSCREEN_FLASH:
                     this.flash_window(display, null);
+                    break;
                 case CDesktopEnums.VisualBellType.FRAME_FLASH:
                     this.flash_window(display, bell_window);
             }

--- a/src/st/croco/cr-utils.c
+++ b/src/st/croco/cr-utils.c
@@ -812,7 +812,7 @@ cr_utils_ucs4_to_utf8 (const guint32 * a_in,
                                 = (0x80 | ((a_in[in_index] >> 12) & 0x3F));
                         a_out[out_index + 4]
                                 = (0x80 | ((a_in[in_index] >> 6) & 0x3F));
-                        a_out[out_index + 4]
+                        a_out[out_index + 5]
                                 = (0x80 | (a_in[in_index] & 0x3F));
                         out_index += 6;
                 } else {


### PR DESCRIPTION
In accessibility.js, there is a missing break in the switch statement.

In cr-utils.c, out_index + 4 is used twice, the second should have been
out_index + 5.