### PR TITLE
Improve handling of invalid panel definitions

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_panel.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_panel.py
@@ -17,6 +17,15 @@ class Monitor:
         self.right = -1
         self.left = -1
 
+    def position_used(self, position):
+        if position == "top":
+            return self.top != -1
+        elif position == "bottom":
+            return self.bottom != -1
+        elif position == "left":
+            return self.left != -1
+        elif position == "right":
+            return self.right != -1
 
 class PanelSettingsPage(SettingsPage):
     def __init__(self, panel_id, settings, position):
@@ -166,6 +175,7 @@ class Module:
                 self.panel_id = ""
 
             self.panels = []
+            self.updating = False
 
             self.previous_button = Gtk.Button(_("Previous panel"))
             self.next_button = Gtk.Button(_("Next panel"))
@@ -279,7 +289,22 @@ class Module:
 
         self.config_stack.set_visible_child(self.current_panel)
 
+    def id_or_monitor_position_used(self, kept_panels, monitor_layout, panel_id, monitor_id, position):
+        for keeper in kept_panels:
+            if keeper.panel_id == panel_id:
+                print("cs_panel: Ignoring panel definition with an already-used ID: (ID: %s, Monitor: %d, Position: %s)" % (panel_id, monitor_id, position))
+                return True
+            if monitor_layout[monitor_id].position_used(position):
+                print("cs_panel: Ignoring panel definition with an already-used monitor:position: (ID: %s, Monitor: %d, Position: %s)" % (panel_id, monitor_id, position))
+                return True
+        return False
+
     def on_panel_list_changed(self, *args):
+        if self.updating:
+            return
+
+        self.updating = True
+
         if len(self.panels) > 0:
             for panel in self.panels:
                 panel.destroy()
@@ -287,18 +312,27 @@ class Module:
         self.panels = []
         monitor_layout = []
 
-        panels = self.settings.get_strv("panels-enabled")
+        panel_defs = self.settings.get_strv("panels-enabled")
         n_mons = Gdk.Screen.get_default().get_n_monitors()
 
         for i in range(n_mons):
             monitor_layout.append(Monitor())
 
         current_found = False
-        for panel in panels:
-            panel_id, monitor_id, position = panel.split(":")
+        already_defined_panels = []
+        removals = []
+
+        for def_ in panel_defs:
+            panel_id, monitor_id, position = def_.split(":")
             monitor_id = int(monitor_id)
+
+            if self.id_or_monitor_position_used(already_defined_panels, monitor_layout, panel_id, monitor_id, position):
+                removals.append(def_)
+                continue
+
             panel_page = PanelSettingsPage(panel_id, self.settings, position)
             self.config_stack.add_named(panel_page, panel_id)
+            already_defined_panels.append(panel_page)
 
             # we may already have a current panel id from the command line or if
             # if the panels-enabled key changed since everything was loaded
@@ -320,6 +354,12 @@ class Module:
                 else:
                     monitor_layout[monitor_id].right = panel_page
 
+        if removals:
+            print("Cleaning up conflicting defs in panels-enabled")
+            for def_ in removals:
+                panel_defs.remove(def_)
+            self.settings.set_strv("panels-enabled", panel_defs)
+
         # Index the panels for the next/previous buttons
         for monitor in monitor_layout:
             for panel_page in (monitor.top, monitor.bottom, monitor.left, monitor.right):
@@ -334,6 +374,7 @@ class Module:
             self.add_panel_button.set_sensitive(True)
             self.current_panel = None
             self.panel_id = None
+            self.updating = False
             return
 
         self.config_stack.show()
@@ -368,6 +409,8 @@ class Module:
             current_idx = self.panels.index(self.panel_id)
         except:
             current_idx = 0
+
+        self.updating = False
 
         if self.proxy:
             self.proxy.highlightPanel('(ib)', int(self.panel_id), True)

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -95,6 +95,12 @@ var PanelLoc = {
     right : 3
 };
 
+const PanelDefElement = {
+    ID  : 0,
+    MONITOR : 1,
+    POSITION: 2
+};
+
 // To make sure the panel corners blend nicely with the panel,
 // we draw background and borders the same way, e.g. drawing
 // them as filled shapes from the outside inwards instead of
@@ -395,6 +401,7 @@ PanelManager.prototype = {
         this._setMainPanel();
 
         this.addPanelMode = false;
+        this.handling_panels_changed = false;
 
         this._panelsEnabledId   = global.settings.connect("changed::panels-enabled", Lang.bind(this, this._onPanelsEnabledChanged));
         this._panelEditModeId   = global.settings.connect("changed::panel-edit-mode", Lang.bind(this, this._onPanelEditModeChanged));
@@ -421,25 +428,59 @@ PanelManager.prototype = {
         let monitor = 0;
         let stash = [];     // panel id, monitor, panel type
 
-        let monitorCount = -1;
+        let monitorCount = global.display.get_n_monitors();
         let panels_used = []; // [monitor] [top, bottom, left, right].  Used to keep track of which panel types are in use,
                               // as we need knowledge of the combinations in order to instruct the correct panel to create a corner
 
-        let panelProperties = getPanelsEnabledList();
+        let panel_defs = getPanelsEnabledList();
         //
         // First pass through just to count the monitors, as there is no ordering to rely on
         //
-        for (let i = 0, len = panelProperties.length; i < len; i++) {
-            let elements = panelProperties[i].split(":");
+        let good_defs = [];
+        let removals = [];
+        for (let i = 0, len = panel_defs.length; i < len; i++) {
+            let elements = panel_defs[i].split(":");
             if (elements.length != 3) {
-                global.log("Invalid panel definition: " + panelProperties[i]);
+                global.log("Invalid panel definition: " + panel_defs[i]);
+                removals.push(i);
                 continue;
             }
 
-            monitor = parseInt(elements[1]);
-            if (monitor > monitorCount)
-                monitorCount = monitor;
+            if (elements[PanelDefElement.MONITOR] >= monitorCount) {
+                // Ignore, but don't remove. Less monitors can be a temporary condition.
+                global.log("Ignoring panel definition for nonexistent monitor: " + panel_defs[i]);
+                continue;
+            }
+
+            // Some sanitizing
+            if (good_defs.find((good_def) => {
+                const good_elements = good_def.split(":");
+                // Ignore any duplicate IDs
+                if (good_elements[PanelDefElement.ID] === elements[PanelDefElement.ID]) {
+                    global.log("Duplicate ID detected in panel definition: " + panel_defs[i]);
+                    return true;
+                }
+                // Ignore any duplicate monitor/position combinations
+                if ((good_elements[PanelDefElement.MONITOR] === elements[PanelDefElement.MONITOR]) && (good_elements[PanelDefElement.POSITION] === elements[PanelDefElement.POSITION])) {
+                    global.log("Duplicate monitor+position detected in panel definition: " + panel_defs[i]);
+                    return true;
+                }
+
+                return false;
+            })) {
+                removals.push(panel_defs[i]);
+                continue;
+            }
+
+            good_defs.push(panel_defs[i]);
         }
+
+        if (removals.length > 0) {
+            let clean_defs = panel_defs.filter((def) => !removals.includes(def));
+            global.log("Removing invalid panel definitions: " + removals);
+            setPanelsEnabledList(clean_defs);
+        }
+
         //
         // initialise the array that records which panels are used (so combinations can be used to select corners)
         //
@@ -453,19 +494,15 @@ PanelManager.prototype = {
         //
         // set up the list of panels
         //
-        for (let i = 0, len = panelProperties.length; i < len; i++) {
-            let elements = panelProperties[i].split(":");
-            if (elements.length != 3) {
-                global.log("Invalid panel definition: " + panelProperties[i]);
-                continue;
-            }
-            let jj = getPanelLocFromName(elements[2]);  // panel orientation
+        for (let i = 0, len = good_defs.length; i < len; i++) {
+            let elements = good_defs[i].split(":");
 
-            monitor = parseInt(elements[1]);
+            let jj = getPanelLocFromName(elements[PanelDefElement.POSITION]);  // panel orientation
 
+            monitor = parseInt(elements[PanelDefElement.MONITOR]);
             panels_used[monitor][jj] = true;
 
-            stash[i] = [parseInt(elements[0]),monitor,jj]; // load what we are going to use to call loadPanel into an array
+            stash[i] = [parseInt(elements[PanelDefElement.ID]), monitor, jj]; // load what we are going to use to call loadPanel into an array
         }
 
         //
@@ -886,6 +923,10 @@ PanelManager.prototype = {
      * i.e. when panels are added, moved or removed.
      */
     _onPanelsEnabledChanged: function() {
+        if (this.handling_panels_changed)
+            return;
+        this.handling_panels_changed = true;
+
         let newPanels = new Array(this.panels.length);
         let newMeta = new Array(this.panels.length);
         let drawcorner = [false,false];
@@ -980,6 +1021,8 @@ PanelManager.prototype = {
                 Lang.bind(this, function() { Util.spawnCommandLine("cinnamon-settings panel"); }));
             lastPanelRemovedDialog.open();
         }
+
+        this.handling_panels_changed = false;
     },
 
     /**


### PR DESCRIPTION
Make sure only valid, and non-overlapping panel definitions are allowed to exist at runtime, and remove them if they're detected either by cinnamon-settings or Cinnamon during startup.