### PR TITLE
[WIP] GWL - bug fixes: handleScroll, cycle apps, thumbnails scroll. Improvements: reverse scrolling, cycle apps hotkeys

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -1000,7 +1000,10 @@ class AppGroup {
 
         let hasFocus = getFocusState(metaWindow);
         if (hasFocus && this.groupState.hasOwnProperty('lastFocused')) {
-            this.listState.set({lastFocusedApp: this.groupState.appId});
+            this.listState.set({
+                lastFocusedApp: this.groupState.appId,
+                lastFocused: metaWindow,
+            });
             this.groupState.set({lastFocused: metaWindow});
         }
         this.onFocusChange(hasFocus);

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -480,6 +480,28 @@ class AppGroup {
         this.label.hide();
     }
 
+    cycleWindows(step) {
+        let lastFocused, focusedIndex, z, count;
+        // Identifies last/current focused window from group (focused group or thumbnails)
+        lastFocused = this.groupState.lastFocused;
+        focusedIndex = findIndex(this.groupState.metaWindows, function(metaWindow) {
+            return metaWindow === lastFocused;
+        });
+        count = this.groupState.metaWindows.length - 1;
+
+        // Set next Window index (z) to focus
+        z = focusedIndex + step
+        // cycle on borders
+        if (z < 0) {
+            z = count;
+        } else if (z > count) {
+            z = 0;
+        }
+
+        let _window = this.groupState.metaWindows[z];
+        Main.activateWindow(_window, global.get_current_time());
+    }
+
     onEnter() {
         if (this.state.panelEditMode) return false;
 

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appList.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appList.js
@@ -16,7 +16,8 @@ class AppList {
         });
         this.listState = createStore({
             workspaceIndex: params.index,
-            lastFocusedApp: null
+            lastFocusedApp: null,
+            lastFocused: null,
         });
         this.listState.connect({
             getWorkspace: () => this.metaWorkspace,
@@ -48,6 +49,7 @@ class AppList {
 
         this.appList = [];
         this.lastFocusedApp = null;
+        this.lastFocused = null;
 
         // Connect all the signals
         this.signals.connect(global.screen, 'window-workspace-changed', (...args) => this.windowWorkspaceChanged(...args));

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appList.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appList.js
@@ -165,6 +165,47 @@ class AppList {
         }
     }
 
+    cycleApps(step) {
+        let lastFocused, focusedIndex, z, count;
+        // Get last focused metaWindow
+        lastFocused = this.listState.lastFocused;
+        // If there is no lastFocused window, select frist lastFocused from first app
+        if (!lastFocused) {
+            lastFocused = this.appList[0].groupState.lastFocused;
+        }
+        // Get the first index of the group with app equals the lastFocusedApp
+        // and has lastFocused windows in its metaWindows array.
+        focusedIndex = findIndex(this.appList, function(appGroup) {
+            return appGroup.groupState.metaWindows.length > 0 &&
+                appGroup.groupState.metaWindows.includes(lastFocused);
+        });
+        count = this.appList.length - 1;
+
+        // Preparation to search the next AppGroup index (z) to focus
+        z = focusedIndex + step
+
+        // The loop below finds the final AppGroup index to focus
+        let limit = count * 2;
+
+        while (!this.appList[z] || !this.appList[z].groupState.lastFocused) {
+            limit--;
+            z += step
+            if (limit < 0) {
+                if (count === 0) {
+                    z = 0;
+                }
+                break;
+            } else if (z < 0) {
+                z = count;
+            } else if (z > count) {
+                z = 0;
+            }
+        }
+
+        let _window = this.appList[z].groupState.lastFocused;
+        Main.activateWindow(_window, global.get_current_time());
+    }
+
     reloadList() {
         let windows;
         windows = this.metaWorkspace.list_windows();

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appList.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appList.js
@@ -179,26 +179,33 @@ class AppList {
             return appGroup.groupState.metaWindows.length > 0 &&
                 appGroup.groupState.metaWindows.includes(lastFocused);
         });
-        count = this.appList.length - 1;
 
-        // Preparation to search the next AppGroup index (z) to focus
-        z = focusedIndex + step
+        // Activates last focused if all minimized
+        if ( this.state.settings.lastFocusedIfMinimized &&
+             (!lastFocused.appears_focused || lastFocused.minimized) ) {
+            z = focusedIndex
+        } else { // Otherwise activates next app group
+            count = this.appList.length - 1;
 
-        // The loop below finds the final AppGroup index to focus
-        let limit = count * 2;
+            // Preparation to search the next AppGroup index (z) to focus
+            z = focusedIndex + step
 
-        while (!this.appList[z] || !this.appList[z].groupState.lastFocused) {
-            limit--;
-            z += step
-            if (limit < 0) {
-                if (count === 0) {
+            // The loop below finds the final AppGroup index to focus
+            let limit = count * 2;
+
+            while (!this.appList[z] || !this.appList[z].groupState.lastFocused) {
+                limit--;
+                z += step
+                if (limit < 0) {
+                    if (count === 0) {
+                        z = 0;
+                    }
+                    break;
+                } else if (z < 0) {
+                    z = count;
+                } else if (z > count) {
                     z = 0;
                 }
-                break;
-            } else if (z < 0) {
-                z = count;
-            } else if (z > count) {
-                z = 0;
             }
         }
 

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -718,15 +718,18 @@ class GroupedWindowListApplet extends Applet.Applet {
             }
 
             // Prepare step direction to cycle based on scroll direction
-            // Also suport horizontal scrolling (i.e. touchpad) and reverse mouse wheel scrolling
-            let isReverseScrolling = this.state.settings.reverseScrolling;
+            // Also suport horizontal scrolling (i.e. touchpad)
             let step;
-            if ( (direction === ScrollDirection.Up && !isReverseScrolling) ||
-                 (direction === ScrollDirection.Down && isReverseScrolling) ||
-                 direction === ScrollDirection.Left){
+            if ( direction === ScrollDirection.Up || direction === ScrollDirection.Left ) {
               step = CycleStep.Backward;
             } else {
               step = CycleStep.Forward;
+            }
+
+            // Reverse scrolling
+            let isReverseScrolling = this.state.settings.reverseScrolling;
+            if (isReverseScrolling) {
+                step = step * (-1)
             }
 
             if (isAppScroll) {

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -321,6 +321,8 @@ class GroupedWindowListApplet extends Applet.Applet {
             {key: 'show-apps-order-timeout', value: 'showAppsOrderTimeout', cb: null},
             {key: 'super-num-hotkeys', value: 'SuperNumHotkeys', cb: this.bindAppKeys},
             {key: 'cycleMenusHotkey', value: 'cycleMenusHotkey', cb: this.bindAppKeys},
+            {key: 'cycleAppsForwardHotkey', value: 'cycleAppsForwardHotkey', cb: this.bindAppKeys},
+            {key: 'cycleAppsBackwardHotkey', value: 'cycleAppsBackwardHotkey', cb: this.bindAppKeys},
             {key: 'enable-hover-peek', value: 'enablePeek', cb: null},
             {key: 'onclick-thumbnails', value: 'onClickThumbs', cb: null},
             {key: 'hover-peek-opacity', value: 'peekOpacity', cb: null},
@@ -466,6 +468,12 @@ class GroupedWindowListApplet extends Applet.Applet {
         Main.keybindingManager.addHotKey('launch-cycle-menus', this.state.settings.cycleMenusHotkey, () =>
             this.cycleMenus()
         );
+        Main.keybindingManager.addHotKey('launch-cycle-apps-forward', this.state.settings.cycleAppsForwardHotkey, () =>
+            this.cycleApps(CycleStep.Forward)
+        );
+        Main.keybindingManager.addHotKey('launch-cycle-apps-backward', this.state.settings.cycleAppsBackwardHotkey, () =>
+            this.cycleApps(CycleStep.Backward)
+        );
     }
 
     unbindAppKeys() {
@@ -501,6 +509,10 @@ class GroupedWindowListApplet extends Applet.Applet {
 
     cycleMenus() {
         this.getCurrentAppList().cycleMenus();
+    }
+
+    cycleApps(step) {
+        this.getCurrentAppList().cycleApps(step);
     }
 
     handleMonitorWindowsPrefsChange(value) {

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -675,13 +675,6 @@ class GroupedWindowListApplet extends Applet.Applet {
     }
 
     handleScroll(e, sourceFromAppGroup) {
-        //if( (this.state.settings.thumbnailScrollBehavior) || (this.state.settings.scrollBehavior === 2) ||
-        //    (this.state.settings.leftClickAction === 3 && this.state.settings.scrollBehavior !== 3
-        //     && !e && sourceFromAppGroup)  ||
-        //    (this.state.settings.leftClickAction !== 3 && this.state.settings.scrollBehavior === 3
-        //                && e && !sourceFromAppGroup)  ||
-        //    (this.state.settings.leftClickAction === 3 && this.state.settings.scrollBehavior === 3)) {
-
         if( ((this.state.settings.scrollBehavior === ScrollBehavior.CycleApps || // groupbar scroll wheel
             this.state.settings.scrollBehavior === ScrollBehavior.CycleWindowsInGroup) &&
                 e && !sourceFromAppGroup) ||
@@ -710,12 +703,6 @@ class GroupedWindowListApplet extends Applet.Applet {
 
             // This if-else block identifies last/current focused app group or window
             if (isAppScroll) { // Identifies last/current focused app group
-                // Get name of the last focused app from current WS (not the app under mouse cursor)
-                //lastFocusedApp = this.appLists[this.state.currentWs].listState.lastFocusedApp;
-                // If there is no lastFocused app, select frist app
-                //if (!lastFocusedApp) {
-                //    lastFocusedApp = this.appLists[this.state.currentWs].appList[0].groupState.appId;
-                //}
                 // Get last focused metaWindow
                 lastFocused = this.appLists[this.state.currentWs].listState.lastFocused;
                 // If there is no lastFocused window, select frist lastFocused from first app
@@ -726,7 +713,6 @@ class GroupedWindowListApplet extends Applet.Applet {
                 // and has lastFocused windows in its metaWindows array.
                 focusedIndex = findIndex(this.appLists[this.state.currentWs].appList, function(appGroup) {
                     return appGroup.groupState.metaWindows.length > 0 &&
-                            //appGroup.groupState.appId === lastFocusedApp &&
                             appGroup.groupState.metaWindows.includes(lastFocused);
                 });
                 count = this.appLists[this.state.currentWs].appList.length - 1;
@@ -742,9 +728,13 @@ class GroupedWindowListApplet extends Applet.Applet {
 
             // Preparation to search the next AppGroup/Window index to focus
             // Also support horizontal scroll
-            z = (direction === ScrollDirection.Up || direction === ScrollDirection.Left) ?
-                focusedIndex - 1
-                : focusedIndex + 1;
+            let step;
+            if (direction === ScrollDirection.Up || direction === ScrollDirection.Left){
+              step = -1 // previous
+            } else {
+              step = +1 // next
+            }
+            z = focusedIndex + step
 
             // While below finds the final AppGroup/Window index to focus
             let limit = count * 2;
@@ -756,11 +746,7 @@ class GroupedWindowListApplet extends Applet.Applet {
                     (!source.groupState.metaWindows[z]
                         || source.groupState.metaWindows[z] === source.groupState.lastFocused))) {
                 limit--;
-                if (direction === ScrollDirection.Up || direction === ScrollDirection.Left) {
-                    z -= 1;
-                } else {
-                    z += 1;
-                }
+                z += step
                 if (limit < 0) {
                     if (count === 0) {
                         z = 0;

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -340,6 +340,7 @@ class GroupedWindowListApplet extends Applet.Applet {
             {key: 'number-display', value: 'numDisplay', cb: this.updateWindowNumberState},
             {key: 'title-display', value: 'titleDisplay', cb: this.updateTitleDisplay},
             {key: 'scroll-behavior', value: 'scrollBehavior', cb: null},
+            {key: 'reverse-scrolling', value: 'reverseScrolling', cb: null},
             {key: 'show-recent', value: 'showRecent', cb: null},
             {key: 'autostart-menu-item', value: 'autoStart', cb: null},
             {key: 'monitor-move-all-windows', value: 'monitorMoveAllWindows', cb: null},
@@ -728,8 +729,11 @@ class GroupedWindowListApplet extends Applet.Applet {
 
             // Preparation to search the next AppGroup/Window index to focus
             // Also support horizontal scroll
+            const isReverseScrolling = this.state.settings.reverseScrolling;
             let step;
-            if (direction === ScrollDirection.Up || direction === ScrollDirection.Left){
+            if ( (direction === ScrollDirection.Up && !isReverseScrolling) ||
+                 (direction === ScrollDirection.Down && isReverseScrolling) ||
+                 direction === ScrollDirection.Left){
               step = -1 // previous
             } else {
               step = +1 // next

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -691,7 +691,7 @@ class GroupedWindowListApplet extends Applet.Applet {
             // thumbnail or left-click cycle
             if (sourceFromAppGroup) {
                 isAppScroll = false;
-                direction = e ? e.get_scroll_direction() : ScrollDirection.Down;
+                direction = e ? e.get_scroll_direction() : ScrollDirection.Right;
                 source = sourceFromAppGroup;
             } else { // scroll wheel cycle
                 isAppScroll = this.state.settings.scrollBehavior === ScrollBehavior.CycleApps;
@@ -728,12 +728,8 @@ class GroupedWindowListApplet extends Applet.Applet {
             }
 
             // Preparation to search the next AppGroup/Window index to focus
-            // Also support horizontal scroll
-            let isLeftClickCycle = (
-                this.state.settings.leftClickAction === LeftClickAction.CycleWindowsInGroup &&
-                !e && sourceFromAppGroup
-            )
-            let isReverseScrolling = isLeftClickCycle?false:this.state.settings.reverseScrolling;
+            // Also support horizontal scroll and reverse mouse wheel scrolling
+            let isReverseScrolling = this.state.settings.reverseScrolling;
             let step;
             if ( (direction === ScrollDirection.Up && !isReverseScrolling) ||
                  (direction === ScrollDirection.Down && isReverseScrolling) ||

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -729,7 +729,11 @@ class GroupedWindowListApplet extends Applet.Applet {
 
             // Preparation to search the next AppGroup/Window index to focus
             // Also support horizontal scroll
-            const isReverseScrolling = this.state.settings.reverseScrolling;
+            let isLeftClickCycle = (
+                this.state.settings.leftClickAction === LeftClickAction.CycleWindowsInGroup &&
+                !e && sourceFromAppGroup
+            )
+            let isReverseScrolling = isLeftClickCycle?false:this.state.settings.reverseScrolling;
             let step;
             if ( (direction === ScrollDirection.Up && !isReverseScrolling) ||
                  (direction === ScrollDirection.Down && isReverseScrolling) ||

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -347,7 +347,9 @@ class GroupedWindowListApplet extends Applet.Applet {
             {key: 'show-recent', value: 'showRecent', cb: null},
             {key: 'autostart-menu-item', value: 'autoStart', cb: null},
             {key: 'monitor-move-all-windows', value: 'monitorMoveAllWindows', cb: null},
-            {key: 'show-all-workspaces', value: 'showAllWorkspaces', cb: this.refreshAllAppLists}
+            {key: 'show-all-workspaces', value: 'showAllWorkspaces', cb: this.refreshAllAppLists},
+            {key: 'last-focused-if-minimized', value: 'lastFocusedIfMinimized', cb: this.refreshAllAppLists}
+
         ];
 
         for (let i = 0, len = settingsProps.length; i < len; i++) {

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -483,6 +483,9 @@ class GroupedWindowListApplet extends Applet.Applet {
         }
         Main.keybindingManager.removeHotKey('launch-show-apps-order');
         Main.keybindingManager.removeHotKey('launch-cycle-menus');
+
+        Main.keybindingManager.removeHotKey('launch-cycle-apps-forward');
+        Main.keybindingManager.removeHotKey('launch-cycle-apps-backward');
     }
 
     bindAppKey(i) {

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/constants.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/constants.js
@@ -67,6 +67,22 @@ const constants = {
         pinnedApps: 1,
         none: 2
     },
+    ScrollBehavior: {
+        None: 1,
+        CycleApps: 2,
+        CycleWindowsInGroup: 3,
+    },
+    LeftClickAction: {
+        None: 1,
+        ToggleLastFocusedWindow: 2,
+        CycleWindowsInGroup: 3,
+    },
+    ScrollDirection: {
+        Up: 0,
+        Down: 1,
+        Left: 2,
+        Right: 3,
+    },
     autoStartStrDir: './.config/autostart',
 };
 

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/constants.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/constants.js
@@ -83,6 +83,10 @@ const constants = {
         Left: 2,
         Right: 3,
     },
+    CycleStep: {
+        Forward: 1,
+        Backward: -1,
+    },
     autoStartStrDir: './.config/autostart',
 };
 

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/settings-schema.json
@@ -31,7 +31,8 @@
         "reverse-scrolling",
         "left-click-action",
         "middle-click-action",
-        "show-all-workspaces"
+        "show-all-workspaces",
+        "last-focused-if-minimized"
       ]
     },
     "appButtonsSection": {
@@ -157,6 +158,11 @@
     "type": "checkbox",
     "default": false,
     "description": "Show windows from all workspaces"
+  },
+  "last-focused-if-minimized": {
+    "type": "checkbox",
+    "default": false,
+    "description": "Cycle apps activates last focused if all minimized"
   },
   "enable-app-button-dragging": {
     "type": "checkbox",

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/settings-schema.json
@@ -28,6 +28,7 @@
       "keys": [
         "group-apps",
         "scroll-behavior",
+        "reverse-scrolling",
         "left-click-action",
         "middle-click-action",
         "show-all-workspaces"
@@ -114,6 +115,12 @@
       "Cycle apps": 2,
       "Cycle windows in group": 3
     }
+  },
+  "reverse-scrolling" : {
+      "type" : "switch",
+      "default" : false,
+      "description" : "Reverse mouse wheel scroll direction",
+      "dependency": "scroll-behavior>1"
   },
   "left-click-action": {
     "type": "combobox",

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/settings-schema.json
@@ -112,7 +112,7 @@
     "options": {
       "None": 1,
       "Cycle apps": 2,
-      "Cycle windows": 3
+      "Cycle windows in group": 3
     }
   },
   "left-click-action": {
@@ -122,7 +122,7 @@
     "options": {
       "None": 1,
       "Toggle activation of last focused window": 2,
-      "Cycle windows": 3
+      "Cycle windows in group": 3
     }
   },
   "middle-click-action": {
@@ -212,7 +212,7 @@
   },
   "thumbnail-scroll-behavior": {
     "type": "checkbox",
-    "default": false,
+    "default": true,
     "description": "Cycle windows on mouse wheel scroll"
   },
   "show-thumbnails": {

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/settings-schema.json
@@ -50,6 +50,8 @@
       "title" : "Hot Keys",
       "keys": [
         "cycleMenusHotkey",
+        "cycleAppsForwardHotkey",
+        "cycleAppsBackwardHotkey",
         "show-apps-order-hotkey",
         "show-apps-order-timeout",
         "super-num-hotkeys"
@@ -175,6 +177,16 @@
     "type": "keybinding",
     "default": "",
     "description": "Global hotkey for cycling through thumbnail menus"
+  },
+  "cycleAppsForwardHotkey": {
+    "type": "keybinding",
+    "default": "",
+    "description": "Cycle apps forward"
+  },
+  "cycleAppsBackwardHotkey": {
+    "type": "keybinding",
+    "default": "",
+    "description": "Cycle apps backward"
   },
   "show-apps-order-hotkey": {
     "type": "keybinding",


### PR DESCRIPTION
- Fix thumbnails scrolling even if thumbnails is off when "group apps" is
  enabled and scroll behaviour is "CycleApp". So now thumbnails scroll
  respects its setting. Its default was also set to true, so users won't
  feel any change.
- Fix wheel scroll behaviour "CycleApp" not working properly when
  "group apps" is disabled. When there are multiple windows of the same
  app, scroll pass only in one of them and skip the others.
- Change "Cycle windows" option text in wheel scroll behaviour and left click action settings
  to "Cycle windows in group", to make clearer how it behaves, and also to
  make it less confusing with "Cycle apps".
- Add support to horizontal scrolling (i.e. touchpad).
- Add new option to reverse mouse scrolling direction - also revert horizontal scrolling.
- Add new hotkeys settings to "Cycle Apps Forward" and "Cycle Apps Backwards". This greatly synergize with libinput-gestures and xdotool to create custom touchpad gestures improving user experience.
- Add new option to "Activate last focused if all minimized" on Cycle Apps
- Add some useful code comments. Hope it will be appreciated.
