### PR TITLE
Fix super+shift+number not disabling in grouped-window-list applet

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -459,11 +459,11 @@ class GroupedWindowListApplet extends Applet.Applet {
     bindAppKeys() {
         this.unbindAppKeys();
 
-        for (let i = 1; i < 10; i++) {
-            if (this.state.settings.SuperNumHotkeys) {
+        if (this.state.settings.SuperNumHotkeys) {
+            for (let i = 1; i < 10; i++) {
                 this.bindAppKey(i);
+                this.bindNewAppKey(i);
             }
-            this.bindNewAppKey(i);
         }
         Main.keybindingManager.addHotKey('launch-show-apps-order', this.state.settings.showAppsOrderHotkey, () =>
             this.showAppsOrder()


### PR DESCRIPTION
- Setting the value of the applet settings parameter 'super-num-hotkeys' to false should now avoid registering the super+shift+number app launcher keybinds whereas it previously it only avoided registering super+number keybinds
- These changes should fix the unexpected behavior reported in #11393.
- You can read a further explanation of the issue below originally from my comment on the original issue.
> I erroneously reported this same error in the cinnamon applets repository a short while ago ([cinnamon-spices-applets#4634](https://github.com/linuxmint/cinnamon-spices-applets/issues/4634)). This also seems related to #10811 #9560. 
> 
> In my case, while it does seem to disable the `Super+<num>` keybinds when the settings value `super-num-hotkeys` is set to false it does not also disable the `Super+Shift+<num>` keybinds. The culprit appears to be this section of code: https://github.com/linuxmint/cinnamon/blob/eafc411664c28af8cb9bfc447b00b8e219b97f25/files/usr/share/cinnamon/applets/grouped-window-list%40cinnamon.org/applet.js#L460-L465
> 
> As you can see, it will still call the `bindNewAppKey` function even if the `SuperNumHotKeys` setting value is false. I will submit a pull request shortly, hopefully fixing the issue. I would also like to find out if this is actually the desired end behavior, since I am not sure how the author (@art-vasilyev) would have unintentionally excluded this call from the condition block when it was added in 9e57733fd880be86ebac61ee3fe2205acf21e09e. If this is the desired behavior we will have to add another toggle specifically for the `Super+Shift+<num>` keybinds to avoid them being overridden.
> 
> I can only speculate as to why this behavior only started occurring a couple of months ago. I assume some update within the Cinnamon DE made it so that applets register their keybindings prior to keybindings set in the global Cinnamon keyboard layout section. This would explain why disabling and re-enabling the `super-num-hotkeys` setting temporarily fixes the problem since doing that unbinds and attempts to rebind all the hotkeys; reverting them to the values set in the global keyboard settings.
> 
> _Originally posted by @t3pfaffe in https://github.com/linuxmint/cinnamon/issues/11393#issuecomment-1411117279_
