### PR TITLE
windowManager: Check whether metaWindow is NULL after destroy animation

### DIFF
--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -1020,8 +1020,7 @@ var WindowManager = class WindowManager {
 
     _destroyWindowDone(cinnamonwm, actor) {
         if (this._destroying.delete(actor)) {
-            actor.remove_all_transitions();
-            let parent = actor.get_meta_window().get_transient_for();
+            const parent = actor.get_meta_window()?.get_transient_for();
             if (parent && actor._parentDestroyId) {
                 parent.disconnect(actor._parentDestroyId);
                 actor._parentDestroyId = 0;


### PR DESCRIPTION
This cleans up a bunch of log spam when restarting cinnamon.

See: https://github.com/GNOME/gnome-shell/commit/e8ab3bf53d1b7224c749ae8187fd64c21671cc59