### PR TITLE
PopupMenu.js rtl arrow fix

### DIFF
--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -2971,9 +2971,7 @@ var PopupSubMenuMenuItem = class PopupSubMenuMenuItem extends PopupBaseMenuItem 
                                                span: -1,
                                                align: St.Align.END });
 
-            this._triangle = this.actor.get_direction() === St.TextDirection.RTL ?
-                arrowIcon(St.Side.LEFT) :
-                arrowIcon(St.Side.RIGHT);
+            this._triangle = arrowIcon(St.Side.RIGHT);
             this._triangle.pivot_point = new Graphene.Point({ x: 0.5, y: 0.5 });
             this._triangleBin.child = this._triangle;
         }


### PR DESCRIPTION
Remove rtl workaround for the triangle arrow direction, It is no longer necessary.
Seems the direction is now inverted by default, so this workaround actually inverted it a second time to an incorrect orientation.