### PR TITLE
Revert "build: disable gir install via list to pacify meson >= 0.60.2 (#10489)"

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -196,7 +196,7 @@ cinnamon_gir = gnome.generate_gir(
     includes: cinnamon_gir_includes,
     install: true,
     install_dir_typelib: pkglibdir,
-    install_dir_gir: [false],
+    install_dir_gir: false,
     extra_args: [
         '-DST_COMPILATION',
         '--quiet',

--- a/src/st/meson.build
+++ b/src/st/meson.build
@@ -213,7 +213,7 @@ st_gir = gnome.generate_gir(
     includes: st_gir_includes,
     install: true,
     install_dir_typelib: pkglibdir,
-    install_dir_gir: [false],
+    install_dir_gir: false,
     extra_args: [
         '-DST_COMPILATION',
         '--quiet',


### PR DESCRIPTION
This reverts commit 8fc2df08b40aa3e1958ed2fde853c50676d8cf48.

This commit was wrong, because it tried to work around a bug in a single version of meson by using something that isn't, wasn't, and won't be a valid value.

The fixed version of meson 0.60.x has been out for a while now, which once again accepts `false`, and 0.61.0 also accepts `false` but was known at the time of this workaround to not work in meson-git master (now meson 0.61.0).

Using `false` is acceptable and the failure to accept it has been qualified as a meson regression. Using `[false]` is just... trying to fuzz meson with random objects until you get something that slips its way through the argument checker and produces desired effects on the python implementation level.