### PR TITLE
Fix xlet-settings TreeListWidget's handling of columns with option lists

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/TreeListWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/TreeListWidgets.py
@@ -150,13 +150,13 @@ class List(SettingsWidget):
             column = Gtk.TreeViewColumn(column_def['title'], renderer)
 
             if has_option_map:
-                def map_func(col, rend, model, row_iter, options):
-                    value = model[row_iter][i]
-                    for key, val in options.items():
+                def map_func(col, rend, model, row_iter, data):
+                    value = model[row_iter][data[1]]
+                    for key, val in data[0].items():
                         if val == value:
                             rend.set_property('text', key)
 
-                column.set_cell_data_func(renderer, map_func, column_def['options'])
+                column.set_cell_data_func(renderer, map_func, [column_def['options'],i])
             else:
                 column.add_attribute(renderer, prop_name, i)
 


### PR DESCRIPTION
When there exists a "list" with a column containing an options set and the column is not the last column defined, the content for that column in the list will be displayed incorrectly. The content displayed will always be based on the last column content rather than the content matching the column index.

Since the map function will only be executed after the 'for' loop has finished, the index in the enclosing scope will always be the index of the last column rather than the index of the expected column. Therefore using the enclosing scope index will cause the map function to use incorrect model data when setting the list column content, unless the column happens to be the last column in the list.

This fix will pass the index variable into the map function as part of the func_data parameter rather than using the index variable directly from the enclosing scope.