### PR TITLE
Show dual batteries properly in Power Management / Cinnamon Settings

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_power.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_power.py
@@ -320,16 +320,10 @@ class Module:
                 else:
                     primary_settings.add_row(self.set_device_ups_primary(device))
             elif device[UP_TYPE] == UPowerGlib.DeviceKind.BATTERY and not ups_as_primary:
-                if not have_primary:
-                    if not primary_settings:
-                        primary_settings = self.battery_page.add_section(_("Batteries"))
-                        primary_settings.add_row(self.set_device_battery_primary(device))
-                        self.show_battery_page = True
-                    have_primary = True
-                else:
-                    widget = self.set_device_battery_additional(device)
-                    if widget:
-                        primary_settings.add_row(widget)
+                if not primary_settings:
+                    primary_settings = self.battery_page.add_section(_("Batteries"))
+                primary_settings.add_row(self.set_device_battery_primary(device))
+                self.show_battery_page = True
             else:
                 if not secondary_settings:
                     secondary_settings = self.battery_page.add_section(_("Devices"))
@@ -438,30 +432,6 @@ class Module:
 
         widget = self.create_battery_row(device_id, "battery", desc, percentage, battery_level, details)
         return widget
-
-    def set_device_battery_additional(self, device):
-        state = device[UP_STATE]
-        details = None
-
-        if state == UPowerGlib.DeviceState.FULLY_CHARGED:
-            details = _("Fully charged")
-        elif state == UPowerGlib.DeviceState.EMPTY:
-            details = _("Empty")
-
-        if details:
-            widget = SettingsWidget()
-            icon = Gtk.Image.new_from_icon_name("battery", Gtk.IconSize.DND)
-            widget.pack_start(icon, False, False, 0)
-            label = Gtk.Label(_("Secondary battery"))
-            widget.pack_start(label, False, False, 0)
-            label = Gtk.Label()
-            label.set_markup(details)
-            label.get_style_context().add_class("dim-label")
-            widget.pack_end(label, False, False, 0)
-
-            return widget
-        else:
-            return None
 
     def add_battery_device_secondary(self, device):
         device_id = device[UP_ID]


### PR DESCRIPTION
I'm using Cinnamon on a ThinkPad T480 with dual batteries. Currently both batteries are shown in the panel applet, but only the internal one is shown in power management:
![grafik](https://github.com/linuxmint/cinnamon/assets/6748024/dd232aff-fa72-404d-8e89-c199f4494911)

The reason for that is, as mentioned in #7745, that additional batteries are only shown if they are fully charged or empty. I see no point doing it like that. Adding the other charging states:
![grafik](https://github.com/linuxmint/cinnamon/assets/6748024/18d7a024-3922-40fa-a402-4177650b83fb)

Now it's visible, but no percentage and it's impossible to rename it. Also can't see the point for doing it like this. So, after making every battery a "primary battery":
![grafik](https://github.com/linuxmint/cinnamon/assets/6748024/627a7fa5-dd3f-4ed4-9086-5410c701e615)

I've also added "PENDING_CHARGE" and "PENDING_DISCHARGE" as separate states, so it's possible to differentiate which battery is in use / being charged. Those will need translations.