### PR TITLE
Align labels in rows in the preferred applications to center

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_default.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_default.py
@@ -235,7 +235,7 @@ class MnemonicLabel(Gtk.Label):
         self.set_text_with_mnemonic(text)
         self.set_mnemonic_widget(widget)
         self.set_alignment(0.0, 0.5)
-        self.set_valign(Gtk.Align.START)
+        self.set_valign(Gtk.Align.CENTER)
         self.set_line_wrap(True)
 
 class DefaultAppChooserButton(Gtk.AppChooserButton):


### PR DESCRIPTION
In the "preferred applications" labels are aligned to up (START), i changed it to CENTER now.
Before
![before](https://github.com/linuxmint/cinnamon/assets/23406555/19edb600-27f4-4cfc-825b-99ea6d9937c7)
After
![after](https://github.com/linuxmint/cinnamon/assets/23406555/2407700d-d69a-483c-acbb-0d0e0b211c1a)
