### PR TITLE
Sound applet: added special case for Firefox icon.

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -434,15 +434,18 @@ class StreamMenuSection extends PopupMenu.PopupMenuSection {
         }
 
         // Special cases
-        if(name === "Banshee") {
+        if (name === "Banshee") {
             iconName = "banshee";
         }
         else if (name === "Spotify") {
             iconName = "spotify";
         }
-        if(name === "VBox") {
+        else if (name === "VBox") {
             name = "Virtualbox";
             iconName = "virtualbox";
+        }
+        else if (name === "Firefox") {
+            iconName = "firefox";
         }
         else if (iconName === "audio") {
             iconName = "audio-x-generic";


### PR DESCRIPTION
The applications section in the sound applet shows a generic icon for Firefox. This PR adds a special case for Firefox, so that the correct icon is shown.

Before:
![before](https://user-images.githubusercontent.com/67810471/205128826-aa16bcc0-f996-4785-a4d9-eea478902925.png)

After:
![after](https://user-images.githubusercontent.com/67810471/205128835-dd8184f4-c1bf-4d5c-b582-c5aef768ca07.png)
