### PR TITLE
replace equality None check with identity None check

### DIFF
--- a/calendar-server/cinnamon-calendar-server.py
+++ b/calendar-server/cinnamon-calendar-server.py
@@ -53,10 +53,10 @@ class CalendarInfo(GObject.Object):
 
         self.disconnect(self.owner_color_signal_id)
 
-        if self.view_cancellable != None:
+        if self.view_cancellable is not None:
             self.view_cancellable.cancel()
 
-        if self.view != None:
+        if self.view is not None:
             self.view.stop()
         self.view = None
 
@@ -111,7 +111,7 @@ class CalendarServer(Gio.Application):
     def update_timezone(self):
         location = ECal.system_timezone_get_location()
 
-        if location == None:
+        if location is None:
             self.zone = ICalGLib.Timezone.get_utc_timezone().copy()
         else:
             self.zone = ICalGLib.Timezone.get_builtin_timezone(location).copy()
@@ -243,11 +243,11 @@ class CalendarServer(Gio.Application):
     def create_view_for_calendar(self, calendar):
         self.hold()
 
-        if calendar.view_cancellable != None:
+        if calendar.view_cancellable is not None:
             calendar.view_cancellable.cancel()
         calendar.view_cancellable = Gio.Cancellable()
 
-        if calendar.view != None:
+        if calendar.view is not None:
             calendar.view.stop()
         calendar.view = None
 
@@ -302,7 +302,7 @@ class CalendarServer(Gio.Application):
 
         for ical_comp in objects:
 
-            if ical_comp.get_uid() == None:
+            if ical_comp.get_uid() is None:
                 continue
 
             if (not ECal.util_component_is_instance (ical_comp)) and \
@@ -318,7 +318,7 @@ class CalendarServer(Gio.Application):
             else:
                 comp = ECal.Component.new_from_icalcomponent(ical_comp)
                 comptext = comp.get_summary()
-                if comptext != None:
+                if comptext is not None:
                     summary = comptext.get_value()
                 else:
                     summary = ""
@@ -330,7 +330,7 @@ class CalendarServer(Gio.Application):
 
                 dte_prop = ical_comp.get_first_property(ICalGLib.PropertyKind.DTEND_PROPERTY)
 
-                if dte_prop != None:
+                if dte_prop is not None:
                     ical_time_end = dte_prop.get_dtend()
                     end_timet = self.ical_time_get_timet(calendar.client, ical_time_end, dte_prop)
                 else:
@@ -362,7 +362,7 @@ class CalendarServer(Gio.Application):
         all_objects = GLib.VariantBuilder(GLib.VariantType.new("a(sssbxx)"))
 
         comptext = comp.get_summary()
-        if comptext != None:
+        if comptext is not None:
             summary = comptext.get_value()
         else:
             summary = ""
@@ -370,11 +370,11 @@ class CalendarServer(Gio.Application):
         default_zone = calendar.client.get_default_timezone()
 
         dts_timezone = instance_start.get_timezone()
-        if dts_timezone == None:
+        if dts_timezone is None:
             dts_timezone = default_zone
 
         dte_timezone = instance_end.get_timezone()
-        if dte_timezone == None:
+        if dte_timezone is None:
             dte_timezone = default_zone
 
         all_day = instance_start.is_date()
@@ -429,12 +429,12 @@ class CalendarServer(Gio.Application):
         mod_timet = 0
 
         mod_prop = ical_comp.get_first_property(ICalGLib.PropertyKind.LASTMODIFIED_PROPERTY)
-        if mod_prop != None:
+        if mod_prop is not None:
             ical_time_modified = mod_prop.get_lastmodified()
             mod_timet = ical_time_modified.as_timet()
         else:
             created_prop = ical_comp.get_first_property(ICalGLib.PropertyKind.CREATED_PROPERTY)
-            if created_prop != None:
+            if created_prop is not None:
                 ical_time_created = created_prop.get_created()
                 mod_timet = ical_time_created.as_timet()
 
@@ -460,7 +460,7 @@ class CalendarServer(Gio.Application):
         return self.get_id_from_comp_id(comp_id, source_id)
 
     def get_id_from_comp_id(self, comp_id, source_id):
-        if comp_id.get_rid() != None:
+        if comp_id.get_rid() is not None:
             return "%s:%s:%s" % (source_id, comp_id.get_uid(), comp_id.get_rid())
         else:
             return "%s:%s" % (source_id, comp_id.get_uid())
@@ -482,7 +482,7 @@ class CalendarServer(Gio.Application):
             self.interface.emit_events_removed(uids_string)
 
     def exit(self):
-        if self.registry_watcher != None:
+        if self.registry_watcher is not None:
             self.registry_watcher.disconnect(self.client_appeared_id)
             self.registry_watcher.disconnect(self.client_disappeared_id)
 

--- a/docs/search-providers-examples/trackerprovider@cinnamon.org/search_provider.py
+++ b/docs/search-providers-examples/trackerprovider@cinnamon.org/search_provider.py
@@ -38,11 +38,11 @@ if __name__ == "__main__":
             #If we have no defined file type or no file url, skip
             continue
         result_types = cursor.get_string(7)[0].split(",")
-        while len(result_types) > 0 and defined_type == None:
+        while len(result_types) > 0 and defined_type is None:
             t = result_types.pop()
             if t in CONVERT_TYPES:
                 defined_type = CONVERT_TYPES[t]
-        if defined_type == None:
+        if defined_type is None:
             defined_type = "files"
         if len(results.setdefault(defined_type, [])) < 10:
             results.setdefault(defined_type, []).append({

--- a/files/usr/share/cinnamon/cinnamon-settings-users/cinnamon-settings-users.py
+++ b/files/usr/share/cinnamon/cinnamon-settings-users/cinnamon-settings-users.py
@@ -104,7 +104,7 @@ class DimmedTable (Gtk.Table):
     def add_labels(self, texts):
         row = 0
         for text in texts:
-            if text != None:
+            if text is not None:
                 label = Gtk.Label(text)
                 label.set_alignment(1, 0.5)
                 label.get_style_context().add_class("dim-label")
@@ -611,14 +611,14 @@ class Module:
 
     def _on_password_button_clicked(self, widget):
         model, treeiter = self.users_treeview.get_selection().get_selected()
-        if treeiter != None:
+        if treeiter is not None:
             user = model[treeiter][INDEX_USER_OBJECT]
             dialog = PasswordDialog(user, self.password_mask, self.groups_label, self.window)
             response = dialog.run()
 
     def _on_groups_button_clicked(self, widget):
         model, treeiter = self.users_treeview.get_selection().get_selected()
-        if treeiter != None:
+        if treeiter is not None:
             user = model[treeiter][INDEX_USER_OBJECT]
             dialog = GroupsDialog(user.get_user_name(), self.window)
             response = dialog.run()
@@ -631,7 +631,7 @@ class Module:
 
     def _on_accounttype_changed(self, combobox):
         model, treeiter = self.users_treeview.get_selection().get_selected()
-        if treeiter != None:
+        if treeiter is not None:
             user = model[treeiter][INDEX_USER_OBJECT]
             if self.account_type_combo.get_active() == 1:
                 user.set_account_type(AccountsService.UserAccountType.ADMINISTRATOR)
@@ -647,7 +647,7 @@ class Module:
 
     def _on_realname_changed(self, widget, text):
         model, treeiter = self.users_treeview.get_selection().get_selected()
-        if treeiter != None:
+        if treeiter is not None:
             user = model[treeiter][INDEX_USER_OBJECT]
             user.set_real_name(text)
             description = "<b>%s</b>\n%s" % (text, user.get_user_name())
@@ -655,7 +655,7 @@ class Module:
 
     def _on_face_browse_menuitem_activated(self, menuitem):
         model, treeiter = self.users_treeview.get_selection().get_selected()
-        if treeiter != None:
+        if treeiter is not None:
             user = model[treeiter][INDEX_USER_OBJECT]
             dialog = Gtk.FileChooserDialog(None, None, Gtk.FileChooserAction.OPEN, (_("Cancel"), Gtk.ResponseType.CANCEL, _("Open"), Gtk.ResponseType.OK))
             filter = Gtk.FileFilter()
@@ -722,7 +722,7 @@ class Module:
     def _on_face_menuitem_activated(self, menuitem, path):
         if os.path.exists(path):
             model, treeiter = self.users_treeview.get_selection().get_selected()
-            if treeiter != None:
+            if treeiter is not None:
                 user = model[treeiter][INDEX_USER_OBJECT]
                 user.set_icon_file(path)
                 self.face_image.set_from_file(path)
@@ -796,7 +796,7 @@ class Module:
         self.password_button.set_tooltip_text("")
 
         model, treeiter = selection.get_selected()
-        if treeiter != None:
+        if treeiter is not None:
             user = model[treeiter][INDEX_USER_OBJECT]
             self.builder.get_object("button_delete_user").set_sensitive(True)
             self.realname_entry.set_text(user.get_real_name())
@@ -824,7 +824,7 @@ class Module:
                     message = "Could not load pixbuf from '%s': %s" % (path, e.message)
                     error = True
 
-                if pixbuf != None:
+                if pixbuf is not None:
                     if pixbuf.get_height() > 96 or pixbuf.get_width() > 96:
                         try:
                             pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(path, 96, 96)
@@ -866,7 +866,7 @@ class Module:
 
     def on_user_deletion(self, event):
         model, treeiter = self.users_treeview.get_selection().get_selected()
-        if treeiter != None:
+        if treeiter is not None:
             user = model[treeiter][INDEX_USER_OBJECT]
             message = _("Are you sure you want to permanently delete %s and all the files associated with this user?") % user.get_user_name()
             d = Gtk.MessageDialog(self.window,
@@ -909,14 +909,14 @@ class Module:
 
     def on_user_edition(self, event):
         model, treeiter = self.users_treeview.get_selection().get_selected()
-        if treeiter != None:
+        if treeiter is not None:
             print("Editing user %s" % model[treeiter][INDEX_USER_OBJECT].get_user_name())
 
 # GROUPS CALLBACKS
 
     def on_group_selection(self, selection):
         model, treeiter = selection.get_selected()
-        if treeiter != None:
+        if treeiter is not None:
             self.builder.get_object("button_edit_group").set_sensitive(True)
             self.builder.get_object("button_delete_group").set_sensitive(True)
             self.builder.get_object("button_delete_group").set_tooltip_text("")
@@ -936,7 +936,7 @@ class Module:
 
     def on_group_deletion(self, event):
         model, treeiter = self.groups_treeview.get_selection().get_selected()
-        if treeiter != None:
+        if treeiter is not None:
             group = model[treeiter][INDEX_GROUPNAME]
             message = _("Are you sure you want to permanently delete %s?") % group
             d = Gtk.MessageDialog(self.window,
@@ -962,7 +962,7 @@ class Module:
 
     def on_group_edition(self, event):
         model, treeiter = self.groups_treeview.get_selection().get_selected()
-        if treeiter != None:
+        if treeiter is not None:
             group = model[treeiter][INDEX_GROUPNAME]
             dialog = GroupDialog(_("Group Name"), group, self.window)
             response = dialog.run()

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/ChooserButtonWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/ChooserButtonWidgets.py
@@ -124,7 +124,7 @@ class PictureChooserButton(BaseChooserButton):
                 message = "Could not load pixbuf from '%s': %s" % (path, e.message)
                 error = True
 
-            if pixbuf != None:
+            if pixbuf is not None:
                 h = pixbuf.get_height()
                 w = pixbuf.get_width()
 
@@ -176,7 +176,7 @@ class PictureChooserButton(BaseChooserButton):
                 message = "Could not load pixbuf from '%s': %s" % (path, e.message)
                 error = True
 
-            if pixbuf != None:
+            if pixbuf is not None:
                 h = pixbuf.get_height()
                 w = pixbuf.get_width()
 

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/ExtensionCore.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/ExtensionCore.py
@@ -995,7 +995,7 @@ class DownloadSpicesPage(SettingsPage):
 
     def build_list(self, *args):
         spices_data = self.spices.get_cache()
-        if spices_data == None:
+        if spices_data is None:
             return
 
         if len(self.extension_rows) > 0:

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py
@@ -109,7 +109,7 @@ class JSONSettingsHandler(object):
         for info in self.bindings[key]:
             if obj == info["obj"]:
                 value = info["obj"].get_property(info["prop"])
-                if "map_set" in info and info["map_set"] != None:
+                if "map_set" in info and info["map_set"] is not None:
                     value = info["map_set"](value)
 
         for info in self.bindings[key]:
@@ -126,7 +126,7 @@ class JSONSettingsHandler(object):
             return
 
         with info["obj"].freeze_notify():
-            if "map_get" in info and info["map_get"] != None:
+            if "map_get" in info and info["map_get"] is not None:
                 value = info["map_get"](value)
             if value != info["obj"].get_property(info["prop"]) and value is not None:
                 info["obj"].set_property(info["prop"], value)
@@ -279,7 +279,7 @@ class JSONSettingsBackend(object):
             bind_object = self.bind_object
         else:
             bind_object = self.content_widget
-        if self.bind_dir != None:
+        if self.bind_dir is not None:
             self.settings.bind(self.key, bind_object, self.bind_prop, self.bind_dir,
                                self.map_get if hasattr(self, "map_get") else None,
                                self.map_set if hasattr(self, "map_set") else None)
@@ -309,7 +309,7 @@ class JSONSettingsBackend(object):
         raise NotImplementedError("SettingsWidget class must implement on_setting_changed().")
 
     def connect_widget_handlers(self, *args):
-        if self.bind_dir == None:
+        if self.bind_dir is None:
             raise NotImplementedError("SettingsWidget classes with no .bind_dir must implement connect_widget_handlers().")
 
 def json_settings_factory(subclass):

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
@@ -28,7 +28,7 @@ class BinFileMonitor(GObject.GObject):
 
         env = GLib.getenv("PATH")
 
-        if env == None:
+        if env is None:
             env = "/bin:/usr/bin:."
 
         self.paths = env.split(":")
@@ -58,7 +58,7 @@ file_monitor = None
 def get_file_monitor():
     global file_monitor
 
-    if file_monitor == None:
+    if file_monitor is None:
         file_monitor = BinFileMonitor()
 
     return file_monitor
@@ -196,7 +196,7 @@ class SidePage(object):
         self.topWindow = None
         self.builder = None
         self.stack = None
-        if self.module != None:
+        if self.module is not None:
             self.module.loaded = False
 
     def add_widget(self, widget):

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/imtools.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/imtools.py
@@ -755,7 +755,7 @@ def put_palette(image_to, image_from, palette=None):
     :param palette: image palette
     :type palette: sequence of (r, g, b) tuples or None
     """
-    if palette == None:
+    if palette is None:
         palette = get_palette(image_from)
     image_to.putpalette(flatten(palette))
     if 'transparency' in image_from.info:
@@ -853,7 +853,7 @@ def paste(destination, source, box=(0, 0), mask=None, force=False):
             source_without_alpha = remove_alpha(source)
             # paste on top of the opaque destination pixels
             destination.paste(source_without_alpha, box, source)
-            if invert_alpha != None:
+            if invert_alpha is not None:
                 # the alpha channel is ok now, so save it
                 destination_alpha = get_alpha(destination)
                 # paste on top of the transparant destination pixels

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/util.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/util.py
@@ -20,19 +20,19 @@ gsound_context = None
 
 def _get_gsound_context():
     global gsound_context
-    if (gsound_context == None):
+    if gsound_context is None:
         gsound_context = GSound.Context()
         gsound_context.init()
     return gsound_context
 
 def play_sound_name(name, channel = None):
     params = {GSound.ATTR_EVENT_ID: name, GSound.ATTR_MEDIA_ROLE: "test"}
-    if channel != None:
+    if channel is not None:
         params[GSound.ATTR_CANBERRA_FORCE_CHANNEL] = channel
     _get_gsound_context().play_simple(params)
 
 def play_sound_file(path, channel = None):
     params = {GSound.ATTR_MEDIA_FILENAME: path, GSound.ATTR_MEDIA_ROLE: "test"}
-    if channel != None:
+    if channel is not None:
         params[GSound.ATTR_CANBERRA_FORCE_CHANNEL] = channel
     _get_gsound_context().play_simple(params)

--- a/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
@@ -566,7 +566,7 @@ class MainWindow(Gio.Application):
         min_width_pixels = 0
         icon_view = Gtk.IconView()
         iter = model.get_iter_first()
-        while iter != None:
+        while iter is not None:
             string = model.get_value(iter, 0)
             split_by_word = string.split(" ")
             for word in split_by_word:

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_backgrounds.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_backgrounds.py
@@ -144,7 +144,7 @@ class ColorsWidget(SettingsWidget):
 
     def on_combo_changed(self, widget, key):
         tree_iter = widget.get_active_iter()
-        if tree_iter != None:
+        if tree_iter is not None:
             value = widget.get_model()[tree_iter][0]
             self.settings.set_string(key, value)
             self.show_or_hide_color2(value)
@@ -372,7 +372,7 @@ class Module:
             self.remove_folder_button.set_sensitive(True)
 
             if image_source != "" and "://" in image_source:
-                while tree_iter != None:
+                while tree_iter is not None:
                     if collection_source == image_source:
                         tree_path = self.collection_store.get_path(tree_iter)
                         self.folder_tree.set_cursor(tree_path)
@@ -763,7 +763,7 @@ class ThreadedIconView(Gtk.IconView):
                 if filename.endswith(".xml"):
                     filename = self.getFirstFileFromBackgroundXml(filename)
                 pix = PIX_CACHE.get_pix(filename, BACKGROUND_ICONS_SIZE)
-                if pix != None:
+                if pix is not None:
                     if "name" in to_load:
                         label = to_load["name"]
                     else:

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_default.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_default.py
@@ -377,7 +377,7 @@ class CustomAppChooserButton(Gtk.AppChooserButton):
 
     def getPreference(self, settings_key):
         strv = self.media_settings.get_strv(settings_key)
-        return strv != None and self.get_content_type() in strv
+        return strv is not None and self.get_content_type() in strv
 
     def getPreferences(self):
         pref_start_app = self.getPreference( PREF_MEDIA_AUTORUN_X_CONTENT_START_APP)
@@ -456,7 +456,7 @@ class OtherTypeDialog(Gtk.Dialog):
                     description = s
                 break
 
-        if description == None:
+        if description is None:
             print("Content type '%s' is missing from the info panel" % content_type)
             return Gio.content_type_get_description(content_type)
 
@@ -476,7 +476,7 @@ class OtherTypeDialog(Gtk.Dialog):
 
     def doHide(self):
         self.hide()
-        if self.application_combo != None:
+        if self.application_combo is not None:
             self.application_combo.destroy()
             self.application_combo = None
             self.table.forgetRow()
@@ -497,7 +497,7 @@ class OtherTypeDialog(Gtk.Dialog):
         heading = model.get_value(iter, 0)
 
         action_container = Gtk.HBox()
-        if self.application_combo != None:
+        if self.application_combo is not None:
             self.application_combo.destroy()
             self.table.forgetRow()
 

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_hotcorner.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_hotcorner.py
@@ -257,7 +257,7 @@ class HotCornerConfiguration(Gtk.Box):
     def on_widget_changed(self, *args):
         def apply(self):
             iter = self.functionCombo.get_active_iter()
-            if iter != None:
+            if iter is not None:
                 function = self.functionStore.get_value(iter, 0)
                 enabled = self.enableSwitch.get_active()
                 delay = str(int(self.hoverDelaySpinner.get_value()))

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_keyboard.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_keyboard.py
@@ -386,7 +386,7 @@ class Module:
             longest_cat_label = " "
 
             for category in self.main_store:
-                if category.parent == None:
+                if category.parent is None:
                     cat_iters[category.int_name] = self.cat_store.append(None)
                 else:
                     cat_iters[category.int_name] = self.cat_store.append(cat_iters[category.parent])

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_mouse.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_mouse.py
@@ -163,7 +163,7 @@ class ScrollMethodCombo(ComboBox):
 
     def on_my_value_changed(self, combo):
         tree_iter = combo.get_active_iter()
-        if tree_iter != None:
+        if tree_iter is not None:
             self.value = self.model[tree_iter][0]
             self.set_value(self.value)
 

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_panel.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_panel.py
@@ -578,5 +578,5 @@ class PanelRange(Range, PanelWidgetBackend):
 
     def on_setting_changed(self, *args):
         value = self.get_value()
-        if value != None and value != int(self.bind_object.get_value()):
+        if value is not None and value != int(self.bind_object.get_value()):
             self.bind_object.set_value(value)

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_power.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_power.py
@@ -806,7 +806,7 @@ class GSettings2ComboBox(SettingsWidget):
 
     def on_my_value_changed(self, widget):
         tree_iter = widget.get_active_iter()
-        if tree_iter != None:
+        if tree_iter is not None:
             self.settings[widget.key] = self.model[tree_iter][0]
 
     def on_my_setting_changed1(self, *args):

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_startup.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_startup.py
@@ -220,7 +220,7 @@ class AutostartApp():
         try:
             key_file = GLib.KeyFile.new()
 
-            if self.user_position == None:
+            if self.user_position is None:
                 self.user_position = os.path.join(GLib.get_user_config_dir(), "autostart")
                 self.path = os.path.join(self.user_position, self.basename)
                 key_file.load_from_file(os.path.join(self.system_position, self.basename), KEYFILE_FLAGS)
@@ -471,7 +471,7 @@ class AutostartBox(Gtk.Box):
         self.on_edit_button_clicked(list_box)
 
     def on_run_button_clicked(self, button):
-        if self.infobar_holder.get_child() != None:
+        if self.infobar_holder.get_child() is not None:
             self.infobar_holder.get_child().destroy()
 
         row = self.list_box.get_selected_row()

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
@@ -248,7 +248,7 @@ class Module:
 
                     dump = True
 
-                if theme_path == None:
+                if theme_path is None:
                     continue
 
                 if os.path.exists(theme_path):

--- a/python3/cinnamon/harvester.py
+++ b/python3/cinnamon/harvester.py
@@ -27,7 +27,7 @@ from . import logger
 from . import proxygsettings
 
 DEBUG = False
-if os.getenv("DEBUG") != None:
+if os.getenv("DEBUG") is not None:
     DEBUG = True
 def debug(msg):
     if DEBUG:
@@ -443,7 +443,7 @@ class Harvester():
             else:
                 pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_scale(paths.thumb_local_path, 24 * ui_scale, 24 * ui_scale, True)
 
-            if pixbuf == None:
+            if pixbuf is None:
                 raise Exception
 
             surf = Gdk.cairo_surface_create_from_pixbuf(pixbuf, ui_scale, None)

--- a/utils/cinnamon-stap-monitor/cinnamon-stap-monitor.py
+++ b/utils/cinnamon-stap-monitor/cinnamon-stap-monitor.py
@@ -151,7 +151,7 @@ class Main:
     def lookup_name_or_new(self, name):
         row_iter = self.model.get_iter_first()
 
-        while row_iter != None:
+        while row_iter is not None:
             existing_name = self.model.get_value(row_iter, 0)
             if name == existing_name:
                 return [False, row_iter]


### PR DESCRIPTION
In python an identity (`is`) check should be used to check for `None`, instead of an equality check (`==`).