### PR TITLE
sound applet ui overhaul

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -1479,13 +1479,12 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
 
     _outputValuesChanged(actor, iconName, percentage) {
         this.setIcon(iconName, "output");
-        //this.mute_out_switch.setIconSymbolicName(iconName);
         this.volume = percentage;
         this.setAppletTooltip();
     }
 
     _inputValuesChanged(actor, iconName) {
-        //this.mute_in_switch.setIconSymbolicName(iconName);
+
     }
 
     _onControlStateChanged() {
@@ -1585,10 +1584,6 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
         } else if (stream instanceof Cvc.MixerSourceOutput) {
             //for source outputs, only show the input section
             this._streams.push({id: id, type: "SourceOutput"});
-            if (this._recordingAppsNum++ === 0) {
-                this._inputVolumeSlider.actor.show()
-                this._selectInputDeviceItem.actor.show()
-            }
         }
     }
 
@@ -1603,11 +1598,6 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
                 if (stream.type === "SinkInput") {
                     if (this._outputApplicationsMenu.menu.numMenuItems === 0) {
                         this._outputApplicationsMenu.actor.hide();
-                    }
-                } else if (stream.type === "SourceOutput") {
-                    if(--this._recordingAppsNum === 0) {
-                        this._inputVolumeSlider.actor.hide()
-                        this._selectInputDeviceItem .actor.hide()
                     }
                 }
                 this._streams.splice(i, 1);


### PR DESCRIPTION
I made some changes to the sound applet. What do you think?

- all volume controls from context menu moved to main menu
  - Within 5 years of using Linux Mint I haven't found the application volume quick setting, just because I wasn't aware of the context menu. I'm pretty sure there are others.
- mute switches replaced by mute button for each slider
  - The slider's icons are now mute buttons, therefore the switches aren't necessary anymore.
- application volume sliders also show the application names
  - Often, applications only have the default icon and you have to hover over them for a tooltip to find the right one. Now, their names are shown above the slider.
- input device controls not hidden anymore when no one is recording
  - for example when using Audacity, you had to click the record button before the applet was showing the input controls
- menu rearranged
- a few refactorings

Other things that could be improved:
- merge submenus "launch player" and "choose active player" into one
- hovering mute button should have visual effect, as an indicator it is clickable (how?)
- remove bug "click to the left of icon triggers slider"

Affected: #10620

## old vs new:
![5_comparison](https://user-images.githubusercontent.com/43345275/163804403-07ecfbf4-b212-4d75-88f9-ddedb0a6b41d.png)