### PR TITLE
cs-info: Don't freeze with the default system-icon-path value

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
@@ -218,9 +218,12 @@ class Module:
 
             systemIconPath = getSystemIcon()
             if systemIconPath is not None:
-                pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_scale (systemIconPath, -1, 160, True)
-                systemIcon = Gtk.Image.new_from_pixbuf(pixbuf)
-                page.add(systemIcon)
+                try:
+                    pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_scale (systemIconPath, -1, 160, True)
+                    systemIcon = Gtk.Image.new_from_pixbuf(pixbuf)
+                    page.add(systemIcon)
+                except GLib.GError:
+                    pass
 
     
     def on_copy_clipboard_button_clicked(self, button):


### PR DESCRIPTION
In NixOS, the module does not open with the default `system-icon-path` value:

```
Using pam module (python3-pampy)
Loading Info module
Traceback (most recent call last):
  File "/nix/store/a8gwxrbqypfbiwxml1bmwgcf4hhp0hn3-cinnamon-common-5.4.12/share/cinnamon/cinnamon-settings/cinnamon-settings.py", line 733, in button_press
    self.side_view_nav(widget, None, category)
  File "/nix/store/a8gwxrbqypfbiwxml1bmwgcf4hhp0hn3-cinnamon-common-5.4.12/share/cinnamon/cinnamon-settings/cinnamon-settings.py", line 165, in side_view_nav
    self.go_to_sidepage(sidePage, user_action=True)
  File "/nix/store/a8gwxrbqypfbiwxml1bmwgcf4hhp0hn3-cinnamon-common-5.4.12/share/cinnamon/cinnamon-settings/cinnamon-settings.py", line 174, in go_to_sidepage
    sidePage.build()
  File "/nix/store/a8gwxrbqypfbiwxml1bmwgcf4hhp0hn3-cinnamon-common-5.4.12/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py", line 212, in build
    self.module.on_module_selected()
  File "/nix/store/a8gwxrbqypfbiwxml1bmwgcf4hhp0hn3-cinnamon-common-5.4.12/share/cinnamon/cinnamon-settings/modules/cs_info.py", line 222, in on_module_selected
    pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_scale (systemIconPath, -1, 160, True)
gi.repository.GLib.GError: g-file-error-quark: Failed to open file “/usr/share/icons/vendor/scalable/emblems/emblem-vendor.svg”: No such file or directory (4)
```

As a vendor, I know how to change the default value but I am lazy :see_no_evil: 

/cc #11090 (the PR introduced system-icon-path)
/cc #11244 (yeah the default is a FHS path which we don't follow)