### PR TITLE
runDialog.js: Don't hardcode the size of the dialog content

### DIFF
--- a/js/ui/runDialog.js
+++ b/js/ui/runDialog.js
@@ -167,8 +167,6 @@ __proto__: ModalDialog.ModalDialog.prototype,
         let label = new St.Label({ style_class: 'run-dialog-label',
                                    text: _("Enter a command") });
 
-        this.contentLayout.set_width(350 * global.ui_scale);
-
         this.contentLayout.add(label, { x_align: St.Align.MIDDLE });
 
         let entry = new St.Entry({ style_class: 'run-dialog-entry' });


### PR DESCRIPTION
This breaks when you change to a larger font size since the dialog can't
resize to adapt to it's content.

Fixes: https://github.com/linuxmint/cinnamon/issues/10829