### PR TITLE
Fix GLib exception:

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_notifications.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_notifications.py
@@ -72,7 +72,7 @@ class Module:
         settings.add_reveal_row(combo, "org.cinnamon.desktop.notifications", "display-notifications")
 
         spin = GSettingsSpinButton(_("Fixed screen number"), "org.cinnamon.desktop.notifications", "notification-fixed-screen", None, 1, 13, 1)
-        settings.add_reveal_row(spin, "org.cinnamon.desktop.notifications", "notification-fixed-screen")
+        settings.add_reveal_row(spin)
         spin.revealer.settings = Gio.Settings("org.cinnamon.desktop.notifications")
         spin.revealer.settings.bind_with_mapping("notification-screen-display", spin.revealer, "reveal-child", Gio.SettingsBindFlags.GET, lambda option: option == "fixed-screen", None)
 


### PR DESCRIPTION
g_settings_bind: property 'reveal-child' on class 'xapp+SettingsWidgets+SettingsRevealer' has type 'gboolean' which is not compatible with type 'i' of key 'notification-fixed-screen' on schema 'org.cinnamon.desktop.notifications'