### PR TITLE
windowManager.js: fix window placement after workspace switch animation

### DIFF
--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -1147,6 +1147,7 @@ var WindowManager = class WindowManager {
 
             to_windows.forEach((w) => {
                 removeTweens(w);
+                w.set_position(w.origX, w.origY);
                 w.origX = undefined;
                 w.origY = undefined;
             });


### PR DESCRIPTION
After a completed or canceled workspace switch, the position of windows in the origin workspace were reset, but the positions of the windows in the destination workspace weren't. This is fine when the tween is allowed to complete because the window ends up right where it's supposed to be, but if the tween is canceled mid-animation (ie. due to another workspace switch), then the coordinates for those windows for the next animation are where ever the window happened to be when the previous tween was canceled, which in turn means that it ends up in the wrong spot. Resetting the position for the destination workspace windows fixes this issue.