### PR TITLE
Fix Main.activateWindow() for windows with normal transient children

### DIFF
--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -1359,7 +1359,9 @@ function activateWindow(window, time, workspaceNum) {
     window.activate(time);
     Mainloop.idle_add(function() {
         window.foreach_transient(function(win) {
-            win.activate(time);
+            if (win.get_window_type() != Meta.WindowType.NORMAL) {
+                win.activate(time);
+            }
         });
     });
 


### PR DESCRIPTION
If a window has a transient child of type Meta.WindowType.NORMAL the behaviour of Main.activateWindow() will be to bring the transient window into focus rather then the window that was requested (i.e. the window of the 'window' parameter).

The change that introduced this behaviour (#1266) was intended to ensure that when the "Open file" dialog for gedit was already open and the user switched back to the gedit window, the transient "Open file" dialog should come to the foreground and have focus. In most cases this is the best action to take since the transient window does not have an entry of its own in the window list (i.e. Alt-TAB) and therefore can't be activated by the user any other way, and in most cases it's exactly what the user wanted anyhow.

But in cases where there is a "normal" window that is a transient child of a selected window, it seems logical to active only the selected window since the "normal" transient child window will have its own entry in the window list and if the user wanted to interact with that child window he/she would have selected that window instead.

A good example of this case is the "Find" dialog opened by gnome-terminal when you press Ctrl+Shift+F. This window appears in the window list and therefore can be switched to directly, but with #1266 the user is forced to switch to the "Find" dialog even when they select the terminal window. The user has no way to get to the terminal window without clicking on it.

With this fix I am proposing to only activate child transient windows when the transient is NOT Meta.WindowType.NORMAL.