### PR TITLE
Stop using CinnamonScreen everywhere.

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -884,8 +884,8 @@ class AppGroup {
                 this.groupState.lastFocused.unminimize();
             }
             let ws = this.groupState.lastFocused.get_workspace().index();
-            if (ws !== global.screen.get_active_workspace_index()) {
-                global.screen.get_workspace_by_index(ws).activate(global.get_current_time());
+            if (ws !== global.workspace_manager.get_active_workspace_index()) {
+                global.workspace_manager.get_workspace_by_index(ws).activate(global.get_current_time());
             }
             Main.activateWindow(this.groupState.lastFocused, global.get_current_time());
             this.actor.add_style_pseudo_class('focus');

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appList.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appList.js
@@ -50,7 +50,7 @@ class AppList {
         this.lastFocusedApp = null;
 
         // Connect all the signals
-        this.signals.connect(global.screen, 'window-workspace-changed', (...args) => this.windowWorkspaceChanged(...args));
+        this.signals.connect(global.display, 'window-workspace-changed', (...args) => this.windowWorkspaceChanged(...args));
         // Ugly change: refresh the removed app instances from all workspaces
         this.signals.connect(this.metaWorkspace, 'window-removed', (...args) => this.windowRemoved(...args));
         this.signals.connect(global.window_manager, 'switch-workspace' , (...args) => this.reloadList(...args));
@@ -235,7 +235,7 @@ class AppList {
         && this.state.monitorWatchList.indexOf(metaWindow.get_monitor()) > -1;
     }
 
-    windowWorkspaceChanged(screen, metaWorkspace, metaWindow) {
+    windowWorkspaceChanged(display, metaWorkspace, metaWindow) {
         this.windowAdded(metaWindow, metaWorkspace);
     }
 

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -189,7 +189,7 @@ class GroupedWindowListApplet extends Applet.Applet {
             instance_id,
             monitorWatchList: [],
             autoStartApps: [],
-            currentWs: global.screen.get_active_workspace_index(),
+            currentWs: global.workspace_manager.get_active_workspace_index(),
             panelEditMode: global.settings.get_boolean('panel-edit-mode'),
             menuOpen: false,
             dragging: {
@@ -293,10 +293,10 @@ class GroupedWindowListApplet extends Applet.Applet {
         this.signals.connect(this.actor, 'scroll-event', (c, e) => this.handleScroll(e));
         this.signals.connect(global, 'scale-changed', (...args) => this.onUIScaleChange(...args));
         this.signals.connect(global.window_manager, 'switch-workspace', (...args) => this.onSwitchWorkspace(...args));
-        this.signals.connect(global.screen, 'workspace-removed', (...args) => this.onWorkspaceRemoved(...args));
-        this.signals.connect(global.screen, 'window-monitor-changed', (...args) => this.onWindowMonitorChanged(...args));
+        this.signals.connect(global.workspace_manager, 'workspace-removed', (...args) => this.onWorkspaceRemoved(...args));
+        this.signals.connect(global.display, 'window-monitor-changed', (...args) => this.onWindowMonitorChanged(...args));
         this.signals.connect(Main.panelManager, 'monitors-changed', (...args) => this._onMonitorsChanged(...args));
-        this.signals.connect(global.screen, 'window-skip-taskbar-changed', (...args) => this.onWindowSkipTaskbarChanged(...args));
+        this.signals.connect(global.display, 'window-skip-taskbar-changed', (...args) => this.onWindowSkipTaskbarChanged(...args));
         this.signals.connect(global.display, 'window-marked-urgent', (...args) => this.updateAttentionState(...args));
         this.signals.connect(global.display, 'window-demands-attention', (...args) => this.updateAttentionState(...args));
         this.signals.connect(global.display, 'window-created', (...args) => this.onWindowCreated(...args));
@@ -446,7 +446,7 @@ class GroupedWindowListApplet extends Applet.Applet {
         return false;
     }
 
-    onWindowMonitorChanged(screen, metaWindow, metaWorkspace) {
+    onWindowMonitorChanged(display, metaWindow, metaWorkspace) {
         if (this.state.monitorWatchList.length !== this.numberOfMonitors) {
             let appList = this.getCurrentAppList();
             if (appList !== null) {
@@ -935,7 +935,7 @@ class GroupedWindowListApplet extends Applet.Applet {
         return true;
     }
 
-    onWorkspaceRemoved(metaScreen, index) {
+    onWorkspaceRemoved(workspaceManager, index) {
         if (this.appLists.length <= index) {
             return;
         }
@@ -955,7 +955,7 @@ class GroupedWindowListApplet extends Applet.Applet {
         for (let i = removedLists.length - 1; i >= 0; i--) {
             this.appLists.splice(removedLists[i], 1);
         }
-        this.state.set({currentWs: global.screen.get_active_workspace_index()});
+        this.state.set({currentWs: global.workspace_manager.get_active_workspace_index()});
     }
 
     onSwitchWorkspace() {
@@ -965,7 +965,7 @@ class GroupedWindowListApplet extends Applet.Applet {
     _onSwitchWorkspace() {
         if (!this.state) return;
         this.state.set({currentWs: global.workspace_manager.get_active_workspace_index()});
-        let metaWorkspace = global.screen.get_workspace_by_index(this.state.currentWs);
+        let metaWorkspace = global.workspace_manager.get_workspace_by_index(this.state.currentWs);
 
         // If the workspace we switched to isn't in our list,
         // we need to create an AppList for it
@@ -990,7 +990,7 @@ class GroupedWindowListApplet extends Applet.Applet {
         this.actor.queue_relayout();
     }
 
-    onWindowSkipTaskbarChanged(screen, metaWindow) {
+    onWindowSkipTaskbarChanged(display, metaWindow) {
         let appList = this.getCurrentAppList();
 
         if (metaWindow.is_skip_taskbar()) {

--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -272,7 +272,7 @@ class AppMenuButton {
         this.drawLabel = false;
         this.labelVisiblePref = false;
         this._signals = new SignalManager.SignalManager();
-        this.xid = global.screen.get_xwindow_for_window(metaWindow);
+        this.xid = metaWindow.get_xwindow();
         this._flashTimer = null;
 
         if (this._applet.orientation == St.Side.TOP)
@@ -1057,9 +1057,9 @@ class CinnamonWindowListApplet extends Applet.Applet {
         this.settings.bind("last-window-order", "lastWindowOrder", null);
 
         this.signals.connect(global.display, 'window-created', this._onWindowAddedAsync, this);
-        this.signals.connect(global.screen, 'window-monitor-changed', this._onWindowMonitorChanged, this);
-        this.signals.connect(global.screen, 'window-workspace-changed', this._onWindowWorkspaceChanged, this);
-        this.signals.connect(global.screen, 'window-skip-taskbar-changed', this._onWindowSkipTaskbarChanged, this);
+        this.signals.connect(global.display, 'window-monitor-changed', this._onWindowMonitorChanged, this);
+        this.signals.connect(global.display, 'window-workspace-changed', this._onWindowWorkspaceChanged, this);
+        this.signals.connect(global.display, 'window-skip-taskbar-changed', this._onWindowSkipTaskbarChanged, this);
         this.signals.connect(Main.panelManager, 'monitors-changed', this._updateWatchedMonitors, this);
         this.signals.connect(global.window_manager, 'switch-workspace', this._refreshAllItems, this);
         this.signals.connect(Cinnamon.WindowTracker.get_default(), "window-app-changed", this._onWindowAppChanged, this);
@@ -1157,16 +1157,16 @@ class CinnamonWindowListApplet extends Applet.Applet {
         this.manager.set_spacing(spacing * global.ui_scale);
     }
 
-    _onWindowAddedAsync(screen, metaWindow, monitor) {
-        Mainloop.timeout_add(20, Lang.bind(this, this._onWindowAdded, screen, metaWindow, monitor));
+    _onWindowAddedAsync(display, metaWindow, monitor) {
+        Mainloop.timeout_add(20, Lang.bind(this, this._onWindowAdded, display, metaWindow, monitor));
     }
 
-    _onWindowAdded(screen, metaWindow, monitor) {
+    _onWindowAdded(display, metaWindow, monitor) {
         if (this._shouldAdd(metaWindow))
             this._addWindow(metaWindow, false);
     }
 
-    _onWindowMonitorChanged(screen, metaWindow, monitor) {
+    _onWindowMonitorChanged(display, metaWindow, monitor) {
         if (this._shouldAdd(metaWindow))
             this._addWindow(metaWindow, false);
         else
@@ -1180,7 +1180,7 @@ class CinnamonWindowListApplet extends Applet.Applet {
             this._refreshItem(window);
     }
 
-    _onWindowWorkspaceChanged(screen, metaWindow, metaWorkspace) {
+    _onWindowWorkspaceChanged(display, metaWindow, metaWorkspace) {
         this._refreshItemByMetaWindow(metaWindow);
     }
 
@@ -1188,13 +1188,13 @@ class CinnamonWindowListApplet extends Applet.Applet {
         this._refreshItemByMetaWindow(metaWindow);
     }
 
-    _onWindowSkipTaskbarChanged(screen, metaWindow) {
+    _onWindowSkipTaskbarChanged(display, metaWindow) {
         if (metaWindow && metaWindow.is_skip_taskbar()) {
             this._removeWindow(metaWindow);
             return;
         }
 
-        this._onWindowAdded(screen, metaWindow, 0);
+        this._onWindowAdded(display, metaWindow, 0);
     }
 
     _updateAttentionGrabber() {

--- a/files/usr/share/cinnamon/applets/windows-quick-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/windows-quick-list@cinnamon.org/applet.js
@@ -62,10 +62,10 @@ class CinnamonWindowsQuickListApplet extends Applet.IconApplet {
         let empty_menu = true;
         let tracker = Cinnamon.WindowTracker.get_default();
 
-        for (let wks = 0; wks < global.screen.n_workspaces; ++wks) {
+        for (let wks = 0; wks < global.workspace_manager.n_workspaces; ++wks) {
             // construct a list with all windows
             let workspace_name = Main.getWorkspaceName(wks);
-            let metaWorkspace = global.screen.get_workspace_by_index(wks);
+            let metaWorkspace = global.workspace_manager.get_workspace_by_index(wks);
             let windows = metaWorkspace.list_windows();
             let sticky_windows = windows.filter(function(w) {
                 return !w.is_skip_taskbar() && w.is_on_all_workspaces();
@@ -103,12 +103,12 @@ class CinnamonWindowsQuickListApplet extends Applet.IconApplet {
                 if (wks > 0) {
                     this._addItem(new PopupMenu.PopupSeparatorMenuItem());
                 }
-                if (global.screen.n_workspaces > 1) {
+                if (global.workspace_manager.n_workspaces > 1) {
                     let item = new WindowMenuItem(null, workspace_name);
                     item.actor.reactive = false;
                     item.actor.can_focus = false;
                     item.label.add_style_class_name('popup-subtitle-menu-item');
-                    if (wks == global.screen.get_active_workspace().index()) {
+                    if (wks == global.workspace_manager.get_active_workspace().index()) {
                         item.setShowDot(true);
                     }
                     this._addItem(item);

--- a/js/misc/signalManager.js
+++ b/js/misc/signalManager.js
@@ -54,7 +54,7 @@ const _disconnect = function(results) {
  * Every Javascript object should have its own @SignalManager, and use it to
  * connect signals of all objects it takes care of. For example, the panel will
  * have one #SignalManger object, which manages all signals from #GSettings,
- * `global.screen` etc.
+ * `global.display` etc.
  *
  * An example usage is as follows:
  * ```

--- a/js/ui/appSwitcher/appSwitcher.js
+++ b/js/ui/appSwitcher/appSwitcher.js
@@ -77,14 +77,14 @@ function getWindowsForBinding(binding) {
             windows = windows.filter( matchWmClass, focused.get_wm_class() );
             this._showAllWorkspaces = global.settings.get_boolean("alttab-switcher-show-all-workspaces");
             if (!this._showAllWorkspaces) {
-                windows = windows.filter( matchWorkspace, global.screen.get_active_workspace() );
+                windows = windows.filter( matchWorkspace, global.workspace_manager.get_active_workspace() );
             }
             break;
         default:
             // Switch between windows of current workspace
             this._showAllWorkspaces = global.settings.get_boolean("alttab-switcher-show-all-workspaces");
             if (!this._showAllWorkspaces) {
-                windows = windows.filter( matchWorkspace, global.screen.get_active_workspace() );
+                windows = windows.filter( matchWorkspace, global.workspace_manager.get_active_workspace() );
             }
             break;
     }
@@ -378,10 +378,10 @@ AppSwitcher.prototype = {
     },
 
     _switchWorkspace: function(direction) {
-        if (global.screen.n_workspaces < 2)
+        if (global.workspace_manager.n_workspaces < 2)
             return false;
 
-        let current = global.screen.get_active_workspace_index();
+        let current = global.workspace_manager.get_active_workspace_index();
 
         if (direction === Clutter.KEY_Left)
             Main.wm.actionMoveWorkspaceLeft();
@@ -390,10 +390,10 @@ AppSwitcher.prototype = {
         else
             return false;
 
-        if (current === global.screen.get_active_workspace_index())
+        if (current === global.workspace_manager.get_active_workspace_index())
             return false;
 
-        let workspace = global.screen.get_active_workspace();
+        let workspace = global.workspace_manager.get_active_workspace();
         this._onWorkspaceSelected(workspace);
         return true;
     },

--- a/js/ui/appSwitcher/appSwitcher3D.js
+++ b/js/ui/appSwitcher/appSwitcher3D.js
@@ -89,7 +89,7 @@ AppSwitcher3D.prototype = {
         let monitor = this._activeMonitor;
         
         // preview windows
-        let currentWorkspace = global.screen.get_active_workspace();
+        let currentWorkspace = global.workspace_manager.get_active_workspace();
         for (let i in this._previews) {
             let preview = this._previews[i];
             let metaWin = this._windows[i];
@@ -176,7 +176,7 @@ AppSwitcher3D.prototype = {
 
     _createList: function() {
         let monitor = this._activeMonitor;
-        let currentWorkspace = global.screen.get_active_workspace();
+        let currentWorkspace = global.workspace_manager.get_active_workspace();
         
         this._previews = [];
         
@@ -316,7 +316,7 @@ AppSwitcher3D.prototype = {
     },
     
     _enableMonitorFix: function() {
-        if(global.screen.get_n_monitors() < 2)
+        if(global.display.get_n_monitors() < 2)
             return;
         
         this._monitorFix = true;

--- a/js/ui/appSwitcher/classicSwitcher.js
+++ b/js/ui/appSwitcher/classicSwitcher.js
@@ -759,7 +759,7 @@ AppList.prototype = {
         SwitcherList.prototype._init.call(this, true, activeMonitor);
 
         // Construct the AppIcons, add to the popup
-        let activeWorkspace = global.screen.get_active_workspace();
+        let activeWorkspace = global.workspace_manager.get_active_workspace();
         let workspaceIcons = [];
         let otherIcons = [];
         for (let i = 0; i < windows.length; i++) {
@@ -899,7 +899,7 @@ ThumbnailList.prototype = {
     _init : function(windows, activeMonitor) {
         SwitcherList.prototype._init.call(this, false, activeMonitor);
 
-        let activeWorkspace = global.screen.get_active_workspace();
+        let activeWorkspace = global.workspace_manager.get_active_workspace();
 
         this._labels = new Array();
         this._thumbnailBins = new Array();

--- a/js/ui/deskletManager.js
+++ b/js/ui/deskletManager.js
@@ -105,7 +105,7 @@ function updateMouseTracking() {
 }
 
 function hasMouseWindow(){
-    let window = global.screen.get_mouse_window(null);
+    let window = global.display.get_pointer_window(null);
     return window && window.window_type !== Meta.WindowType.DESKTOP;
 }
 

--- a/js/ui/expoThumbnail.js
+++ b/js/ui/expoThumbnail.js
@@ -652,12 +652,12 @@ ExpoWorkspaceThumbnail.prototype = {
         this.doRemoveWindow(metaWin);
     },
 
-    windowEnteredMonitor : function(metaScreen, monitorIndex, metaWin) {
+    windowEnteredMonitor : function(metaDisplay, monitorIndex, metaWin) {
         // important if workspaces-only-on-primary is in effect
         this.doAddWindow(metaWin);
     },
 
-    windowLeftMonitor : function(metaScreen, monitorIndex, metaWin) {
+    windowLeftMonitor : function(metaDisplay, monitorIndex, metaWin) {
         // important if workspaces-only-on-primary is in effect
         this.doRemoveWindow(metaWin);
     },
@@ -1144,7 +1144,7 @@ ExpoThumbnailsBox.prototype = {
             global.window_manager.connect('switch-workspace',
                                           Lang.bind(this, this.activeWorkspaceChanged));
 
-        this.workspaceAddedId = global.workspace_manager.connect('workspace-added', Lang.bind(this, function(screen, index) {
+        this.workspaceAddedId = global.workspace_manager.connect('workspace-added', Lang.bind(this, function(ws_manager, index) {
             this.addThumbnails(index, 1);
         }));
         this.workspaceRemovedId = global.workspace_manager.connect('workspace-removed', Lang.bind(this, function() {

--- a/js/ui/hotCorner.js
+++ b/js/ui/hotCorner.js
@@ -245,7 +245,7 @@ class HotCorner {
                     Main.overview.toggle();
                 break;
             case 'desktop':
-                global.screen.toggle_desktop(timestamp);
+                global.workspace_manager.toggle_desktop(timestamp);
                 break;
             default:
                 Util.spawnCommandLine(this.action);

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -48,7 +48,7 @@ Monitor.prototype = {
     },
 
     get inFullscreen() {
-        return global.screen.get_monitor_in_fullscreen(this.index);
+        return global.display.get_monitor_in_fullscreen(this.index);
     }
 };
 
@@ -230,7 +230,7 @@ LayoutManager.prototype = {
     },
 
     get currentMonitor() {
-        let index = global.screen.get_current_monitor();
+        let index = global.display.get_current_monitor();
         return Main.layoutManager.monitors[index];
     },
 
@@ -488,13 +488,13 @@ Chrome.prototype = {
 
         this._layoutManager.connect('monitors-changed',
                                     Lang.bind(this, this._relayout));
-        global.screen.connect('restacked',
+        global.display.connect('restacked',
                               Lang.bind(this, this._windowsRestacked));
-        global.screen.connect('in-fullscreen-changed', Lang.bind(this, this._updateVisibility));
+        global.display.connect('in-fullscreen-changed', Lang.bind(this, this._updateVisibility));
         global.window_manager.connect('switch-workspace', Lang.bind(this, this._queueUpdateRegions));
 
         // Need to update struts on new workspaces when they are added
-        global.screen.connect('notify::n-workspaces',
+        global.workspace_manager.connect('notify::n-workspaces',
                               Lang.bind(this, this._queueUpdateRegions));
 
         this._relayout();
@@ -635,7 +635,7 @@ Chrome.prototype = {
             else if (global.stage_input_mode == Cinnamon.StageInputMode.FULLSCREEN) {
                 let monitor = this.findMonitorForActor(actorData.actor);
 
-                if (global.screen.get_n_monitors() == 1 || !monitor.inFullscreen) {
+                if (global.display.get_n_monitors() == 1 || !monitor.inFullscreen) {
                     visible = true;
                 } else {
                     if (Main.modalActorFocusStack.length > 0) {
@@ -863,9 +863,9 @@ Chrome.prototype = {
 
         global.set_stage_input_region(rects);
 
-        let screen = global.screen;
-        for (let w = 0; w < screen.n_workspaces; w++) {
-            let workspace = screen.get_workspace_by_index(w);
+        let ws_manager = global.workspace_manager;
+        for (let w = 0; w < ws_manager.n_workspaces; w++) {
+            let workspace = ws_manager.get_workspace_by_index(w);
             workspace.set_builtin_struts(struts);
         }
 

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -227,7 +227,7 @@ function _addXletDirectoriesToSearchPath() {
 }
 
 function _initUserSession() {
-    global.screen.override_workspace_layout(Meta.DisplayCorner.TOPLEFT, false, 1, -1);
+    global.workspace_manager.override_workspace_layout(Meta.DisplayCorner.TOPLEFT, false, 1, -1);
 
     systrayManager = new Systray.SystrayManager();
 
@@ -570,7 +570,7 @@ function _fillWorkspaceNames(index) {
 }
 
 function _shouldTrimWorkspace(i) {
-    return i >= 0 && (i >= global.screen.n_workspaces || !workspace_names[i].length);
+    return i >= 0 && (i >= global.workspace_manager.n_workspaces || !workspace_names[i].length);
 }
 
 function _trimWorkspaceNames() {
@@ -636,12 +636,12 @@ function hasDefaultWorkspaceName(index) {
 }
 
 function _addWorkspace() {
-    global.screen.append_new_workspace(false, global.get_current_time());
+    global.workspace_manager.append_new_workspace(false, global.get_current_time());
     return true;
 }
 
 function _removeWorkspace(workspace) {
-    if (global.screen.n_workspaces == 1)
+    if (global.workspace_manager.n_workspaces == 1)
         return false;
     let index = workspace.index();
     if (index < workspace_names.length) {
@@ -649,7 +649,7 @@ function _removeWorkspace(workspace) {
     }
     _trimWorkspaceNames();
     wmSettings.set_strv("workspace-names", workspace_names);
-    global.screen.remove_workspace(workspace, global.get_current_time());
+    global.workspace_manager.remove_workspace(workspace, global.get_current_time());
     return true;
 }
 
@@ -666,16 +666,16 @@ function _removeWorkspace(workspace) {
  */
 function moveWindowToNewWorkspace(metaWindow, switchToNewWorkspace) {
     if (switchToNewWorkspace) {
-        let targetCount = global.screen.n_workspaces + 1;
-        let nnwId = global.screen.connect('notify::n-workspaces', function() {
-            global.screen.disconnect(nnwId);
-            if (global.screen.n_workspaces === targetCount) {
-                let newWs = global.screen.get_workspace_by_index(global.screen.n_workspaces - 1);
+        let targetCount = global.workspace_manager.n_workspaces + 1;
+        let nnwId = global.workspace_manager.connect('notify::n-workspaces', function() {
+            global.workspace_manager.disconnect(nnwId);
+            if (global.workspace_manager.n_workspaces === targetCount) {
+                let newWs = global.workspace_manager.get_workspace_by_index(global.workspace_manager.n_workspaces - 1);
                 newWs.activate(global.get_current_time());
             }
         });
     }
-    metaWindow.change_workspace_by_index(global.screen.n_workspaces, true, global.get_current_time());
+    metaWindow.change_workspace_by_index(global.workspace_manager.n_workspaces, true, global.get_current_time());
 }
 
 /**
@@ -1320,13 +1320,13 @@ function getRunDialog() {
  * activation will be handled in muffin.
  */
 function activateWindow(window, time, workspaceNum) {
-    let activeWorkspaceNum = global.screen.get_active_workspace_index();
+    let activeWorkspaceNum = global.workspace_manager.get_active_workspace_index();
 
     if (!time)
         time = global.get_current_time();
 
     if ((workspaceNum !== undefined) && activeWorkspaceNum !== workspaceNum) {
-        let workspace = global.screen.get_workspace_by_index(workspaceNum);
+        let workspace = global.workspace_manager.get_workspace_by_index(workspaceNum);
         workspace.activate_with_focus(window, time);
         return;
     }
@@ -1489,8 +1489,7 @@ function isInteresting(metaWindow) {
 
 /**
  * getTabList:
- * @workspaceOpt (Meta.Workspace): (optional) workspace, defaults to global.screen.get_active_workspace()
- * @screenOpt (Meta.Screen): (optional) screen, defaults to global.screen
+ * @workspaceOpt (Meta.Workspace): (optional) workspace, defaults to global.workspace_manager.get_active_workspace()
  *
  * Return a list of the interesting windows on a workspace (by default,
  * the active workspace).
@@ -1498,14 +1497,12 @@ function isInteresting(metaWindow) {
  *
  * Returns (array): list of windows
  */
-function getTabList(workspaceOpt, screenOpt) {
-    let screen = screenOpt || global.screen;
-    let display = screen.get_display();
-    let workspace = workspaceOpt || screen.get_active_workspace();
+function getTabList(workspaceOpt) {
+    let workspace = workspaceOpt || global.workspace_manager.get_active_workspace();
 
     let windows = []; // the array to return
 
-    let allwindows = display.get_tab_list(Meta.TabList.NORMAL_ALL, workspace);
+    let allwindows = global.display.get_tab_list(Meta.TabList.NORMAL_ALL, workspace);
     let registry = {}; // to avoid duplicates
 
     for (let i = 0; i < allwindows.length; ++i) {

--- a/js/ui/osdWindow.js
+++ b/js/ui/osdWindow.js
@@ -145,7 +145,7 @@ OsdWindow.prototype = {
             return;
 
         if (!this.actor.visible) {
-            Meta.disable_unredirect_for_screen(global.screen);
+            Meta.disable_unredirect_for_display(global.display);
             this._level.setLevelBarHeight(this._sizeMultiplier);
             this.actor.show();
             this.actor.opacity = 0;

--- a/js/ui/overview.js
+++ b/js/ui/overview.js
@@ -276,7 +276,7 @@ Overview.prototype = {
         this._coverPane.hide();
 
         // Disable unredirection while in the overview
-        Meta.disable_unredirect_for_screen(global.screen);
+        Meta.disable_unredirect_for_display(global.display);
         this._group.show();
 
         this.workspacesView = new WorkspacesView.WorkspacesView();

--- a/js/ui/virtualKeyboard.js
+++ b/js/ui/virtualKeyboard.js
@@ -488,7 +488,7 @@ Keyboard.prototype = {
     },
 
     _moveTemporarily: function () {
-        let currentWindow = global.screen.get_display().focus_window;
+        let currentWindow = global.display.focus_window;
         let rect = currentWindow.get_outer_rect();
 
         let newX = rect.x;

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -1235,7 +1235,7 @@ var WindowManager = class WindowManager {
     showWorkspaceOSD() {
         this._hideWorkspaceOSD(true);
         if (global.settings.get_boolean('workspace-osd-visible')) {
-            let current_workspace_index = global.screen.get_active_workspace_index();
+            let current_workspace_index = global.workspace_manager.get_active_workspace_index();
             if (this.wm_settings.get_boolean('workspaces-only-on-primary')) {
                 this._showWorkspaceOSDOnMonitor(Main.layoutManager.primaryMonitor.index, current_workspace_index);
             }
@@ -1311,8 +1311,8 @@ var WindowManager = class WindowManager {
             return;
         }
         this._movingWindow = window;
-        let workspace = global.screen.get_active_workspace().get_neighbor(direction);
-        if (workspace != global.screen.get_active_workspace()) {
+        let workspace = global.workspace_manager.get_active_workspace().get_neighbor(direction);
+        if (workspace != global.workspace_manager.get_active_workspace()) {
             window.change_workspace(workspace);
             workspace.activate_with_focus(window, global.get_current_time());
         }
@@ -1327,7 +1327,7 @@ var WindowManager = class WindowManager {
     }
 
     moveToWorkspace(workspace, direction_hint) {
-        let active = global.screen.get_active_workspace();
+        let active = global.workspace_manager.get_active_workspace();
         // if (workspace != active) {
             // if (direction_hint)
                 // workspace.activate_with_direction_hint(direction_hint, global.get_current_time());
@@ -1347,7 +1347,7 @@ var WindowManager = class WindowManager {
             return;
         }
 
-        if (global.screen.n_workspaces === 1)
+        if (global.workspace_manager.n_workspaces === 1)
             return;
 
         if (bindingName === 'switch-to-workspace-left') {
@@ -1358,7 +1358,7 @@ var WindowManager = class WindowManager {
     }
 
     actionMoveWorkspaceLeft() {
-        let active = global.screen.get_active_workspace();
+        let active = global.workspace_manager.get_active_workspace();
         let neighbor = active.get_neighbor(Meta.MotionDirection.LEFT)
         if (active != neighbor) {
             this.moveToWorkspace(neighbor, Meta.MotionDirection.LEFT);
@@ -1366,7 +1366,7 @@ var WindowManager = class WindowManager {
     }
 
     actionMoveWorkspaceRight() {
-        let active = global.screen.get_active_workspace();
+        let active = global.workspace_manager.get_active_workspace();
         let neighbor = active.get_neighbor(Meta.MotionDirection.RIGHT)
         if (active != neighbor) {
             this.moveToWorkspace(neighbor, Meta.MotionDirection.RIGHT);
@@ -1374,15 +1374,15 @@ var WindowManager = class WindowManager {
     }
 
     actionMoveWorkspaceUp() {
-        global.screen.get_active_workspace().get_neighbor(Meta.MotionDirection.UP).activate(global.get_current_time());
+        global.workspace_manager.get_active_workspace().get_neighbor(Meta.MotionDirection.UP).activate(global.get_current_time());
     }
 
     actionMoveWorkspaceDown() {
-        global.screen.get_active_workspace().get_neighbor(Meta.MotionDirection.DOWN).activate(global.get_current_time());
+        global.workspace_manager.get_active_workspace().get_neighbor(Meta.MotionDirection.DOWN).activate(global.get_current_time());
     }
 
     actionFlipWorkspaceLeft() {
-        let active = global.screen.get_active_workspace();
+        let active = global.workspace_manager.get_active_workspace();
         let neighbor = active.get_neighbor(Meta.MotionDirection.LEFT);
         if (active != neighbor) {
             neighbor.activate(global.get_current_time());
@@ -1392,7 +1392,7 @@ var WindowManager = class WindowManager {
     }
 
     actionFlipWorkspaceRight() {
-        let active = global.screen.get_active_workspace();
+        let active = global.workspace_manager.get_active_workspace();
         let neighbor = active.get_neighbor(Meta.MotionDirection.RIGHT);
         if (active != neighbor) {
             neighbor.activate(global.get_current_time());

--- a/js/ui/wmGtkDialogs.js
+++ b/js/ui/wmGtkDialogs.js
@@ -73,7 +73,7 @@ var CloseDialog = GObject.registerClass({
             this.proc = Gio.Subprocess.new(
                 [
                 "cinnamon-close-dialog",
-                 global.screen.get_xwindow_for_window(this._window).toString(),
+                 this._window.get_xwindow().toString(),
                  this._window.get_title()
                 ],
                 0);

--- a/js/ui/workspace.js
+++ b/js/ui/workspace.js
@@ -545,9 +545,9 @@ WorkspaceMonitor.prototype = {
             this._windowRemovedId = this.metaWorkspace.connect('window-removed',
                                                   this._windowRemoved.bind(this));
         }
-        this._windowEnteredMonitorId = global.screen.connect('window-entered-monitor',
+        this._windowEnteredMonitorId = global.display.connect('window-entered-monitor',
                                               this._windowEnteredMonitor.bind(this));
-        this._windowLeftMonitorId = global.screen.connect('window-left-monitor',
+        this._windowLeftMonitorId = global.display.connect('window-left-monitor',
                                               this._windowLeftMonitor.bind(this));
 
         this._animating = false; // Indicate if windows are being repositioned
@@ -715,7 +715,7 @@ WorkspaceMonitor.prototype = {
         // Start the animations
         let slots = this._computeAllWindowSlots(clones.length);
 
-        let currentWorkspace = global.screen.get_active_workspace();
+        let currentWorkspace = global.workspace_manager.get_active_workspace();
         let isOnCurrentWorkspace = this.metaWorkspace == null || this.metaWorkspace == currentWorkspace;
 
         if (clones.length > 0 && animate && isOnCurrentWorkspace) {
@@ -830,7 +830,7 @@ WorkspaceMonitor.prototype = {
     },
 
     _showAllOverlays: function() {
-        let currentWorkspace = global.screen.get_active_workspace();
+        let currentWorkspace = global.workspace_manager.get_active_workspace();
         let fade = this.metaWorkspace == null || this.metaWorkspace === currentWorkspace;
         for (let clone of this._windows) {
             this._showWindowOverlay(clone, fade);
@@ -945,13 +945,13 @@ WorkspaceMonitor.prototype = {
         this._doRemoveWindow(metaWin);
     },
 
-    _windowEnteredMonitor : function(metaScreen, monitorIndex, metaWin) {
+    _windowEnteredMonitor : function(metaDisplay, monitorIndex, metaWin) {
         if (monitorIndex === this.monitorIndex) {
             this._doAddWindow(metaWin);
         }
     },
 
-    _windowLeftMonitor : function(metaScreen, monitorIndex, metaWin) {
+    _windowLeftMonitor : function(metaDisplay, monitorIndex, metaWin) {
         if (monitorIndex === this.monitorIndex) {
             this._doRemoveWindow(metaWin);
         }
@@ -983,7 +983,7 @@ WorkspaceMonitor.prototype = {
 
     // Animates the return from Overview mode
     zoomFromOverview : function() {
-        let currentWorkspace = global.screen.get_active_workspace();
+        let currentWorkspace = global.workspace_manager.get_active_workspace();
 
         this.leavingOverview = true;
 
@@ -1053,8 +1053,8 @@ WorkspaceMonitor.prototype = {
             this.metaWorkspace.disconnect(this._windowAddedId);
             this.metaWorkspace.disconnect(this._windowRemovedId);
         }
-        global.screen.disconnect(this._windowEnteredMonitorId);
-        global.screen.disconnect(this._windowLeftMonitorId);
+        global.display.disconnect(this._windowEnteredMonitorId);
+        global.display.disconnect(this._windowLeftMonitorId);
 
         // Usually, the windows will be destroyed automatically with
         // their parent (this.actor), but we might have a zoomed window

--- a/src/cinnamon-global.c
+++ b/src/cinnamon-global.c
@@ -1426,7 +1426,7 @@ cinnamon_global_create_app_launch_context (CinnamonGlobal *global)
 
   // Make sure that the app is opened on the current workspace even if
   // the user switches before it starts
-  gdk_app_launch_context_set_desktop (context, cinnamon_screen_get_active_workspace_index (global->cinnamon_screen));
+  gdk_app_launch_context_set_desktop (context, meta_workspace_manager_get_active_workspace_index (global->workspace_manager));
 
   return (GAppLaunchContext *)context;
 }


### PR DESCRIPTION
CinnamonScreen exists only for compatibility, as MetaScreen went away in 5.4.

Quite a bit had already been ported, but this gets rid of the remaining users.

CinnamonScreen itself still remains for xlets (though they should consider doing this eventually as well).