### PR TITLE
Fixing tooltip clipping for applets close to the top of the screen as well.

### DIFF
--- a/js/ui/tooltips.js
+++ b/js/ui/tooltips.js
@@ -374,8 +374,11 @@ PanelItemTooltip.prototype = {
                 tooltipTop = this._panelItem.actor.get_transformed_position()[1];
                 tooltipTop += Math.round((this._panelItem.actor.height - tooltipHeight) / 2);
 
-                // Fix for the tooltip clipping outside the screen when it's very close to the bottom.
-                if (tooltipTop + tooltipHeight > monitor.y + monitor.height) {
+                // Fix for the tooltip clipping outside the screen when it's very close to the top or bottom.
+                if (tooltipTop < monitor.y) {
+                    tooltipTop = monitor.y;
+                }
+                else if (tooltipTop + tooltipHeight > monitor.y + monitor.height) {
                     tooltipTop = monitor.y + monitor.height - tooltipHeight;
                 }
 
@@ -386,8 +389,11 @@ PanelItemTooltip.prototype = {
                 tooltipTop = this._panelItem.actor.get_transformed_position()[1];
                 tooltipTop += Math.round((this._panelItem.actor.height - tooltipHeight) / 2);
 
-                // Fix for the tooltip clipping outside the screen when it's very close to the bottom.
-                if (tooltipTop + tooltipHeight > monitor.y + monitor.height) {
+                // Fix for the tooltip clipping outside the screen when it's very close to the top or bottom.
+                if (tooltipTop < monitor.y) {
+                    tooltipTop = monitor.y;
+                }
+                else if (tooltipTop + tooltipHeight > monitor.y + monitor.height) {
                     tooltipTop = monitor.y + monitor.height - tooltipHeight;
                 }
 


### PR DESCRIPTION
**Hi!**

This is somewhat of an addition to my previous commit. ( #11980 )

The same issue of tooltips clipping outside the screen when the applets were very close to the bottom, was also occuring when the tooltips were close to the top of the screen as well.

Unlike the previous one, this doesn't happen with the default panel layout.
Yet, it's still a possible scenario, (if you edit the panel, and put a cornerbar at the top, for example), so now it's fixed too.


**Before:**
![bal-előtte](https://github.com/linuxmint/cinnamon/assets/33727121/28a6930f-a6d1-434e-b122-7c80afbf24c5)
![jobb-előtte](https://github.com/linuxmint/cinnamon/assets/33727121/6f0648f5-3487-4bbe-9bdd-53d96e234189)

**After:**
![bal-utána](https://github.com/linuxmint/cinnamon/assets/33727121/8ba0c210-8f91-442f-8fb0-0986281ee406)
![jobb-utána](https://github.com/linuxmint/cinnamon/assets/33727121/702c6057-b23d-4034-ab68-3b25dd1364b8)
