### PR TITLE
Use same icon used in cinnamon-settings...

### DIFF
--- a/files/usr/share/applications/cinnamon-settings-users.desktop
+++ b/files/usr/share/applications/cinnamon-settings-users.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Exec=cinnamon-settings-users
-Icon=system-users
+Icon=cs-user-accounts
 Terminal=false
 Type=Application
 Categories=System;Settings;


### PR DESCRIPTION
...in keeping with other cinnamon-settings icons.

The icon specified in cinnamon-settings-users.desktop does not match the icon used in cinnamon-settings. This means that, depending on the icon theme (e.g. Adwaita, Papirus), the icon for Users and Groups in cinnamon-settings app may not match the icon used in the menu applet.