### PR TITLE
Calendar Applet: single day event now shows end time

### DIFF
--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/eventView.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/eventView.js
@@ -972,6 +972,8 @@ class EventRow {
             } else {
                 // a timed event: "12:00 pm"
                 final_str += this.event.start.format(time_format);
+                final_str += ARROW_SEPARATOR;
+                final_str += this.event.end.format(time_format);
             }
 
             this.event_time.set_text(final_str);


### PR DESCRIPTION
In the current version of the Calendar Applet, in the Events view, the end times or end days is only shown for events that last more than one day. This small PR changes so that the end time is shown for events that are only one day. I personally find this feature to be useful for time management.

To the maintainers, I have some questions. Was it intentional to NOT show the end times for single day events? If so, should I add a toggle in the settings so that users can switch it on or off?