### PR TITLE
Rename "Preferences" to "Applet preferences" in applets where it might be confusing

### DIFF
--- a/cinnamon.pot
+++ b/cinnamon.pot
@@ -795,12 +795,16 @@ msgstr ""
 msgid "Move to another workspace"
 msgstr ""
 
-#: files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js:156
-#: files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js:68
-#: files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js:907
+
 #: files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py:59
 #: files/usr/share/cinnamon/cinnamon-settings/modules/cs_tiling.py:29
 msgid "Preferences"
+msgstr ""
+
+#: files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js:156
+#: files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js:68
+#: files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js:907
+msgid "Applet preferences"
 msgstr ""
 
 #. grouped-window-list@cinnamon.org->metadata.json->name

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
@@ -154,7 +154,7 @@ class AppMenuButtonRightClickMenu extends Applet.AppletPopupMenu {
         }
 
         // Preferences
-        let subMenu = new PopupMenu.PopupSubMenuMenuItem(_('Preferences'));
+        let subMenu = new PopupMenu.PopupSubMenuMenuItem(_('Applet preferences'));
         this.addMenuItem(subMenu);
 
         item = createMenuItem({label: _('About...'), icon: 'dialog-question'});

--- a/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/panel-launchers@cinnamon.org/applet.js
@@ -65,7 +65,7 @@ class PanelAppLauncherMenu extends Applet.AppletPopupMenu {
 
         this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
-        let subMenu = new PopupMenu.PopupSubMenuMenuItem(_("Preferences"));
+        let subMenu = new PopupMenu.PopupSubMenuMenuItem(_("Applet preferences"));
         this.addMenuItem(subMenu);
 
         item = new PopupMenu.PopupIconMenuItem(_("About..."), "dialog-question", St.IconType.SYMBOLIC);

--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -901,7 +901,7 @@ class AppMenuButtonRightClickMenu extends Applet.AppletPopupMenu {
         }
 
         // Preferences
-        let subMenu = new PopupMenu.PopupSubMenuMenuItem(_("Preferences"));
+        let subMenu = new PopupMenu.PopupSubMenuMenuItem(_("Applet preferences"));
         this.addMenuItem(subMenu);
 
         item = new PopupMenu.PopupIconMenuItem(_("About..."), "dialog-question", St.IconType.SYMBOLIC);


### PR DESCRIPTION
Fixes #11197 

In grouped-window-list, panel-launchers, and window-list, the right-click menu shows different options for each program/window on right-click. To make it clear that the "Preferences" submenu doesn't refer to the program/window, I've renamed it to "Applet preferences".

This does not conflict with any other naming, as no other applet uses this string in a similar context (see the `.pot` file to verify).

## Screenshots
In `panel-launchers`:
![image](https://user-images.githubusercontent.com/6352172/194855345-4957a9ab-cb1b-4304-bad7-cc46c8d9a587.png)
In `grouped-window-list` and `window-list`:
![image](https://user-images.githubusercontent.com/6352172/194855476-b6adc71f-89a4-4040-ad52-9d7705576075.png)
