### PR TITLE
simplify DEBUG detection harvester.py

### DIFF
--- a/python3/cinnamon/harvester.py
+++ b/python3/cinnamon/harvester.py
@@ -24,9 +24,7 @@ from gi.repository import Gdk, Gtk, Gio, GLib
 from . import logger
 from . import proxygsettings
 
-DEBUG = False
-if os.getenv("DEBUG") is not None:
-    DEBUG = True
+DEBUG = os.getenv("DEBUG") is not None
 def debug(msg):
     if DEBUG:
         print(msg)


### PR DESCRIPTION
Instead of checking if `os.getenv("DEBUG") is not None` and then setting `DEBUG` to `True`, the result of `os.getenv("DEBUG") is not None` can directly be assigned to `DEBUG`.