### PR TITLE
theme: Restore the styling of gwl window thumbnails

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -1415,7 +1415,7 @@ StScrollBar StButton#vhandle:hover {
     border: 2px solid #a5a5a5;
     border-radius: 8px;
     color: white;
-    text-shadow: black 0px 0px 2px;
+    text-shadow: 0px 0px 2px black;
     padding: 8px;
     spacing: 4px;
 }
@@ -1436,7 +1436,7 @@ StScrollBar StButton#vhandle:hover {
 .grouped-window-list-number-label {
     font-size: 10px;
     z-index: 99;
-    text-shadow: black 1px 0px 2px;
+    text-shadow: 1px 0px 2px black;
     color:#fff;
     padding: 0;
 }
@@ -1533,6 +1533,10 @@ StScrollBar StButton#vhandle:hover {
 .grouped-window-list-thumbnail-menu {
 }
 .grouped-window-list-thumbnail-menu .item-box {
+    background: rgba(80,80,80,0.8);
+    border: 2px solid #a5a5a5;
+    color: white;
+    text-shadow: 0px 0px 2px black;
     padding: 10px;
     border-radius: 8px;
     spacing: 4px;


### PR DESCRIPTION
Not exactly sure what happened to these but this gets the styling back in place.