### PR TITLE
Adds option to always show the input switch in the sound applet. (Closes #11232)

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -953,6 +953,7 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
         if (this.hideSystray) this.registerSystrayIcons();
 
         this.settings.bind("keyOpen", "keyOpen", this._setKeybinding);
+        this.settings.bind("alwaysShowMuteInput", "alwaysShowMuteInput", this.on_settings_changed);
 
         this.settings.bind("tooltipShowVolume", "tooltipShowVolume", this.on_settings_changed);
         this.settings.bind("tooltipShowPlayer", "tooltipShowPlayer", this.on_settings_changed);
@@ -1042,7 +1043,10 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
         this.mute_in_switch = new PopupMenu.PopupSwitchIconMenuItem(_("Mute input"), false, "microphone-sensitivity-muted", St.IconType.SYMBOLIC);
         this._applet_context_menu.addMenuItem(this.mute_out_switch);
         this._applet_context_menu.addMenuItem(this.mute_in_switch);
-        this.mute_in_switch.actor.hide();
+        if (this.alwaysShowMuteInput)
+            this.mute_in_switch.actor.show();
+        else
+            this.mute_in_switch.actor.hide();
 
         this._applet_context_menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
@@ -1108,6 +1112,11 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
         else
             this.setAppletTextIcon();
 
+        if (this.alwaysShowMuteInput)
+            this.mute_in_switch.actor.show();
+        else if (this._recordingAppsNum === 0)
+            this.mute_in_switch.actor.hide();
+
         this._changeActivePlayer(this._activePlayer);
     }
 
@@ -1151,13 +1160,9 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
         if (!this._input)
             return;
 
-        if (this._input.is_muted) {
-            this._input.change_is_muted(false);
-            this.mute_in_switch.setToggleState(false);
-        } else {
-            this._input.change_is_muted(true);
-            this.mute_in_switch.setToggleState(true);
-        }
+        let newStatus = !this._input.is_muted;
+        this._input.change_is_muted(newStatus);
+        this.mute_in_switch.setToggleState(newStatus);
     }
 
     _onScrollEvent(actor, event) {
@@ -1691,6 +1696,8 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
                         this._inputSection.actor.hide();
                         this.mute_in_switch.actor.hide();
                     }
+                    if (this.alwaysShowMuteInput)
+                        this.mute_in_switch.actor.show();
                 }
                 this._streams.splice(i, 1);
                 break;

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/settings-schema.json
@@ -20,6 +20,12 @@
         "default": "<Shift><Super>s",
         "tooltip" : "Set keybinding(s) to show the sound applet menu."
     },
+    "alwaysShowMuteInput": {
+        "type": "switch",
+        "description": "Always show input switch",
+        "tooltip": "Always show the 'Mute input' switch in the context menu.",
+        "default": false
+    },
     "_knownPlayers": {
         "type": "generic",
         "default": ["banshee", "vlc", "rhythmbox"]


### PR DESCRIPTION
The PR https://github.com/linuxmint/cinnamon/pull/10620/ hides the input switch, if no recording device is open. But let's say you want to mute your microphone before starting a video session, you need that input switch _before_ you start the conference software!

This adds a switch to the configuration screen to always enable the input switch. The default is the old behaviour: Only show it, when a recording device is open. (But you may want to change that.)

This is based on the commit
https://github.com/linuxmint/cinnamon-spices-applets/commit/670c97dc987c42b8c13da9d8cb034bd0f080577a for the sound150@claudiux spice. Thanks @claudiux!