### PR TITLE
Remove simple-system-monitor@ariel as a known conflict

### DIFF
--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -32,8 +32,7 @@ var knownCinnamon4Conflicts = [
     'vnstat@linuxmint.com',
     'netusagemonitor@pdcurtis',
     // Desklets
-    'netusage@30yavash.com',
-    'simple-system-monitor@ariel'
+    'netusage@30yavash.com'
 ];
 
 // macro for creating extension types


### PR DESCRIPTION
The desklet has been cleaned up by linuxmint/cinnamon-spices-desklets#816 but this needs to be merged before linuxmint/cinnamon-spices-desklets#832.