### PR TITLE
Allow "no tooltips" on the window list as well as the existing "title" or "thumbnail" options

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -386,7 +386,7 @@ class AppMenuButton {
         if (this._tooltip)
             this._tooltip.destroy();
 
-        if (this._applet.usePreview)
+        if (this._applet.windowHover == "thumbnail")
             this._tooltip = new WindowPreview(this, this.metaWindow, this._applet.previewScale, this._applet.showLabel);
         else
             this._tooltip = new Tooltips.PanelItemTooltip(this, "", this._applet.orientation);
@@ -521,7 +521,7 @@ class AppMenuButton {
         if (title.length > MAX_TEXT_LENGTH)
             title = title.substr(0, MAX_TEXT_LENGTH);
 
-        if (this._tooltip  && this._tooltip.set_text)
+        if (this._tooltip && this._applet.windowHover != "nothing" && this._tooltip.set_text)
             this._tooltip.set_text(title);
 
         if (this.metaWindow.minimized) {
@@ -1046,7 +1046,7 @@ class CinnamonWindowListApplet extends Applet.Applet {
         this.settings.bind("button-width", "buttonWidth", this._refreshAllItems);
         this.settings.bind("buttons-use-entire-space", "buttonsUseEntireSpace", this._refreshAllItems);
         this.settings.bind("panel-show-label", "showLabelPanel", this._updateLabels);
-        this.settings.bind("window-preview", "usePreview", this._onPreviewChanged);
+        this.settings.bind("window-hover", "windowHover", this._onPreviewChanged);
         this.settings.bind("window-preview-show-label", "showLabel", this._onPreviewChanged);
         this.settings.bind("window-preview-scale", "previewScale", this._onPreviewChanged);
         this.settings.bind("last-window-order", "lastWindowOrder", null);

--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/settings-schema.json
@@ -59,16 +59,21 @@
       "description": "Window buttons can have different sizes and use the entire space available",
       "dependency": "panel-show-label"
   },
-  "window-preview": {
-      "type": "switch",
-      "default": true,
-      "description": "Show window thumbnails on hover"
+  "window-hover": {
+      "type": "radiogroup",
+      "default": "thumbnail",
+      "description": "Choose what to show when hovering over a window button",
+      "options": {
+          "Nothing": "nothing",
+          "Title": "title",
+          "Thumbnail": "thumbnail"
+      }
   },
   "window-preview-show-label": {
       "type": "switch",
       "default": true,
       "description": "Show title above thumbnail",
-      "dependency": "window-preview"
+      "dependency": "window-hover=thumbnail"
   },
   "window-preview-scale": {
       "type": "radiogroup",
@@ -80,7 +85,7 @@
           "Large": 1.25,
           "Largest": 1.5
       },
-      "dependency": "window-preview"
+      "dependency": "window-hover=thumbnail"
   },
   "last-window-order": {
       "type": "generic",


### PR DESCRIPTION
This patch changes the window list applet config to use a menu to choose the behaviour when hovering over a window:
![window-list-menu-screenshot](https://github.com/linuxmint/cinnamon/assets/7988240/449f290d-6c0a-43a3-8103-dadd38cb1ccf)

The existing behaviours (window title or window thumbnail) are offered, as well as a new "nothing" option which disables any kind of tooltip.

My personal motivation for this is that when I am switching to a terminal window, it's natural for me to leave the mouse cursor on the terminal window's icon in the window list, but that means the tooltip obscures the bottom part of the terminal window I'm typing into. This is similar to the concerns raised in https://github.com/linuxmint/Cinnamon/issues/4549. I hope you'll agree that this patch doesn't make the user experience worse for those who like the tooltips while allowing an unobtrusive way to disable them.

There has been (limited) [discussion of this patch on the Mint forums](https://forums.linuxmint.com/viewtopic.php?t=405983&sid=f5377b30f47d8fa6de3336662f5ffad3). Note that the first version of the patch posted to that thread has been superseded by this one - it worked, but had a clunky configuration setting.