### PR TITLE
Do not crash on systemd/tzdata reporting Univeral timezone

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_calendar.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_calendar.py
@@ -255,7 +255,7 @@ class TimeZoneSelector(SettingsWidget):
             self.region_map[region].append([city, _(city_display_name)])
 
     def set_timezone(self, timezone):
-        if timezone == "Etc/UTC":
+        if timezone == "Etc/UTC" or timezone == "Universal":
             return
 
         self.timezone = timezone


### PR DESCRIPTION
On a fresh / YOCTO build raspi image with

* tzdata 2022a
* systemd 250.4
* a 'print(timezone)' added at line 260

the following log is created:
| using systemd backend
| Universal
| Traceback (most recent call last):
|  File "/usr/share/cinnamon/cinnamon-settings/modules/cs_calendar.py", line 149, in _on_proxy_ready
|    self.proxy_ready_callback()
|  File "/usr/share/cinnamon/cinnamon-settings/modules/cs_calendar.py", line 77, in _on_proxy_ready
|    self.tz_selector.set_timezone(self.zone)
|  File "/usr/share/cinnamon/cinnamon-settings/modules/cs_calendar.py", line 263, in set_timezone
|    region, city = timezone.split('/', maxsplit=1)
|ValueError: not enough values to unpack (expected 2, got 1)

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>