### PR TITLE
Fix #11313

### DIFF
--- a/files/usr/share/cinnamon/applets/keyboard@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/keyboard@cinnamon.org/applet.js
@@ -4,7 +4,6 @@ const St = imports.gi.St;
 const Main = imports.ui.main;
 const PopupMenu = imports.ui.popupMenu;
 const Util = imports.misc.util;
-const Mainloop = imports.mainloop;
 const Gio = imports.gi.Gio;
 const Cairo = imports.cairo;
 const Signals = imports.signals;
@@ -390,7 +389,7 @@ class CinnamonKeyboardApplet extends Applet.TextIconApplet {
         this._setLayoutItems(layoutItems);
         this._setLayoutIcons(layoutIcons);
 
-        Mainloop.idle_add(() => this._syncGroup());
+        this._syncGroup();
     }
 
     _syncGroup() {


### PR DESCRIPTION
Fixes #11313. When the applet was used in a vertical panel it would appear blank at first, until the mouse cursor was hovered over it.

Calling _syncGroup directly from _syncConfig, instead of using idle_add fixes the problem.

Doing so should not cause any problems though. Both _syncGroup and _syncConfig are signal handlers. So there should not be any threading issues necessitating the use of idle_add.