### PR TITLE
Replace util.js polyfills with JS natives...

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -10,7 +10,7 @@ const Tooltips = imports.ui.tooltips;
 const PopupMenu = imports.ui.popupMenu;
 const Mainloop = imports.mainloop;
 const {SignalManager} = imports.misc.signalManager;
-const {each, findIndex, unref} = imports.misc.util;
+const {unref} = imports.misc.util;
 const {createStore} = imports.misc.state;
 
 const {AppMenuButtonRightClickMenu, HoverMenuController, AppThumbnailHoverMenu} = require('./menus');
@@ -39,9 +39,9 @@ const getTextDirection = function(text) {
 // centered in length
 
 const center = function(length, naturalLength) {
-    let maxLength = Math.min(length, naturalLength);
-    let x1 = Math.floor((length - maxLength) / 2);
-    let x2 = x1 + maxLength;
+    const maxLength = Math.min(length, naturalLength);
+    const x1 = Math.floor((length - maxLength) / 2);
+    const x2 = x1 + maxLength;
     return [x1, x2];
 };
 
@@ -73,7 +73,7 @@ class AppGroup {
             windowCount: params.metaWindows ? params.metaWindows.length : 0,
             lastFocused: params.metaWindow || null,
             isFavoriteApp: !params.metaWindow ? true : params.isFavoriteApp === true,
-            autoStartIndex: findIndex(this.state.autoStartApps, (app) => app.id === params.appId),
+            autoStartIndex: this.state.autoStartApps.findIndex( app => app.id === params.appId),
             willUnmount: false,
             tooltip: null,
             // Not to be confused with the vertical thumbnail setting, this is for overriding horizontal
@@ -201,7 +201,7 @@ class AppGroup {
     }
 
     initRightClickMenu() {
-        let {state, groupState, actor} = this;
+        const {state, groupState, actor} = this;
         this.rightClickMenu = new AppMenuButtonRightClickMenu({
             state,
             groupState,
@@ -238,7 +238,7 @@ class AppGroup {
 
         this.actor.style = null;
 
-        let panelHeight = this.state.trigger('getPanelHeight');
+        const panelHeight = this.state.trigger('getPanelHeight');
 
         if (this.state.isHorizontal) {
             this.actor.height = panelHeight;
@@ -282,7 +282,7 @@ class AppGroup {
             });
         }
 
-        let oldChild = this.iconBox.get_child();
+        const oldChild = this.iconBox.get_child();
         this.iconBox.set_child(icon);
 
         if (oldChild) oldChild.destroy();
@@ -337,23 +337,21 @@ class AppGroup {
     }
 
     getPreferredWidth(actor, forHeight, alloc) {
-        let [iconMinSize, iconNaturalSize] = this.iconBox.get_preferred_width(forHeight);
-        let [labelMinSize, labelNaturalSize] = this.label.get_preferred_width(forHeight);
+        const [iconMinSize, iconNaturalSize] = this.iconBox.get_preferred_width(forHeight);
+        const [labelMinSize, labelNaturalSize] = this.label.get_preferred_width(forHeight);
         // The label text starts in the center of the icon, so we should allocate the space
         // needed for the icon plus the space needed for(label - icon/2)
         alloc.min_size = 1 * global.ui_scale;
 
-        let {appId, metaWindows, lastFocused} = this.groupState;
+        const {appId} = this.groupState;
 
-        let allocateForLabel = false;
-
-        allocateForLabel = this.labelVisiblePref ||
-                           (this.state.settings.titleDisplay == TitleDisplay.Focused &&
+        const allocateForLabel = this.labelVisiblePref ||
+                            (this.state.settings.titleDisplay == TitleDisplay.Focused &&
                             this.listState.lastFocusedApp === appId);
 
         if (this.state.orientation === St.Side.TOP || this.state.orientation === St.Side.BOTTOM) {
             if (allocateForLabel) {
-                let max = this.labelVisiblePref && this.groupState.metaWindows.length > 0 ?
+                const max = this.labelVisiblePref && this.groupState.metaWindows.length > 0 ?
                     labelNaturalSize + iconNaturalSize + 6 : 0;
                 alloc.natural_size = Math.min(iconNaturalSize + Math.max(max, labelNaturalSize), MAX_BUTTON_WIDTH * global.ui_scale);
             } else {
@@ -440,10 +438,10 @@ class AppGroup {
 
         // Call set_icon_geometry for support of Cinnamon's minimize animation
         if (this.groupState.metaWindows.length > 0 && this.actor.realized) {
-            let rect = new Meta.Rectangle();
+            const rect = new Meta.Rectangle();
             [rect.x, rect.y] = this.actor.get_transformed_position();
             [rect.width, rect.height] = this.actor.get_transformed_size();
-            each(this.groupState.metaWindows, (metaWindow) => {
+            this.groupState.metaWindows.forEach( metaWindow => {
                 if (metaWindow) {
                     metaWindow.set_icon_geometry(rect);
                 }
@@ -462,7 +460,7 @@ class AppGroup {
             return;
         }
 
-        let width = MAX_BUTTON_WIDTH * global.ui_scale;
+        const width = MAX_BUTTON_WIDTH * global.ui_scale;
 
         this.labelVisiblePref = true;
         if (this.label.text == null) {
@@ -520,13 +518,7 @@ class AppGroup {
     checkFocusStyle() {
         if (this.actor.is_finalized()) return;
 
-        let focused = false;
-        each(this.groupState.metaWindows, function(metaWindow) {
-            if (getFocusState(metaWindow)) {
-                focused = true;
-                return false;
-            }
-        });
+        const focused = this.groupState.metaWindows.some( metaWindow => getFocusState(metaWindow) );
 
         if (focused) {
             this.actor.add_style_pseudo_class('focus');
@@ -547,11 +539,11 @@ class AppGroup {
     }
 
     averageProgress() {
-        let {metaWindows} = this.groupState;
+        const {metaWindows} = this.groupState;
         let total = 0;
         let count = 0;
-        each(metaWindows, function(metaWindow) {
-            let {progress} = metaWindow;
+        metaWindows.forEach( metaWindow => {
+            const {progress} = metaWindow;
             if (progress < 1) return;
             total += progress;
             count++;
@@ -574,7 +566,7 @@ class AppGroup {
     }
 
     onProgressChange(metaWindow) {
-        let progress = this.averageProgress();
+        const progress = this.averageProgress();
         if (progress !== this.progress) {
             this.progress = progress;
             if (this.progress > 0) {
@@ -587,7 +579,7 @@ class AppGroup {
     }
 
     onFocusChange(hasFocus) {
-        let {appId, metaWindows, lastFocused} = this.groupState;
+        const {appId, metaWindows, lastFocused} = this.groupState;
 
         if (hasFocus === undefined) {
             hasFocus = this.listState.lastFocusedApp === appId;
@@ -599,6 +591,9 @@ class AppGroup {
             this.listState.trigger('updateFocusState', appId);
             this.actor.add_style_pseudo_class('focus');
             this.actor.remove_style_class_name('grouped-window-list-item-demands-attention');
+            if (this.hoverMenu) {
+                this.hoverMenu.appThumbnails.forEach( thumbnail => thumbnail.setThumbnailDemandsAttention(false) );
+            }
             this._needsAttention = false;
         } else {
             this.actor.remove_style_pseudo_class('focus');
@@ -615,7 +610,7 @@ class AppGroup {
         if (!this.groupState || !this.groupState.groupReady || this.groupState.willUnmount) {
             return;
         }
-        let windows = this.groupState.metaWindows;
+        const windows = this.groupState.metaWindows;
         for (let i = 0, len = windows.length; i < len; i++) {
             if (windows[i] === metaWindow) {
                 // Even though this may not be the last focused window, we want it to be
@@ -654,7 +649,7 @@ class AppGroup {
             || this.state.panelEditMode) {
             return DND.DragMotionResult.CONTINUE;
         }
-        let nWindows = this.groupState.metaWindows.length;
+        const nWindows = this.groupState.metaWindows.length;
         if (nWindows > 0 && this.groupState.lastFocused) {
             if (nWindows === 1) {
                 Main.activateWindow(this.groupState.lastFocused, global.get_current_time());
@@ -705,14 +700,14 @@ class AppGroup {
             return;
         }
 
-        let button = event.get_button();
-        let nWindows = this.groupState.metaWindows.length;
+        const button = event.get_button();
+        const nWindows = this.groupState.metaWindows.length;
 
-        let modifiers = Cinnamon.get_event_state(event);
-        let ctrlPressed = (modifiers & Clutter.ModifierType.CONTROL_MASK);
-        let shiftPressed = (modifiers & Clutter.ModifierType.SHIFT_MASK);
+        const modifiers = Cinnamon.get_event_state(event);
+        const ctrlPressed = (modifiers & Clutter.ModifierType.CONTROL_MASK);
+        const shiftPressed = (modifiers & Clutter.ModifierType.SHIFT_MASK);
 
-        let shouldStartInstance = (
+        const shouldStartInstance = (
             (button === 1 && ctrlPressed)
             || (button === 1 && shiftPressed)
             || (button === 1
@@ -723,7 +718,7 @@ class AppGroup {
                 && this.state.settings.middleClickAction === 2)
         );
 
-        let shouldEndInstance = button === 2
+        const shouldEndInstance = button === 2
             && this.state.settings.middleClickAction === 3
             && this.groupState.lastFocused
             && nWindows > 0;
@@ -738,7 +733,7 @@ class AppGroup {
             return;
         }
 
-        let handleMinimizeToggle = (win) => {
+        const handleMinimizeToggle = (win) => {
             if (this.state.settings.onClickThumbs && nWindows > 1) {
                 if (!this.hoverMenu) this.initThumbnailMenu();
                 if (this.hoverMenu.isOpen) {
@@ -819,7 +814,7 @@ class AppGroup {
     }
 
     onAppButtonPress(actor, event) {
-        let button = event.get_button();
+        const button = event.get_button();
         this.groupState.pressed = true;
 
         if (button === 3) return true;
@@ -878,7 +873,7 @@ class AppGroup {
             if (this.groupState.lastFocused.minimized) {
                 this.groupState.lastFocused.unminimize();
             }
-            let ws = this.groupState.lastFocused.get_workspace().index();
+            const ws = this.groupState.lastFocused.get_workspace().index();
             if (ws !== global.workspace_manager.get_active_workspace_index()) {
                 global.workspace_manager.get_workspace_by_index(ws).activate(global.get_current_time());
             }
@@ -888,8 +883,8 @@ class AppGroup {
     }
 
     windowAdded(metaWindow) {
-        let {metaWindows, trigger, set} = this.groupState;
-        let refWindow = metaWindows.indexOf(metaWindow);
+        const {metaWindows, trigger, set} = this.groupState;
+        const refWindow = metaWindows.indexOf(metaWindow);
         if (metaWindow) {
             this.signals.connect(metaWindow, 'notify::title', (...args) => this.onWindowTitleChanged(...args));
             this.signals.connect(metaWindow, 'notify::appears-focused', (...args) => this.onFocusWindowChange(...args));
@@ -976,7 +971,7 @@ class AppGroup {
             return;
         }
 
-        let shouldHideLabel = this.state.settings.titleDisplay === TitleDisplay.None
+        const shouldHideLabel = this.state.settings.titleDisplay === TitleDisplay.None
             || !this.state.isHorizontal;
 
         if (shouldHideLabel) {
@@ -1000,12 +995,12 @@ class AppGroup {
         metaWindow.lastTitle = metaWindow.title;
 
         if (this.hoverMenu) {
-            each(this.hoverMenu.appThumbnails, (thumbnail) => {
-                if (thumbnail.metaWindow === metaWindow) {
-                    thumbnail.labelContainer.child.set_text(metaWindow.title);
-                    return false;
-                }
-            });
+            const thumbnail = this.hoverMenu.appThumbnails.find(
+                thumbnail => thumbnail.metaWindow === metaWindow
+            );
+            if (thumbnail) {
+                thumbnail.labelContainer.child.set_text(metaWindow.title);
+            }
         }
 
         this.groupState.set({
@@ -1018,7 +1013,7 @@ class AppGroup {
     onFocusWindowChange(metaWindow) {
         if (this.groupState.metaWindows.length === 0) return;
 
-        let hasFocus = getFocusState(metaWindow);
+        const hasFocus = getFocusState(metaWindow);
         if (hasFocus && this.groupState.hasOwnProperty('lastFocused')) {
             this.listState.set({lastFocusedApp: this.groupState.appId});
             this.groupState.set({lastFocused: metaWindow});
@@ -1080,7 +1075,7 @@ class AppGroup {
     calcWindowNumber() {
         if (this.groupState.willUnmount) return;
 
-        let windowCount = this.groupState.metaWindows ? this.groupState.metaWindows.length : 0;
+        const windowCount = this.groupState.metaWindows ? this.groupState.metaWindows.length : 0;
         this.numberLabel.text = windowCount.toString();
 
         this.groupState.set({windowCount});
@@ -1098,13 +1093,13 @@ class AppGroup {
     }
 
     handleTitleDisplayChange() {
-        each(this.groupState.metaWindows, (win) => {
-            this.onWindowTitleChanged(win, true);
-        });
+        this.groupState.metaWindows.forEach(
+            win => this.onWindowTitleChanged(win, true)
+        );
     }
 
     animate() {
-        let effect = this.state.settings.launcherAnimationEffect;
+        const effect = this.state.settings.launcherAnimationEffect;
 
         if (effect === 1) return;
         else if (effect === 2) {

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/menus.js
@@ -2,7 +2,6 @@ const Clutter = imports.gi.Clutter;
 const Meta = imports.gi.Meta;
 const St = imports.gi.St;
 const Gio = imports.gi.Gio;
-const AppletManager = imports.ui.appletManager;
 const Main = imports.ui.main;
 const Tweener = imports.ui.tweener;
 const PopupMenu = imports.ui.popupMenu;
@@ -11,7 +10,7 @@ const SignalManager = imports.misc.signalManager;
 const WindowUtils = imports.misc.windowUtils;
 const Mainloop = imports.mainloop;
 
-const {each, findIndex, tryFn, unref, trySpawnCommandLine, spawn_async, getDesktopActionIcon} = imports.misc.util;
+const {tryFn, unref, trySpawnCommandLine, spawn_async, getDesktopActionIcon} = imports.misc.util;
 const {
     CLOSE_BTN_SIZE,
     CLOSED_BUTTON_STYLE,
@@ -53,9 +52,9 @@ class AppMenuButtonRightClickMenu extends Applet.AppletPopupMenu {
 
     monitorMoveWindows(i) {
         if (this.state.settings.monitorMoveAllWindows) {
-            let metaWindows = this.groupState.metaWindows.slice();
+            const metaWindows = this.groupState.metaWindows.slice();
             while (metaWindows.length > 0) {
-                let metaWindow = metaWindows[0];
+                const metaWindow = metaWindows[0];
                 if (metaWindow === this.groupState.lastFocused) {
                     Main.activateWindow(metaWindow, global.get_current_time());
                 }
@@ -74,10 +73,10 @@ class AppMenuButtonRightClickMenu extends Applet.AppletPopupMenu {
 
         let item;
         let length;
-        let hasWindows = this.groupState.metaWindows.length > 0;
-        let isWindowBacked = this.groupState.app.is_window_backed();
+        const hasWindows = this.groupState.metaWindows.length > 0;
+        const isWindowBacked = this.groupState.app.is_window_backed();
 
-        let createMenuItem = (opts = {label: '', icon: null}) => {
+        const createMenuItem = (opts = {label: '', icon: null}) => {
             if (opts.icon) {
                 return new PopupMenu.PopupIconMenuItem(opts.label, opts.icon, St.IconType.SYMBOLIC);
             }
@@ -91,7 +90,7 @@ class AppMenuButtonRightClickMenu extends Applet.AppletPopupMenu {
         if (hasWindows) {
             // Monitors
             if (Main.layoutManager.monitors.length > 1) {
-                let connectMonitorEvent = (item, i) => {
+                const connectMonitorEvent = (item, i) => {
                     this.signals.connect(item, 'activate', () => this.monitorMoveWindows(i));
                 };
                 for (let i = 0, len = Main.layoutManager.monitors.length; i < len; i++) {
@@ -130,17 +129,17 @@ class AppMenuButtonRightClickMenu extends Applet.AppletPopupMenu {
                     item = new PopupMenu.PopupSubMenuMenuItem(_('Move to another workspace'));
                     this.addMenuItem(item);
 
-                    let connectWorkspaceEvent = (ws, j) => {
+                    const connectWorkspaceEvent = (ws, j) => {
                         this.signals.connect(ws, 'activate', () => {
                             this.groupState.lastFocused.change_workspace(global.workspace_manager.get_workspace_by_index(j));
                         });
                     };
                     for (let i = 0; i < length; i++) {
                         // Make the index a local variable to pass to function
-                        let j = i;
-                        let name = Main.workspace_names[i] ? Main.workspace_names[i] : Main._makeDefaultWorkspaceName(i);
-                        let menuItem = createMenuItem({label: _(name)});
-                        let ws = this.groupState.lastFocused.get_workspace();
+                        const j = i;
+                        const name = Main.workspace_names[i] ? Main.workspace_names[i] : Main._makeDefaultWorkspaceName(i);
+                        const menuItem = createMenuItem({label: _(name)});
+                        const ws = this.groupState.lastFocused.get_workspace();
 
                         if (ws && i === ws.index()) {
                             menuItem.setSensitive(false);
@@ -155,7 +154,7 @@ class AppMenuButtonRightClickMenu extends Applet.AppletPopupMenu {
         }
 
         // Preferences
-        let subMenu = new PopupMenu.PopupSubMenuMenuItem(_('Applet preferences'));
+        const subMenu = new PopupMenu.PopupSubMenuMenuItem(_('Applet preferences'));
         this.addMenuItem(subMenu);
 
         item = createMenuItem({label: _('About...'), icon: 'dialog-question'});
@@ -175,14 +174,14 @@ class AppMenuButtonRightClickMenu extends Applet.AppletPopupMenu {
         if (this.state.settings.showRecent) {
             // Places
             if (this.groupState.appId === 'nemo.desktop' || this.groupState.appId === 'nemo-home.desktop') {
-                let subMenu = new PopupMenu.PopupSubMenuMenuItem(_('Places'));
+                const subMenu = new PopupMenu.PopupSubMenuMenuItem(_('Places'));
                 this.addMenuItem(subMenu);
 
-                let defualtPlaces = this.listDefaultPlaces();
-                let bookmarks = this.listBookmarks();
-                let devices = this.listDevices();
-                let places = [...defualtPlaces, ...bookmarks, ...devices];
-                let handlePlaceLaunch = (item, i) => {
+                const defualtPlaces = this.listDefaultPlaces();
+                const bookmarks = this.listBookmarks();
+                const devices = this.listDevices();
+                const places = [...defualtPlaces, ...bookmarks, ...devices];
+                const handlePlaceLaunch = (item, i) => {
                     this.signals.connect(item, 'activate', () => places[i].launch());
                 };
                 for (let i = 0, len = places.length; i < len; i++) {
@@ -194,12 +193,12 @@ class AppMenuButtonRightClickMenu extends Applet.AppletPopupMenu {
             }
 
             // Recent Files
-            let recentItems = this.state.trigger('getRecentItems');
-            let items = [];
+            const recentItems = this.state.trigger('getRecentItems');
+            const items = [];
 
             for (let i = 0, len = recentItems.length; i < len; i++) {
-                let mimeType = recentItems[i].get_mime_type();
-                let appInfo = Gio.app_info_get_default_for_type(mimeType, false);
+                const mimeType = recentItems[i].get_mime_type();
+                const appInfo = Gio.app_info_get_default_for_type(mimeType, false);
                 if (appInfo && this.groupState.appInfo && appInfo.get_id() === this.groupState.appId) {
                     items.push(recentItems[i]);
                 }
@@ -207,13 +206,13 @@ class AppMenuButtonRightClickMenu extends Applet.AppletPopupMenu {
             let itemsLength = items.length;
 
             if (itemsLength > 0) {
-                let subMenu = new PopupMenu.PopupSubMenuMenuItem(_('Recent'));
+                const subMenu = new PopupMenu.PopupSubMenuMenuItem(_('Recent'));
                 this.addMenuItem(subMenu);
-                let num = 10;
+                const num = 10;
                 if (itemsLength > num) {
                     itemsLength = num;
                 }
-                let handleRecentLaunch = (item, i) => {
+                const handleRecentLaunch = (item, i) => {
                     this.signals.connect(item, 'activate', () => {
                         Gio.app_info_launch_default_for_uri(items[i].get_uri(), global.create_app_launch_context())
                     });
@@ -239,10 +238,10 @@ class AppMenuButtonRightClickMenu extends Applet.AppletPopupMenu {
         // Actions
         tryFn(() => {
             if (!this.groupState.appInfo) return;
-            let actions = this.groupState.appInfo.list_actions();
+            const actions = this.groupState.appInfo.list_actions();
             if (actions) {
                 this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-                let handleAction = (action) => {
+                const handleAction = (action) => {
                     let icon = getDesktopActionIcon(action);
                     if (icon == null)
                         icon = 'application-x-executable';
@@ -283,7 +282,7 @@ class AppMenuButtonRightClickMenu extends Applet.AppletPopupMenu {
             this.signals.connect(this.pinToggleItem, 'activate', (...args) => this.toggleFavorite(...args));
             this.addMenuItem(this.pinToggleItem);
             if (this.state.settings.autoStart) {
-                let label = this.groupState.autoStartIndex !== -1 ? _('Remove from Autostart') : _('Add to Autostart');
+                const label = this.groupState.autoStartIndex !== -1 ? _('Remove from Autostart') : _('Add to Autostart');
                 item = createMenuItem({label: label, icon: 'insert-object'});
                 this.signals.connect(item, 'activate', (...args) => this.toggleAutostart(...args));
                 this.addMenuItem(item);
@@ -298,7 +297,7 @@ class AppMenuButtonRightClickMenu extends Applet.AppletPopupMenu {
 
         // Window controls
         if (hasWindows) {
-            let metaWindowActor = this.groupState.lastFocused.get_compositor_private();
+            const metaWindowActor = this.groupState.lastFocused.get_compositor_private();
             // Miscellaneous
             if (metaWindowActor && metaWindowActor.opacity !== 255) {
                 item = createMenuItem({label: _('Restore to full opacity')});
@@ -339,7 +338,7 @@ class AppMenuButtonRightClickMenu extends Applet.AppletPopupMenu {
                 // Close others
                 item = createMenuItem({label: _('Close others'), icon: 'window-close'});
                 this.signals.connect(item, 'activate', () => {
-                    each(this.groupState.metaWindows, (metaWindow) => {
+                    this.groupState.metaWindows.forEach( metaWindow => {
                         if (metaWindow !== this.groupState.lastFocused && !metaWindow._needsAttention) {
                             metaWindow.delete(global.get_current_time());
                         }
@@ -390,7 +389,7 @@ class AppMenuButtonRightClickMenu extends Applet.AppletPopupMenu {
             this.state.autoStartApps.splice(this.groupState.autoStartIndex, 1);
             this.groupState.set({autoStartIndex: -1});
         } else {
-            let filePath = this.groupState.appInfo.get_filename();
+            const filePath = this.groupState.appInfo.get_filename();
             trySpawnCommandLine('bash -c "cp ' + filePath + ' ' + autoStartStrDir + '"');
             setTimeout(() => {
                 this.state.trigger('getAutoStartApps');
@@ -412,8 +411,8 @@ class AppMenuButtonRightClickMenu extends Applet.AppletPopupMenu {
     }
 
     createShortcut() {
-        let proc = this.groupState.lastFocused.get_pid();
-        let cmd = [
+        const proc = this.groupState.lastFocused.get_pid();
+        const cmd = [
             'bash',
             '-c',
             'python3 /usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/utils.py get_process ' + proc.toString()
@@ -429,8 +428,8 @@ class AppMenuButtonRightClickMenu extends Applet.AppletPopupMenu {
     }
 
     listDefaultPlaces(pattern) {
-        let defaultPlaces = Main.placesManager.getDefaultPlaces();
-        let res = [];
+        const defaultPlaces = Main.placesManager.getDefaultPlaces();
+        const res = [];
         for (let i = 0, len = defaultPlaces.length; i < len; i++) {
             if (!pattern || defaultPlaces[i].name.toLowerCase().indexOf(pattern) !== -1) {
                 res.push(defaultPlaces[i]);
@@ -440,8 +439,8 @@ class AppMenuButtonRightClickMenu extends Applet.AppletPopupMenu {
     }
 
     listBookmarks(pattern) {
-        let bookmarks = Main.placesManager.getBookmarks();
-        let res = [];
+        const bookmarks = Main.placesManager.getBookmarks();
+        const res = [];
         for (let i = 0, len = bookmarks.length; i < len; i++) {
             if (!pattern || bookmarks[i].name.toLowerCase().indexOf(pattern) !== -1) {
                 res.push(bookmarks[i]);
@@ -451,8 +450,8 @@ class AppMenuButtonRightClickMenu extends Applet.AppletPopupMenu {
     }
 
     listDevices(pattern) {
-        let devices = Main.placesManager.getMounts();
-        let res = [];
+        const devices = Main.placesManager.getMounts();
+        const res = [];
         for (let i = 0, len = devices.length; i < len; i++) {
             if (!pattern || devices[i].name.toLowerCase().indexOf(pattern) !== -1) {
                 res.push(devices[i]);
@@ -569,7 +568,7 @@ class WindowThumbnail {
             y_expand: false
         });
 
-        let label = new St.Label({
+        const label = new St.Label({
             style_class: 'grouped-window-list-thumbnail-label',
             important: true
         });
@@ -630,16 +629,21 @@ class WindowThumbnail {
         this.button.set_opacity(0);
     }
 
-    onWindowDemandsAttention(window) {
-        if (this._needsAttention) {
-            return false;
-        }
-        this._needsAttention = true;
-        if (this.metaWindow === window) {
+    setThumbnailDemandsAttention(attention) {
+        //if (this.metaWindow === window) {
+        if (attention) {
+            if (this._needsAttention) {
+                return;
+            }
+            this._needsAttention = true;
             this.actor.add_style_class_name('grouped-window-list-thumbnail-alert');
-            return true;
+        } else {
+            if (!this._needsAttention) {
+                return;
+            }
+            this._needsAttention = false;
+            this.actor.remove_style_class_name('grouped-window-list-thumbnail-alert');
         }
-        return false;
     }
 
     onFocusWindowChange() {
@@ -675,7 +679,7 @@ class WindowThumbnail {
     }
 
     onCloseButtonRelease(actor, event) {
-        let button = event.get_button();
+        const button = event.get_button();
         if (button === 1 && actor === this.button) {
             this.handleCloseClick();
         }
@@ -686,7 +690,7 @@ class WindowThumbnail {
             this.groupState.trigger('hoverMenuClose');
             return;
         }
-        let button = typeof event === 'number' ? event : event.get_button();
+        const button = typeof event === 'number' ? event : event.get_button();
         if (button === 1 && !this.stopClick) {
             Main.activateWindow(this.metaWindow, global.get_current_time());
             this.groupState.trigger('hoverMenuClose');
@@ -713,7 +717,7 @@ class WindowThumbnail {
         if (this.metaWindowActor && !this.metaWindowActor.is_finalized()) {
             this.signals.connect(this.metaWindow, 'unmanaging', () => this.disconnectSizeNotify());
 
-            let texture = this.metaWindowActor.get_texture();
+            const texture = this.metaWindowActor.get_texture();
             if (texture == null) {
                 return;
             }
@@ -721,7 +725,7 @@ class WindowThumbnail {
             this.signals.connect(texture, 'size-changed', () => this.refreshThumbnail());
 
             let [width, height] = this.metaWindowActor.get_size();
-            let scale = Math.min(1.0, thumbnailWidth / width, thumbnailHeight / height) * global.ui_scale;
+            const scale = Math.min(1.0, thumbnailWidth / width, thumbnailHeight / height) * global.ui_scale;
             width = Math.round(width * scale);
             height = Math.round(height * scale);
             if (this.thumbnailActor.child == null || (this.thumbnailActor.child.name?.startsWith("TextureWindowClone"))) {
@@ -748,7 +752,7 @@ class WindowThumbnail {
     disconnectSizeNotify(actor) {
         this.signals.disconnect('unmanaging', this.metaWindow);
 
-        let texture = this.metaWindowActor.get_texture();
+        const texture = this.metaWindowActor.get_texture();
         if (texture) {
             this.signals.disconnect("size-changed", texture);
         }
@@ -764,12 +768,12 @@ class WindowThumbnail {
             return;
         }
 
-        let monitor = this.state.trigger('getPanelMonitor');
+        const monitor = this.state.trigger('getPanelMonitor');
         if (!monitor) return;
 
         if (!this.thumbnailActor || this.thumbnailActor.is_finalized()) return;
 
-        let divider = 80 * global.ui_scale;
+        const divider = 80 * global.ui_scale;
         let {thumbSize} = this.state.settings;
 
         if (monitor.height / global.ui_scale <= 1024) {
@@ -790,8 +794,8 @@ class WindowThumbnail {
             thumbnailSize = thumbnailWidth;
         }
 
-        let padding = this.thumbnailActor.style_length('padding');
-        let margin = this.thumbnailActor.style_length('margin');
+        const padding = this.thumbnailActor.style_length('padding');
+        const margin = this.thumbnailActor.style_length('margin');
 
         let i = 0;
         while (((thumbnailSize + this.thumbnailPadding + padding + margin) * this.groupState.windowCount > monitorSize)
@@ -809,12 +813,12 @@ class WindowThumbnail {
 
         // If we can't fit all the thumbnails, revert to a vertical menu orientation
         // with no thumbnails, which can hold more window selections.
-        let verticalThumbs = ((thumbnailSize + this.thumbnailPadding + padding + margin) * this.groupState.windowCount) > monitorSize;
-        let currentVerticalThumbsState = this.groupState.verticalThumbs;
+        const verticalThumbs = ((thumbnailSize + this.thumbnailPadding + padding + margin) * this.groupState.windowCount) > monitorSize;
+        const currentVerticalThumbsState = this.groupState.verticalThumbs;
         this.groupState.set({verticalThumbs});
         if (verticalThumbs !== currentVerticalThumbsState) return;
 
-        let scaledWidth = thumbnailWidth * global.ui_scale;
+        const scaledWidth = thumbnailWidth * global.ui_scale;
         this.thumbnailActor.width = scaledWidth;
         this.container.style = `width: ${Math.floor(thumbnailWidth - 16)}px;`;
         if (this.groupState.verticalThumbs || (this.state.settings.verticalThumbs && this.state.settings.showThumbs)) {
@@ -863,7 +867,7 @@ class WindowThumbnail {
         if (!this.state.lastOverlayPreview) return;
 
         if (this.state.settings.peekTimeOut) {
-            let currOverlayPreview = this.state.lastOverlayPreview;
+            const currOverlayPreview = this.state.lastOverlayPreview;
             setOpacity(
                 this.state.settings.peekTimeOut,
                 currOverlayPreview,
@@ -925,8 +929,8 @@ class AppThumbnailHoverMenu extends PopupMenu.PopupMenu {
                 // over the menu and closes it if not.
                 setTimeout(() => {
                     let [x, y, mask] = global.get_pointer();
-                    let draggedOverActor = global.stage.get_actor_at_pos(Clutter.PickMode.ALL, x, y);
-                    let parent = draggedOverActor.get_parent();
+                    const draggedOverActor = global.stage.get_actor_at_pos(Clutter.PickMode.ALL, x, y);
+                    const parent = draggedOverActor.get_parent();
                     if (!(parent instanceof St.Widget)) {
                         this.close(true);
                     }
@@ -941,7 +945,7 @@ class AppThumbnailHoverMenu extends PopupMenu.PopupMenu {
                 this.queuedWindows.push(win);
             },
             removeThumbnailFromMenu: (win) => {
-                let index = findIndex(this.appThumbnails, (item) => item.metaWindow === win);
+                let index = this.appThumbnails.findIndex( item => item.metaWindow === win);
                 if (index > -1) {
                     this.appThumbnails[index].destroy();
                     this.appThumbnails[index] = undefined;
@@ -952,7 +956,7 @@ class AppThumbnailHoverMenu extends PopupMenu.PopupMenu {
             },
             verticalThumbs: () => {
                 // Preserve the menu's open state after refreshing
-                let {isOpen} = this;
+                const {isOpen} = this;
                 this.setVerticalSetting();
                 if (isOpen) this.open(true);
             },
@@ -963,18 +967,18 @@ class AppThumbnailHoverMenu extends PopupMenu.PopupMenu {
                     // 50ms loop until the menu closes so we continue getting data in the absence of events.
                     this.interval = setInterval(() => {
                         let [x, y, mask] = global.get_pointer();
-                        let draggedOverActor = global.stage.get_actor_at_pos(Clutter.PickMode.ALL, x, y);
+                        const draggedOverActor = global.stage.get_actor_at_pos(Clutter.PickMode.ALL, x, y);
                         if (draggedOverActor instanceof Meta.ShapedTexture) {
                             this.groupState.set({fileDrag: false});
                             this.close(true);
                             return;
                         }
-                        each(this.appThumbnails, function(thumbnail) {
+                        for (const thumbnail of this.appThumbnails) {
                             if (thumbnail.thumbnailActor === draggedOverActor) {
                                 Main.activateWindow(thumbnail.metaWindow, global.get_current_time());
-                                return false;
+                                break;
                             }
-                        });
+                        }
                     }, 50);
                 } else if (this.interval) {
                     clearInterval(this.interval);
@@ -989,7 +993,7 @@ class AppThumbnailHoverMenu extends PopupMenu.PopupMenu {
 
     addQueuedThumbnails() {
         if (this.queuedWindows.length === 0) return;
-        each(this.queuedWindows, (win) => this.addThumbnail(win));
+        this.queuedWindows.forEach( win => this.addThumbnail(win));
         this.queuedWindows = [];
     }
 
@@ -1041,7 +1045,7 @@ class AppThumbnailHoverMenu extends PopupMenu.PopupMenu {
     }
 
     onKeyRelease(actor, event) {
-        let symbol = event.get_key_symbol();
+        const symbol = event.get_key_symbol();
         if (this.isOpen && (symbol === Clutter.KEY_Super_L || symbol === Clutter.KEY_Super_R)) {
             // Close this menu, if opened by super + #
             this.close(true);
@@ -1092,16 +1096,14 @@ class AppThumbnailHoverMenu extends PopupMenu.PopupMenu {
     }
 
     onKeyPress(actor, e) {
-        let {orientation} = this.state;
-        let {vertical} = this.box;
+        const {orientation} = this.state;
+        const {vertical} = this.box;
 
-        let symbol = e.get_key_symbol();
-        let i = findIndex(this.appThumbnails, (item) => item.entered === true);
-        let entered = i > -1;
+        const symbol = e.get_key_symbol();
+        let i = this.appThumbnails.findIndex( item => item.entered === true );
+        const entered = i > -1;
         if (!entered) {
-            i = findIndex(this.appThumbnails, function(thumbnail) {
-                return thumbnail.isFocused;
-            });
+            i = this.appThumbnails.findIndex( thumbnail => thumbnail.isFocused );
             if (i === -1) {
                 i = 0;
             }
@@ -1194,9 +1196,9 @@ class AppThumbnailHoverMenu extends PopupMenu.PopupMenu {
                 return b.metaWindow.user_time - a.metaWindow.user_time;
             });
         }
-        let refThumb = findIndex(this.appThumbnails, (thumbnail) => thumbnail.metaWindow === metaWindow);
+        const refThumb = this.appThumbnails.findIndex( thumbnail => thumbnail.metaWindow === metaWindow );
         if (!this.appThumbnails[refThumb] && refThumb === -1) {
-            let thumbnail = new WindowThumbnail({
+            const thumbnail = new WindowThumbnail({
                 state: this.state,
                 groupState: this.groupState,
                 metaWindow: metaWindow,
@@ -1272,3 +1274,9 @@ class AppThumbnailHoverMenu extends PopupMenu.PopupMenu {
         unref(this, RESERVE_KEYS);
     }
 }
+
+module.exports = {
+    AppMenuButtonRightClickMenu,
+    HoverMenuController,
+    AppThumbnailHoverMenu
+};

--- a/js/misc/util.js
+++ b/js/misc/util.js
@@ -460,102 +460,6 @@ function queryCollection(collection, query, indexOnly = false) {
 }
 
 /**
- * findIndex:
- * @array (array): Array to be iterated.
- * @callback (function): The function to call on every iteration,
- * should return a boolean value.
- *
- * Returns (number): the index of @array, else -1.
- */
-function findIndex(array, callback) {
-    for (let i = 0, len = array.length; i < len; i++) {
-        if (array[i] && callback(array[i], i, array)) {
-            return i;
-        }
-    }
-    return -1;
-}
-
-/**
- * find:
- * @array (array): Array to be iterated.
- * @callback (function): The function to call on every iteration,
- * should return a boolean value.
- *
- * Returns (any): Returns the matched element, else null.
- */
-function find(arr, callback) {
-    for (let i = 0, len = arr.length; i < len; i++) {
-        if (callback(arr[i], i, arr)) {
-            return arr[i];
-        }
-    }
-    return null;
-};
-
-/**
- * each:
- * @array (array|object): Array or object to be iterated.
- * @callback (function): The function to call on every iteration.
- *
- * Iteratee functions may exit iteration early by explicitly returning false.
- */
-function each(obj, callback) {
-    if (Array.isArray(obj)) {
-        for (let i = 0, len = obj.length; i < len; i++) {
-            if (callback(obj[i], i) === false) {
-                return;
-            }
-        }
-    } else {
-        let keys = Object.keys(obj);
-        for (let i = 0, len = keys.length; i < len; i++) {
-            let key = keys[i];
-            callback(obj[key], key);
-        }
-    }
-};
-
-/**
- * filter:
- * @array (array): Array to be iterated.
- * @callback (function): The function to call on every iteration.
- *
- * Returns (array): Returns the new filtered array.
- */
-function filter(arr, callback) {
-    let result = [];
-    for (let i = 0, len = arr.length; i < len; i++) {
-        if (callback(arr[i], i, arr)) {
-            result.push(arr[i]);
-        }
-    }
-    return result;
-};
-
-/**
- * map:
- * @array (array): Array to be iterated.
- * @callback (function): The function to call on every iteration.
- *
- * Returns (array): Returns the new mapped array.
- */
-function map(arr, callback) {
-    if (arr == null) {
-        return [];
-    }
-
-    let len = arr.length;
-    let out = Array(len);
-
-    for (let i = 0; i < len; i++) {
-        out[i] = callback(arr[i], i, arr);
-    }
-
-    return out;
-};
-
-/**
  * tryFn:
  * @callback (function): Function to wrap in a try-catch block.
  * @errCallback (function): The function to call on error.
@@ -717,7 +621,7 @@ const FastObject = function(o) {
 }
 FastObject();
 function toFastProperties(obj) {
-    each(obj, function(value) {
+    Object.values(obj).forEach( value => {
         if (value && !Array.isArray(value)) FastObject(value);
     });
 };

--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -210,7 +210,7 @@ var Applet = class Applet {
         if (!instance_id) instance_id = this.instance_id;
         let appletDefinition = AppletManager.getAppletDefinition({applet_id: instance_id});
         if (appletDefinition) {
-            let panelIndex = Util.findIndex(Main.panelManager.panels, function(panel) {
+            const panelIndex = Main.panelManager.panels.findIndex( panel => {
                 return panel && (panel.panelId === appletDefinition.panelId);
             });
             if (panelIndex > -1) {

--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -10,7 +10,7 @@ const Applet = imports.ui.applet;
 const Extension = imports.ui.extension;
 const ModalDialog = imports.ui.modalDialog;
 const {getModuleByIndex} = imports.misc.fileUtils;
-const {queryCollection, findIndex} = imports.misc.util;
+const {queryCollection} = imports.misc.util;
 const Gettext = imports.gettext;
 const Panel = imports.ui.panel;
 
@@ -279,7 +279,7 @@ function onEnabledAppletsChanged() {
         if (unChangedApplets.indexOf(oldDefinitions[i].applet_id) === -1) {
             removedApplets.push({changed: false, definition: oldDefinitions[i]});
         } else {
-            let removedIndex = findIndex(removedApplets, function(item) {
+            const removedIndex = removedApplets.findIndex( item => {
                 return item.definition.applet_id === oldDefinitions[i].applet_id;
             });
             if (removedIndex === -1) continue;

--- a/js/ui/overrides.js
+++ b/js/ui/overrides.js
@@ -26,12 +26,12 @@ function overrideDumpStack() {
 }
 
 function overrideGObject() {
-    const {each, toFastProperties} = imports.misc.util;
+    const {toFastProperties} = imports.misc.util;
 
     const originalInit = GObject.Object.prototype._init;
     GObject.Object.prototype._init = function _init() {
         originalInit.call(this, ...arguments);
-        each(this, function(value) {
+        Object.values(this).forEach( value => {
             if (value && !Array.isArray(value)) toFastProperties(value);
         });
     }

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -3035,8 +3035,8 @@ Panel.prototype = {
         ];
 
         /* Iterate thru the sizeSets to get our sizes for all 3 types */
-        Util.each(sizeSets, (set, i) => {
-            let [typeString, settingKey, getSizeFunc, defaults] = set;
+        sizeSets.forEach( sizeSet => {
+            let [typeString, settingKey, getSizeFunc, defaults] = sizeSet;
 
             let settingsArray = this._getJSONProperty(settingKey);
 
@@ -3054,7 +3054,7 @@ Panel.prototype = {
 
             /* Now, iterate thru the individual set's values (an individual setting key's array of panel sizes),
              * then compute their display sizes and stick them in this._panelZoneSizes for the current type. */
-            Util.each(settingsArray, (sizes, i) => {
+            settingsArray.forEach( sizes => {
                 if (sizes.panelId !== this.panelId) return;
 
                 haveSettings = true;
@@ -3104,10 +3104,10 @@ Panel.prototype = {
             [this._rightBox, "right"]
         ];
 
-        Util.each(zones, (zone, i) => {
+        zones.forEach( zone => {
             let [actor, zoneString] = zone;
 
-            let value = this._panelZoneSizes["text"][zoneString];
+            const value = this._panelZoneSizes["text"][zoneString];
 
             if (value > 0.0) {
                 actor.set_style("font-size: %.1fpt;".format(value));
@@ -3182,16 +3182,16 @@ Panel.prototype = {
             ["text", PANEL_ZONE_TEXT_SIZES]
         ];
 
-        Util.each(sizeSets, (set, i) => {
-            let [typeString, settingKey] = set;
+        sizeSets.forEach( sizeSet => {
+            let [typeString, settingKey] = sizeSet;
 
             let settingsArray = this._getJSONProperty(settingKey);
 
             /* Temporarily disconnect setting handler, so we don't trigger for our own update */
             this._signalManager.disconnect("changed::" + settingKey);
 
-            let zoneIndex = Util.findIndex(settingsArray, (obj) => {
-                return obj.panelId === this.panelId;
+            const zoneIndex = settingsArray.findIndex( obj => {
+                return obj && obj.panelId === this.panelId;
             });
 
             if (zoneIndex >= 0) {
@@ -3845,7 +3845,7 @@ Panel.prototype = {
     },
 
     getIsVisible: function() {
-        return !this._hidden;
+        return this._shouldShow;
     },
 
     resetDNDZones: function() {

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -3845,7 +3845,7 @@ Panel.prototype = {
     },
 
     getIsVisible: function() {
-        return this._shouldShow;
+        return !this._hidden;
     },
 
     resetDNDZones: function() {

--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -2084,7 +2084,7 @@ var PopupMenuBase = class PopupMenuBase {
     _menuQueueRelayout() {
         let node = this.actor.peek_theme_node();
         if (node && node.get_background_image()) {
-            Util.each(this.box.get_children(), (actor) => actor.queue_relayout());
+            this.box.get_children().forEach( actor => actor.queue_relayout());
         }
     }
 

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -7,7 +7,6 @@ const Meta = imports.gi.Meta;
 const St = imports.gi.St;
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
-const Util = imports.misc.util;
 const Main = imports.ui.main;
 const WindowMenu = imports.ui.windowMenu;
 const GObject = imports.gi.GObject;
@@ -796,7 +795,7 @@ var WindowManager = class WindowManager {
                 this._dimWindow(window, true);
         } else if (!shouldDim && window._dimmed) {
             window._dimmed = false;
-            this._dimmedWindows = Util.filter(this._dimmedWindows, function(win) {
+            this._dimmedWindows = this._dimmedWindows.filter(function(win) {
                 return win !== window;
             });
             if (!Main.overview.visible)


### PR DESCRIPTION
Replace all instances of `js/misc/util.js` polyfills (`findIndex(), find(), each(), filter() & map()`) with JS natives in cinnamon and delete these polyfills from `util.js`.

These were originally added for performance but are now slower in current cjs. They are no longer used by any xlets in linuxmint/cinnamon-spices-applets, linuxmint/cinnamon-spices-desklets, or linuxmint/cinnamon-spices-extensions. However, they are still used in the cinnamon menu applet so this PR depends on https://github.com/linuxmint/cinnamon/pull/11865 also being merged.

+grouped-window-list applet: Always add alert style to thumbnail when app window needs attention and implement same style removal when app is focused (not previously implemented)

+grouped-window-list applet: used `const` instead of `let` where possible.