### PR TITLE
deskletManager.js: correct logging of startup time

### DIFF
--- a/js/ui/deskletManager.js
+++ b/js/ui/deskletManager.js
@@ -60,15 +60,15 @@ function unloadRemovedDesklets(removedDeskletUUIDs) {
  *
  * Initialize desklet manager
  */
-function init(){
-    let startTime = new Date().getTime();
+function init() {
+    const startTime = new Date().getTime();
     try {
         desklets = imports.desklets;
     } catch (e) {
         desklets = {};
     }
     deskletMeta = Extension.Type.DESKLET.legacyMeta;
-    deskletsLoaded = false
+    deskletsLoaded = false;
 
     definitions = getDefinitions();
 
@@ -79,7 +79,7 @@ function init(){
 
         deskletsLoaded = true;
         updateMouseTracking();
-        global.log("DeskletManager started in " + new Date().getTime() - startTime + "ms");
+        global.log(`DeskletManager started in ${new Date().getTime() - startTime} ms`);
     });
 }
 


### PR DESCRIPTION
Before:
```
Cjs-Message: 04:16:09.536: JS LOG: Cinnamon started at Tue Feb 15 2022 04:16:09 GMT+0200 (EET)
Cjs-Message: 04:16:09.566: JS LOG: [LookingGlass/info] ExtensionSystem started in 2 ms
Cjs-Message: 04:16:09.567: JS LOG: [LookingGlass/info] NaNms
Cjs-Message: 04:16:09.567: JS LOG: [LookingGlass/info] SearchProviderManager started in 2 ms
```

After:
```
Cjs-Message: 04:36:55.117: JS LOG: Cinnamon started at Tue Feb 15 2022 04:36:55 GMT+0200 (EET)
Cjs-Message: 04:36:55.148: JS LOG: [LookingGlass/info] ExtensionSystem started in 3 ms
Cjs-Message: 04:36:55.149: JS LOG: [LookingGlass/info] DeskletManager started in 2 ms
Cjs-Message: 04:36:55.149: JS LOG: [LookingGlass/info] SearchProviderManager started in 3 ms
```