### PR TITLE
gtkdoc: remove dependencies on custom target files

### DIFF
--- a/docs/reference/cinnamon-js/meson.build
+++ b/docs/reference/cinnamon-js/meson.build
@@ -12,7 +12,6 @@ gnome.gtkdoc(
     'cinnamon-js',
     mode: 'xml',
     main_xml: 'cinnamon-js-docs.sgml',
-    dependencies: parts_files,
     src_dir: meson.current_build_dir(),
     install: true,
 )


### PR DESCRIPTION
Sadly, the `dependencies` kwarg does not actually do what it seems to be trying to be used for, here. It is for listing dependency or library objects whose compiler flags should be added to gtkdoc-scangobj.

It will not actually add ninja target dependencies. The similar kwarg in other meson functions (e.g. genmarshal and compile_schemas) that *do* allow adding target dependencies, is `depend_files`.

Older versions of meson simply did nothing in an if/elif/elif block where these custom_targets never matched anything, and were thus silently ignored.

Meson 0.61 type-validates the arguments and rejects CustomTarget as invalid:

```
docs/reference/cinnamon-js/meson.build:11:6: ERROR: gnome.gtkdoc keyword argument 'dependencies' was of type array[CustomTarget] but should have been array[Dependency | SharedLibrary | StaticLibrary]
```