### PR TITLE
Always show panel if a menu open on it

### DIFF
--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -368,7 +368,7 @@ function start() {
 
     global.reparentActor(global.top_window_group, global.stage);
 
-    global.menuStackLength = 0;
+    global.menuStack = [];
 
     layoutManager = new Layout.LayoutManager();
 

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -3548,6 +3548,26 @@ Panel.prototype = {
     },
 
     /**
+     * _panelHasOpenMenus:
+     * 
+     * Checks if panel has open menus in the global.menuStack
+     * @returns 
+     */
+    _panelHasOpenMenus: function() {
+        if (global.menuStack == null || global.menuStack.length == 0)
+            return false;
+
+        for (let i = 0; i < global.menuStack.length; i++) {
+            let menu = global.menuStack[i];
+            if (menu.getPanel() === this.actor) {
+                return true;
+            }
+        }
+
+        return false;
+    },
+
+    /**
      * _updatePanelVisibility:
      *
      * Checks whether the panel should show based on the autohide settings and
@@ -3557,7 +3577,7 @@ Panel.prototype = {
      * true = autohide, false = always show, intel = Intelligent
      */
     _updatePanelVisibility: function() {
-        if (this._panelEditMode || this._peeking)
+        if (this._panelEditMode || this._peeking || this._panelHasOpenMenus())
             this._shouldShow = true;
         else {
             switch (this._autohideSettings) {
@@ -3787,7 +3807,7 @@ Panel.prototype = {
         if (this._destroyed) return;
         this._showHideTimer = 0;
 
-        if ((this._shouldShow && !force) || global.menuStackLength > 0) return;
+        if ((this._shouldShow && !force) || global.menuStack.length > 0) return;
 
         // setup panel tween - slide out the monitor edge leaving one pixel
         // if horizontal panel, animation on y. if vertical, animation on x.
@@ -3845,7 +3865,7 @@ Panel.prototype = {
     },
 
     getIsVisible: function() {
-        return this._shouldShow || global.menuStackLength > 0;
+        return this._shouldShow;
     },
 
     resetDNDZones: function() {

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -3807,7 +3807,7 @@ Panel.prototype = {
         if (this._destroyed) return;
         this._showHideTimer = 0;
 
-        if ((this._shouldShow && !force) || this._panelHasOpenMenus()) return;
+        if ((this._shouldShow && !force)) return;
 
         // setup panel tween - slide out the monitor edge leaving one pixel
         // if horizontal panel, animation on y. if vertical, animation on x.

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -3807,7 +3807,7 @@ Panel.prototype = {
         if (this._destroyed) return;
         this._showHideTimer = 0;
 
-        if ((this._shouldShow && !force) || global.menuStack.length > 0) return;
+        if ((this._shouldShow && !force) || this._panelHasOpenMenus()) return;
 
         // setup panel tween - slide out the monitor edge leaving one pixel
         // if horizontal panel, animation on y. if vertical, animation on x.

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -3845,7 +3845,7 @@ Panel.prototype = {
     },
 
     getIsVisible: function() {
-        return this._shouldShow;
+        return this._shouldShow || global.menuStackLength > 0;
     },
 
     resetDNDZones: function() {

--- a/js/ui/tooltips.js
+++ b/js/ui/tooltips.js
@@ -340,7 +340,7 @@ PanelItemTooltip.prototype = {
     },
 
     show: function() {
-        if (this._tooltip.get_text() == "" || global.menuStackLength > 0 || !this.mousePosition)
+        if (this._tooltip.get_text() == "" || global.menuStack.length > 0 || !this.mousePosition)
             return;
 
         let op = this._tooltip.get_opacity();


### PR DESCRIPTION
instead of the current policy of "Don't hide the panel if a menu is open on it". With this, if you open an applet with a keybinding, the panel for it will also show.

I made these changes for another PR, so I thought I open it. Discuss it among yourselves if it's really needed. Maybe it can be turned into an optional toggle (feature).