### PR TITLE
[power] Show brightness text and value when dragging slider on power applet

### DIFF
--- a/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
@@ -298,6 +298,8 @@ class BrightnessSlider extends PopupMenu.PopupSliderMenuItem {
             this.tooltipText += ": " + value + "%";
 
         this.tooltip.set_text(this.tooltipText);
+        if (this._dragging)
+            this.tooltip.show();
     }
 
     /* Overriding PopupSliderMenuItem so we can modify the scroll step */


### PR DESCRIPTION
This PR displays the current brightness value on the power applet while the user is dragging the brightness slider.

Relevant issue: https://github.com/linuxmint/cinnamon/issues/10622