### PR TITLE
Fix the power applet battery status when the seconds var is 3600

### DIFF
--- a/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
@@ -434,7 +434,7 @@ class CinnamonPowerApplet extends Applet.TextIconApplet {
             if (time == 0) {
                 status = _("Charging");
             }
-            else if (time > 60) {
+            else if (time >= 60) {
                 if (minutes == 0) {
                     status = ngettext("Charging - %d hour until fully charged", "Charging - %d hours until fully charged", hours).format(hours);
                 }
@@ -455,7 +455,7 @@ class CinnamonPowerApplet extends Applet.TextIconApplet {
             if (time == 0) {
                 status = _("Using battery power");
             }
-            else if (time > 60) {
+            else if (time >= 60) {
                 if (minutes == 0) {
                     status = ngettext("Using battery power - %d hour remaining", "Using battery power - %d hours remaining", hours).format(hours);
                 }


### PR DESCRIPTION
In the edgecase of the charge/discharge seconds var being the magic number 3600, the power applet will erroneously report `0 minutes remaining` as the conditional statement will not take exactly 1 hour into account, with the time var equaling 60.

This PR fixes issue #11930

This is my first time committing to the Cinnamon repo, so any pointers are highly appreciated!