### PR TITLE
The middle click toggles the sound and places the microphone in the same state.

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -1202,8 +1202,9 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
         //mute or play / pause players on middle click
         if (buttonId === 2) {
             if (this.middleClickAction === "mute") {
+                if (this._output.is_muted === this._input.is_muted)
+                    this._toggle_in_mute();
                 this._toggle_out_mute();
-                this._toggle_in_mute();
             } else if (this.middleClickAction === "out_mute")
                 this._toggle_out_mute();
             else if (this.middleClickAction === "in_mute")


### PR DESCRIPTION
Proposed solution for issue 11255