### PR TITLE
LM 21.1: Fix old thumbnail cache folder

### DIFF
--- a/python3/cinnamon/harvester.py
+++ b/python3/cinnamon/harvester.py
@@ -151,7 +151,7 @@ class Harvester:
         self.index_cache = {}
         self.cache_lock = threading.Lock()
 
-        self.cache_folder = '%s/.cinnamon/spices.cache/%s/' % (home, self.spice_type)
+        self.cache_folder = os.path.join(GLib.get_user_cache_dir(), 'cinnamon', 'spices', self.spice_type)
 
         self.index_file = os.path.join(self.cache_folder, "index.json")
 


### PR DESCRIPTION
This was forgotten in PR #11176 and results in many useless requests where thumbnails are redownloaded because they can't be found in the new location but are saved to the old one.

Can be easily tested with `DEBUG=1 cinnamon-spice-updater --list-simple applet`:
Without this PR `Downloading thumbnail for ...` is always shown, even if the images got downloaded seconds ago

This reduces server load by a lot and should be picked up before stable release of Linux Mint 21.1