### PR TITLE
Fix thumbnails not appearing for windows created while menu is open

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
@@ -821,7 +821,9 @@ class WindowThumbnail {
         }
 
         this.labelContainer.child.text = this.metaWindow.title || '';
-        this.getThumbnail(thumbnailWidth, thumbnailHeight);
+        setTimeout(() => {
+            this.getThumbnail(thumbnailWidth, thumbnailHeight);
+        }, 0);
     }
 
     hoverPeek(opacity) {


### PR DESCRIPTION
With this change, I don't have #11106 happen anymore.

For me, the bug happened whenever a window is created while the hover menu is open.

Thumbnails objects were being created and added to the list of thumbnails in the `AppThumbnailHoverMenu`. However, then `refreshThumbnail` is called, which calls `getThumbnail`. In `getThumbnail`, `metaWindowActor` is still null and `metaWindow.get_compositor_private` returned null, causing it to remove the thumbnail again before it was ever visible.

With the `setTimeout(..., 0)`, `getThumbnail` is called on the next event loop turn, so that the actor will be returned by `get_compositor_private`.

If the menu isn't open when the window is created, then the window is added to the `queuedWindows` array and added later on when the actor is available.

I don't understand the code great (like when events are triggered and the actor lifecycle), so I'm not sure if there would be a better fix. This seems like a fairly safe fix, and it's currently quite broken since it misses all windows that are opened while the menu is open. I haven't noticed issues from it. Does this seem like a reasonable fix or is there possibly a better one?
