### PR TITLE
Use `XDG_STATE_HOME` for logfiles instead of `~/.cinnamon`

### DIFF
--- a/files/usr/bin/cinnamon-launcher
+++ b/files/usr/bin/cinnamon-launcher
@@ -12,7 +12,7 @@ import psutil
 import threading
 import gi
 gi.require_version('Gtk', '3.0')  # noqa
-from gi.repository import Gtk, GLib, Gio
+from gi.repository import Gtk, GLib, Gio, GLib
 
 FALLBACK_COMMAND = "metacity"
 FALLBACK_ARGS = ("--replace",)
@@ -113,7 +113,7 @@ class Launcher():
         os.execvp(sys.argv[0], sys.argv)
 
     def log_kill(self, memory, limit, delay):
-        directory = os.path.expanduser("~/.cinnamon")
+        directory = os.path.join(GLib.get_user_state_dir(), 'cinnamon')
         string = "%s - Usage: %d MB - Limit: %d MB - Freq: %s sec" % (time.strftime("%Y.%m.%d %H:%M:%S"), memory, limit, delay)
         if not os.path.exists(directory):
             os.mkdir(directory)

--- a/files/usr/bin/cinnamon-launcher
+++ b/files/usr/bin/cinnamon-launcher
@@ -113,7 +113,11 @@ class Launcher():
         os.execvp(sys.argv[0], sys.argv)
 
     def log_kill(self, memory, limit, delay):
-        directory = os.path.join(GLib.get_user_state_dir(), 'cinnamon')
+        try:
+            directory = os.path.join(GLib.get_user_state_dir(), 'cinnamon')
+        except AttributeError:
+            directory = os.path.expanduser("~/.cinnamon")
+
         string = "%s - Usage: %d MB - Limit: %d MB - Freq: %s sec" % (time.strftime("%Y.%m.%d %H:%M:%S"), memory, limit, delay)
         if not os.path.exists(directory):
             os.mkdir(directory)

--- a/files/usr/share/cinnamon/cinnamon-looking-glass/cinnamon-looking-glass.py
+++ b/files/usr/share/cinnamon/cinnamon-looking-glass/cinnamon-looking-glass.py
@@ -146,7 +146,6 @@ class NewLogDialog(Gtk.Dialog):
         box.add(label)
 
         self.store = Gtk.ListStore(str, str)
-        self.store.append(["glass.log", "~/.cinnamon/glass.log"])
         self.store.append(["custom", "<Select file>"])
 
         self.combo = Gtk.ComboBox.new_with_model(self.store)

--- a/python3/cinnamon/logger.py
+++ b/python3/cinnamon/logger.py
@@ -3,9 +3,11 @@
 import os
 import threading
 import queue
+from pathlib import Path
+from gi.repository import GLib
 
 # Share among multiple Harvesters
-logfile = '%s/.cinnamon/harvester.log' % os.path.expanduser("~")
+logfile = os.path.join(GLib.get_user_state_dir(), 'cinnamon', 'harvester.log')
 
 class ActivityLogger():
     def __init__(self):
@@ -17,6 +19,9 @@ class ActivityLogger():
         self.queue.put(entry)
 
     def write_to_file_thread(self):
+        directory = Path(logfile).parent
+        if not directory.exists():
+            os.makedirs(directory)
         while True:
             entry = self.queue.get()
             with open(logfile, "a") as f:

--- a/python3/cinnamon/logger.py
+++ b/python3/cinnamon/logger.py
@@ -7,7 +7,10 @@ from pathlib import Path
 from gi.repository import GLib
 
 # Share among multiple Harvesters
-logfile = os.path.join(GLib.get_user_state_dir(), 'cinnamon', 'harvester.log')
+try:
+    logfile = os.path.join(GLib.get_user_state_dir(), 'cinnamon', 'harvester.log')
+except AttributeError:
+    logfile = '%s/.cinnamon/harvester.log' % os.path.expanduser("~")
 
 class ActivityLogger():
     def __init__(self):


### PR DESCRIPTION
Although I've not seen any of these logfiles on my system.

glass.log entry was removed because it doesn't exists anymore.