### PR TITLE
Grouped window list: Spacing is defined by CSS

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -1424,6 +1424,12 @@ StScrollBar StButton#vhandle:hover {
  * Grouped window list (grouped-window-list@cinnamon.org)
  * ===================================================================*/
 
+.grouped-window-list-box {
+    spacing: 2px;
+}
+.grouped-window-list-box.vertical {
+    spacing: 3px;
+}
 .grouped-window-list-thumbnail-label {
     padding-left: 4px;
 }

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -249,9 +249,14 @@ class AppGroup {
     }
 
     setMargin() {
-        let direction = this.state.isHorizontal ? 'right' : 'bottom';
-        let existingStyle = this.actor.style ? this.actor.style : '';
-        this.actor.style = existingStyle + 'margin-' + direction + ':6px;';
+        const applet = this.state.appletActor;
+        const direction = this.state.isHorizontal ? 'right' : 'bottom';
+        const existingStyle = this.actor.style ? this.actor.style : '';
+        let spacing = parseInt(applet.get_theme_node().get_length('spacing'));
+        if (!spacing) {
+            spacing = 6;
+        }
+        this.actor.style = existingStyle + 'margin-' + direction + ':' + spacing + 'px;';
     }
 
     setIcon(metaWindow) {

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -200,6 +200,7 @@ class GroupedWindowListApplet extends Applet.Applet {
                 pos: -1,
                 isForeign: null,
             },
+            appletActor: null,
             appletReady: false,
             willUnmount: false,
             settings: {},
@@ -284,6 +285,10 @@ class GroupedWindowListApplet extends Applet.Applet {
         // Declare vertical panel compatibility
         this.setAllowedLayout(Applet.AllowedLayout.BOTH);
         Gettext.bindtextdomain(metadata.uuid, GLib.get_home_dir() + '/.local/share/locale');
+
+        this.actor.set_style_class_name('grouped-window-list-box');
+        this.state.set({appletActor: this.actor});
+        this.on_orientation_changed(null);
 
         this.getAutoStartApps();
         this.onSwitchWorkspace = throttle(this.onSwitchWorkspace, 35, false); //Note: causes a 35ms delay in execution
@@ -401,10 +406,12 @@ class GroupedWindowListApplet extends Applet.Applet {
     }
 
     on_orientation_changed(orientation) {
-        this.state.set({
-            orientation: orientation,
-            isHorizontal: orientation === St.Side.TOP || orientation === St.Side.BOTTOM
-        });
+        if (orientation) {
+            this.state.set({
+                orientation: orientation,
+                isHorizontal: orientation === St.Side.TOP || orientation === St.Side.BOTTOM
+            });
+        }
         if (this.state.isHorizontal) {
             this.actor.remove_style_class_name('vertical');
         } else {


### PR DESCRIPTION
Adding ability to adjust a spacing between app groups via theme CSS. This is done as in window list applet but using following classes:

```
/* ===================================================================
 * Grouped window list (grouped-window-list@cinnamon.org)
 * ===================================================================*/
.grouped-window-list-box {
    spacing: 2px;
}
.grouped-window-list-box.vertical {
    spacing: 3px;
}
```

If there is no spacing defined in CSS, the old value of 6px is used.

Related to https://github.com/linuxmint/cinnamon/issues/10407