### PR TITLE
deprecated use of GObject.SIGNAL_RUN_FIRST

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings-users/cinnamon-settings-users.py
+++ b/files/usr/share/cinnamon/cinnamon-settings-users/cinnamon-settings-users.py
@@ -121,7 +121,7 @@ class DimmedTable (Gtk.Table):
 class EditableEntry (Gtk.Notebook):
 
     __gsignals__ = {
-        'changed': (GObject.SIGNAL_RUN_FIRST, None,
+        'changed': (GObject.SignalFlags.RUN_FIRST, None,
                     (str,))
     }
 


### PR DESCRIPTION
`GObject.SIGNAL_RUN_FIRST` is now deprecated and should be replaced by` GObject.SignalFlags.RUN_FIRST`