### PR TITLE
cinnamon ui: improve overview animation

### DIFF
--- a/js/ui/overview.js
+++ b/js/ui/overview.js
@@ -407,7 +407,7 @@ Overview.prototype = {
             // Make other elements fade out.
             Tweener.addTween(this._group, {
                 opacity: 0,
-                transition: 'easeOutQuad',
+                transition: 'easeInQuad',
                 time: ANIMATION_TIME,
                 onComplete: this._hideDone,
                 onCompleteScope: this

--- a/js/ui/overview.js
+++ b/js/ui/overview.js
@@ -289,7 +289,7 @@ Overview.prototype = {
             Tweener.addTween(this._group, {
                 opacity: 255,
                 transition: 'easeOutQuad',
-                time: ANIMATION_TIME / 2.5,
+                time: ANIMATION_TIME * 0.45,
                 onComplete: this._showDone,
                 onCompleteScope: this
             });

--- a/js/ui/overview.js
+++ b/js/ui/overview.js
@@ -289,7 +289,7 @@ Overview.prototype = {
             Tweener.addTween(this._group, {
                 opacity: 255,
                 transition: 'easeOutQuad',
-                time: ANIMATION_TIME,
+                time: ANIMATION_TIME / 2.5,
                 onComplete: this._showDone,
                 onCompleteScope: this
             });

--- a/js/ui/workspace.js
+++ b/js/ui/workspace.js
@@ -1009,7 +1009,7 @@ WorkspaceMonitor.prototype = {
                                    y: clone.origY,
                                    scale_x: 1.0,
                                    scale_y: 1.0,
-                                   time: Overview.ANIMATION_TIME,
+                                   time: Overview.ANIMATION_TIME / 2,
                                    opacity: 255,
                                    transition: 'easeOutQuad'
                                  });

--- a/js/ui/workspace.js
+++ b/js/ui/workspace.js
@@ -765,7 +765,7 @@ WorkspaceMonitor.prototype = {
                                    scale_x: scale,
                                    scale_y: scale,
                                    time: Overview.ANIMATION_TIME,
-                                   transition: 'easeOutQuad',
+                                   transition: 'easeInOutQuad',
                                    onComplete: () => {
                                        this._animating = false
                                        this._showWindowOverlay(clone, true);
@@ -1009,7 +1009,7 @@ WorkspaceMonitor.prototype = {
                                    y: clone.origY,
                                    scale_x: 1.0,
                                    scale_y: 1.0,
-                                   time: Overview.ANIMATION_TIME / 2.5,
+                                   time: Overview.ANIMATION_TIME * 0.45,
                                    opacity: 255,
                                    transition: 'easeOutQuad'
                                  });

--- a/js/ui/workspace.js
+++ b/js/ui/workspace.js
@@ -1009,7 +1009,7 @@ WorkspaceMonitor.prototype = {
                                    y: clone.origY,
                                    scale_x: 1.0,
                                    scale_y: 1.0,
-                                   time: Overview.ANIMATION_TIME / 2,
+                                   time: Overview.ANIMATION_TIME / 2.5,
                                    opacity: 255,
                                    transition: 'easeOutQuad'
                                  });


### PR DESCRIPTION
The hidden windows were being shown before the end of the overview animation. Now the window will return to its original place before the real hidden window is shown in place.

May fix https://github.com/linuxmint/cinnamon/issues/11373