### PR TITLE
lightbox: Reduce color banding by adding random noise (dithering)

### DIFF
--- a/js/ui/lightbox.js
+++ b/js/ui/lightbox.js
@@ -17,12 +17,15 @@ uniform float brightness;\n\
 uniform float vignette_sharpness;\n';
 
 const VIGNETTE_CODE = '\
+const float NOISE_GRANULARITY = 1.0/255.0;\n\
 cogl_color_out.a = cogl_color_in.a;\n\
 cogl_color_out.rgb = vec3(0.0, 0.0, 0.0);\n\
 vec2 position = cogl_tex_coord_in[0].xy - 0.5;\n\
 float t = length(2.0 * position);\n\
 t = clamp(t, 0.0, 1.0);\n\
 float pixel_brightness = mix(1.0, 1.0 - vignette_sharpness, t);\n\
+float pseudo_rand = fract(sin(dot(position.xy, vec2(12.9898,78.233))) * 43758.5453);\n\
+pixel_brightness += mix(-NOISE_GRANULARITY, NOISE_GRANULARITY, pseudo_rand);\n\
 cogl_color_out.a = cogl_color_out.a * (1 - pixel_brightness * brightness);';
 ;
 


### PR DESCRIPTION
Fixes: #11753

Before:

![Screenshot from 2023-07-17 05-51-52](https://github.com/linuxmint/cinnamon/assets/58893963/4f0d9cd4-62ea-4c50-a463-0ff41556e5e3)


After:

![Screenshot from 2023-07-17 05-50-44](https://github.com/linuxmint/cinnamon/assets/58893963/494fafa7-936a-49f8-a506-484071872d57)


before, close up & increased contrast

![Screenshot from 2023-07-17 05-29-42](https://github.com/linuxmint/cinnamon/assets/58893963/5a3e373f-5907-46c1-b4a7-fe9b689ab527)


after, close up & increased contrast

![Screenshot from 2023-07-17 05-12-20](https://github.com/linuxmint/cinnamon/assets/58893963/de0906c5-b8e3-4e6f-9804-71af5d8b3d35)
