### PR TITLE
Move spices download cache to `XDG_CACHE_HOME` directory

### DIFF
--- a/files/usr/bin/xlet-about-dialog
+++ b/files/usr/bin/xlet-about-dialog
@@ -7,7 +7,7 @@ import gettext
 import datetime
 import gi
 gi.require_version('Gtk', '3.0')
-from gi.repository import Gtk, GdkPixbuf
+from gi.repository import Gtk, GdkPixbuf, GLib
 
 usage = """
 usage : xlet-about-dialog applets/desklets/extensions uuid
@@ -81,7 +81,7 @@ class AboutDialog(Gtk.AboutDialog):
 
     def get_spices_id(self):
         try:
-            cache_path = os.path.join(home, '.cinnamon', 'spices.cache', self.stype[0:-1], 'index.json')
+            cache_path = os.path.join(GLib.get_user_cache_dir(), 'cinnamon', 'spices', self.stype[0:-1], 'index.json'),
             if os.path.exists(cache_path):
                 with open(cache_path, 'r') as cache_file:
                     index_cache = json.load(cache_file)
@@ -89,7 +89,7 @@ class AboutDialog(Gtk.AboutDialog):
                         return index_cache[self.metadata['uuid']]['spices-id']
             return None
         except Exception as e:
-            print('Failed to load/parse index.json');
+            print('Failed to load/parse index.json')
             print(e)
             return None
 

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
@@ -149,7 +149,7 @@ class Spice_Harvester(GObject.Object):
         self.total_jobs = 0
         self.download_total_files = 0
         self.download_current_file = 0
-        self.cache_folder = '%s/.cinnamon/spices.cache/%s/' % (home, self.collection_type)
+        self.cache_folder = os.path.join(GLib.get_user_cache_dir(), 'cinnamon', 'spices', self.collection_type)
 
         if self.themes:
             self.settings = Gio.Settings.new('org.cinnamon.theme')

--- a/python3/cinnamon/harvester.py
+++ b/python3/cinnamon/harvester.py
@@ -21,7 +21,7 @@ import gi
 gi.require_version('Gtk', '3.0')
 gi.require_version('Gdk', '3.0')
 gi.require_version('Gio', '2.0')
-from gi.repository import Gdk, Gtk, Gio
+from gi.repository import Gdk, Gtk, Gio, GLib
 
 from . import logger
 from . import proxygsettings
@@ -125,7 +125,7 @@ class SpiceUpdate():
 
 class SpicePathSet():
     def __init__(self, cache_item, spice_type):
-        cache_folder = Path('%s/.cinnamon/spices.cache/%s/' % (home, spice_type))
+        cache_folder = os.path.join(GLib.get_user_cache_dir(), 'cinnamon', 'spices', spice_type)
 
         is_theme = spice_type == "theme"
 


### PR DESCRIPTION
The reason is to move stuff out of the `.cinnamon` directory for stuff to be eventually in XDG cache, data, state and config directories instead of just dumping them into the user's home directory.  

Users will need to redownload the cache, there are no other side effects.