### PR TITLE
layout.js: Check existence of monitor before usage

### DIFF
--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -648,11 +648,14 @@ Chrome.prototype = {
                 }
             } else if (this._inOverview)
                 visible = true;
-            else if (!actorData.visibleInFullscreen &&
-                     this.findMonitorForActor(actorData.actor).inFullscreen)
-                visible = false;
-            else
-                visible = true;
+            else {
+                let monitor = this.findMonitorForActor(actorData.actor);
+                
+                if (!actorData.visibleInFullscreen && monitor && monitor.inFullscreen)
+                    visible = false;
+                else
+                    visible = true;
+            }
             Main.uiGroup.set_skip_paint(actorData.actor, !visible);
         }
         this._queueUpdateRegions();


### PR DESCRIPTION
This prevents errors when no display is found (e.g. turned off monitor) during login after screensaver

**Steps to reproduce the exception**
- Lock the screen
- Turn off your display
- Enter some text/password
- Turn on your display
- `.xsession_errors` shows the following exception without this PR

```
(cinnamon:2273): Gjs-WARNING **: 18:46:27.661: JS ERROR: Exception in callback for signal: monitors-changed: TypeError: this.findMonitorForActor(...) is undefined
_updateVisibility@/usr/share/cinnamon/js/ui/layout.js:652:27
_relayout@/usr/share/cinnamon/js/ui/layout.js:675:14
_emit@resource:///org/gnome/gjs/modules/core/_signals.js:114:47
_monitorsChanged@/usr/share/cinnamon/js/ui/layout.js:216:14
```