### PR TITLE
fix: Popup menu content not stretching to its full size on rerender

### DIFF
--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -2197,7 +2197,9 @@ var PopupMenu = class PopupMenu extends PopupMenuBase {
         this._slidePosition = -1;
 
         this.actor = new St.Bin({ style_class: 'menu',
-                                  important: true });
+                                  important: true,
+                                  y_fill: true,
+								  x_fill: true });
         this.actor._delegate = this;
         this._signals.connect(this.actor, 'key-press-event', Lang.bind(this, this._onKeyPressEvent));
 


### PR DESCRIPTION
PopupMenu Content should be using the full size of the popup menu even after content has been resized.

See picture:

![Screenshot from 2023-04-04 20-01-47](https://user-images.githubusercontent.com/22377521/230906653-19e158fd-c6d6-494c-b992-4140303ed467.png)

The horizontal lines are simple separators added to the PopupMenu. They should be spanning full width, but they don't.

Steps to reproduce:
* Cinnamon 5.4+
* Weather Applet, than right click-> Refresh. Open the applet before the refresh finished.

Explanation:
The menu must be open for this to happen. The menu starts out with data already filled in. In the weather applet in full refresh, the menu content gets rebuilt and starts out with the same layout, but without data. Because of that, the total size will be smaller. When the elements get filled up with actual data, the size remains the same even if it should expand.

Notes: 
* Maybe there is a problem on how I construct the menu for the weather applet
* I noticed since 5.4+ `St.Bin` needs the `x_fill` and `y_fill` options to be se to true to still take up all the space even if it's child shrunk
* The `PopupMenu` is an `St.Bin` with an `St.BoxLayout` inside.
* There might be other ways to fix/work around this problem, like the `BoxLayout`'s `x_align: Clutter.ActorAlign.FILL, x_expand: true` options.

Now this fixes the problem with the weather applet and with probably applets that have popup menus resizing while they are open, but I don't actually know what the underlying cause of this. Maybe this is intended with the library updates, maybe not.