### PR TITLE
Menu applet: Reduce default menu size

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/settings-schema.json
@@ -192,11 +192,11 @@
  },
  "popup-width" : {
     "type" : "generic",
-    "default" : 630
+    "default" : 590
  },
  "popup-height" : {
     "type" : "generic",
-    "default" : 615
+    "default" : 515
  },
  "reset-menu-size-button" : {
     "type" : "button",


### PR DESCRIPTION
fixes https://github.com/linuxmint/mint21.2-beta/issues/26

I think when I chose the default size I was using a larger font size and had more category buttons, but with default theme/fonts, it does seem a bit big. Maybe these sizes are more reasonable?

Note that these numbers are smaller than they would have been before #11720 because they no longer take into account menu border/padding etc.