### PR TITLE
cinnamon.css: Center text in .applet-box

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -1817,6 +1817,7 @@ StScrollBar StButton#vhandle:hover {
     color: #ccc;
     text-shadow: black 0px 0px 2px;
     transition-duration: 300;
+    text-align: center;
 }
 .panel-top .applet-box,
 .panel-bottom .applet-box {


### PR DESCRIPTION
This is similar to existing Mint-X and Mint-Y themes in mint-themes and center aligns the time value in the Calendar applet.

Similar to linuxmint/mint-themes#452