### PR TITLE
Fixed calculate a sidePage height when it comes as standalone

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
@@ -219,6 +219,7 @@ class MainWindow(Gio.Application):
             m, n = widget.get_preferred_width()
             width += n
         self.top_bar.set_size_request(width + 20, -1)
+        self.calculate_bar_heights()
         self.maybe_resize(sidePage)
 
     def maybe_resize(self, sidePage):
@@ -236,7 +237,8 @@ class MainWindow(Gio.Application):
             use_height = sidePage.size + self.bar_heights + WIN_H_PADDING
         elif sidePage.size == -1:
             # Module requested the window to fit it (i.e. shrink the window if necessary)
-            use_height = total_height
+            use_height = total_height + self.bar_heights + WIN_H_PADDING
+
 
         self.window.resize(WIN_WIDTH, use_height)
 

--- a/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
@@ -237,7 +237,7 @@ class MainWindow(Gio.Application):
             use_height = sidePage.size + self.bar_heights + WIN_H_PADDING
         elif sidePage.size == -1:
             # Module requested the window to fit it (i.e. shrink the window if necessary)
-            use_height = total_height + self.bar_heights + WIN_H_PADDING
+            use_height = total_height + self.bar_heights
 
 
         self.window.resize(WIN_WIDTH, use_height)


### PR DESCRIPTION
All modules, when called as standalone (via menu), were too small (in height). I added the missing variables and called the calculus function in this case.
Before:
![image](https://github.com/linuxmint/cinnamon/assets/23406555/9c970294-05ca-4c9a-84b3-4945ab79f96c)


After:
![image](https://github.com/linuxmint/cinnamon/assets/23406555/0e0c8786-ad55-4336-8fad-3faa213418c2)
