### PR TITLE
fix: variable name causing potential NameError

### DIFF
--- a/python3/cinnamon/harvester.py
+++ b/python3/cinnamon/harvester.py
@@ -412,7 +412,7 @@ class Harvester():
 
     def write_to_log(self, uuid, action):
         new_version = "<none>"
-        old_verison = "<none>"
+        old_version = "<none>"
 
         try:
             remote_item = self.index_cache[uuid]


### PR DESCRIPTION
The typo causes, that `old_version` might not be initialized in case of an `KeyError`.
In that case `activity_logger.log("%s %s %s %s %s %s" % (log_timestamp, self.spice_type, action, uuid, old_version, new_version))` would fail with an `NameError`