### PR TITLE
Use `XDG_CONFIG_HOME` to store background config files instead of .cinnamon

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_backgrounds.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_backgrounds.py
@@ -43,6 +43,10 @@ BACKGROUND_ICONS_SIZE = 100
 BACKGROUND_COLLECTION_TYPE_DIRECTORY = "directory"
 BACKGROUND_COLLECTION_TYPE_XML = "xml"
 
+CONFIG_FOLDER = os.path.join(GLib.get_user_config_dir(), 'cinnamon', 'backgrounds')
+OLD_CONFIG_FOLDER = os.path.expanduser("~/.cinnamon/backgrounds")
+USER_FOLDERS_FILE_NAME = 'user-folders.lst'
+
 # even though pickle supports higher protocol versions, we want to version 2 because it's the latest
 # version supported by python2 which (at this time) is still used by older versions of Cinnamon.
 # When those versions are no longer supported, we can consider using a newer version.
@@ -340,7 +344,9 @@ class Module:
 
     def get_user_backgrounds(self):
         self.user_backgrounds = []
-        path = os.path.expanduser("~/.cinnamon/backgrounds/user-folders.lst")
+        path = os.path.join(CONFIG_FOLDER, USER_FOLDERS_FILE_NAME)
+        old_path = os.path.join(OLD_CONFIG_FOLDER, USER_FOLDERS_FILE_NAME)
+        path = path if os.path.exists(path) else old_path
         if os.path.exists(path):
             with open(path) as f:
                 folders = f.readlines()
@@ -463,10 +469,10 @@ class Module:
                         break
 
     def update_folder_list(self):
-        path = os.path.expanduser("~/.cinnamon/backgrounds")
+        path = CONFIG_FOLDER
         if not os.path.exists(path):
             os.makedirs(path, mode=0o755, exist_ok=True)
-        path = os.path.expanduser("~/.cinnamon/backgrounds/user-folders.lst")
+        path = os.path.join(CONFIG_FOLDER, USER_FOLDERS_FILE_NAME)
         if len(self.user_backgrounds) == 0:
             file_data = ""
         else:


### PR DESCRIPTION
Changes in background settings:
* If `user-folders.lst` is at the new place it will use that, else it will use the one in the old location.
* When changed it will save into the new location, effectively orphaning the old one.