### PR TITLE
fix: use `XDG_DATA_HOME` to store custom launchers, also fix launcher desklet

### DIFF
--- a/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
@@ -20,7 +20,8 @@ const SignalManager = imports.misc.signalManager;
 const PANEL_EDIT_MODE_KEY = 'panel-edit-mode';
 const PANEL_LAUNCHERS_KEY = 'panel-launchers';
 
-const CUSTOM_LAUNCHERS_PATH = GLib.get_home_dir() + '/.cinnamon/panel-launchers';
+const CUSTOM_LAUNCHERS_PATH = GLib.get_user_data_dir() + "/cinnamon/panel-launchers/";
+const OLD_CUSTOM_LAUNCHERS_PATH = GLib.get_home_dir() + '/.cinnamon/panel-launchers/';
 
 let pressLauncher = null;
 
@@ -578,7 +579,11 @@ class CinnamonPanelLaunchersApplet extends Applet.Applet {
         let app = appSys.lookup_app(path);
         let appinfo = null;
         if (!app) {
-            appinfo = CMenu.DesktopAppInfo.new_from_filename(CUSTOM_LAUNCHERS_PATH+"/"+path);
+            appinfo = CMenu.DesktopAppInfo.new_from_filename(CUSTOM_LAUNCHERS_PATH + path);
+            // Fallback to old launcher folder
+            if (!appinfo) {
+                appinfo = CMenu.DesktopAppInfo.new_from_filename(OLD_CUSTOM_LAUNCHERS_PATH + path);
+            }
             if (!appinfo) {
                 global.logWarning(`Failed to add launcher from path: ${path}`);
                 return null;
@@ -641,8 +646,10 @@ class CinnamonPanelLaunchersApplet extends Applet.Applet {
         }
         if (delete_file) {
             let appid = launcher.getId();
-            let file = Gio.file_new_for_path(CUSTOM_LAUNCHERS_PATH+"/"+appid);
+            let file = Gio.file_new_for_path(CUSTOM_LAUNCHERS_PATH + appid);
             if (file.query_exists(null)) file.delete(null);
+            let old_file = Gio.file_new_for_path(OLD_CUSTOM_LAUNCHERS_PATH + appid);
+            if (old_file.query_exists(null)) old_file.delete(null);
         }
 
         this.sync_settings_proxy_to_settings();

--- a/files/usr/share/cinnamon/cinnamon-desktop-editor/cinnamon-desktop-editor.py
+++ b/files/usr/share/cinnamon/cinnamon-desktop-editor/cinnamon-desktop-editor.py
@@ -26,7 +26,8 @@ gettext.install("cinnamon", "/usr/share/locale")
 
 #_ = gettext.gettext # bug !!! _ is already defined by gettext.install!
 home = os.path.expanduser("~")
-PANEL_LAUNCHER_PATH = os.path.join(home, ".cinnamon", "panel-launchers")
+PANEL_LAUNCHER_PATH = os.path.join(GLib.get_user_data_dir(), "cinnamon", "panel-launchers")
+OLD_PANEL_LAUNCHER_PATH = os.path.join(home, ".cinnamon", "panel-launchers")
 
 EXTENSIONS = (".png", ".xpm", ".svg")
 
@@ -270,8 +271,10 @@ class CinnamonLauncherEditor(ItemEditor):
             i = 1
             while True:
                 name = os.path.join(PANEL_LAUNCHER_PATH, 'cinnamon-custom-launcher-' + str(i) + '.desktop')
+                old_name = os.path.join(OLD_PANEL_LAUNCHER_PATH, 'cinnamon-custom-launcher-' + str(i) + '.desktop')
                 file = Gio.file_parse_name(name)
-                if not file.query_exists(None):
+                old_file = Gio.file_parse_name(old_name)
+                if not file.query_exists(None) and not old_file.query_exists(None):
                     break
                 i += 1
             self.item_path = name
@@ -395,7 +398,8 @@ class Main:
         self.search_menu_sys()
         if self.orig_file is None:
             panel_launchers = glob.glob(os.path.join(PANEL_LAUNCHER_PATH, "*.desktop"))
-            for launcher in panel_launchers:
+            old_panel_launchers = glob.glob(os.path.join(OLD_PANEL_LAUNCHER_PATH, "*.desktop"))
+            for launcher in (panel_launchers + old_panel_launchers):
                 if os.path.split(launcher)[1] == self.desktop_file:
                     self.orig_file = launcher
 

--- a/files/usr/share/cinnamon/desklets/launcher@cinnamon.org/editorDialog.py
+++ b/files/usr/share/cinnamon/desklets/launcher@cinnamon.org/editorDialog.py
@@ -6,13 +6,14 @@ import os.path
 
 import gi
 gi.require_version('Gtk', '3.0')
-from gi.repository import Gtk, Gio
+from gi.repository import Gtk, Gio, GLib
 
 SCHEMAS = "org.cinnamon.desklets.launcher"
 LAUNCHER_KEY = "launcher-list"
 
 HOME_DIR = os.path.expanduser("~")+"/"
-CUSTOM_LAUNCHERS_PATH = HOME_DIR + ".cinnamon/panel-launchers/"
+CUSTOM_LAUNCHERS_PATH = os.path.join(GLib.get_user_data_dir(), "cinnamon", "panel-launchers")
+OLD_CUSTOM_LAUNCHERS_PATH = HOME_DIR + ".cinnamon/panel-launchers/"
 EDITOR_DIALOG_UI_PATH = "/usr/share/cinnamon/desklets/launcher@cinnamon.org/editorDialog.ui"
 
 class EditorDialog:
@@ -110,10 +111,9 @@ class EditorDialog:
         self.dialog.destroy()
 
     def on_edit_ok_clicked(self, widget):
-        if not self.name_entry.get_text():
-            return None
-
         if (self.launcher_type == "Application"):
+            if not self.name_entry.get_text():
+                return None
             launcher_name = self.name_entry.get_text() + ".desktop"
         elif (self.launcher_type == "Custom Application"):
             launcher_name = self.write_custom_application()
@@ -144,24 +144,23 @@ class EditorDialog:
 
         self.dialog.destroy()
 
-    def get_custom_id(self):
-        i = 1
+    def get_custom_path(self):
         directory = Gio.file_new_for_path(CUSTOM_LAUNCHERS_PATH)
         if not directory.query_exists(None):
             directory.make_directory_with_parents(None)
 
-        fileRec = Gio.file_parse_name(CUSTOM_LAUNCHERS_PATH + 'cinnamon-custom-launcher-' + str(i) + '.desktop')
-        while fileRec.query_exists(None):
-            i = i + 1
-            fileRec = Gio.file_parse_name(CUSTOM_LAUNCHERS_PATH + 'cinnamon-custom-launcher-' + str(i) + '.desktop')
+        i = 1
+        while True:
+            name = 'cinnamon-custom-launcher-' + str(i) + '.desktop'
+            path = os.path.join(CUSTOM_LAUNCHERS_PATH, name)
+            oldPath = os.path.join(OLD_CUSTOM_LAUNCHERS_PATH, name)
+            if not os.path.exists(path) and not os.path.exists(oldPath):
+                return (name, path)
 
-        return i;
+            i = i + 1
 
     def write_custom_application(self):
-        i = self.get_custom_id();
-
-        file_name = "cinnamon-custom-launcher-" + str(i) + ".desktop"
-        file_path = CUSTOM_LAUNCHERS_PATH + file_name
+        file_name, file_path = self.get_custom_path()
 
         title = self.title_entry.get_text()
         command = self.command_entry.get_text()
@@ -184,8 +183,12 @@ class Application:
         self.title = None
         self.command = None
 
-        if (os.path.exists(CUSTOM_LAUNCHERS_PATH + file_name)):
-            self._path = CUSTOM_LAUNCHERS_PATH + file_name
+        custom_path = os.path.join(CUSTOM_LAUNCHERS_PATH, file_name)
+        old_custom_path = os.path.join(OLD_CUSTOM_LAUNCHERS_PATH, file_name)
+        if (os.path.exists(custom_path)):
+            self._path = custom_path
+        elif (os.path.exists(old_custom_path)):
+            self._path = old_custom_path
         elif (os.path.exists("/usr/share/applications/" + file_name)):
             self._path = "/usr/share/applications/" + file_name
 


### PR DESCRIPTION
So the custom .desktop files does not end up in `~/.cinnamon` but in the correct XDG folder. backwards compatible. Also fixed some bugs in the launcher desklet. 

Changes:
* use `XDG_DATA_HOME/cinnamon/panel-launchers` folder to save launcher configs, with a fallback when getting the config to the old path in .cinnamon
* Remove launcher desklet's right click->Add new launcher because it is very broken (desklet is added but it's never visually on the desktop so it cannot be interacted with) and new instances can be added from the desklets settings anyway.
* Make sure associated custom launchers are removed when a launcher desklet is removed
* When adding a custom launcher for the desklet name is not needed (it's greyed out) but without it it cannot be added. Fixed.