### PR TITLE
fix: wrong (undeclared) variable being used

### DIFF
--- a/python3/cinnamon/harvester.py
+++ b/python3/cinnamon/harvester.py
@@ -92,8 +92,8 @@ class SpiceUpdate():
         self.author = ""
         try:
             author = index_node["author_user"]
-            if name not in ("none", "unknown"):
-                self.author = name
+            if author not in ("none", "unknown"):
+                self.author = author
         except:
             pass
 


### PR DESCRIPTION
The variable 'name' (yet undeclared) was being used instead of the one which was intended to be used, the variable 'author'