### PR TITLE
Menu applet: Fix bug where menu is partly behind panel

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1318,6 +1318,9 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
     _updateKeybinding() {
         Main.keybindingManager.addHotKey("overlay-key-" + this.instance_id, this.overlayKey, Lang.bind(this, function() {
             if (!Main.overview.visible && !Main.expo.visible)
+                if (this.forceShowPanel && !this.isOpen) {
+                    this.panel.peekPanel();
+                }
                 this.menu.toggle_with_options(this.enableAnimation);
         }));
     }
@@ -1495,10 +1498,6 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
             this._allAppsCategoryButton.actor.style_class = "menu-category-button-selected";
 
             Mainloop.idle_add(Lang.bind(this, this._initial_cat_selection, n));
-
-            if (this.forceShowPanel) {
-                this.panel.peekPanel();
-            }
         } else {
             this.actor.remove_style_pseudo_class('active');
             if (this.searchActive) {


### PR DESCRIPTION
Call peekPanel() before toggling menu open to ensure menu is positioned correctly.

Note: this PR makes no difference to current behaviour either way (doesn't fix the bug nor cause any other issues) unless PR #11770 is also merged. _updateKeybinding() is also the correct place to call peekPanel() anyway because it's only needed when menu is opened with key-press.

Fixes #10970, #11035, #11429, #11547