### PR TITLE
Fix getTabList in js.main

### DIFF
--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -1523,8 +1523,7 @@ function getTabList(workspaceOpt, screenOpt) {
 
     let windows = []; // the array to return
 
-    let allwindows = display.get_tab_list(Meta.TabList.NORMAL_ALL, screen,
-                                       workspace);
+    let allwindows = display.get_tab_list(Meta.TabList.NORMAL_ALL, workspace);
     let registry = {}; // to avoid duplicates
 
     for (let i = 0; i < allwindows.length; ++i) {


### PR DESCRIPTION
Function crashes because `Meta.Display.get_tab_list` do not require `Screen` as parameter anymore. [Link to docs](https://gjs-docs.gnome.org/meta7~7_api/meta.display#method-get_tab_list)