### PR TITLE
cinnamon-settings: pop sys.argv args before Gio

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
@@ -413,6 +413,8 @@ class MainWindow(Gio.Application):
                     opts = getopt.getopt(sys.argv[2:], "t:s:", ["tab=", "sort="])[0]
             except getopt.GetoptError:
                 pass
+            # pop the arg once we consume it so we don't pass it go Gio.application.run
+            sys.argv.pop(1)
 
             for opt, arg in opts:
                 if opt in ("-t", "--tab"):
@@ -425,6 +427,9 @@ class MainWindow(Gio.Application):
                         self.sort = int(arg)
                     elif arg in sorts_literal.keys():
                         self.sort = sorts_literal[arg]
+                # remove the args we consume
+                sys.argv.remove(opt)
+                sys.argv.remove(arg)
 
             # If we're launching a module directly, set the WM class so GWL
             # can consider it as a standalone app and give it its own


### PR DESCRIPTION
We pass `sys.argv` to `Gio.application.run(*args)` which
cause an error because `Gio.application.run()` is not
setup to handle our args.

```
cinnamon-settings keyboard -t shortcuts
Using pam module (python3-pampy)
/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py:433: DeprecationWarning: Gtk.Window.set_wmclass is deprecated
  self.window.set_wmclass(wm_class, wm_class)
Loading Keyboard module
/usr/share/cinnamon/cinnamon-settings/bin/capi.py:62: Warning: g_object_class_override_property: Can't find property to override for 'CcRegionPanel::argv'
  return GObject.new(panel_type)
Unknown option -t
```

The `-t` is unknown and causes the application to terminate.

Pop the args from `sys.argv` as we use them so they aren't passed.