### PR TITLE
photoframe: Avoid showing hidden files or files under hidden directories

### DIFF
--- a/files/usr/share/cinnamon/desklets/photoframe@cinnamon.org/desklet.js
+++ b/files/usr/share/cinnamon/desklets/photoframe@cinnamon.org/desklet.js
@@ -86,10 +86,14 @@ class CinnamonPhotoFrameDesklet extends Desklet.Desklet {
 
     _scan_dir(dir) {
         let dir_file = Gio.file_new_for_uri(dir);
-        let fileEnum = dir_file.enumerate_children('standard::type,standard::name', Gio.FileQueryInfoFlags.NONE, null);
+        let fileEnum = dir_file.enumerate_children('standard::type,standard::name,standard::is-hidden', Gio.FileQueryInfoFlags.NONE, null);
 
         let info;
         while ((info = fileEnum.next_file(null)) != null) {
+            if (info.get_is_hidden()) {
+                continue;
+            }
+
             let fileType = info.get_file_type();
             let fileName = dir + '/' + info.get_name();
             if (fileType != Gio.FileType.DIRECTORY) {


### PR DESCRIPTION
This is the follow up to a previous pull request [10488](https://github.com/linuxmint/cinnamon/pull/10488)

The hidden files and files under hidden directories are skipped now.