### PR TITLE
Fix inconsistent keyboard navigation in the Scale View and in the Expo View.

### DIFF
--- a/js/misc/gridNavigator.js
+++ b/js/misc/gridNavigator.js
@@ -12,8 +12,6 @@ function nextIndex(itemCount, numCols, currentIndex, symbol) {
         let curRow = Math.floor(currentIndex/numCols);
         let curCol = currentIndex % numCols;
 
-        const rowDelta = symbol === Clutter.KEY_Down ? 1 : -1;
-        let newIndex = (curRow + rowDelta) * numCols + curCol;
         if (symbol === Clutter.KEY_Down) { // down
             if (curRow < numRows - 2) {
                 return (curRow + 1) * numCols + curCol;
@@ -27,32 +25,33 @@ function nextIndex(itemCount, numCols, currentIndex, symbol) {
                 return (actualCurCol < numCols - 1) ? actualCurCol + 1 : 0;
             }
 
-            if (curCol >= lastRowColStart && curCol < lastRowColStart + numColsLastRow)
+            if (curCol >= lastRowColStart && curCol < lastRowColStart + numColsLastRow) {
                 return (curRow + 1) * numCols + curCol - lastRowColStart;
+            }
 
             return (curCol < numCols - 1) ? curCol + 1 : 0;
         }
         else { // up
-            let numFullRows = Math.floor(itemCount/numCols);
-            let numIOILR = itemCount % numCols; //num Items on Incompl. Last Row
-            if (newIndex >= 0) {
-                return newIndex;
+            if (curRow > 0 && curRow < numRows - 1) {
+                return (curRow - 1) * numCols + curCol;
+            }
+
+            let numColsLastRow = itemCount % numCols || numCols;
+            let lastRowColStart = Math.floor((numCols - numColsLastRow) / 2);
+
+            if (curRow === numRows - 1) {
+                return (curRow - 1) * numCols + curCol + lastRowColStart;
             }
 
             if (curCol === 0) {
-                // Wrap to the bottom of the right-most column, may not be on last row:
-                return (numFullRows * numCols) - 1;
+                return (numColsLastRow === numCols) ? itemCount - 1 : (numRows - 1) * numCols - 1;
             }
 
-            /* If we're on the 
-            top row but not in the first column, we want to move to the bottom of the
-            column to the left, even though that may not be the bottom of the grid.
-            */
-            if (numIOILR && curCol > numIOILR) {
-                return ((numFullRows - 1) * numCols) + curCol - 1;
+            if (curCol > lastRowColStart && curCol <= lastRowColStart + numColsLastRow) {
+                return (numRows - 1) * numCols + curCol - 1 - lastRowColStart;
             }
 
-            return ((numRows - 1) * numCols) + curCol - 1;
+            return (numRows - 2) * numCols + curCol - 1;
         }
     }
     else if (symbol === Clutter.KEY_Left || symbol === Clutter.KEY_Up) {

--- a/js/misc/gridNavigator.js
+++ b/js/misc/gridNavigator.js
@@ -14,18 +14,23 @@ function nextIndex(itemCount, numCols, currentIndex, symbol) {
 
         const rowDelta = symbol === Clutter.KEY_Down ? 1 : -1;
         let newIndex = (curRow + rowDelta) * numCols + curCol;
-        if (rowDelta >= 0) { // down
-            if (newIndex < itemCount) {
-                return newIndex;
+        if (symbol === Clutter.KEY_Down) { // down
+            if (curRow < numRows - 2) {
+                return (curRow + 1) * numCols + curCol;
             }
 
-            if (curCol < numCols - 1) {
-                // wrap to top row, one column to the right:
-                return curCol + 1;
+            let numColsLastRow = itemCount % numCols || numCols;
+            let lastRowColStart = Math.floor((numCols - numColsLastRow) / 2);
+
+            if (curRow === numRows - 1) {
+                let actualCurCol = curCol + lastRowColStart;
+                return (actualCurCol < numCols - 1) ? actualCurCol + 1 : 0;
             }
 
-            // wrap to top row, left-most column:
-            return 0;
+            if (curCol >= lastRowColStart && curCol < lastRowColStart + numColsLastRow)
+                return (curRow + 1) * numCols + curCol - lastRowColStart;
+
+            return (curCol < numCols - 1) ? curCol + 1 : 0;
         }
         else { // up
             let numFullRows = Math.floor(itemCount/numCols);

--- a/js/misc/gridNavigator.js
+++ b/js/misc/gridNavigator.js
@@ -12,13 +12,13 @@ function nextIndex(itemCount, numCols, currentIndex, symbol) {
         let curRow = Math.floor(currentIndex/numCols);
         let curCol = currentIndex % numCols;
 
+        let numColsLastRow = itemCount % numCols || numCols;
+        let lastRowColStart = Math.floor((numCols - numColsLastRow) / 2);
+
         if (symbol === Clutter.KEY_Down) {
             if (curRow < numRows - 2) {
                 return (curRow + 1) * numCols + curCol;
             }
-
-            let numColsLastRow = itemCount % numCols || numCols;
-            let lastRowColStart = Math.floor((numCols - numColsLastRow) / 2);
 
             if (curRow === numRows - 1) {
                 let actualCurCol = curCol + lastRowColStart;
@@ -39,9 +39,6 @@ function nextIndex(itemCount, numCols, currentIndex, symbol) {
             if (curRow > 0 && curRow < numRows - 1) {
                 return (curRow - 1) * numCols + curCol;
             }
-
-            let numColsLastRow = itemCount % numCols || numCols;
-            let lastRowColStart = Math.floor((numCols - numColsLastRow) / 2);
 
             if (curRow === numRows - 1) {
                 return (curRow - 1) * numCols + curCol + lastRowColStart;

--- a/js/misc/gridNavigator.js
+++ b/js/misc/gridNavigator.js
@@ -12,7 +12,7 @@ function nextIndex(itemCount, numCols, currentIndex, symbol) {
         let curRow = Math.floor(currentIndex/numCols);
         let curCol = currentIndex % numCols;
 
-        if (symbol === Clutter.KEY_Down) { // down
+        if (symbol === Clutter.KEY_Down) {
             if (curRow < numRows - 2) {
                 return (curRow + 1) * numCols + curCol;
             }
@@ -31,7 +31,11 @@ function nextIndex(itemCount, numCols, currentIndex, symbol) {
 
             return (curCol < numCols - 1) ? curCol + 1 : 0;
         }
-        else { // up
+        else {
+            if (numRows === 1) {
+                return (curCol > 0) ? curCol - 1 : itemCount - 1;
+            }
+
             if (curRow > 0 && curRow < numRows - 1) {
                 return (curRow - 1) * numCols + curCol;
             }
@@ -47,7 +51,7 @@ function nextIndex(itemCount, numCols, currentIndex, symbol) {
                 return (numColsLastRow === numCols) ? itemCount - 1 : (numRows - 1) * numCols - 1;
             }
 
-            if (curCol > lastRowColStart && curCol <= lastRowColStart + numColsLastRow) {
+            if (curCol >= lastRowColStart + 1 && curCol < lastRowColStart + numColsLastRow + 1) {
                 return (numRows - 1) * numCols + curCol - 1 - lastRowColStart;
             }
 

--- a/js/misc/gridNavigator.js
+++ b/js/misc/gridNavigator.js
@@ -58,10 +58,10 @@ function nextIndex(itemCount, numCols, currentIndex, symbol) {
             return (numRows - 2) * numCols + curCol - 1;
         }
     }
-    else if (symbol === Clutter.KEY_Left || symbol === Clutter.KEY_Up) {
+    else if (symbol === Clutter.KEY_Left || symbol === Clutter.KEY_Down) {
         result = (currentIndex < 1 ? itemCount : currentIndex) - 1;
     }
-    else if (symbol === Clutter.KEY_Right || symbol === Clutter.KEY_Down) {
+    else if (symbol === Clutter.KEY_Right || symbol === Clutter.KEY_Up) {
         result = (currentIndex + 1) % itemCount;
     }
     else if (symbol === Clutter.KEY_Home) {


### PR DESCRIPTION
Fixes #11070.

The function responsible for managing the keyboard navigation in the expo or scale view, when pressing up or down, assumed the columns in the last row started at the same position as the other rows, even when it had less columns than the other rows, when in reality the last row is always visually centered.

The edge case of having less than 4 workspaces / windows was also modified because it cycled through cells in the opposite direction as when there are 4 or more workspaces, before and after the changes.