### PR TITLE
cs-info: Add system icon

### DIFF
--- a/data/org.cinnamon.gschema.xml
+++ b/data/org.cinnamon.gschema.xml
@@ -501,7 +501,22 @@
       <summary>If true, Cinnamon will no longer attempt to be the session notification handler.</summary>
     </key>
 
-    <child name="theme" schema="org.cinnamon.theme"/>   
+    <key type="b" name="system-icon-enabled">
+      <default>true</default>
+      <summary>If true, Cinnamon will show the system icon in the "System Info" settings app.</summary>
+    </key>
+
+    <key type="s" name="system-icon-path">
+      <default>"/usr/share/icons/vendor/scalable/emblems/emblem-vendor.svg"</default>
+      <summary>The logo to use in the system info settings</summary>
+      <description>
+        An icon name or absolute path to an icon, which will be used for the system icon in the "System Info" settings app.
+        The default path is the emblem-vendor image stored in /usr/share/icons/vendor.
+        Requires the "system-icon-enabled" schema to be set to true.
+      </description>
+    </key>
+
+    <child name="theme" schema="org.cinnamon.theme"/>
     <child name="recorder" schema="org.cinnamon.recorder"/>
     <child name="keyboard" schema="org.cinnamon.keyboard"/>
     <child name="desklets" schema="org.cinnamon.desklets" />

--- a/data/org.cinnamon.gschema.xml
+++ b/data/org.cinnamon.gschema.xml
@@ -501,18 +501,14 @@
       <summary>If true, Cinnamon will no longer attempt to be the session notification handler.</summary>
     </key>
 
-    <key type="b" name="system-icon-enabled">
-      <default>true</default>
-      <summary>If true, Cinnamon will show the system icon in the "System Info" settings app.</summary>
-    </key>
-
     <key type="s" name="system-icon-path">
       <default>"/usr/share/icons/vendor/scalable/emblems/emblem-vendor.svg"</default>
       <summary>The logo to use in the system info settings</summary>
       <description>
         An icon name or absolute path to an icon, which will be used for the system icon in the "System Info" settings app.
         The default path is the emblem-vendor image stored in /usr/share/icons/vendor.
-        Requires the "system-icon-enabled" schema to be set to true.
+        .
+        Disabled if no value is set.
       </description>
     </key>
 

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
@@ -96,11 +96,11 @@ def getProcInfos():
 def getSystemIcon():
     schema = Gio.Settings(schema="org.cinnamon")
 
-    if schema.get_boolean("system-icon-enabled"):
-        iconPath = schema.get_string("system-icon-path")
-        return iconPath
-    else:
-        return
+    iconPath = schema.get_string("system-icon-path")
+    if iconPath is None:
+        return None
+
+    return iconPath
 
 
 def createSystemInfos():
@@ -215,8 +215,10 @@ class Module:
                 settings.add_row(widget)
 
             systemIconPath = getSystemIcon()
-            systemIcon = Gtk.Image.new_from_file(systemIconPath)
-            page.add(systemIcon)
+            if systemIconPath is not None:
+                systemIcon = Gtk.Image.new_from_file(systemIconPath)
+                page.add(systemIcon)
+
     
     def on_copy_clipboard_button_clicked(self, button):
         try:

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
@@ -93,6 +93,16 @@ def getProcInfos():
     return result
 
 
+def getSystemIcon():
+    schema = Gio.Settings(schema="org.cinnamon")
+
+    if schema.get_boolean("system-icon-enabled"):
+        iconPath = schema.get_string("system-icon-path")
+        return iconPath
+    else:
+        return
+
+
 def createSystemInfos():
     procInfos = getProcInfos()
     infos = []
@@ -203,6 +213,10 @@ class Module:
                 button.connect("clicked", self.on_copy_clipboard_button_clicked)
                 widget.pack_start(button, True, True, 0)
                 settings.add_row(widget)
+
+            systemIconPath = getSystemIcon()
+            systemIcon = Gtk.Image.new_from_file(systemIconPath)
+            page.add(systemIcon)
     
     def on_copy_clipboard_button_clicked(self, button):
         try:

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
@@ -97,7 +97,7 @@ def getSystemIcon():
     schema = Gio.Settings(schema="org.cinnamon")
 
     iconPath = schema.get_string("system-icon-path")
-    if iconPath is None:
+    if iconPath is "":  # left empty, so its disabled
         return None
 
     return iconPath


### PR DESCRIPTION
A vendor can disable this. It simply adds a Gtk Image under
the system info data which can be configured
by a gschema.

---
examples:
![Screenshot from 2022-08-19 22-01-32](https://user-images.githubusercontent.com/24401303/185725367-ee594d22-1d74-411b-950b-fdd787db826a.png)
![Screenshot from 2022-08-19 22-00-16](https://user-images.githubusercontent.com/24401303/185725368-86e2064a-e4e1-4467-9f4a-fd227d08c76f.png)
![Screenshot from 2022-08-19 21-59-10](https://user-images.githubusercontent.com/24401303/185725369-265a095b-42d6-4fc2-894a-0ac5cb9d5ba4.png)
![Screenshot from 2022-08-19 21-58-11](https://user-images.githubusercontent.com/24401303/185725370-f4fce001-ade9-4bb5-84b0-d075ea7e9dc2.png)

(Of course, the dimensions would have to be adjusted correctly by the vendor. I just downloaded these online, so like the LM logo would need configuring)