### PR TITLE
window lists: don't attention flash focused window

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -612,7 +612,7 @@ class AppGroup {
         }
         const windows = this.groupState.metaWindows;
         for (let i = 0, len = windows.length; i < len; i++) {
-            if (windows[i] === metaWindow) {
+            if (windows[i] === metaWindow && !getFocusState(windows[i])) {
                 // Even though this may not be the last focused window, we want it to be
                 // the window that gets focused when a user responds to an alert.
                 this.groupState.set({lastFocused: metaWindow});

--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -1221,6 +1221,10 @@ class CinnamonWindowListApplet extends Applet.Applet {
         if (i == -1)
             return;
 
+        // Window already has focus
+        if (this._windows[i]._hasFocus())
+            return;
+
         // Asks AppMenuButton to flash. Returns false if already flashing
         if (!this._windows[i].getAttention())
             return;


### PR DESCRIPTION
Clearing the attention flash on an already focused window was unintuitive, since it would require the user unfocusing the window and focusing it again.  Since the user is already focused on the window, we don't need to flash for its attention in the first place.