### PR TITLE
theme settings page: add a small l/r margin

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/themes.ui
+++ b/files/usr/share/cinnamon/cinnamon-settings/themes.ui
@@ -14,6 +14,8 @@
         <property name="halign">center</property>
         <property name="valign">start</property>
         <property name="margin-top">45</property>
+        <property name="margin-left">20</property>
+        <property name="margin-right">20</property>
         <property name="row-spacing">16</property>
         <property name="column-spacing">16</property>
         <child>


### PR DESCRIPTION
Some l/r margin is needed when a larger font size than the default is used.