### PR TITLE
main.js: re-declare Main.gpu_offload_supported

### DIFF
--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -183,6 +183,7 @@ var popup_rendering_actor = null;
 var xlet_startup_error = false;
 
 var gpuOffloadHelper = null;
+var gpu_offload_supported = false;
 
 var RunState = {
     INIT : 0,


### PR DESCRIPTION
I was evaluating `Main.gpu_offload_supported` in Melange and found it undefined. Probably this is removed in 00b0a65b by accident.

I have `JS LOG: [LookingGlass/info] GPU offload supported: true` in my journal and with this change I can see the "Run with dedicated GPU" item in menu.

---

Screenshot of the menu, journal, melange, etc (**after** this change):

<details>

![](https://github.com/linuxmint/cinnamon/assets/20080233/9b413dd6-0db2-4f63-8d55-a171a83d0763)

</details>

---

I am aware 5.8.0 is not tagged but I am playing this myself (on NixOS) :-) If "Run with dedicated GPU" is expected to present without this change, here are some info of my setup.

- I am on 93135ed3741cab016b75a91a03c1fc9b48ec70b4.
- `switcheroo-control.service` is running
- ```
  $ xapp-gpu-offload -l
  1 default DRI_PRIME=pci-0000_00_02_0  [Intel Corporation CoffeeLake-H GT2 [UHD Graphics 630]]
  0        __GLX_VENDOR_LIBRARY_NAME=nvidia __NV_PRIME_RENDER_OFFLOAD=1 __VK_LAYER_NV_optimus=NVIDIA_only  [NVIDIA Corporation GP107M [GeForce GTX 1050 3 GB Max-Q]]
  ```
- Open Melange and go to Log, I can see `info t=2023-06-05T15:24:59Z GPU offload supported: true`.

Let me know if I missed something!
