### PR TITLE
menu applet: fix category button styling bug

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -2160,7 +2160,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
 
     _buttonLeaveEvent (button) {
         if (button instanceof CategoryButton) {
-            if (button.categoryId !== this.lastSelectedCategory) {
+            if (button.categoryId !== this.lastSelectedCategory && !this.searchActive) {
                 button.actor.set_style_class_name("menu-category-button");
                 if (button.actor.has_style_pseudo_class("hover")) {
                     button.actor.remove_style_pseudo_class("hover");


### PR DESCRIPTION
Don't change category button style on button leave event when search is active and "change categories on hover" option is off.