### PR TITLE
Add Telegram desktop to list of players without seek support.

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -24,7 +24,7 @@ const MEDIA_PLAYER_2_PLAYER_NAME = "org.mpris.MediaPlayer2.Player";
 const OUTPUT_ICON_SHOW_TIME_SECONDS = 3;
 
 /* global values */
-let players_without_seek_support = ['spotify', 'totem', 'xplayer', 'gnome-mplayer', 'pithos',
+let players_without_seek_support = ['telegram desktop', 'spotify', 'totem', 'xplayer', 'gnome-mplayer', 'pithos',
     'smplayer'];
 let players_with_seek_support = [
     'clementine', 'banshee', 'rhythmbox', 'rhythmbox3', 'pragha', 'quodlibet',


### PR DESCRIPTION
Telegram desktop audio player send negative seek value after 35:55.  In melange log i see value like this -2147308296. After that player skips to the begin. To solve that problem I added Telegram desktop in list of players without seek support. https://github.com/telegramdesktop/tdesktop/issues/23892