### PR TITLE
virtualKeyboard.js: Check layout existence before usage

### DIFF
--- a/js/ui/virtualKeyboard.js
+++ b/js/ui/virtualKeyboard.js
@@ -366,11 +366,12 @@ Keyboard.prototype = {
     },
 
     _redraw: function () {
-        if (!this._enableKeyboard)
-            return;
-
         let focus = Main.layoutManager.focusMonitor;
         let index = Main.layoutManager.focusIndex;
+        
+        if (!this._enableKeyboard || !focus || !index)
+            return;
+
 
         let panelPadding = 0;
         let panels = Main.getPanels();


### PR DESCRIPTION
This prevents errors when the virtual keyboard is enabled and no display is found (e.g. turned off monitor) during login after screensaver

**Steps to reproduce the exception**
- Lock the screen
- Turn off your display
- Enter some text/password
- Turn on your display
- `.xsession_errors` shows the following exception without this PR

```
(cinnamon:2552): Gjs-WARNING **: 18:15:19.059: JS ERROR: Exception in callback for signal: monitors-changed: TypeError: focus is undefined
_redraw@/usr/share/cinnamon/js/ui/virtualKeyboard.js:388:9
_emit@resource:///org/gnome/gjs/modules/core/_signals.js:114:47
_monitorsChanged@/usr/share/cinnamon/js/ui/layout.js:157:14
```