### PR TITLE
Show search bar by default when choosing an application in Startup Applications

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_startup.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_startup.py
@@ -916,6 +916,7 @@ class AppChooserDialog(Gtk.Dialog):
         self.search_bar = Gtk.SearchBar()
         self.search_bar.add(self.entry)
         self.search_bar.props.hexpand = True
+        self.search_bar.set_search_mode(True)
 
         list_box = Gtk.ListBox()
         list_box.set_sort_func(self.sort_apps, None)


### PR DESCRIPTION
**Description:** 

This is a simple proposal for a UI/UX inconvenience I personally came across when using the _Startup Applications_ app. I've tested it and this addition fixes this problem. This change should be easy to test as it is just one added line, after which the Startup Applications app can be opened again to see the change.

**Background:**

I've often wanted to add an application to the Startup Applications. Unfortunately, there was no indication that I could search the list. The current behavior is that the search bar will only appear once you type in a character. I did not know that a search bar existed in this window until I've looked at the source code (this should say a lot :sweat_smile:).

This is not a great UI/UX behavior in my opinion, as many search implementations either a) show a search button or b) at least display it upon pressing `Ctrl+F` (this does not work here too). My proposal is to at least show that the search bar exists when the window is opened. Users can also immediately start typing ahead. The rest of the behavior stays the same.

**Screenshots:**

Before this change, selecting the _Choose application_ button upon pressing the plus icon would show such a window:

![before](https://github.com/linuxmint/cinnamon/assets/111225446/8d71ebe9-9fc5-4f6e-80e9-9b986d0f3f96)

After this change, the search bar appears:

![after](https://github.com/linuxmint/cinnamon/assets/111225446/fe446b56-c985-474d-ae45-2f7ac29d8b0c)