### PR TITLE
settings-schema.json, applet.js and appGroup.js : Add an option to manage spacing on Grouped Window List applet

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -260,7 +260,7 @@ class AppGroup {
         const applet = this.state.appletActor;
         const direction = this.state.isHorizontal ? 'right' : 'bottom';
         const existingStyle = this.actor.style ? this.actor.style : '';
-        let spacing = parseInt(applet.get_theme_node().get_length('spacing'));
+        let spacing = parseInt(this.state.settings.iconSpacing);
         if (!spacing) {
             spacing = 6;
         }

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -313,6 +313,7 @@ class GroupedWindowListApplet extends Applet.Applet {
 
     bindSettings() {
         let settingsProps = [
+            {key: "icon-spacing", value: "iconSpacing", cb: null },
             {key: 'group-apps', value: 'groupApps', cb: this.refreshCurrentAppList},
             {key: 'enable-app-button-dragging', value: 'enableDragging', cb: this.draggableSettingChanged},
             {key: 'launcher-animation-effect', value: 'launcherAnimationEffect', cb: null},

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/settings-schema.json
@@ -5,7 +5,7 @@
     "generalPage": {
       "type" : "page",
       "title" : "General",
-      "sections": ["generalSection", "hotKeysSection"]
+      "sections": ["generalSection", "hotKeysSection", "appearance"]
     },
     "panelPage": {
       "type" : "page",
@@ -31,6 +31,13 @@
         "left-click-action",
         "middle-click-action",
         "show-all-workspaces"
+      ]
+    },
+    "appearance": {
+      "type": "section",
+      "title": "Appearance",
+      "keys": [
+        "icon-spacing"
       ]
     },
     "appButtonsSection": {
@@ -143,6 +150,15 @@
     "type": "checkbox",
     "default": true,
     "description": "Group windows by application"
+  },
+  "icon-spacing": {
+    "type": "spinbutton",
+    "default": 12,
+    "min": 1,
+    "max": 48,
+    "step": 1,
+    "units": "pixels",
+    "description": "Space between icons"
   },
   "show-all-workspaces": {
     "type": "checkbox",


### PR DESCRIPTION
I've added an option to manage spacing between icons on Grouped Window List applet, so users can manage spacing as they want/need.