### PR TITLE
Sound applet: Hide microphone mute toggle if mic is not being used

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -1010,6 +1010,7 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
         this.mute_in_switch = new PopupMenu.PopupSwitchIconMenuItem(_("Mute input"), false, "microphone-sensitivity-none", St.IconType.SYMBOLIC);
         this._applet_context_menu.addMenuItem(this.mute_out_switch);
         this._applet_context_menu.addMenuItem(this.mute_in_switch);
+        this.mute_in_switch.actor.hide();
 
         this._applet_context_menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
@@ -1620,8 +1621,10 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
         } else if (stream instanceof Cvc.MixerSourceOutput) {
             //for source outputs, only show the input section
             this._streams.push({id: id, type: "SourceOutput"});
-            if (this._recordingAppsNum++ === 0)
+            if (this._recordingAppsNum++ === 0) {
                 this._inputSection.actor.show();
+                this.mute_in_switch.actor.show();
+            }
         }
     }
 
@@ -1637,8 +1640,10 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
                     if (this._outputApplicationsMenu.menu.numMenuItems === 0)
                         this._outputApplicationsMenu.actor.hide();
                 } else if (stream.type === "SourceOutput") {
-                    if(--this._recordingAppsNum === 0)
+                    if(--this._recordingAppsNum === 0) {
                         this._inputSection.actor.hide();
+                        this.mute_in_switch.actor.hide();
+                    }
                 }
                 this._streams.splice(i, 1);
                 break;


### PR DESCRIPTION
There is no microphone icon at all when no mic is present and it gets stuck after connecting and disconnecting a microphone.
Note: This _isn't_ optimal since there could be a situtation when a program tries recording but no actual mic is present, but I Saw it is already being done with the mic sensitivity slider and so used that existing logic.