### PR TITLE
Improve Timestamp for Notifications

### DIFF
--- a/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
@@ -306,7 +306,11 @@ function timeify(orig_time) {
     let now = new Date();
     let diff = Math.floor((now.getTime() - orig_time.getTime()) / 1000); // get diff in seconds
     let str;
-    str = orig_time.toLocaleFormat('%x, %X');
+    if (use_24h) {
+        str = orig_time.toLocaleFormat('%x, %T');
+    } else {
+        str = orig_time.toLocaleFormat('%x, %r');
+    }
     switch (true) {
         case (diff <= 15): {
             str += " (" + _("just now") + ")";

--- a/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
@@ -306,11 +306,7 @@ function timeify(orig_time) {
     let now = new Date();
     let diff = Math.floor((now.getTime() - orig_time.getTime()) / 1000); // get diff in seconds
     let str;
-    if (use_24h) {
-        str = orig_time.toLocaleFormat('%T');
-    } else {
-        str = orig_time.toLocaleFormat('%r');
-    }
+    str = orig_time.toLocaleFormat('%x, %X');
     switch (true) {
         case (diff <= 15): {
             str += " (" + _("just now") + ")";


### PR DESCRIPTION
1. display the whole Timestamp-String including the Date, as the pure Time of Day is useless when looking at a Notification from several Days ago

2. use the User's Locale instead of a Flag "use_24h", moreover as this Flag is not Part of the App's Configuration-Settings