### PR TITLE
To fix the error of referencing a non-existent variable.

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/ChooserButtonWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/ChooserButtonWidgets.py
@@ -9,12 +9,13 @@ gettext.install("cinnamon", "/usr/share/locale")
 class BaseChooserButton(Gtk.Button):
     def __init__ (self, has_button_label=False):
         super(BaseChooserButton, self).__init__()
+        self.has_button_label = has_button_label
         self.set_valign(Gtk.Align.CENTER)
         self.menu = Gtk.Menu()
         self.button_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=2)
         self.button_image = Gtk.Image()
         self.button_box.add(self.button_image)
-        if has_button_label:
+        if self.has_button_label:
             self.button_label = Gtk.Label()
             self.button_box.add(self.button_label)
         self.add(self.button_box)
@@ -132,7 +133,8 @@ class PictureChooserButton(BaseChooserButton):
             self.button_image.set_from_icon_name("user-generic", Gtk.IconSize.BUTTON)
 
     def set_button_label(self, label):
-        self.button_label.set_markup(label)
+        if self.has_button_label:
+            self.button_label.set_markup(label)
 
     def _on_picture_selected(self, menuitem, path, callback, id=None):
         if id is not None:


### PR DESCRIPTION
I added a condition in set_button_label because if we set has_button_label to False and then use set_button_label, we will encounter an exception.
> kacper@kacper-VirtualBox:~$ cinnamon-settings themes
> /usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py:442: DeprecationWarning: Gtk.Window.set_wmclass is deprecated
>   self.window.set_wmclass(wm_class, wm_class)
> Loading Themes module
> /home/kacper/.local/share/themes does not exist! Skipping
> Mint-Y-Sand
> dupa
> Traceback (most recent call last):
>   File "/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py", line 793, in <module>
>     window = MainWindow()
>   File "/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py", line 314, in __init__
>     if self.load_sidepage_as_standalone():
>   File "/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py", line 448, in load_sidepage_as_standalone
>     self.go_to_sidepage(sp_data.sp, user_action=False)
>   File "/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py", line 174, in go_to_sidepage
>     sidePage.build()
>   File "/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py", line 212, in build
>     self.module.on_module_selected()
>   File "/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py", line 187, in on_module_selected
>     self.icon_chooser = self.create_button_chooser(self.settings, 'icon-theme', 'icons', 'icons', button_picture_size=ICON_SIZE, menu_pictures_size=ICON_SIZE, num_cols=4)
>   File "/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py", line 722, in create_button_chooser
>     self.set_button_chooser(chooser, theme, path_prefix, path_suffix, button_picture_size)
>   File "/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py", line 726, in set_button_chooser
>     self.set_button_chooser_text(chooser, theme)
>   File "/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py", line 748, in set_button_chooser_text
>     chooser.set_button_label(theme)
>   File "/usr/share/cinnamon/cinnamon-settings/bin/ChooserButtonWidgets.py", line 135, in set_button_label
>     self.button_label.set_markup(label)
> AttributeError: 'PictureChooserButton' object has no attribute 'button_label'. Did you mean: 'button_box'?
> Error in sys.excepthook:
> Traceback (most recent call last):
>   File "/usr/lib/python3/dist-packages/apport_python_hook.py", line 153, in apport_excepthook
>     with os.fdopen(os.open(pr_filename,
> FileNotFoundError: [Errno 2] Nie ma takiego pliku ani katalogu: '/var/crash/_usr_share_cinnamon_cinnamon-settings_cinnamon-settings.py.1000.crash'
> 
> Original exception was:
> Traceback (most recent call last):
>   File "/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py", line 793, in <module>
>     window = MainWindow()
>   File "/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py", line 314, in __init__
>     if self.load_sidepage_as_standalone():
>   File "/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py", line 448, in load_sidepage_as_standalone
>     self.go_to_sidepage(sp_data.sp, user_action=False)
>   File "/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py", line 174, in go_to_sidepage
>     sidePage.build()
>   File "/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py", line 212, in build
>     self.module.on_module_selected()
>   File "/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py", line 187, in on_module_selected
>     self.icon_chooser = self.create_button_chooser(self.settings, 'icon-theme', 'icons', 'icons', button_picture_size=ICON_SIZE, menu_pictures_size=ICON_SIZE, num_cols=4)
>   File "/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py", line 722, in create_button_chooser
>     self.set_button_chooser(chooser, theme, path_prefix, path_suffix, button_picture_size)
>   File "/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py", line 726, in set_button_chooser
>     self.set_button_chooser_text(chooser, theme)
>   File "/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py", line 748, in set_button_chooser_text
>     chooser.set_button_label(theme)
>   File "/usr/share/cinnamon/cinnamon-settings/bin/ChooserButtonWidgets.py", line 135, in set_button_label
>     self.button_label.set_markup(label)
> AttributeError: 'PictureChooserButton' object has no attribute 'button_label'. Did you mean: 'button_box'?
