### PR TITLE
window-list: make UseEntrieSpace honor buttonWidth

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -658,7 +658,7 @@ class AppMenuButton {
                 if (this._applet.buttonsUseEntireSpace) {
                     let [lminSize, lnaturalSize] = this._label.get_preferred_width(forHeight);
                     let spacing = this.actor.get_theme_node().get_length('spacing');
-                    alloc.natural_size = Math.max(150 * global.ui_scale,
+                    alloc.natural_size = Math.max(this._applet.buttonWidth * global.ui_scale,
                             naturalSize + spacing + lnaturalSize);
                 } else {
                     alloc.natural_size = this._applet.buttonWidth * global.ui_scale;


### PR DESCRIPTION
Currently, `window-list` applet uses a hardcoded minimum window button width when "use the entrie space available" setting is checked.

This fix makes it use the "Window button width" setting as the minimum instead.

I personally set width to zero, to make the buttons only as wide as their text. Leaving it at the default 150 results in keeping the current behavior.