### PR TITLE
tooltip.js: trigger a relayout after triggering a reallocation

### DIFF
--- a/js/ui/tooltips.js
+++ b/js/ui/tooltips.js
@@ -246,6 +246,9 @@ Tooltip.prototype = {
         this._tooltip.set_text(text);
         this._tooltip.clutter_text.set_use_markup(false);
         this._tooltip.clutter_text.allocate_preferred_size(Clutter.AllocationFlags.NONE);
+        // we need to trigger a reallocation to make the tooltip the right size, but this can lead to the text getting
+        // off-center in some situations, so also trigger a relayout.
+        this._tooltip.queue_relayout();
     },
 
     /**
@@ -258,6 +261,9 @@ Tooltip.prototype = {
         this._tooltip.set_text(markup);
         this._tooltip.clutter_text.set_use_markup(true);
         this._tooltip.clutter_text.allocate_preferred_size(Clutter.AllocationFlags.NONE);
+        // we need to trigger a reallocation to make the tooltip the right size, but this can lead to the text getting
+        // off-center in some situations, so also trigger a relayout.
+        this._tooltip.queue_relayout();
     },
 
     _destroy: function() {


### PR DESCRIPTION
This fixes a bug in which the text sometimes becomes off-center from the rest of the tooltip.