### PR TITLE
sound@cinnamon.org: Truncate applet panel text by grapheme instead...

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -1296,8 +1296,9 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
             else {
                 title_text = player._title + ' - ' + player._artist;
             }
-            if (this.truncatetext < title_text.length) {
-                title_text = title_text.substr(0, this.truncatetext) + "...";
+            const graphemes = Util.splitByGrapheme(title_text);
+            if (this.truncatetext < graphemes.length) {
+                title_text = graphemes.slice(0, this.truncatetext).join("") + "...";
             }
         }
         this.set_applet_label(title_text);

--- a/js/misc/util.js
+++ b/js/misc/util.js
@@ -866,3 +866,25 @@ function getDesktopActionIcon(action) {
     else return null;
 }
 
+/**
+ * splitByGrapheme:
+ * @str (string): The string to be converted
+ *
+ * Converts a string, possibly containing multiple codepoint unicode characters (e.g. emoji), into
+ * an array of unicode graphemes. For example: "👩‍👩‍👧‍👧😃".length === 13, but splitByGrapheme("👩‍👩‍👧‍👧😃")
+ * returns ["👩‍👩‍👧‍👧", "😃"] which is length 2.
+ * 
+ * Returns (array): Array of unicode graphemes.
+ */
+ //Copied from https://stackoverflow.com/a/72072071
+function splitByGrapheme(str) { 
+    let arr = [...str]
+
+    for (i = arr.length-1; i--; i>= 0){
+        if (arr[i].charCodeAt(0) == 8205) { // find & handle special combination character
+            arr[i-1] += arr[i] + arr[i+1];
+            arr.splice(i, 2)
+        }
+    }
+    return arr;
+}


### PR DESCRIPTION
... of codepoint.

Applet panel text (song information) is truncated by js string length resulting in multiple codepoint characters, e.g. emoji, being shown incorrectly. Count string length and truncate string by unicode grapheme instead.

fixes #11691