### PR TITLE
fix: Resizing Applet PopupMenus will go behind panel if panel is set to auto hide

### DIFF
--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -3845,7 +3845,7 @@ Panel.prototype = {
     },
 
     getIsVisible: function() {
-        return this._shouldShow;
+        return !this._hidden;
     },
 
     resetDNDZones: function() {

--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -2428,6 +2428,7 @@ var PopupMenu = class PopupMenu extends PopupMenuBase {
             this.actor.show();
         }
 
+        Main.panelManager.updatePanelsVisibility();
         this.emit('open-state-changed', true);
     }
 


### PR DESCRIPTION
See Weather Applet if the hourly weather button is clicked and the panel is set to auto hide. 

The problem is that the panel reports it's not visible even though it is, so the  x,y calculation for PopupMenus are incorrect.

~Panels are not hidden until `global.menuStackLength` is bigger than one (meaning a PopupMenu is open for example)~

~**Note I do not know what manipulates `global.menuStackLength` so it contains something something else other than applet PopupMenu states this change probably will have unintended side effects.** _I checked it looks like it's only for PopupMenus._~

~Also we don't know which panels the stackItems belong to, so this will report that all of them are visible. _In theory_ this should not be a problem because you are only able to open only one, right?... but I somehow doubt that.~

~Now this PR has an opinionated decision to show panels that has open popup menus. This seems to be the easiest way to make sure panels report the correct visibility and popupMenus have correct positioning with using both mouse and keyboard bindings to open them.~

* Fix https://github.com/linuxmint/cinnamon-spices-applets/issues/4964