### PR TITLE
messageTray.js and cs_notifications.py: Add an option for showing notifications in fullscreen

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_notifications.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_notifications.py
@@ -69,6 +69,9 @@ class Module:
         spin.revealer.settings = Gio.Settings("org.cinnamon.desktop.notifications")
         spin.revealer.settings.bind_with_mapping("notification-screen-display", spin.revealer, "reveal-child", Gio.SettingsBindFlags.GET, lambda option: option == "fixed-screen", None)
 
+        switch = GSettingsSwitch(_("Display notifications over fullscreen windows (experimental)"), "org.cinnamon.desktop.notifications", "fullscreen-notifications")
+        settings.add_reveal_row(switch, "org.cinnamon.desktop.notifications", "display-notifications")
+
         spin = GSettingsSpinButton(_("Notification duration"), "org.cinnamon.desktop.notifications", "notification-duration", _("seconds"), 1, 60, 1, 1)
         settings.add_reveal_row(spin, "org.cinnamon.desktop.notifications", "display-notifications")
 

--- a/js/ui/messageTray.js
+++ b/js/ui/messageTray.js
@@ -993,7 +993,9 @@ MessageTray.prototype = {
         if (!this._notification.silent || this._notification.urgency >= Urgency.HIGH) {
             Main.soundManager.play('notification');
         }
-        if (this._notification.urgency == Urgency.CRITICAL) {
+
+        this._showFullscreenNotifications = this.settings.get_boolean("fullscreen-notifications");
+        if (this._notification.urgency == Urgency.CRITICAL || this._showFullscreenNotifications) {
             Main.layoutManager._chrome.modifyActorParams(this._notificationBin, { visibleInFullscreen: true });
         } else {
             Main.layoutManager._chrome.modifyActorParams(this._notificationBin, { visibleInFullscreen: false });


### PR DESCRIPTION
In tandem with linuxmint/cinnamon-desktop#233.

Closes #9529