### PR TITLE
Fixes panel tooltips clipping outside the screen when the applet is close to the bottom.

### DIFF
--- a/js/ui/tooltips.js
+++ b/js/ui/tooltips.js
@@ -373,12 +373,24 @@ PanelItemTooltip.prototype = {
                 panel = Main.panelManager.getPanel(monitor.index, PanelLoc.left);
                 tooltipTop = this._panelItem.actor.get_transformed_position()[1];
                 tooltipTop += Math.round((this._panelItem.actor.height - tooltipHeight) / 2);
+
+                // Fix for the tooltip clipping outside the screen when it's very close to the bottom.
+                if (tooltipTop + tooltipHeight > monitor.y + monitor.height) {
+                    tooltipTop = monitor.y + monitor.height - tooltipHeight;
+                }
+
                 tooltipLeft = monitor.x + panel.actor.width;
                 break;
             case St.Side.RIGHT:
                 panel = Main.panelManager.getPanel(monitor.index, PanelLoc.right);
                 tooltipTop = this._panelItem.actor.get_transformed_position()[1];
                 tooltipTop += Math.round((this._panelItem.actor.height - tooltipHeight) / 2);
+
+                // Fix for the tooltip clipping outside the screen when it's very close to the bottom.
+                if (tooltipTop + tooltipHeight > monitor.y + monitor.height) {
+                    tooltipTop = monitor.y + monitor.height - tooltipHeight;
+                }
+
                 tooltipLeft = monitor.x + monitor.width - tooltipWidth - panel.actor.width;
                 break;
             default:


### PR DESCRIPTION
### Hello!

*(I'm not hyper-familiar with the logic of cinnamon, and I've not used javascript much for anything before...* ***But!*** *Unless I've missed something important, this fixes the problem.)*

### This fixes the issue (which I've opened a few days ago) of panel tooltips clipping out the bottom of the screen when an applet is very close to the bottom.

**Before:**
![bal-előtte](https://github.com/linuxmint/cinnamon/assets/33727121/36bac837-a5c2-40a8-9d90-3f47a61980c0)
![jobb-előtte](https://github.com/linuxmint/cinnamon/assets/33727121/d75ab0ab-cec2-47b2-b310-3c74939b042b)


**After:**
![bal-utána](https://github.com/linuxmint/cinnamon/assets/33727121/b08042f3-2cc3-4704-9134-a7621718b190)
![jobb-utána](https://github.com/linuxmint/cinnamon/assets/33727121/747b34db-8511-4abe-941a-c44b8aec0a1e)

( fixes #11978 )