### PR TITLE
build.yml: Add xdg-desktop-portal-xapp dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,5 +32,6 @@ jobs:
         linuxmint/cjs,
         linuxmint/muffin,
         linuxmint/nemo,
-        linuxmint/xapp
+        linuxmint/xapp,
+        linuxmint/xdg-desktop-portal-xapp
       ##############################


### PR DESCRIPTION
This depends on xapp being built against a bookworm base so that 2.5.0 can be built successfully first.