### PR TITLE
Cinnamon theme: allow different text sizes in menu applet search box

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -1319,7 +1319,6 @@ StScrollBar StButton#vhandle:hover {
     caret-color: rgb(128, 128, 128);
     caret-size: 1px;
     width: 250px;
-    height: 15px;
     transition-duration: 300;
     box-shadow: inset 0px 2px 4px rgba(0,0,0,0.6);
 }


### PR DESCRIPTION
fixes #11716