### PR TITLE
docs: add images or videos section in the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,6 +29,10 @@ assignees: ''
 
 
 
+### Images or Videos, if applicable
+
+
+
 ### Other information
 
 


### PR DESCRIPTION
I suggest adding a section for users to add Images or Videos of the bug that is happening (when applicable) which may help debug and reproduce the error or bug.