### PR TITLE
Add category hover style for Cinnamenu applet...

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -1244,6 +1244,11 @@ StScrollBar StButton#vhandle:hover {
     padding-right: 7px;
     padding-bottom: 7px;
 }
+.menu-category-button:hover {
+    background-color: rgba(128,128,128,0.2);
+    border-radius: 4px;
+    border-image: none;
+}
 .menu-category-button-greyed {
     padding-top: 7px;
     padding-left: 7px;
@@ -1272,9 +1277,6 @@ StScrollBar StButton#vhandle:hover {
 }
 .menu-category-button-label:rtl {
     padding-right: 5px;
-
-}
-.menu-category-button-selected:hover {
 }
 /* Name and description of the currently hovered item in the menu
  * This appears on the bottom right hand corner of the menu*/


### PR DESCRIPTION
... and possible future use in the menu applet which currently only uses `.menu-category-button-selected` style for hover. (the pseudo class `hover` for category buttons is only for use when the 'activate categories on click' menu option is set.)

This also works well as a reasonable fallback style in all other light & dark themes I have tested as it will add to the style of `.menu-category-button` in themes where `.menu-category-button:hover` is not defined. This fallback style works because `.menu-category-button:hover` has a higher specificity than `.menu-category-button`

Note: this change only currently affects Cinnamenu applet. See https://github.com/linuxmint/cinnamon/issues/10935#issuecomment-1196301388 for more details.