### PR TITLE
Fix testsound volume

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/util.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/util.py
@@ -26,13 +26,13 @@ def _get_gsound_context():
     return gsound_context
 
 def play_sound_name(name, channel = None):
-    params = {GSound.ATTR_EVENT_ID: name}
+    params = {GSound.ATTR_EVENT_ID: name, GSound.ATTR_MEDIA_ROLE: "test"}
     if channel != None:
         params[GSound.ATTR_CANBERRA_FORCE_CHANNEL] = channel
     _get_gsound_context().play_simple(params)
 
 def play_sound_file(path, channel = None):
-    params = {GSound.ATTR_MEDIA_FILENAME: path}
+    params = {GSound.ATTR_MEDIA_FILENAME: path, GSound.ATTR_MEDIA_ROLE: "test"}
     if channel != None:
         params[GSound.ATTR_CANBERRA_FORCE_CHANNEL] = channel
     _get_gsound_context().play_simple(params)


### PR DESCRIPTION
This fixes the sound volume for channel tests and system sound previews. Before, it used the defined system sound volume which resulted in no output when system sounds are muted.
This restores the way this worked in Cinnamon 5.2