### PR TITLE
Fix layout bug in expo view

### DIFF
--- a/js/ui/expoThumbnail.js
+++ b/js/ui/expoThumbnail.js
@@ -1605,7 +1605,7 @@ ExpoThumbnailsBox.prototype = {
         let childBox = new Clutter.ActorBox();
         
         let calcPaddingX = function(nCols) {
-            let neededX = (thumbnailWidth * nCols) + totalSpacingX + (spacing * 2);
+            let neededX = (thumbnailWidth * nCols) + (spacing * (nCols + 1));
             let extraSpaceX = (box.x2 - box.x1) - neededX;
             return spacing + extraSpaceX/2;
         };


### PR DESCRIPTION
Fixes #10612.

The bug was caused by the function responsible for adding spaces between the thumbnails of a given row ignoring the fact the last row could have less thumbnails and, therefore, need less spacing, causing it to be off place.
