### PR TITLE
cs_themes: load theme thumbnail from XDG_DATA_DIRS

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
@@ -319,10 +319,10 @@ class Module:
                 chooser.set_picture_from_file(path)
         else:
             try:
-                for path in ["/usr/share/%s/%s/%s/thumbnail.png" % (path_prefix, theme, path_suffix),
-                             os.path.expanduser("~/.%s/%s/%s/thumbnail.png" % (path_prefix, theme, path_suffix)),
+                for path in ([os.path.join(datadir, path_prefix, theme, path_suffix, "thumbnail.png") for datadir in GLib.get_system_data_dirs()]
+                             + [os.path.expanduser("~/.%s/%s/%s/thumbnail.png" % (path_prefix, theme, path_suffix)),
                              "/usr/share/cinnamon/thumbnails/%s/%s.png" % (path_suffix, theme),
-                             "/usr/share/cinnamon/thumbnails/%s/unknown.png" % path_suffix]:
+                             "/usr/share/cinnamon/thumbnails/%s/unknown.png" % path_suffix]):
                     if os.path.exists(path):
                         chooser.set_picture_from_file(path)
                         break


### PR DESCRIPTION
On NixOS themes are installed in `/run/current-system/sw/share/{icons,themes}`

This makes theme thumbnail missing on NixOS because we don't search those paths. Let's follow https://freedesktop.org/wiki/DesktopThemeSpec/ and look for cursor themes and GTK themes in `XDG_DATA_DIRS`.

Screenshot on NixOS (cs_themes module - before changing any of the settings):

| Before | After |
|----|---|
| ![](https://user-images.githubusercontent.com/20080233/217859942-5b7b36c0-937d-470f-9f5c-d3834ba283f9.png) | ![](https://user-images.githubusercontent.com/20080233/217860243-6c130723-6329-44f0-a0ec-fb5a72bb7476.png) |



