### PR TITLE
menu applet: fix menu changing size

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1431,9 +1431,6 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         this.main_container.natural_height = (height * global.ui_scale);
         this.main_container.natural_width = (width * global.ui_scale);
 
-        this.menu.actor.set_width(width * global.ui_scale);
-        this.menu.actor.set_height(height * global.ui_scale);
-
         this._update_scroll_policy(this.favoritesBox, this.favoritesScrollBox);
         this._update_scroll_policy(this.categoriesBox, this.categoriesScrollBox);
 

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/settings-schema.json
@@ -192,11 +192,11 @@
  },
  "popup-width" : {
     "type" : "generic",
-    "default" : 650
+    "default" : 630
  },
  "popup-height" : {
     "type" : "generic",
-    "default" : 650
+    "default" : 615
  },
  "reset-menu-size-button" : {
     "type" : "button",


### PR DESCRIPTION
Fix menu changing size after reopening by using main_container to size the menu rather than menu.actor

fixes: #11712

fixes: https://github.com/linuxmint/mint21.2-beta/issues/6

I've also adjusted the default sizes so that the menu is about the same size in Mint-Y theme as it was before this change.