### PR TITLE
workspace switcher applet: relayout when a new monitor is added or removed

### DIFF
--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
@@ -282,6 +282,8 @@ class CinnamonWorkspaceSwitcher extends Applet.Applet {
 
         this.actor.connect('scroll-event', this.hook.bind(this));
 
+        this.signals.connect(Main.layoutManager, 'monitors-changed', this.onWorkspacesUpdated, this);
+
         this.queueCreateButtons();
         global.workspace_manager.connect('notify::n-workspaces', () => { this.onWorkspacesUpdated() });
         global.workspace_manager.connect('workspaces-reordered', () => { this.onWorkspacesUpdated() });


### PR DESCRIPTION
When connecting a new monitor to the computer, the layout of the workspace-switcher applet would keep the same, now it will update whenever new monitors are added or removed.