### PR TITLE
Revert to `~/.themes` and `~/.icons` directory as default instead of XDG equivalents because GTK2 apps couldn't use them

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
@@ -160,8 +160,8 @@ class Spice_Harvester(GObject.Object):
             self.enabled_key = 'enabled-%ss' % self.collection_type
 
         if self.themes:
-            self.install_folder = os.path.join(GLib.get_user_data_dir(), 'themes')
-            old_install_folder = '%s/.themes/' % home
+            self.install_folder = '%s/.themes/' % home
+            old_install_folder = os.path.join(GLib.get_user_data_dir(), 'themes')
             self.spices_directories = (self.install_folder, old_install_folder)
         else:
             self.install_folder = '%s/.local/share/cinnamon/%ss/' % (home, self.collection_type)
@@ -425,9 +425,6 @@ class Spice_Harvester(GObject.Object):
                         if not self.themes:
                             print(detail)
                             print("Skipping %s: there was a problem trying to read metadata.json" % uuid)
-            elif directory == self.install_folder:
-                print("%s does not exist! Creating it now." % directory)
-                subprocess.call(["mkdir", "-p", directory])
             else:
                 print("%s does not exist! Skipping" % directory)
 
@@ -646,6 +643,10 @@ class Spice_Harvester(GObject.Object):
                         locale_dir = os.path.join(locale_inst, lang, 'LC_MESSAGES')
                         os.makedirs(locale_dir, mode=0o755, exist_ok=True)
                         subprocess.call(['msgfmt', '-c', os.path.join(po_dir, file), '-o', os.path.join(locale_dir, '%s.mo' % uuid)])
+        
+        # Create install folder on demand
+        if not os.path.exists(self.install_folder):
+            subprocess.call(["mkdir", "-p", self.install_folder])
 
         dest = os.path.join(self.install_folder, uuid)
         if os.path.exists(dest):

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
@@ -21,13 +21,13 @@ ICON_SIZE = 48
 # but it's helpful to be aware of it.
 
 ICON_FOLDERS = [
-    os.path.join(GLib.get_user_data_dir(), "icons"),
-    os.path.join(GLib.get_home_dir(), ".icons")
+    os.path.join(GLib.get_home_dir(), ".icons"),
+    os.path.join(GLib.get_user_data_dir(), "icons")
 ] + [os.path.join(datadir, "icons") for datadir in GLib.get_system_data_dirs()]
 
 THEME_FOLDERS = [
-    os.path.join(GLib.get_user_data_dir(), "themes"),
-    os.path.join(GLib.get_home_dir(), ".themes")
+    os.path.join(GLib.get_home_dir(), ".themes"),
+    os.path.join(GLib.get_user_data_dir(), "themes")
 ] + [os.path.join(datadir, "themes") for datadir in GLib.get_system_data_dirs()]
 
 


### PR DESCRIPTION
Fixes https://github.com/linuxmint/cinnamon/pull/11175#issuecomment-1457237711