### PR TITLE
[WIP] add Cinnamon Menu Editor to Menu by default

### DIFF
--- a/files/usr/share/applications/cinnamon-menu-editor.desktop
+++ b/files/usr/share/applications/cinnamon-menu-editor.desktop
@@ -1,11 +1,10 @@
 [Desktop Entry]
-Name=Cinnamon Menu Editor
+Name=Menu Editor
 Comment=Edit the entries of the Cinnamon menu applet
 Exec=cinnamon-menu-editor
 Icon=alacarte
 OnlyShowIn=X-Cinnamon;
 Terminal=false
 Type=Application
-NoDisplay=true
-Categories=GNOME;GTK;Settings;DesktopSettings;
+Categories=Settings;
 StartupNotify=false


### PR DESCRIPTION
Currently, the menu editor by default only opens with 
'Right-click on the menu launch button - Edit menu.'

To figure out how to edit the Menu, I first spent about 20 minutes searching for this function in the Menu and System Settings. Then I googled it, but the search in Google in my language only suggested using third-party programs, and only the search in English gave a result. 
I think it would be useful to add the menu editor by default to the Menu and possibly to the System Settings.
![image](https://github.com/linuxmint/cinnamon/assets/96445511/8727eb0c-33d1-4585-97cd-b13fc30b0e54)

This is my first pull request and I would appreciate help and feedback.
I have a few questions:
What do I need to do to properly localize this item in the Menu?
Do I need to add it to generate_additional_files.py or somewhere else, or is the translation to .desktop done manually?
Do I need to do the translation myself using Google Translate or are there separate people doing this?

If you agree, then I would also like to add this to the System Settings, I would be grateful if you could tell me where to start.

Thank you for your attention and sorry for my English.
