### PR TITLE
Update cs_info.py - increase inxi verbosity

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
@@ -240,7 +240,7 @@ class Module:
                 inxiOutput = None
 
                 try:
-                    inxiOutput = subprocess.run(['inxi', '-Fxxrzc0'], check=True, stdout=subprocess.PIPE).stdout
+                    inxiOutput = subprocess.run(['inxi', '-FJxxxrzc0'], check=True, stdout=subprocess.PIPE).stdout
                 except Exception as e:
                     print("An error occurred while copying the system information to clipboard")
                     print(e)


### PR DESCRIPTION
Add a third 'x' option to the inxi command so it will also provide the partitioning scheme for drives. It is useful for people helping with installation or boot issues to know upfront whether GPT or MBR is used.

Also adds the 'J' option to make inxi provide information about USB devices, to put it on par with the information mintreport provides.