### PR TITLE
fix: Actually use `XDG_DATA_HOME` to download themes and icons instead of home

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
@@ -159,8 +159,9 @@ class Spice_Harvester(GObject.Object):
             self.enabled_key = 'enabled-%ss' % self.collection_type
 
         if self.themes:
-            self.install_folder = '%s/.themes/' % (home)
-            self.spices_directories = (self.install_folder, )
+            self.install_folder = os.path.join(GLib.get_user_data_dir(), 'themes')
+            old_install_folder = '%s/.themes/' % (home)
+            self.spices_directories = (self.install_folder, old_install_folder)
         else:
             self.install_folder = '%s/.local/share/cinnamon/%ss/' % (home, self.collection_type)
             self.spices_directories = ('/usr/share/cinnamon/%ss/' % self.collection_type, self.install_folder)
@@ -422,9 +423,11 @@ class Spice_Harvester(GObject.Object):
                     except Exception as detail:
                         print(detail)
                         print("Skipping %s: there was a problem trying to read metadata.json" % uuid)
-            else:
+            elif (directory == self.install_folder):
                 print("%s does not exist! Creating it now." % directory)
                 subprocess.call(["mkdir", "-p", directory])
+            else:
+                print("%s does not exist! Skipping" % directory)
 
     def _directory_changed(self, *args):
         self._load_metadata()

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
@@ -141,14 +141,14 @@ class Module:
 
             self.builder = self.sidePage.builder
 
-            for path in [os.path.expanduser("~/.themes"), os.path.expanduser("~/.icons")]:
+            for path in [THEME_FOLDERS[0], ICON_FOLDERS[0]]:
                 try:
                     os.makedirs(path)
                 except OSError:
                     pass
 
             self.monitors = []
-            for path in [os.path.expanduser("~/.themes"), "/usr/share/themes", os.path.expanduser("~/.icons"), "/usr/share/icons"]:
+            for path in (THEME_FOLDERS + ICON_FOLDERS):
                 if os.path.exists(path):
                     file_obj = Gio.File.new_for_path(path)
                     try:
@@ -456,7 +456,7 @@ class Module:
         return res
 
     def update_cursor_theme_link(self, path, name):
-        default_dir = os.path.join(os.path.expanduser("~"), ".icons", "default")
+        default_dir = os.path.join(ICON_FOLDERS[0], "default")
         index_path = os.path.join(default_dir, "index.theme")
 
         try:


### PR DESCRIPTION
Mainly to not clutter up the user home folder when downloading themes, it was always creating `~/.themes`. `~/.icons` was created when a theme had extra icons.

Changes:
* Change themes install dir to `XDG_DATA_HOME/themes`
* when we initialize the `Spice_Harvester` we only ensure (create) the `install_folder` not the other directories
* Make sure the default icons dir is in `XDG_DATA_HOME`

Checked that themes still load from old location.