### PR TITLE
cs_info: Fix space in URLs

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
@@ -222,31 +222,12 @@ class Module:
 
     def on_copy_clipboard_button_clicked(self, button):
         try:
-            # taken from https://github.com/linuxmint/xapp/blob/master/scripts/upload-system-info
-            subproc = Gio.Subprocess.new(['inxi', '-Fxxrzc0'], Gio.SubprocessFlags.STDOUT_PIPE |  Gio.SubprocessFlags.STDERR_PIPE)
-            subproc.wait_check_async(None, self.on_copy_clipboard_complete)
+            inxiOutput = subprocess.run(['inxi', '-Fxxrzc0'], check=True, stdout=subprocess.PIPE).stdout
+            clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
+            clipboard.set_text(inxiOutput.decode("utf-8"), -1)
         except Exception as e:
             print("An error occurred while copying the system information to clipboard")
             print(e)
-
-    def on_copy_clipboard_complete(self, subproc, result):
-        def _convert_stream_to_string(stream):
-            """Convert Gio.InputStream to string"""
-            bytes = bytearray(0)
-            buf = stream.read_bytes(1024, None).get_data()
-            while buf:
-                bytes += buf
-                buf = stream.read_bytes(1024, None).get_data()
-            stream.close()
-            content = bytes.decode("utf-8")
-            return content
-        try:
-            status = subproc.wait_check_finish(result)
-            if status:
-                clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
-                clipboard.set_text(_convert_stream_to_string(subproc.get_stdout_pipe()), -1)
-        except Exception as e:
-            print("copying to clipboard failed : %s" % e.message)
 
     def on_button_clicked(self, button, spinner):
 


### PR DESCRIPTION
Fixes spaces in repo-URLs

Steps to reproduce: `cinnamon-settings info` -> "Copy to clipboard" -> Paste it somewhere

Before:
```
Repos:
[...]
  Active apt repos in: /etc/apt/sources.list.d/official-package-repositories.list
    1: deb http: //packages.linuxmint.com/linuxmint/packages victoria main upstream import backport
    2: deb http: //packages.linuxmint.com/ubuntu jammy main restricted universe multiverse
    3: deb http: //packages.linuxmint.com/ubuntu jammy-updates main restricted universe multiverse
    4: deb http: //packages.linuxmint.com/ubuntu jammy-backports main restricted universe multiverse
    5: deb http: //packages.linuxmint.com/ubuntu jammy-security main restricted universe multiverse
```


With this PR:
```
Repos:
[...]
  Active apt repos in: /etc/apt/sources.list.d/official-package-repositories.list
    1: deb http://packages.linuxmint.com/linuxmint/packages victoria main upstream import backport
    2: deb http://packages.linuxmint.com/ubuntu jammy main restricted universe multiverse
    3: deb http://packages.linuxmint.com/ubuntu jammy-updates main restricted universe multiverse
    4: deb http://packages.linuxmint.com/ubuntu jammy-backports main restricted universe multiverse
    5: deb http://packages.linuxmint.com/ubuntu jammy-security main restricted universe multiverse
```

This uses python subprocess instead of Gio.Subprocess to reduce the amount of code needed.
Requires Python >= 3.5

This is synchronous call which may not be desired, even if it's only a second, feel free to edit.