### PR TITLE
[5.8] Expose middle-click paste setting.

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_mouse.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_mouse.py
@@ -44,6 +44,9 @@ class Module:
             switch = GSettingsSwitch(_("Emulate middle click by clicking both left and right buttons"), "org.cinnamon.desktop.peripherals.mouse", "middle-click-emulation")
             settings.add_row(switch)
 
+            switch = GSettingsSwitch(_("Paste the current selection when middle-click is pressed"), "org.cinnamon.desktop.interface", "gtk-enable-primary-paste")
+            settings.add_row(switch)
+
             spin = GSettingsSpinButton(_("Drag-and-drop threshold"), "org.cinnamon.desktop.peripherals.mouse", "drag-threshold", _("pixels"), 1, 400)
             settings.add_row(spin)
 


### PR DESCRIPTION
ref:
linuxmint/cinnamon-desktop@a573e21850723edbe5ab149ef2c1265d16f0bf02 linuxmint/cinnamon-settings-daemon@66a86cfabd33b6bc0006f5a88f8b6e1618f5cc82

Fixes #11358