### PR TITLE
calendar events: Check if evolution-data-server is running before enabling events.

### DIFF
--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/calendar.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/calendar.js
@@ -159,7 +159,7 @@ class Calendar {
         this.desktop_settings = new Gio.Settings({ schema_id: DESKTOP_SCHEMA });
         this.desktop_settings.connect("changed::" + FIRST_WEEKDAY_KEY, Lang.bind(this, this._onSettingsChange));
 
-        this.events_enabled = true;
+        this.events_enabled = false;
         this.events_manager.connect("events-updated", this._events_updated.bind(this));
         this.events_manager.connect("events-manager-ready", this._update_events_enabled.bind(this));
         this.events_manager.connect("has-calendars-changed", this._update_events_enabled.bind(this));

--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/eventView.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/eventView.js
@@ -17,6 +17,7 @@ const Main = imports.ui.main;
 const Util = imports.misc.util;
 const Mainloop = imports.mainloop;
 const Tweener = imports.ui.tweener;
+const Interfaces = imports.misc.interfaces;
 
 const STATUS_UNKNOWN = 0;
 const STATUS_NO_CALENDARS = 1;
@@ -302,16 +303,40 @@ class EventsManager {
 
     start_events() {
         if (this._calendar_server == null) {
-            Cinnamon.CalendarServerProxy.new_for_bus(
-                Gio.BusType.SESSION,
-                // Gio.DBusProxyFlags.NONE,
-                Gio.DBusProxyFlags.DO_NOT_AUTO_START_AT_CONSTRUCTION,
-                "org.cinnamon.CalendarServer",
-                "/org/cinnamon/CalendarServer",
-                null,
-                this._calendar_server_ready.bind(this)
-            );
+            Interfaces.getDBusAsync((proxy, error) => {
+                if (error) {
+                    this.log_dbus_error(error);
+                    return;
+                }
+
+                proxy.NameHasOwnerRemote("org.gnome.evolution.dataserver.Calendar8", (has_owner, error) => {
+                    if (error) {
+                        this.log_dbus_error(error);
+                        return;
+                    }
+
+                    if (has_owner[0]) {
+                        log("calendar@cinnamon.org: Calendar events supported.")
+
+                        Cinnamon.CalendarServerProxy.new_for_bus(
+                            Gio.BusType.SESSION,
+                            Gio.DBusProxyFlags.DO_NOT_AUTO_START_AT_CONSTRUCTION,
+                            "org.cinnamon.CalendarServer",
+                            "/org/cinnamon/CalendarServer",
+                            null,
+                            this._calendar_server_ready.bind(this)
+                        );
+                    } else {
+                        log("calendar@cinnamon.org: No calendar event support (needs evolution-data-server)")
+
+                    }
+                });
+            })
         }
+    }
+
+    log_dbus_error(e) {
+        global.logError(`calendar@cinnamon.org: Could not check for calendar event support: ${e.toString()}`);
     }
 
     _calendar_server_ready(obj, res) {

--- a/js/misc/interfaces.js
+++ b/js/misc/interfaces.js
@@ -13,6 +13,10 @@ const DBusIface = '\
             <arg type="s" direction="in" /> \
             <arg type="s" direction="out" /> \
         </method> \
+        <method name="NameHasOwner"> \
+            <arg type="s" direction="in" /> \
+            <arg type="b" direction="out" /> \
+        </method> \
         <method name="ListNames"> \
             <arg type="as" direction="out" /> \
         </method> \


### PR DESCRIPTION
None of the e-d-s libraries actually depend on evolution-data-server
(which is what provides the backend to these libraries). Also, not
everyone may want this sort of thing in the first place.

So, check if the e-d-s service we require is active before trying
to enable event support.

ref: #10597, #10567