### PR TITLE
Use `XDG_CONFIG_HOME` to store spices configs instead of `~/.cinnamon`

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
@@ -24,7 +24,8 @@ except ImportError:
 
 home = os.path.expanduser("~")
 locale_inst = '%s/.local/share/locale' % home
-settings_dir = '%s/.cinnamon/configs/' % home
+settings_dir = os.path.join(GLib.get_user_config_dir(), 'cinnamon', 'spices')
+old_settings_dir = '%s/.cinnamon/configs/' % home
 
 URL_SPICES_HOME = "https://cinnamon-spices.linuxmint.com"
 URL_MAP = {
@@ -697,6 +698,8 @@ class Spice_Harvester(GObject.Object):
                 # Uninstall settings file, if any
                 if (os.path.exists(os.path.join(settings_dir, uuid))):
                     shutil.rmtree(os.path.join(settings_dir, uuid))
+                if (os.path.exists(os.path.join(old_settings_dir, uuid))):
+                    shutil.rmtree(os.path.join(old_settings_dir, uuid))
             shutil.rmtree(os.path.join(self.install_folder, uuid))
         except Exception as detail:
             self.errorMessage(_("A problem occurred while removing %s.") % job['uuid'], str(detail))

--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -346,17 +346,20 @@ function removeAppletFromPanels(appletDefinition, deleteConfig, changed = false)
 }
 
 function _removeAppletConfigFile(uuid, instanceId) {
-    let config_path = (GLib.get_home_dir() + "/" +
-                               ".cinnamon" + "/" +
-                                 "configs" + "/" +
-                                      uuid + "/" +
-                                instanceId + ".json");
-    let file = Gio.File.new_for_path(config_path);
-    if (file.query_exists(null)) {
-        try {
-            file.delete(null);
-        } catch (e) {
-            global.logError("Problem removing applet config file during cleanup.  UUID is " + uuid + " and filename is " + config_path);
+    let config_paths = [
+        [GLib.get_home_dir(), ".cinnamon", "configs", uuid, instanceId + ".json"].join("/"),
+        [GLib.get_user_config_dir(), "cinnamon", "spices", uuid, instanceId + ".json"].join("/")
+    ];
+
+    for (let i = 0; i < config_paths.length; i++) {
+        const config_path = array[i];
+        let file = Gio.File.new_for_path(config_path);
+        if (file.query_exists(null)) {
+            try {
+                file.delete(null);
+            } catch (e) {
+                global.logError("Problem removing applet config file during cleanup.  UUID is " + uuid + " and filename is " + config_path);
+            }
         }
     }
 }

--- a/js/ui/deskletManager.js
+++ b/js/ui/deskletManager.js
@@ -275,17 +275,20 @@ function _unloadDesklet(deskletDefinition, deleteConfig) {
 }
 
 function _removeDeskletConfigFile(uuid, instanceId) {
-    let config_path = (GLib.get_home_dir() + "/" +
-                               ".cinnamon" + "/" +
-                                 "configs" + "/" +
-                                      uuid + "/" +
-                                instanceId + ".json");
-    let file = Gio.File.new_for_path(config_path);
-    if (file.query_exists(null)) {
-        try {
-            file.delete(null);
-        } catch (e) {
-            global.logError("Problem removing desklet config file during cleanup.  UUID is " + uuid + " and filename is " + config_path);
+    let config_paths = [
+        [GLib.get_home_dir(), ".cinnamon", "configs", uuid, instanceId + ".json"].join("/"),
+        [GLib.get_user_config_dir(), "cinnamon", "spices", uuid, instanceId + ".json"].join("/")
+    ];
+
+    for (let i = 0; i < config_paths.length; i++) {
+        const config_path = array[i];
+        let file = Gio.File.new_for_path(config_path);
+        if (file.query_exists(null)) {
+            try {
+                file.delete(null);
+            } catch (e) {
+                global.logError("Problem removing desklet config file during cleanup.  UUID is " + uuid + " and filename is " + config_path);
+            }
         }
     }
 }

--- a/js/ui/settings.js
+++ b/js/ui/settings.js
@@ -689,10 +689,21 @@ XletSettingsBase.prototype = {
     },
 
     _ensureSettingsFiles: function() {
-        let configPath = [GLib.get_home_dir(), ".cinnamon", "configs", this.uuid].join("/");
+        let configPath = [GLib.get_user_config_dir(), "cinnamon", "spices", this.uuid].join("/");
         let configDir = Gio.file_new_for_path(configPath);
         if (!configDir.query_exists(null)) configDir.make_directory_with_parents(null);
-        this.file = configDir.get_child(this.instanceId + ".json");
+
+        let configFile = configDir.get_child(this.instanceId + ".json")
+
+        let oldConfigDir = Gio.file_new_for_path([GLib.get_home_dir(), ".cinnamon", "configs", this.uuid].join("/"));
+        let oldConfigFile = oldConfigDir.get_child(this.instanceId + ".json");
+
+        // We only use the config under the old path if it's the only one for backwards compatibility
+        if (oldConfigFile.query_exists(null) && !configFile.query_exists(null))
+            this.file = oldConfigFile;
+        else 
+            this.file = configFile;
+
         this.monitor = this.file.monitor_file(Gio.FileMonitorFlags.NONE, null);
 
         // If the settings have already been installed previously we need to check if the schema

--- a/python3/cinnamon/harvester.py
+++ b/python3/cinnamon/harvester.py
@@ -21,7 +21,7 @@ import gi
 gi.require_version('Gtk', '3.0')
 gi.require_version('Gdk', '3.0')
 gi.require_version('Gio', '2.0')
-from gi.repository import Gdk, Gtk, Gio
+from gi.repository import Gdk, Gtk, Gio, GLib
 
 from . import logger
 from . import proxygsettings
@@ -71,7 +71,7 @@ TIMEOUT_DOWNLOAD_ZIP = 120
 
 home = os.path.expanduser("~")
 locale_inst = '%s/.local/share/locale' % home
-settings_dir = '%s/.cinnamon/configs/' % home
+settings_dir = os.path.join(GLib.get_user_config_dir(), 'cinnamon', 'spices')
 
 activity_logger = logger.ActivityLogger()
 


### PR DESCRIPTION
Use `$XDG_CONFIG_HOME/cinnamon/spices` path to store configs instead of dumping them into `~/.cinnamon`. Code prioritizes the new path but it will still fall back to old path if config file only exists there.

I'm not removing/moving config files because that would cause more problems than be useful.