### PR TITLE
grouped window list: fix drag and move app icon on the app list

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -548,7 +548,7 @@ class GroupedWindowListApplet extends Applet.Applet {
     }
 
     refreshCurrentAppList() {
-        let appList = this.appLists[this.state.currentWs];
+        let appList = this.getCurrentAppList();
         if (appList) appList.refreshList();
     }
 
@@ -643,7 +643,16 @@ class GroupedWindowListApplet extends Applet.Applet {
     }
 
     getCurrentAppList() {
-        if (typeof this.appLists[this.state.currentWs] !== 'undefined') {
+        let metaWorkspace = global.workspace_manager.get_workspace_by_index(this.state.currentWs);
+
+        let refWorkspace = findIndex(
+            this.appLists,
+            (item) => item.metaWorkspace && item.metaWorkspace === metaWorkspace
+        );
+
+        if (refWorkspace !== -1) {
+            return this.appLists[refWorkspace];
+        } else if (typeof this.appLists[this.state.currentWs] !== 'undefined') {
             return this.appLists[this.state.currentWs];
         } else if (typeof this.appLists[0] !== 'undefined') {
             return this.appLists[0];
@@ -694,6 +703,8 @@ class GroupedWindowListApplet extends Applet.Applet {
 
             this.state.set({scrollActive: true});
 
+            let appList = this.getCurrentAppList();
+
             let isAppScroll = this.state.settings.scrollBehavior === 2;
             let direction, source;
 
@@ -708,15 +719,15 @@ class GroupedWindowListApplet extends Applet.Applet {
             let lastFocusedApp, z, count
 
             if (isAppScroll) {
-                lastFocusedApp = this.appLists[this.state.currentWs].listState.lastFocusedApp;
+                lastFocusedApp = appList.listState.lastFocusedApp;
                 if (!lastFocusedApp) {
-                    lastFocusedApp = this.appLists[this.state.currentWs].appList[0].groupState.appId
+                    lastFocusedApp = appList.appList[0].groupState.appId
                 }
-                let focusedIndex = findIndex(this.appLists[this.state.currentWs].appList, function(appGroup) {
+                let focusedIndex = findIndex(appList.appList, function(appGroup) {
                     return appGroup.groupState.metaWindows.length > 0 && appGroup.groupState.appId === lastFocusedApp;
                 });
                 z = direction === 0 ? focusedIndex - 1 : focusedIndex + 1;
-                count = this.appLists[this.state.currentWs].appList.length - 1;
+                count = appList.appList.length - 1;
             } else {
                 if (!source.groupState || source.groupState.metaWindows.length < 1) {
                     return;
@@ -731,8 +742,8 @@ class GroupedWindowListApplet extends Applet.Applet {
             let limit = count * 2;
 
             while ((isAppScroll
-                && (!this.appLists[this.state.currentWs].appList[z]
-                    || !this.appLists[this.state.currentWs].appList[z].groupState.lastFocused))
+                && (!appList.appList[z]
+                    || !appList.appList[z].groupState.lastFocused))
                 || (!isAppScroll &&
                     (!source.groupState.metaWindows[z]
                         || source.groupState.metaWindows[z] === source.groupState.lastFocused))) {
@@ -755,7 +766,7 @@ class GroupedWindowListApplet extends Applet.Applet {
             }
 
             let _window = isAppScroll ?
-                this.appLists[this.state.currentWs].appList[z].groupState.lastFocused
+                appList.appList[z].groupState.lastFocused
                 : source.groupState.metaWindows[z];
             Main.activateWindow(_window, global.get_current_time());
             setTimeout(() => this.state.set({scrollActive: false}, 4000));
@@ -768,7 +779,7 @@ class GroupedWindowListApplet extends Applet.Applet {
         if(actor.name === 'xdnd-proxy-actor')
             return DND.DragMotionResult.CONTINUE;
 
-        let appList = this.appLists[this.state.currentWs];
+        let appList = this.getCurrentAppList();
         let rtl_horizontal = this.state.isHorizontal
             && St.Widget.get_default_direction () === St.TextDirection.RTL;
 
@@ -897,6 +908,13 @@ class GroupedWindowListApplet extends Applet.Applet {
 
         Meta.later_add(Meta.LaterType.BEFORE_REDRAW, () => {
             appList.updateAppGroupIndexes();
+
+            // Refresh app lists in other workspaces
+            each(this.appLists, function(_appList) {
+                if (_appList !== appList)
+                    setTimeout(() => _appList.refreshList(), 0);
+            });
+
             // Refresh the group's thumbnails so hoverMenu is aware of the position change
             // In the case of dragging a group that has a delay before Cinnamon can grab its
             // thumbnail texture, e.g., LibreOffice, defer the refresh.

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -645,13 +645,12 @@ class GroupedWindowListApplet extends Applet.Applet {
     getCurrentAppList() {
         let metaWorkspace = global.workspace_manager.get_workspace_by_index(this.state.currentWs);
 
-        let refWorkspace = findIndex(
-            this.appLists,
+        let currentAppList = find(this.appLists,
             (item) => item.metaWorkspace && item.metaWorkspace === metaWorkspace
         );
 
-        if (refWorkspace !== -1) {
-            return this.appLists[refWorkspace];
+        if (currentAppList) {
+            return currentAppList;
         } else if (typeof this.appLists[this.state.currentWs] !== 'undefined') {
             return this.appLists[this.state.currentWs];
         } else if (typeof this.appLists[0] !== 'undefined') {

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -552,15 +552,18 @@ class GroupedWindowListApplet extends Applet.Applet {
         if (appList) appList.refreshList();
     }
 
-    refreshAllAppLists() {
+    refreshAllAppLists(options = {exceptCurrentOne: false}) {
+        let currentAppList = this.getCurrentAppList();
         each(this.appLists, function(appList) {
+            if (options.exceptCurrentOne && currentAppList === appList)
+                return;
             setTimeout(() => appList.refreshList(), 0);
         });
     }
 
     updateFavorites() {
         this.pinnedFavorites.reload();
-        this.refreshCurrentAppList();
+        this.refreshAllAppLists();
     }
 
     updateThumbnailSize() {
@@ -908,12 +911,6 @@ class GroupedWindowListApplet extends Applet.Applet {
         Meta.later_add(Meta.LaterType.BEFORE_REDRAW, () => {
             appList.updateAppGroupIndexes();
 
-            // Refresh app lists in other workspaces
-            each(this.appLists, function(_appList) {
-                if (_appList !== appList)
-                    setTimeout(() => _appList.refreshList(), 0);
-            });
-
             // Refresh the group's thumbnails so hoverMenu is aware of the position change
             // In the case of dragging a group that has a delay before Cinnamon can grab its
             // thumbnail texture, e.g., LibreOffice, defer the refresh.
@@ -945,6 +942,8 @@ class GroupedWindowListApplet extends Applet.Applet {
                         this.pinnedFavorites.moveFavoriteToPos(opts);
                 }
             }
+
+            this.refreshAllAppLists({ exceptCurrentOne: true });
 
             return false;
         });


### PR DESCRIPTION
#### This fixes the following bug:
1. Go to any workspace but the first one
2. Reload the grouped-window-list applet
3. Go to another workspace
4. Try to move the pinned apps in the grouped window list applet (It will probably not work)
5. Try to drag any app from the menu and drop in the grouped window list (It will also not work, probably)

#### .xsession-errors error log:

![Screenshot from 2023-07-02 01-37-01](https://github.com/linuxmint/cinnamon/assets/63073056/fb747f3f-89e0-4523-9f39-cd0b2e57e49f)

---
  
I've also fixed https://github.com/linuxmint/cinnamon/issues/8534

