### PR TITLE
Proposal for actions/xlets dependencies

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
@@ -5,6 +5,7 @@ import sys
 
 try:
     from gi.repository import Gio, Gtk, GObject, Gdk, GdkPixbuf, GLib
+    import mintcommon.aptdaemon
     import tempfile
     import zipfile
     import shutil
@@ -879,6 +880,10 @@ class Spice_Harvester(GObject.Object):
 
             self.settings.set_strv(self.enabled_key, enabled)
         elif self.actions:
+            dependencies = self.meta_map[uuid].get('dependencies', [])
+            if len(dependencies) > 0:
+                self.apt = mintcommon.aptdaemon.APT(None)
+                self.apt.install_packages(dependencies)
             disabled_extensions = self.settings.get_strv(self.enabled_key)
             uuid_name = f"{uuid}.nemo_action"
             if uuid_name in disabled_extensions:


### PR DESCRIPTION
I really like the new downloadable Nemo actions introduced with Mint 21.3. However, I have concerns about the usability. Nearly all of them needs specific packages installed to work properly. I doubt that users will read the corresponding readme.md. They rather install it and then wonder why it's not working. Wouldn't it be possible to add a new `dependency` section to the spice's `metadata.json` where to put the necessary package names in? The xlet manager could then check and ask to install it.

This PR is just a quick proof of concept and needs more work for productive use. Maybe it should be extended for desklets too.