### PR TITLE
cs_themes: Add a simplified UI

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/appearance-dark.svg
+++ b/files/usr/share/cinnamon/cinnamon-settings/appearance-dark.svg
@@ -1,0 +1,318 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="112"
+   height="80"
+   id="svg4729"
+   version="1.1"
+   sodipodi:docname="appearance-dark.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1352"
+     id="namedview55"
+     showgrid="false"
+     inkscape:zoom="8"
+     inkscape:cx="24.5625"
+     inkscape:cy="24.25"
+     inkscape:window-x="2560"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4729"
+     inkscape:pagecheckerboard="0" />
+  <defs
+     id="defs4731">
+    <linearGradient
+       xlink:href="#linearGradient3924-4"
+       id="linearGradient9678"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6263817,0,0,0.43555485,351.27065,412.22031)"
+       x1="14.066927"
+       y1="6.6480942"
+       x2="14.066927"
+       y2="80.117599" />
+    <linearGradient
+       id="linearGradient3924-4">
+      <stop
+         id="stop3926-8"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0" />
+      <stop
+         offset="0.06316455"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         id="stop3928-5" />
+      <stop
+         id="stop3930-6-4"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         offset="0.95056331" />
+      <stop
+         id="stop3932-25"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         offset="1" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       id="filter1523"
+       x="-0.057365855"
+       width="1.1147317"
+       y="-0.29400001"
+       height="1.588">
+      <feGaussianBlur
+         stdDeviation="0.98"
+         id="feGaussianBlur1525" />
+    </filter>
+    <linearGradient
+       xlink:href="#linearGradient3924-4"
+       id="linearGradient1529"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6263817,0,0,0.43555485,57.05491,13.10443)"
+       x1="14.447668"
+       y1="6.6480026"
+       x2="14.447668"
+       y2="93.893044" />
+    <filter
+       height="1.0884571"
+       y="-0.044228551"
+       width="1.0607059"
+       x="-0.030352949"
+       id="filter4700"
+       style="color-interpolation-filters:sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur4702"
+         stdDeviation="0.6450012" />
+    </filter>
+    <filter
+       height="1.2063999"
+       y="-0.10319996"
+       width="1.1416471"
+       x="-0.070823553"
+       id="filter4733"
+       style="color-interpolation-filters:sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur4735"
+         stdDeviation="1.5050028" />
+    </filter>
+    <filter
+       height="1.2063999"
+       y="-0.10319996"
+       width="1.1416471"
+       x="-0.070823553"
+       id="filter4733-6"
+       style="color-interpolation-filters:sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur4735-2"
+         stdDeviation="1.5050028" />
+    </filter>
+    <filter
+       height="1.0884571"
+       y="-0.044228551"
+       width="1.0607059"
+       x="-0.030352949"
+       id="filter4700-6"
+       style="color-interpolation-filters:sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur4702-1"
+         stdDeviation="0.6450012" />
+    </filter>
+    <linearGradient
+       y2="80.117599"
+       x2="14.066927"
+       y1="6.6480942"
+       x1="14.066927"
+       gradientTransform="matrix(2.6263817,0,0,0.43555485,351.27065,412.22031)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4798"
+       xlink:href="#linearGradient3924-4" />
+    <filter
+       height="1.0441815"
+       y="-0.022090762"
+       width="1.052541"
+       x="-0.026270477"
+       id="filter4818"
+       style="color-interpolation-filters:sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur4820"
+         stdDeviation="0.4050032" />
+    </filter>
+    <filter
+       height="1.2063999"
+       y="-0.10319996"
+       width="1.1416471"
+       x="-0.070823553"
+       id="filter4733-6-3"
+       style="color-interpolation-filters:sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur4735-2-6"
+         stdDeviation="1.5050028" />
+    </filter>
+    <filter
+       height="1.0884571"
+       y="-0.044228551"
+       width="1.0607059"
+       x="-0.030352949"
+       id="filter4700-6-7"
+       style="color-interpolation-filters:sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur4702-1-5"
+         stdDeviation="0.6450012" />
+    </filter>
+    <filter
+       height="1.2063999"
+       y="-0.10319996"
+       width="1.1416471"
+       x="-0.070823553"
+       id="filter4733-60"
+       style="color-interpolation-filters:sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur4735-6"
+         stdDeviation="1.5050028" />
+    </filter>
+    <filter
+       height="1.0884571"
+       y="-0.044228551"
+       width="1.0607059"
+       x="-0.030352949"
+       id="filter4700-2"
+       style="color-interpolation-filters:sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur4702-6"
+         stdDeviation="0.6450012" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3924-4"
+       id="linearGradient5561"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6263817,0,0,0.43555485,351.27065,412.22031)"
+       x1="14.066927"
+       y1="6.6480942"
+       x2="14.066927"
+       y2="80.117599" />
+  </defs>
+  <metadata
+     id="metadata4734">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g4742"
+     transform="translate(-349.31939,-400.9566)">
+    <rect
+       ry="2"
+       rx="2"
+       y="415.61584"
+       x="364.71573"
+       height="35.00008"
+       width="51.00008"
+       id="rect1143-9-0"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.502164;marker:none;filter:url(#filter4733);enable-background:accumulate" />
+    <rect
+       transform="matrix(0.95291158,0,0,1,18.374644,0)"
+       ry="2"
+       rx="2"
+       y="414.61584"
+       x="364.71573"
+       height="35.00008"
+       width="51.00008"
+       id="rect1143-9"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.502164;marker:none;filter:url(#filter4700);enable-background:accumulate" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.975822;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.502164;marker:none;enable-background:accumulate"
+       id="rect4993-0-2"
+       width="50"
+       height="34"
+       x="365.21576"
+       y="414.11594"
+       rx="1.5"
+       ry="1.5" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.745;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect4993-0"
+       width="51.00008"
+       height="35.00008"
+       x="364.71573"
+       y="413.61588"
+       rx="2"
+       ry="2" />
+    <rect
+       style="opacity:0.15;fill:none;stroke:url(#linearGradient9678);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect6741"
+       y="414.61591"
+       x="365.71576"
+       ry="0.99999994"
+       rx="0.99999994"
+       height="33"
+       width="48.999996" />
+  </g>
+  <g
+     id="g4742-2"
+     transform="translate(-328.52272,-390.62684)">
+    <rect
+       ry="2"
+       rx="2"
+       y="415.61584"
+       x="364.71573"
+       height="35.00008"
+       width="51.00008"
+       id="rect1143-9-0-0"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.502164;marker:none;filter:url(#filter4733-60);enable-background:accumulate" />
+    <rect
+       transform="matrix(0.95291158,0,0,1,18.374644,0)"
+       ry="2"
+       rx="2"
+       y="414.61584"
+       x="364.71573"
+       height="35.00008"
+       width="51.00008"
+       id="rect1143-9-2"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.502164;marker:none;filter:url(#filter4700-2);enable-background:accumulate" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.975822;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.502164;marker:none;enable-background:accumulate"
+       id="rect4993-0-2-3"
+       width="50"
+       height="34"
+       x="365.21576"
+       y="414.11594"
+       rx="1.5"
+       ry="1.5" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.745;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect4993-0-7"
+       width="51.00008"
+       height="35.00008"
+       x="364.71573"
+       y="413.61588"
+       rx="2"
+       ry="2" />
+    <rect
+       style="opacity:0.15;fill:none;stroke:url(#linearGradient5561);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect6741-5"
+       y="414.61591"
+       x="365.71576"
+       ry="0.99999994"
+       rx="0.99999994"
+       height="33"
+       width="48.999996" />
+  </g>
+</svg>

--- a/files/usr/share/cinnamon/cinnamon-settings/appearance-light.svg
+++ b/files/usr/share/cinnamon/cinnamon-settings/appearance-light.svg
@@ -1,0 +1,318 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="112"
+   height="80"
+   id="svg4729"
+   version="1.1"
+   sodipodi:docname="appearance-light.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1352"
+     id="namedview55"
+     showgrid="false"
+     inkscape:zoom="11.313708"
+     inkscape:cx="23.997437"
+     inkscape:cy="72.831999"
+     inkscape:window-x="2560"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4729"
+     inkscape:pagecheckerboard="0" />
+  <defs
+     id="defs4731">
+    <linearGradient
+       xlink:href="#linearGradient3924-4"
+       id="linearGradient9678"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6263817,0,0,0.43555485,351.27065,412.22031)"
+       x1="14.066927"
+       y1="6.6480942"
+       x2="14.066927"
+       y2="80.117599" />
+    <linearGradient
+       id="linearGradient3924-4">
+      <stop
+         id="stop3926-8"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0" />
+      <stop
+         offset="0.06316455"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         id="stop3928-5" />
+      <stop
+         id="stop3930-6-4"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         offset="0.95056331" />
+      <stop
+         id="stop3932-25"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         offset="1" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       id="filter1523"
+       x="-0.057365855"
+       width="1.1147317"
+       y="-0.29400001"
+       height="1.588">
+      <feGaussianBlur
+         stdDeviation="0.98"
+         id="feGaussianBlur1525" />
+    </filter>
+    <linearGradient
+       xlink:href="#linearGradient3924-4"
+       id="linearGradient1529"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6263817,0,0,0.43555485,57.05491,13.10443)"
+       x1="14.447668"
+       y1="6.6480026"
+       x2="14.447668"
+       y2="93.893044" />
+    <filter
+       height="1.0884571"
+       y="-0.044228551"
+       width="1.0607059"
+       x="-0.030352949"
+       id="filter4700"
+       style="color-interpolation-filters:sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur4702"
+         stdDeviation="0.6450012" />
+    </filter>
+    <filter
+       height="1.2063999"
+       y="-0.10319996"
+       width="1.1416471"
+       x="-0.070823553"
+       id="filter4733"
+       style="color-interpolation-filters:sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur4735"
+         stdDeviation="1.5050028" />
+    </filter>
+    <filter
+       height="1.2063999"
+       y="-0.10319996"
+       width="1.1416471"
+       x="-0.070823553"
+       id="filter4733-6"
+       style="color-interpolation-filters:sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur4735-2"
+         stdDeviation="1.5050028" />
+    </filter>
+    <filter
+       height="1.0884571"
+       y="-0.044228551"
+       width="1.0607059"
+       x="-0.030352949"
+       id="filter4700-6"
+       style="color-interpolation-filters:sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur4702-1"
+         stdDeviation="0.6450012" />
+    </filter>
+    <linearGradient
+       y2="80.117599"
+       x2="14.066927"
+       y1="6.6480942"
+       x1="14.066927"
+       gradientTransform="matrix(2.6263817,0,0,0.43555485,351.27065,412.22031)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4798"
+       xlink:href="#linearGradient3924-4" />
+    <filter
+       height="1.0441815"
+       y="-0.022090762"
+       width="1.052541"
+       x="-0.026270477"
+       id="filter4818"
+       style="color-interpolation-filters:sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur4820"
+         stdDeviation="0.4050032" />
+    </filter>
+    <filter
+       height="1.2063999"
+       y="-0.10319996"
+       width="1.1416471"
+       x="-0.070823553"
+       id="filter4733-6-3"
+       style="color-interpolation-filters:sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur4735-2-6"
+         stdDeviation="1.5050028" />
+    </filter>
+    <filter
+       height="1.0884571"
+       y="-0.044228551"
+       width="1.0607059"
+       x="-0.030352949"
+       id="filter4700-6-7"
+       style="color-interpolation-filters:sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur4702-1-5"
+         stdDeviation="0.6450012" />
+    </filter>
+    <filter
+       height="1.2063999"
+       y="-0.10319996"
+       width="1.1416471"
+       x="-0.070823553"
+       id="filter4733-6-36"
+       style="color-interpolation-filters:sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur4735-2-7"
+         stdDeviation="1.5050028" />
+    </filter>
+    <filter
+       height="1.0884571"
+       y="-0.044228551"
+       width="1.0607059"
+       x="-0.030352949"
+       id="filter4700-6-5"
+       style="color-interpolation-filters:sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur4702-1-3"
+         stdDeviation="0.6450012" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3924-4"
+       id="linearGradient954"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6263817,0,0,0.43555485,351.27065,412.22031)"
+       x1="14.066927"
+       y1="6.6480942"
+       x2="14.066927"
+       y2="80.117599" />
+  </defs>
+  <metadata
+     id="metadata4734">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g4742-0-1"
+     transform="matrix(1.0137255,0,0,0.9976589,-354.34059,-399.9618)">
+    <rect
+       ry="2"
+       rx="2"
+       y="415.61584"
+       x="364.71573"
+       height="35.00008"
+       width="51.00008"
+       id="rect1143-9-0-2-2"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.502164;marker:none;filter:url(#filter4733-6-36);enable-background:accumulate" />
+    <rect
+       transform="matrix(0.95291158,0,0,1,18.374644,0)"
+       ry="2"
+       rx="2"
+       y="414.61584"
+       x="364.71573"
+       height="35.00008"
+       width="51.00008"
+       id="rect1143-9-3-7"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.502164;marker:none;filter:url(#filter4700-6-5);enable-background:accumulate" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#fafafa;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.975822;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.502164;marker:none;enable-background:accumulate"
+       id="rect4993-0-2-7-0"
+       width="50"
+       height="34"
+       x="365.21576"
+       y="414.11594"
+       rx="1.5"
+       ry="1.5" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect4993-0-5-9"
+       width="51.00008"
+       height="35.00008"
+       x="364.71573"
+       y="413.61588"
+       rx="2"
+       ry="2" />
+    <rect
+       style="opacity:1;fill:none;stroke:url(#linearGradient954);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect6741-9-3"
+       y="414.61591"
+       x="365.71576"
+       ry="0.99999994"
+       rx="0.99999994"
+       height="33"
+       width="48.999996" />
+  </g>
+  <g
+     id="g4742-0"
+     transform="translate(-328.5229,-390.62672)">
+    <rect
+       ry="2"
+       rx="2"
+       y="415.61584"
+       x="364.71573"
+       height="35.00008"
+       width="51.00008"
+       id="rect1143-9-0-2"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.502164;marker:none;filter:url(#filter4733-6);enable-background:accumulate" />
+    <rect
+       transform="matrix(0.95291158,0,0,1,18.374644,0)"
+       ry="2"
+       rx="2"
+       y="414.61584"
+       x="364.71573"
+       height="35.00008"
+       width="51.00008"
+       id="rect1143-9-3"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.502164;marker:none;filter:url(#filter4700-6);enable-background:accumulate" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#fafafa;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.975822;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.502164;marker:none;enable-background:accumulate"
+       id="rect4993-0-2-7"
+       width="50"
+       height="34"
+       x="365.21576"
+       y="414.11594"
+       rx="1.5"
+       ry="1.5" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect4993-0-5"
+       width="51.00008"
+       height="35.00008"
+       x="364.71573"
+       y="413.61588"
+       rx="2"
+       ry="2" />
+    <rect
+       style="opacity:1;fill:none;stroke:url(#linearGradient4798);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect6741-9"
+       y="414.61591"
+       x="365.71576"
+       ry="0.99999994"
+       rx="0.99999994"
+       height="33"
+       width="48.999996" />
+  </g>
+</svg>

--- a/files/usr/share/cinnamon/cinnamon-settings/appearance-mixed.svg
+++ b/files/usr/share/cinnamon/cinnamon-settings/appearance-mixed.svg
@@ -1,0 +1,286 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="112"
+   height="80"
+   id="svg4729"
+   version="1.1"
+   sodipodi:docname="appearance-mixed.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1352"
+     id="namedview55"
+     showgrid="false"
+     inkscape:zoom="8"
+     inkscape:cx="24.5625"
+     inkscape:cy="24.25"
+     inkscape:window-x="2560"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4729"
+     inkscape:pagecheckerboard="0" />
+  <defs
+     id="defs4731">
+    <linearGradient
+       xlink:href="#linearGradient3924-4"
+       id="linearGradient9678"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6263817,0,0,0.43555485,351.27065,412.22031)"
+       x1="14.066927"
+       y1="6.6480942"
+       x2="14.066927"
+       y2="80.117599" />
+    <linearGradient
+       id="linearGradient3924-4">
+      <stop
+         id="stop3926-8"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0" />
+      <stop
+         offset="0.06316455"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         id="stop3928-5" />
+      <stop
+         id="stop3930-6-4"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         offset="0.95056331" />
+      <stop
+         id="stop3932-25"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         offset="1" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       id="filter1523"
+       x="-0.057365855"
+       width="1.1147317"
+       y="-0.29400001"
+       height="1.588">
+      <feGaussianBlur
+         stdDeviation="0.98"
+         id="feGaussianBlur1525" />
+    </filter>
+    <linearGradient
+       xlink:href="#linearGradient3924-4"
+       id="linearGradient1529"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6263817,0,0,0.43555485,57.05491,13.10443)"
+       x1="14.447668"
+       y1="6.6480026"
+       x2="14.447668"
+       y2="93.893044" />
+    <filter
+       height="1.0884571"
+       y="-0.044228551"
+       width="1.0607059"
+       x="-0.030352949"
+       id="filter4700"
+       style="color-interpolation-filters:sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur4702"
+         stdDeviation="0.6450012" />
+    </filter>
+    <filter
+       height="1.2063999"
+       y="-0.10319996"
+       width="1.1416471"
+       x="-0.070823553"
+       id="filter4733"
+       style="color-interpolation-filters:sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur4735"
+         stdDeviation="1.5050028" />
+    </filter>
+    <filter
+       height="1.2063999"
+       y="-0.10319996"
+       width="1.1416471"
+       x="-0.070823553"
+       id="filter4733-6"
+       style="color-interpolation-filters:sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur4735-2"
+         stdDeviation="1.5050028" />
+    </filter>
+    <filter
+       height="1.0884571"
+       y="-0.044228551"
+       width="1.0607059"
+       x="-0.030352949"
+       id="filter4700-6"
+       style="color-interpolation-filters:sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur4702-1"
+         stdDeviation="0.6450012" />
+    </filter>
+    <linearGradient
+       y2="80.117599"
+       x2="14.066927"
+       y1="6.6480942"
+       x1="14.066927"
+       gradientTransform="matrix(2.6263817,0,0,0.43555485,351.27065,412.22031)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4798"
+       xlink:href="#linearGradient3924-4" />
+    <filter
+       height="1.0441815"
+       y="-0.022090762"
+       width="1.052541"
+       x="-0.026270477"
+       id="filter4818"
+       style="color-interpolation-filters:sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur4820"
+         stdDeviation="0.4050032" />
+    </filter>
+    <filter
+       height="1.2063999"
+       y="-0.10319996"
+       width="1.1416471"
+       x="-0.070823553"
+       id="filter4733-6-3"
+       style="color-interpolation-filters:sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur4735-2-6"
+         stdDeviation="1.5050028" />
+    </filter>
+    <filter
+       height="1.0884571"
+       y="-0.044228551"
+       width="1.0607059"
+       x="-0.030352949"
+       id="filter4700-6-7"
+       style="color-interpolation-filters:sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur4702-1-5"
+         stdDeviation="0.6450012" />
+    </filter>
+  </defs>
+  <metadata
+     id="metadata4734">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g4742"
+     transform="translate(-349.31939,-400.9566)">
+    <rect
+       ry="2"
+       rx="2"
+       y="415.61584"
+       x="364.71573"
+       height="35.00008"
+       width="51.00008"
+       id="rect1143-9-0"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.502164;marker:none;filter:url(#filter4733);enable-background:accumulate" />
+    <rect
+       transform="matrix(0.95291158,0,0,1,18.374644,0)"
+       ry="2"
+       rx="2"
+       y="414.61584"
+       x="364.71573"
+       height="35.00008"
+       width="51.00008"
+       id="rect1143-9"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.502164;marker:none;filter:url(#filter4700);enable-background:accumulate" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.975822;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.502164;marker:none;enable-background:accumulate"
+       id="rect4993-0-2"
+       width="50"
+       height="34"
+       x="365.21576"
+       y="414.11594"
+       rx="1.5"
+       ry="1.5" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.745;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect4993-0"
+       width="51.00008"
+       height="35.00008"
+       x="364.71573"
+       y="413.61588"
+       rx="2"
+       ry="2" />
+    <rect
+       style="opacity:0.15;fill:none;stroke:url(#linearGradient9678);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect6741"
+       y="414.61591"
+       x="365.71576"
+       ry="0.99999994"
+       rx="0.99999994"
+       height="33"
+       width="48.999996" />
+  </g>
+  <g
+     id="g4742-0"
+     transform="translate(-328.5229,-390.62672)">
+    <rect
+       ry="2"
+       rx="2"
+       y="415.61584"
+       x="364.71573"
+       height="35.00008"
+       width="51.00008"
+       id="rect1143-9-0-2"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.502164;marker:none;filter:url(#filter4733-6);enable-background:accumulate" />
+    <rect
+       transform="matrix(0.95291158,0,0,1,18.374644,0)"
+       ry="2"
+       rx="2"
+       y="414.61584"
+       x="364.71573"
+       height="35.00008"
+       width="51.00008"
+       id="rect1143-9-3"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.502164;marker:none;filter:url(#filter4700-6);enable-background:accumulate" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#fafafa;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.975822;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.502164;marker:none;enable-background:accumulate"
+       id="rect4993-0-2-7"
+       width="50"
+       height="34"
+       x="365.21576"
+       y="414.11594"
+       rx="1.5"
+       ry="1.5" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect4993-0-5"
+       width="51.00008"
+       height="35.00008"
+       x="364.71573"
+       y="413.61588"
+       rx="2"
+       ry="2" />
+    <rect
+       style="opacity:1;fill:none;stroke:url(#linearGradient4798);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect6741-9"
+       y="414.61591"
+       x="365.71576"
+       ry="0.99999994"
+       rx="0.99999994"
+       height="33"
+       width="48.999996" />
+  </g>
+</svg>

--- a/files/usr/share/cinnamon/cinnamon-settings/color_dot.svg
+++ b/files/usr/share/cinnamon/cinnamon-settings/color_dot.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="22"
+   height="22"
+   viewBox="0 0 22 22"
+   version="1.1"
+   id="svg1697"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   sodipodi:docname="color_dot.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs7">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2859">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop2855" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1"
+         offset="1"
+         id="stop2857" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2859"
+       id="radialGradient2863"
+       cx="-9.086544"
+       cy="11.246915"
+       fx="-9.086544"
+       fy="11.246915"
+       r="4.4860001"
+       gradientTransform="matrix(3.401277,3.1348755,-1.8509056,1.743225,59.749721,19.908028)"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="namedview5"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     width="22px"
+     inkscape:zoom="45.254834"
+     inkscape:cx="11.788796"
+     inkscape:cy="11.777747"
+     inkscape:window-width="2560"
+     inkscape:window-height="1352"
+     inkscape:window-x="2560"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="g985"
+       transform="rotate(90,11,11)">
+      <path
+         id="path1780"
+         style="opacity:1;fill:#71718e;fill-opacity:1;stroke:none;stroke-width:0.126607;stroke-opacity:1"
+         d="M 11,0 A 11,11 0 0 0 0,11 H 22 A 11,11 0 0 0 11,0 Z" />
+      <path
+         id="path1780-3"
+         style="fill:#8cffbe;fill-opacity:1;stroke:none;stroke-width:0.126607;stroke-opacity:1"
+         d="M 11,22 A 11,11 0 0 1 0,11 H 22 A 11,11 0 0 1 11,22 Z" />
+    </g>
+    <circle
+       style="opacity:0.224129;fill:url(#radialGradient2863);fill-opacity:1;stroke:none;stroke-width:5.2544;stroke-opacity:1"
+       id="path2413"
+       cx="11"
+       cy="11"
+       r="11" />
+  </g>
+</svg>

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
@@ -196,6 +196,13 @@ class Module:
             self.active_mode_name = None
             self.active_variant = None
 
+            # HiDPI support
+            for mode in ["mixed", "dark", "light"]:
+                path = f"/usr/share/cinnamon/cinnamon-settings/appearance-{mode}.svg"
+                pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(path, 112*self.scale, 80*self.scale)
+                surface = Gdk.cairo_surface_create_from_pixbuf(pixbuf, self.scale)
+                builder.get_object(f"image_{mode}").set_from_surface(surface)
+
             self.color_dot_svg = ""
             with open("/usr/share/cinnamon/cinnamon-settings/color_dot.svg") as f:
                 self.color_dot_svg = f.read()
@@ -478,8 +485,9 @@ class Module:
                     svg = svg.replace("#71718e", variant.color2)
                     svg = str.encode(svg)
                     stream = Gio.MemoryInputStream.new_from_bytes(GLib.Bytes.new(svg))
-                    pixbuf = GdkPixbuf.Pixbuf.new_from_stream(stream, None)
-                    image = Gtk.Image.new_from_pixbuf(pixbuf)
+                    pixbuf = GdkPixbuf.Pixbuf.new_from_stream_at_scale(stream, 16*self.scale, 16*self.scale, True, None)
+                    surface = Gdk.cairo_surface_create_from_pixbuf(pixbuf, self.scale)
+                    image = Gtk.Image.new_from_surface(surface)
                     button = Gtk.ToggleButton()
                     button.add(image)
                     button.show_all()

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
@@ -81,6 +81,8 @@ class Module:
             self.customize_button = builder.get_object("customize_button")
             self.preset_button = builder.get_object("preset_button")
             self.color_label = builder.get_object("color_label")
+            self.main_stack = builder.get_object("main_stack")
+            self.custom_stack = builder.get_object("custom_stack")
             self.active_style = None
             self.active_mode = None
             self.active_variant = None
@@ -112,16 +114,15 @@ class Module:
 
             self.reset_look_ui()
 
+            if self.active_variant is not None:
+                self.main_stack.set_visible_child_name("custom_page")
+
             self.mixed_button.connect("clicked", self.on_mode_button_clicked, "mixed")
             self.dark_button.connect("clicked", self.on_mode_button_clicked, "dark")
             self.light_button.connect("clicked", self.on_mode_button_clicked, "light")
             self.customize_button.connect("clicked", self.on_customize_button_clicked)
 
             self.sidePage.stack.add_named(page, "themes")
-
-
-            self.main_stack = builder.get_object("main_stack")
-            self.custom_stack = builder.get_object("custom_stack")
 
             page = SettingsPage()
             self.custom_stack.add_titled(page, "themes", _("Themes"))

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
@@ -77,10 +77,10 @@ class Module:
     category = "appear"
 
     def __init__(self, content_box):
-        self.keywords = _("themes, style, look, feel")
+        self.keywords = _("themes, style")
         self.icon = "cs-themes"
         self.window = None
-        sidePage = SidePage(_("Look & Feel"), self.icon, self.keywords, content_box, module=self)
+        sidePage = SidePage(_("Themes"), self.icon, self.keywords, content_box, module=self)
         self.sidePage = sidePage
         self.refreshing = False # flag to ensure we only refresh once at any given moment
 

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
@@ -494,6 +494,10 @@ class Module:
         self.ui_ready = True
 
     def on_customize_button_clicked(self, button):
+        self.set_button_chooser(self.icon_chooser, self.settings.get_string("icon-theme"), 'icons', 'icons', ICON_SIZE)
+        self.set_button_chooser(self.cursor_chooser, self.settings.get_string("cursor-theme"), 'icons', 'cursors', 32)
+        self.set_button_chooser(self.theme_chooser, self.settings.get_string("gtk-theme"), 'themes', 'gtk-3.0', 35)
+        self.set_button_chooser(self.cinnamon_chooser, self.cinnamon_settings.get_string("name"), 'themes', 'cinnamon', 60)
         self.main_stack.set_visible_child_name("custom_page")
 
     def on_preset_button_clicked(self, button):
@@ -550,10 +554,6 @@ class Module:
             return
         self.refreshing = True
         GLib.timeout_add_seconds(5, self.refresh)
-
-    def refresh(self):
-        self.refresh_themes()
-        self.refresh_choosers()
 
     def refresh_choosers(self):
         array = [(self.cursor_chooser, "cursors", self.cursor_themes, self._on_cursor_theme_selected),
@@ -678,8 +678,11 @@ class Module:
     def create_button_chooser(self, settings, key, path_prefix, path_suffix, button_picture_size, menu_pictures_size, num_cols):
         chooser = PictureChooserButton(num_cols=num_cols, button_picture_size=button_picture_size, menu_pictures_size=menu_pictures_size, has_button_label=True)
         theme = settings.get_string(key)
-        chooser.set_button_label(theme)
-        chooser.set_tooltip_text(theme)
+        self.set_button_chooser(chooser, theme, path_prefix, path_suffix, button_picture_size)
+        return chooser
+
+    def set_button_chooser(self, chooser, theme, path_prefix, path_suffix, button_picture_size):
+        self.set_button_chooser_text(chooser, theme)
         if path_suffix == "cinnamon" and theme == "cinnamon":
             chooser.set_picture_from_file("/usr/share/cinnamon/theme/thumbnail.png")
         elif path_suffix == "icons":
@@ -699,13 +702,15 @@ class Module:
                         break
             except:
                 chooser.set_picture_from_file("/usr/share/cinnamon/thumbnails/%s/unknown.png" % path_suffix)
-        return chooser
+
+    def set_button_chooser_text(self, chooser, theme):
+        chooser.set_button_label(theme)
+        chooser.set_tooltip_text(theme)
 
     def _on_icon_theme_selected(self, path, theme):
         try:
             self.settings.set_string("icon-theme", theme)
-            self.icon_chooser.set_button_label(theme)
-            self.icon_chooser.set_tooltip_text(theme)
+            self.set_button_chooser_text(self.icon_chooser, theme)
         except Exception as detail:
             print(detail)
         return True
@@ -713,8 +718,7 @@ class Module:
     def _on_gtk_theme_selected(self, path, theme):
         try:
             self.settings.set_string("gtk-theme", theme)
-            self.theme_chooser.set_button_label(theme)
-            self.theme_chooser.set_tooltip_text(theme)
+            self.set_button_chooser_text(self.theme_chooser, theme)
         except Exception as detail:
             print(detail)
         return True
@@ -722,8 +726,7 @@ class Module:
     def _on_cursor_theme_selected(self, path, theme):
         try:
             self.settings.set_string("cursor-theme", theme)
-            self.cursor_chooser.set_button_label(theme)
-            self.cursor_chooser.set_tooltip_text(theme)
+            self.set_button_chooser_text(self.cursor_chooser, theme)
         except Exception as detail:
             print(detail)
 
@@ -733,8 +736,7 @@ class Module:
     def _on_cinnamon_theme_selected(self, path, theme):
         try:
             self.cinnamon_settings.set_string("name", theme)
-            self.cinnamon_chooser.set_button_label(theme)
-            self.cinnamon_chooser.set_tooltip_text(theme)
+            self.set_button_chooser_text(self.cinnamon_chooser, theme)
         except Exception as detail:
             print(detail)
         return True

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
@@ -108,7 +108,6 @@ class Module:
             # Populate the style combo
             for name in sorted(self.styles.keys()):
                 self.style_combo.append_text(name)
-            self.style_combo.append_text(_("Custom"))
             self.style_combo.connect("changed", self.on_style_combo_changed)
 
             self.reset_look_ui()
@@ -279,6 +278,14 @@ class Module:
         for child in self.color_box.get_children():
             self.color_box.remove(child)
         self.color_label.hide()
+        model = self.style_combo.get_model()
+        iter = model.get_iter_first()
+        while (iter != None):
+            name = model.get_value(iter, 0)
+            if name == _("Custom"):
+                model.remove(iter)
+                break
+            iter = model.iter_next(iter)
 
     def reset_look_ui(self):
         if not self.ui_ready:
@@ -343,6 +350,7 @@ class Module:
                     button.connect("clicked", self.on_color_button_clicked, variant)
         else:
             # Position style combo on "Custom"
+            self.style_combo.append_text(_("Custom"))
             self.style_combo.set_active(len(self.styles.keys()))
         self.ui_ready = True
 
@@ -365,8 +373,6 @@ class Module:
 
     def on_style_combo_changed(self, combobox):
         selected_name = combobox.get_active_text()
-        if selected_name == _("Custom"):
-            self.cleanup_ui()
         for name in self.styles.keys():
             if name == selected_name:
                 style = self.styles[name]

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
@@ -485,7 +485,7 @@ class Module:
                     svg = svg.replace("#71718e", variant.color2)
                     svg = str.encode(svg)
                     stream = Gio.MemoryInputStream.new_from_bytes(GLib.Bytes.new(svg))
-                    pixbuf = GdkPixbuf.Pixbuf.new_from_stream_at_scale(stream, 16*self.scale, 16*self.scale, True, None)
+                    pixbuf = GdkPixbuf.Pixbuf.new_from_stream_at_scale(stream, 22*self.scale, 22*self.scale, True, None)
                     surface = Gdk.cairo_surface_create_from_pixbuf(pixbuf, self.scale)
                     image = Gtk.Image.new_from_surface(surface)
                     button = Gtk.ToggleButton()

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
@@ -426,26 +426,23 @@ class Module:
         GLib.timeout_add_seconds(5, self.refresh)
 
     def refresh(self):
-        choosers = [(self.cursor_chooser, "cursors", self._load_cursor_themes(), self._on_cursor_theme_selected),
-                    (self.theme_chooser, "gtk-3.0", self._load_gtk_themes(), self._on_gtk_theme_selected),
-                    (self.cinnamon_chooser, "cinnamon", self._load_cinnamon_themes(), self._on_cinnamon_theme_selected),
-                    (self.icon_chooser, "icons", self._load_icon_themes(), self._on_icon_theme_selected)]
-        for chooser in choosers:
-            chooser[0].clear_menu()
-            chooser[0].set_sensitive(False)
-            chooser[0].progress = 0.0
+        self.refresh_themes()
+        self.refresh_choosers()
 
-            chooser_obj = chooser[0]
-            path_suffix = chooser[1]
-            themes = chooser[2]
-            callback = chooser[3]
-            payload = (chooser_obj, path_suffix, themes, callback)
-            self.refresh_chooser(payload)
+    def refresh_choosers(self):
+        array = [(self.cursor_chooser, "cursors", self.cursor_themes, self._on_cursor_theme_selected),
+                    (self.theme_chooser, "gtk-3.0", self.gtk_themes, self._on_gtk_theme_selected),
+                    (self.cinnamon_chooser, "cinnamon", self.cinnamon_themes, self._on_cinnamon_theme_selected),
+                    (self.icon_chooser, "icons", self.icon_themes, self._on_icon_theme_selected)]
+        for element in array:
+            chooser, path_suffix, themes, callback = element
+            chooser.clear_menu()
+            chooser.set_sensitive(False)
+            chooser.progress = 0.0
+            self.refresh_chooser(chooser, path_suffix, themes, callback)
         self.refreshing = False
 
-    def refresh_chooser(self, payload):
-        (chooser, path_suffix, themes, callback) = payload
-
+    def refresh_chooser(self, chooser, path_suffix, themes, callback):
         inc = 1.0
         if len(themes) > 0:
             inc = 1.0 / len(themes)

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
@@ -334,10 +334,29 @@ class Module:
 
     def is_variant_valid(self, variant):
         # returns whether or not the given variant is valid (i.e. made of themes which are currently installed)
-        if variant.gtk_theme is None \
-            or variant.icon_theme is None \
-            or variant.cinnamon_theme is None \
-            or variant.cursor_theme is None:
+        if variant.gtk_theme is None:
+            print("No Gtk theme defined")
+            return False
+        if variant.icon_theme is None:
+            print("No icon theme defined")
+            return False
+        if variant.cinnamon_theme is None:
+            print("No Cinnamon theme defined")
+            return False
+        if variant.cursor_theme is None:
+            print("No cursor theme defined")
+            return False
+        if variant.gtk_theme not in self.gtk_theme_names:
+            print("Gtk theme not found:", variant.gtk_theme)
+            return False
+        if variant.icon_theme not in self.icon_theme_names:
+            print("icon theme not found:", variant.icon_theme)
+            return False
+        if variant.cinnamon_theme not in self.cinnamon_theme_names and variant.cinnamon_theme != "cinnamon":
+            print("Cinnamon theme not found:", variant.cinnamon_theme)
+            return False
+        if variant.cursor_theme not in self.cursor_theme_names:
+            print("Cursor theme not found:", variant.cursor_theme)
             return False
         return True
 

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
@@ -104,7 +104,7 @@ class Module:
                         self.gtk_themes.remove(theme)
             self.gtk_theme_names.add(name)
             self.gtk_themes.append((name, path))
-        self.gtk_themes.sort(key=lambda a: self.get_theme_sort_key(a[0]))
+        self.gtk_themes.sort(key=lambda a: a[0].lower())
 
         # Cinnamon themes
         for (name, path) in walk_directories(THEME_FOLDERS, lambda d: os.path.exists(os.path.join(d, "cinnamon")), return_directories=True):
@@ -116,7 +116,7 @@ class Module:
                         self.cinnamon_themes.remove(theme)
             self.cinnamon_theme_names.add(name)
             self.cinnamon_themes.append((name, path))
-        self.cinnamon_themes.sort(key=lambda a: self.get_theme_sort_key(a[0]))
+        self.cinnamon_themes.sort(key=lambda a: a[0].lower())
 
         # Icon themes
         walked = walk_directories(ICON_FOLDERS, lambda d: os.path.isdir(d), return_directories=True)
@@ -133,7 +133,7 @@ class Module:
                             break
                 except Exception as e:
                     print (e)
-        valid.sort(key=lambda a: self.get_theme_sort_key(a[0]))
+        valid.sort(key=lambda a: a[0].lower())
         for (name, path) in valid:
             if name not in self.icon_theme_names:
                 self.icon_theme_names.append(name)
@@ -738,21 +738,6 @@ class Module:
         except Exception as detail:
             print(detail)
         return True
-
-    def get_theme_sort_key(self, name):
-        name = name.lower()
-        legacy = 0
-        darker = 0
-        dark = 0
-        if "legacy" in name:
-            legacy = 1
-        if "darker" in name:
-            darker = 1
-        if "dark" in name and "darker" not in name:
-            dark = 1
-        name = name.replace("darker", "").replace("dark", "").replace("legacy", "")
-        name = f"{legacy}{dark}{darker}{name}"
-        return name
 
     def filter_func_gtk_dir(self, directory):
         theme_dir = Path(directory)

--- a/files/usr/share/cinnamon/cinnamon-settings/themes.ui
+++ b/files/usr/share/cinnamon/cinnamon-settings/themes.ui
@@ -51,7 +51,7 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="label" translatable="yes">Colour</property>
+                        <property name="label" translatable="yes">Color</property>
                         <attributes>
                           <attribute name="scale" value="1.2"/>
                         </attributes>

--- a/files/usr/share/cinnamon/cinnamon-settings/themes.ui
+++ b/files/usr/share/cinnamon/cinnamon-settings/themes.ui
@@ -93,7 +93,7 @@
                                 <property name="border-width">0</property>
                                 <property name="orientation">vertical</property>
                                 <child>
-                                  <object class="GtkImage">
+                                  <object class="GtkImage" id="image_mixed">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
                                     <property name="pixbuf">appearance-mixed.svg</property>
@@ -141,7 +141,7 @@
                                 <property name="can-focus">False</property>
                                 <property name="orientation">vertical</property>
                                 <child>
-                                  <object class="GtkImage">
+                                  <object class="GtkImage" id="image_dark">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
                                     <property name="pixbuf">appearance-dark.svg</property>
@@ -189,7 +189,7 @@
                                 <property name="can-focus">False</property>
                                 <property name="orientation">vertical</property>
                                 <child>
-                                  <object class="GtkImage">
+                                  <object class="GtkImage" id="image_light">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
                                     <property name="pixbuf">appearance-light.svg</property>

--- a/files/usr/share/cinnamon/cinnamon-settings/themes.ui
+++ b/files/usr/share/cinnamon/cinnamon-settings/themes.ui
@@ -1,0 +1,351 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
+<interface>
+  <requires lib="gtk+" version="3.18"/>
+  <object class="GtkBox" id="page_themes">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="orientation">vertical</property>
+    <child>
+      <object class="GtkStack" id="main_stack">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <child>
+          <object class="GtkScrolledWindow">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="hscrollbar-policy">never</property>
+            <child>
+              <object class="GtkViewport">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <child>
+                  <!-- n-columns=2 n-rows=5 -->
+                  <object class="GtkGrid">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">center</property>
+                    <property name="valign">start</property>
+                    <property name="margin-left">90</property>
+                    <property name="margin-right">90</property>
+                    <property name="margin-top">45</property>
+                    <property name="row-spacing">16</property>
+                    <property name="column-spacing">16</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">Appearance</property>
+                        <attributes>
+                          <attribute name="scale" value="1.2"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="color_label">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">Colour</property>
+                        <attributes>
+                          <attribute name="scale" value="1.2"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">In mixed mode most applications are light. Some desktop elements and multimedia apps are dark to create a nice contrast.</property>
+                        <property name="wrap">True</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButtonBox">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="hexpand">False</property>
+                        <property name="homogeneous">True</property>
+                        <property name="layout-style">expand</property>
+                        <child>
+                          <object class="GtkToggleButton" id="mixed_button">
+                            <property name="visible">True</property>
+                            <property name="sensitive">False</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">True</property>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="orientation">vertical</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                  <object class="GtkImage">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="pixbuf">appearance-mixed.svg</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Mixed</property>
+                                    <attributes>
+                                      <attribute name="weight" value="bold"/>
+                                    </attributes>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkToggleButton" id="dark_button">
+                            <property name="visible">True</property>
+                            <property name="sensitive">False</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">True</property>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="orientation">vertical</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                  <object class="GtkImage">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="pixbuf">appearance-dark.svg</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Dark</property>
+                                    <attributes>
+                                      <attribute name="weight" value="bold"/>
+                                    </attributes>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkToggleButton" id="light_button">
+                            <property name="visible">True</property>
+                            <property name="sensitive">False</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">True</property>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="orientation">vertical</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                  <object class="GtkImage">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="pixbuf">appearance-light.svg</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Light</property>
+                                    <attributes>
+                                      <attribute name="weight" value="bold"/>
+                                    </attributes>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButtonBox" id="color_box">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="hexpand">False</property>
+                        <property name="homogeneous">True</property>
+                        <property name="layout-style">expand</property>
+                        <child>
+                          <placeholder/>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="customize_button">
+                        <property name="label" translatable="yes">Advanced settings...</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
+                        <property name="halign">end</property>
+                        <property name="relief">none</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">Style</property>
+                        <attributes>
+                          <attribute name="scale" value="1.2"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBoxText" id="style_combo">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="name">preset_page</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="border-width">12</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">16</property>
+            <child>
+              <object class="GtkStackSwitcher">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="halign">center</property>
+                <property name="stack">custom_stack</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkStack" id="custom_stack">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <child>
+                  <placeholder/>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="name">custom_page</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">True</property>
+        <property name="fill">True</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+  </object>
+</interface>

--- a/files/usr/share/cinnamon/cinnamon-settings/themes.ui
+++ b/files/usr/share/cinnamon/cinnamon-settings/themes.ui
@@ -65,7 +65,7 @@
                       <object class="GtkLabel">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="label" translatable="yes">In mixed mode most applications are light. Some desktop elements and multimedia apps are dark to create a nice contrast.</property>
+                        <property name="label" translatable="yes">In mixed mode most applications are light. Some desktop elements and multimedia apps are dark to create contrast.</property>
                         <property name="wrap">True</property>
                       </object>
                       <packing>

--- a/files/usr/share/cinnamon/cinnamon-settings/themes.ui
+++ b/files/usr/share/cinnamon/cinnamon-settings/themes.ui
@@ -90,8 +90,8 @@
                               <object class="GtkBox">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
+                                <property name="border-width">0</property>
                                 <property name="orientation">vertical</property>
-                                <property name="spacing">6</property>
                                 <child>
                                   <object class="GtkImage">
                                     <property name="visible">True</property>
@@ -108,6 +108,7 @@
                                   <object class="GtkLabel">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
+                                    <property name="margin-bottom">3</property>
                                     <property name="label" translatable="yes">Mixed</property>
                                     <attributes>
                                       <attribute name="weight" value="bold"/>
@@ -139,7 +140,6 @@
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="orientation">vertical</property>
-                                <property name="spacing">6</property>
                                 <child>
                                   <object class="GtkImage">
                                     <property name="visible">True</property>
@@ -156,6 +156,7 @@
                                   <object class="GtkLabel">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
+                                    <property name="margin-bottom">3</property>
                                     <property name="label" translatable="yes">Dark</property>
                                     <attributes>
                                       <attribute name="weight" value="bold"/>
@@ -187,7 +188,6 @@
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="orientation">vertical</property>
-                                <property name="spacing">6</property>
                                 <child>
                                   <object class="GtkImage">
                                     <property name="visible">True</property>
@@ -204,6 +204,7 @@
                                   <object class="GtkLabel">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
+                                    <property name="margin-bottom">3</property>
                                     <property name="label" translatable="yes">Light</property>
                                     <attributes>
                                       <attribute name="weight" value="bold"/>

--- a/files/usr/share/cinnamon/styles.d/00_cinnamon.styles
+++ b/files/usr/share/cinnamon/styles.d/00_cinnamon.styles
@@ -1,0 +1,27 @@
+{
+  "styles": [
+    {
+      "name": "Adwaita",
+      "mixed": [
+          {
+            "name": "blue",
+            "color": "#3584e4",
+            "themes": "Adwaita",
+            "cinnamon": "cinnamon"
+          }
+        ],
+      "dark": [
+          {
+            "name": "blue",
+            "color": "#15539e",
+            "themes": "Adwaita-dark",
+            "icons": "Adwaita",
+            "cinnamon": "cinnamon",
+            "cursor": "Adwaita"
+          }
+        ],
+      "light": [
+        ]
+    }
+  ]
+}

--- a/files/usr/share/cinnamon/styles.d/00_cinnamon.styles
+++ b/files/usr/share/cinnamon/styles.d/00_cinnamon.styles
@@ -10,6 +10,13 @@
           {"name": "blue", "color": "#15539e", "themes": "Adwaita-dark", "icons": "Adwaita", "cinnamon": "cinnamon", "cursor": "Adwaita"}
         ],
       "light": []
+    },
+    {
+      "name": "HighContrast",
+      "default": "light",
+      "light": [
+          {"default": "true", "name": "contrast", "color": "#000000", "themes": "HighContrast", "cinnamon": "cinnamon", "cursor": "Adwaita"}
+      ]
     }
   ]
 }

--- a/files/usr/share/cinnamon/styles.d/00_cinnamon.styles
+++ b/files/usr/share/cinnamon/styles.d/00_cinnamon.styles
@@ -2,26 +2,14 @@
   "styles": [
     {
       "name": "Adwaita",
+      "default": "mixed",
       "mixed": [
-          {
-            "name": "blue",
-            "color": "#3584e4",
-            "themes": "Adwaita",
-            "cinnamon": "cinnamon"
-          }
-        ],
+          {"default": "true", "name": "blue", "color": "#3584e4", "themes": "Adwaita", "cinnamon": "cinnamon"}
+      ],
       "dark": [
-          {
-            "name": "blue",
-            "color": "#15539e",
-            "themes": "Adwaita-dark",
-            "icons": "Adwaita",
-            "cinnamon": "cinnamon",
-            "cursor": "Adwaita"
-          }
+          {"name": "blue", "color": "#15539e", "themes": "Adwaita-dark", "icons": "Adwaita", "cinnamon": "cinnamon", "cursor": "Adwaita"}
         ],
-      "light": [
-        ]
+      "light": []
     }
   ]
 }


### PR DESCRIPTION
TODO:

- [x] Don't show styles which point to non-existing themes
- [x] Support a default mode/variant for a given style
- [x] Refresh UI properly
- [x] Harmonize "Themes" vs "Look & Feel" name
- [x] Remove custom legacy/dark sort in custom theme selectors
- [x] Go straight to custom page if the user uses a custom selection
- [x] Remove Custom in combo when it's not needed
- [x] HiDPI support for dots and appearance images
