### PR TITLE
cs_windows.py: Properly import CDesktopEnums

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_windows.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_windows.py
@@ -2,6 +2,7 @@
 
 import gi
 gi.require_version('Gtk', '3.0')
+gi.require_version('CDesktopEnums', '3.0')
 from gi.repository import Gio, Gtk, CDesktopEnums
 
 from SettingsWidgets import SidePage


### PR DESCRIPTION
A PyGIWarning would be thrown into the console for not specifying version. This ensures the right version of CDesktopEnums is loaded.

----

Found on Ubuntu Cinnamon 22.04  (I cloned on the latest branch so it is not a 5.2.2 issue.)
```
jpeisach@Joshua-UCRGamingTest:~/Desktop/cinnamon-layout-settings/files/usr/share/cinnamon/cinnamon-settings$ python3 cinnamon-settings.py 
/home/jpeisach/Desktop/cinnamon-layout-settings/files/usr/share/cinnamon/cinnamon-settings/modules/cs_windows.py:5: PyGIWarning: CDesktopEnums was imported without specifying a version first. Use gi.require_version('CDesktopEnums', '3.0') before import to ensure that the right version gets loaded.
  from gi.repository import Gio, Gtk, CDesktopEnums
failed to load python module <module 'cs_panel_layouts' from '/home/jpeisach/Desktop/cinnamon-layout-settings/files/usr/share/cinnamon/cinnamon-settings/modules/cs_panel_layouts.py'>
Traceback (most recent call last):
  File "/home/jpeisach/Desktop/cinnamon-layout-settings/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py", line 498, in load_python_modules
    mod = module.Module(self.content_box)
TypeError: Module.__init__() takes 1 positional argument but 2 were given
Using pam module (python3-pampy)
^C
```