### PR TITLE
fix unresponsive upper pixel in top window list

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -687,7 +687,7 @@ class AppMenuButton {
                Assigning the natural size to the full panel height used to cause recursion errors but seems fine now.
                If this happens to avoid this you can subtract 1 or 2 pixels, but this will give an unreactive
                strip at the edge of the screen */
-            alloc.natural_size = this._applet._panelHeight;
+            alloc.natural_size = this._applet._panelHeight + 1;
         } else {
             alloc.natural_size = naturalSize1;
         }


### PR DESCRIPTION
With cinnamon 5.4.2 (possibly some versions before as well) on Archlinux, the uppermost pixel of the window-list applet is unresponsive, if the bar orientation is set to the top. All other orientations (bottom, left, right) seem fine.

Not sure if this is the right way to do it, but adding `1` fixes the issue.