### PR TITLE
popupMenu.js: bring back the call to actor.destroy()

### DIFF
--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -2161,6 +2161,7 @@ var PopupMenuBase = class PopupMenuBase {
     destroy() {
         this._signals.disconnectAllSignals();
         this.removeAll();
+        this.actor.destroy();
         /**
          * SIGNAL:destroy
          *


### PR DESCRIPTION
Removing it caused a regression in the sound applet where the mpris player content wasn't properly destroyed when a player disconnected from dbus.

ref: e1bc6c6ea4523778b2fbc8ce15523a221b151a9b