### PR TITLE
Fix docs and re-enable

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -156,3 +156,15 @@ Description: Debugging symbols for the Cinnamon desktop
  and flexible.
  .
  This package contains the debugging symbols.
+
+Package: cinnamon-doc
+Section: doc
+Architecture: all
+Multi-Arch: foreign
+Depends: devhelp, ${misc:Depends}
+Description: Cinnamon documentation
+ Cinnamon is a modern Linux desktop which provides advanced innovative
+ features and a traditional user experience. It's easy to use, powerful
+ and flexible.
+ .
+ This package contains the code documentation for various Cinnamon components.

--- a/debian/rules
+++ b/debian/rules
@@ -16,6 +16,7 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 override_dh_auto_configure:
 	dh_auto_configure -- \
 		--libexecdir=/usr/libexec/cinnamon \
+		-D docs=true \
 		-D deprecated_warnings=false \
 		-D py3modules_dir=/usr/lib/python3/dist-packages
 

--- a/docs/reference/cinnamon/meson.build
+++ b/docs/reference/cinnamon/meson.build
@@ -1,5 +1,6 @@
 ignore = [
     'cinnamon-recorder-src.h',
+    'cinnamon-recorder.h',
     st_headers,
     st_private_headers,
     tray_headers,

--- a/src/st/meson.build
+++ b/src/st/meson.build
@@ -89,6 +89,7 @@ st_private_headers = [
     'croco/cr-utils.h',
     'croco/libcroco-config.h',
     'croco/libcroco.h',
+    'st-background-effect.h',
     'st-private.h',
     'st-table-private.h',
     'st-theme-private.h',


### PR DESCRIPTION
We may or may not want `st-background-effect.h` and/or `cinnamon-recorder.h` to be included in the docs in the future, but for now, docs without them is still better than no docs at all.