### PR TITLE
system settings csd+window size changes

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
@@ -165,10 +165,10 @@ class MainWindow(Gio.Application):
                 self.go_to_sidepage(sidePage, user_action=True)
 
     def _on_sidepage_hide_stack(self):
-        self.top_bar.hide()
+        self.header_stack.hide()
 
     def _on_sidepage_show_stack(self):
-        self.top_bar.show()
+        self.header_stack.show()
 
     def go_to_sidepage(self, sidePage: SettingsWidgets.SidePage, user_action=True):
         sidePage.build()
@@ -200,16 +200,16 @@ class MainWindow(Gio.Application):
                 else:
                     sidePage.stack.set_visible_child(l[0])
                 if sidePage.stack.get_visible():
-                    self.top_bar.show()
+                    self.header_stack.show()
                 else:
-                    self.top_bar.hide()
+                    self.header_stack.hide()
                 if hasattr(sidePage, "connect_proxy"):
                     sidePage.connect_proxy("hide_stack", self._on_sidepage_hide_stack)
                     sidePage.connect_proxy("show_stack", self._on_sidepage_show_stack)
             else:
-                self.top_bar.hide()
+                self.header_stack.hide()
         else:
-            self.top_bar.hide()
+            self.header_stack.hide()
 
         if user_action:
             self.main_stack.set_visible_child_name("content_box_page")
@@ -223,7 +223,7 @@ class MainWindow(Gio.Application):
 
     def maybe_resize(self, sidePage):
         m, cb_n = self.content_box.get_preferred_size()
-        m, tb_n = self.top_bar.get_preferred_size()
+        m, tb_n = self.header_stack.get_preferred_size()
         
         # Resize vertically depending on the height requested by the module
         use_height = 0
@@ -262,7 +262,6 @@ class MainWindow(Gio.Application):
         self.window.set_titlebar(self.header_bar)
         main_box = self.builder.get_object("main_box")
         self.window.add(main_box)
-        self.top_bar = self.builder.get_object("top_bar")
         self.side_view = {}
         self.main_stack = self.builder.get_object("main_stack")
         self.main_stack.set_transition_type(Gtk.StackTransitionType.CROSSFADE)
@@ -374,7 +373,7 @@ class MainWindow(Gio.Application):
 
         self.set_headerbar_height()
         self.button_back.hide()
-        self.top_bar.hide()
+        self.header_stack.hide()
 
         self.search_entry.grab_focus()
         self.window.connect("key-press-event", self.on_keypress)
@@ -776,7 +775,7 @@ class MainWindow(Gio.Application):
                 c_widgets = child.get_children()
                 for c_widget in c_widgets:
                     c_widget.hide()
-        self.top_bar.hide()
+        self.header_stack.hide()
         self.main_stack.set_visible_child_name("side_view_page")
         self.search_entry.show()
         self.search_entry.grab_focus()

--- a/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.ui
+++ b/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.ui
@@ -35,60 +35,32 @@
     <property name="can-focus">False</property>
     <property name="orientation">vertical</property>
     <child>
-      <object class="GtkToolbar" id="top_bar">
+      <object class="GtkStack" id="header_stack">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="toolbar_style">icons</property>
+        <property name="can-focus">False</property>
+        <property name="margin-top">8</property>
         <child>
-          <object class="GtkToolItem" id="toolbutton1">
+          <object class="GtkBox" id="box2">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="valign">center</property>
-            <child>
-              <object class="GtkStack" id="header_stack">
+            <property name="can-focus">False</property>
+            <property name="border-width">1</property>
+            <child type="center">
+              <object class="GtkStackSwitcher" id="stack_switcher">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <child>
-                  <object class="GtkBox" id="box2">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="border_width">1</property>
-                    <child type="center">
-                      <object class="GtkStackSwitcher" id="stack_switcher">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="halign">center</property>
-                      </object>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="name">content_box</property>
-                    <property name="title">content_box</property>
-                  </packing>
-                </child>
+                <property name="halign">center</property>
               </object>
             </child>
-            <style>
-              <class name="raised"/>
-            </style>
+            <child>
+              <placeholder/>
+            </child>
           </object>
           <packing>
-            <property name="expand">True</property>
-            <property name="homogeneous">False</property>
+            <property name="name">content_box</property>
+            <property name="title">content_box</property>
           </packing>
         </child>
-        <style>
-          <class name="primary-toolbar"/>
-        </style>
       </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">0</property>
-      </packing>
     </child>
     <child>
       <object class="GtkStack" id="main_stack">

--- a/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.ui
+++ b/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.ui
@@ -1,10 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
-  <requires lib="gtk+" version="3.0"/>
+  <requires lib="gtk+" version="3.24"/>
+  <object class="GtkHeaderBar" id="header_bar">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="show-close-button">True</property>
+    <child>
+      <object class="GtkButton" id="button_back">
+        <property name="label" translatable="yes">All Settings</property>
+        <property name="visible">True</property>
+        <property name="can-focus">True</property>
+        <property name="focus-on-click">False</property>
+        <property name="receives-default">True</property>
+        <style>
+          <class name="raised"/>
+        </style>
+      </object>
+    </child>
+    <child>
+      <object class="GtkSearchEntry" id="search_box">
+        <property name="visible">True</property>
+        <property name="can-focus">True</property>
+        <property name="caps-lock-warning">False</property>
+      </object>
+      <packing>
+        <property name="pack-type">end</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+  </object>
   <object class="GtkBox" id="main_box">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="orientation">vertical</property>
     <child>
       <object class="GtkToolbar" id="top_bar">
@@ -19,86 +47,26 @@
             <child>
               <object class="GtkStack" id="header_stack">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <child>
-                  <object class="GtkBox" id="hbox2">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="border_width">1</property>
-                    <child>
-                      <object class="GtkEntry" id="search_box">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="halign">start</property>
-                        <property name="invisible_char">●</property>
-                        <property name="width_chars">25</property>
-                        <property name="caps_lock_warning">False</property>
-                        <property name="primary_icon_name">edit-find-symbolic</property>
-                        <property name="secondary_icon_name">edit-clear-symbolic</property>
-                        <property name="placeholder_text">Search...</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="pack_type">end</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="name">side_view</property>
-                    <property name="title">side_view</property>
-                  </packing>
-                </child>
+                <property name="can-focus">False</property>
                 <child>
                   <object class="GtkBox" id="box2">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="border_width">1</property>
-                    <child>
-                      <object class="GtkButton" id="button_back">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="focus_on_click">False</property>
-                        <property name="receives_default">True</property>
-                        <child>
-                          <object class="GtkImage" id="image1">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="icon_name">go-previous-symbolic</property>
-                          </object>
-                        </child>
-                        <style>
-                          <class name="raised"/>
-                          <class name="image-button"/>
-                        </style>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
                     <child type="center">
                       <object class="GtkStackSwitcher" id="stack_switcher">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">center</property>
                       </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">2</property>
-                      </packing>
+                    </child>
+                    <child>
+                      <placeholder/>
                     </child>
                   </object>
                   <packing>
                     <property name="name">content_box</property>
                     <property name="title">content_box</property>
-                    <property name="position">1</property>
                   </packing>
                 </child>
               </object>
@@ -125,26 +93,26 @@
     <child>
       <object class="GtkStack" id="main_stack">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <child>
-          <object class="GtkScrolledWindow" id="side_view_sw">
-            <property name="height_request">125</property>
+          <object class="GtkScrolledWindow" id="category_view_sw">
+            <property name="height-request">125</property>
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="hscrollbar_policy">never</property>
+            <property name="can-focus">True</property>
+            <property name="hscrollbar-policy">never</property>
             <child>
               <object class="GtkViewport" id="viewport2">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="vexpand">True</property>
-                <property name="vscroll_policy">natural</property>
-                <property name="shadow_type">none</property>
+                <property name="vscroll-policy">natural</property>
+                <property name="shadow-type">none</property>
                 <child>
                   <object class="GtkBox" id="category_box">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="valign">start</property>
-                    <property name="border_width">10</property>
+                    <property name="border-width">10</property>
                     <property name="orientation">vertical</property>
                     <child>
                       <placeholder/>
@@ -161,24 +129,24 @@
         </child>
         <child>
           <object class="GtkScrolledWindow" id="content_box_sw">
-            <property name="can_focus">True</property>
+            <property name="can-focus">True</property>
             <property name="hexpand">True</property>
             <property name="vexpand">True</property>
-            <property name="hscrollbar_policy">never</property>
+            <property name="hscrollbar-policy">never</property>
             <child>
               <object class="GtkViewport" id="viewport1">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="vexpand">True</property>
-                <property name="shadow_type">none</property>
+                <property name="shadow-type">none</property>
                 <child>
                   <object class="GtkVBox" id="content_box">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                     <property name="hexpand">True</property>
                     <property name="vexpand">True</property>
-                    <property name="border_width">6</property>
+                    <property name="border-width">6</property>
                     <property name="spacing">3</property>
                     <child>
                       <placeholder/>

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_calendar.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_calendar.py
@@ -17,7 +17,7 @@ class Module:
 
     def __init__(self, content_box):
         keywords = _("time, date, calendar, format, network, sync")
-        self.sidePage = SidePage(_("Date & Time"), "cs-date-time", keywords, content_box, 560, module=self)
+        self.sidePage = SidePage(_("Date & Time"), "cs-date-time", keywords, content_box, module=self)
 
     def on_module_selected(self):
         if not self.loaded:

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_default.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_default.py
@@ -568,7 +568,7 @@ class Module:
 
     def __init__(self, content_box):
         keywords = _("media, defaults, applications, programs, removable, browser, email, calendar, music, videos, photos, images, cd, autoplay, favorite, apps")
-        sidePage = SidePage(_("Preferred Applications"), "cs-default-applications", keywords, content_box, 560, module=self)
+        sidePage = SidePage(_("Preferred Applications"), "cs-default-applications", keywords, content_box, module=self)
         self.sidePage = sidePage
 
     def on_module_selected(self):

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_display.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_display.py
@@ -10,7 +10,7 @@ class Module:
 
     def __init__(self, content_box):
         keywords = _("display, screen, monitor, layout, resolution, dual, lcd")
-        self.sidePage = SidePage(_("Display"), "cs-display", keywords, content_box, 650, module=self)
+        self.sidePage = SidePage(_("Display"), "cs-display", keywords, content_box, module=self)
         self.display_c_widget = None
 
     def on_module_selected(self):

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_online_accounts.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_online_accounts.py
@@ -10,7 +10,7 @@ class Module:
 
     def __init__(self, content_box):
         keywords = _("google, facebook, twitter, yahoo, web, online, chat, calendar, mail, contact, owncloud, kerberos, imap, smtp, pocket, readitlater, account")
-        self.sidePage = SidePage(_("Online Accounts"), "cs-online-accounts", keywords, content_box, 560, module=self)
+        self.sidePage = SidePage(_("Online Accounts"), "cs-online-accounts", keywords, content_box, module=self)
 
     def on_module_selected(self):
         if not self.loaded:

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_power.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_power.py
@@ -108,7 +108,7 @@ class Module:
 
     def __init__(self, content_box):
         keywords = _("power, suspend, hibernate, laptop, desktop, brightness, screensaver")
-        self.sidePage = SidePage(_("Power Management"), "cs-power", keywords, content_box, -1, module=self)
+        self.sidePage = SidePage(_("Power Management"), "cs-power", keywords, content_box, module=self)
 
     def on_module_selected(self):
         if self.loaded:


### PR DESCRIPTION
@mtwebster Since I already made the changes, I thought I post them here for testing in case it gives you some ideas on what you want to do.

I think that keeping the same window size when going to or from modules makes a big difference instead of frequent window size changes which looks jarring. Also, it was annoying when you resized the window only for it to change back to a default size as soon as you switched to a settings page or back.

Also, if you're not planning to make any major changes before 5.8 is released, would this not be a good temporary improvement for the next mint release, before you revamp things later?

Edit: btw. trying to have widgets fit a certain fixed window size doesn't work because of theming, font scaling etc.