### PR TITLE
calendar: allow to use line breaks on a custom date format

### DIFF
--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
@@ -238,6 +238,8 @@ class CinnamonCalendarApplet extends Applet.TextApplet {
 
         if (!this.use_custom_format) {
             label_string = label_string.capitalize();
+        } else {
+            label_string = label_string.replaceAll('\\n', '\n');
         }
 
         this.go_home_button.reactive = !this._calendar.todaySelected();
@@ -257,6 +259,8 @@ class CinnamonCalendarApplet extends Applet.TextApplet {
             if (!dateFormattedTooltip) {
                 global.logError("Calendar applet: bad tooltip time format string - check your string.");
                 dateFormattedTooltip = this.clock.get_clock_for_format("~CLOCK FORMAT ERROR~ %l:%M %p");
+            } else {
+                dateFormattedTooltip = dateFormattedTooltip.replaceAll('\\n', '\n');
             }
         }
 


### PR DESCRIPTION
This will make it possible to format the date as shown in the image below:

![Captura de ecrã de 2023-12-31 19-10-57](https://github.com/linuxmint/cinnamon/assets/63073056/2280a00b-2470-4514-92f6-8851ca017600)
