### PR TITLE
fix: incorrect icon for app running in a separate pid namespace

### DIFF
--- a/src/cinnamon-window-tracker.c
+++ b/src/cinnamon-window-tracker.c
@@ -567,9 +567,11 @@ get_app_for_window (CinnamonWindowTracker    *tracker,
   if (result != NULL)
     return result;
 
+#if 0
   result = get_app_from_window_pid (tracker, window);
   if (result != NULL)
     return result;
+#endif
 
   /* Now we check whether we have a match through startup-notification */
   startup_id = meta_window_get_startup_id (window);


### PR DESCRIPTION
To reproduce:
With grouped-window-list, keep 'Group windows by application' off.
Run Chromium in a separate pid namespace. Chromium gets pid 2. (In my case firejail and 'ip netns' are used.)
Run another app in another pid namespace. It gets pid 2 too.
Sometimes the icon of this app in the grouped-window-list is replaced with the Chromium's icon, quite often after closing and opening a new window.

After examining the window properties of the two apps above, I find their _NET_WM_PID are both 2, and this makes get_app_from_window_pid() return the same CinnamonApp.