### PR TITLE
Sound applet: Truncate applet panel text by glyph

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -1296,8 +1296,9 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
             else {
                 title_text = player._title + ' - ' + player._artist;
             }
-            if (this.truncatetext < title_text.length) {
-                title_text = title_text.substr(0, this.truncatetext) + "...";
+            const glyphs = Util.splitByGlyph(title_text);
+            if (glyphs.length > this.truncatetext) {
+                title_text = glyphs.slice(0, this.truncatetext - 3).join("") + "...";
             }
         }
         this.set_applet_label(title_text);

--- a/js/misc/util.js
+++ b/js/misc/util.js
@@ -11,6 +11,7 @@
 
 const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
+const Gtk = imports.gi.Gtk;
 const GObject = imports.gi.GObject;
 const Gir = imports.gi.GIRepository;
 const Mainloop = imports.mainloop;
@@ -866,3 +867,27 @@ function getDesktopActionIcon(action) {
     else return null;
 }
 
+/**
+ * splitByGlyph:
+ * @str (string): The string to be converted
+ *
+ * Converts a string, possibly containing multiple codepoint unicode characters (e.g. emoji), into
+ * an array of unicode graphemes clusters (glyphs). For example: "👩‍👩‍👧‍👧😃".length === 13, but splitByGlyph("👩‍👩‍👧‍👧😃")
+ * returns ["👩‍👩‍👧‍👧", "😃"] which is length 2.
+ * 
+ * Returns (array): Array of unicode grapheme clusters (glyphs).
+ */
+function splitByGlyph(str) {
+    const glyphs = [];
+    const buffer = new Gtk.TextBuffer();
+    buffer.set_text(str, -1);
+    const iter = buffer.get_start_iter();
+    const iter2 = buffer.get_start_iter();
+    
+    while (!iter2.is_end()) {
+        iter2.forward_cursor_position();
+        glyphs.push(buffer.get_text(iter, iter2, false));
+        iter.forward_cursor_position();
+    }
+    return glyphs;
+}


### PR DESCRIPTION
Applet panel text (song information) is truncated by js string length resulting in multiple codepoint characters, e.g. emoji, being shown incorrectly. Count string length and truncate string by unicode grapheme cluster (glyph) instead.

fixes #11691