### PR TITLE
Improve settings icons

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/ExtensionCore.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/ExtensionCore.py
@@ -756,7 +756,7 @@ class DownloadSpicesRow(Gtk.ListBoxRow):
         size_groups[3].add_widget(self.button_box)
 
         if not self.installed:
-            download_button = Gtk.Button.new_from_icon_name('go-down-symbolic', 2)
+            download_button = Gtk.Button.new_from_icon_name('folder-download-symbolic', 2)
             self.button_box.pack_start(download_button, False, False, 0)
             download_button.connect('clicked', self.download)
             download_button.set_tooltip_text(_("Install"))

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_startup.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_startup.py
@@ -441,7 +441,7 @@ class AutostartBox(Gtk.Box):
         self.remove_button.set_sensitive(False)
         box.add(self.remove_button)
 
-        self.run_button = Gtk.Button.new_from_icon_name("system-run-symbolic", Gtk.IconSize.BUTTON)
+        self.run_button = Gtk.Button.new_from_icon_name("media-playback-start-symbolic", Gtk.IconSize.BUTTON)
         self.run_button.set_tooltip_text(_("Run now"))
         self.run_button.connect("clicked", self.on_run_button_clicked)
         button_group.add_widget(self.run_button)


### PR DESCRIPTION
I'd like to suggest to improve the Applet, Desklet and Extension download icon. Since Mint 21, it does not look like a download button anymore (more like a dropdown menu) which is confusing for new users.
![downloadbtn](https://github.com/linuxmint/cinnamon/assets/17480795/ad25df50-6f49-45c8-9bc4-51ca58baa5ae)

Furthermore, the execute button in the autostart settings looks more like "edit" or "settings" instead of an "execute now". That's why I suggest to display a play button instead.
![executebtn](https://github.com/linuxmint/cinnamon/assets/17480795/d24fb986-445d-4664-8606-fd0fe5366233)
