### PR TITLE
xlet-settings.py: Ensure settings window expands to fit toolbar

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/xlet-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/xlet-settings.py
@@ -194,6 +194,7 @@ class MainWindow(object):
 
         toolbar = Gtk.Toolbar()
         toolbar.get_style_context().add_class("primary-toolbar")
+        toolbar.set_show_arrow(False)
         main_box.add(toolbar)
 
         toolitem = Gtk.ToolItem()


### PR DESCRIPTION
Fix bug where toolbar disappears if the window is too narrow.

As the settings window Toolbar only contains one ToolItem, this ToolItem can disappear if the window is too narrow and Toolbar:show-arrow property is set to true. Set Toolbar:show-arrow to false to ensure that the window will expand to accommodate the full width of the Toolbar.

ref. https://github.com/linuxmint/cinnamon-spices-applets/issues/5065