### PR TITLE
cs_themes: Fix the stack switcher sensitivity

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
@@ -529,10 +529,14 @@ class Module:
         else:
             transition = Gtk.StackTransitionType.CROSSFADE
 
+        switcher_widget = Gio.Application.get_default().stack_switcher
+
         if mode == "simplified":
-            Gio.Application.get_default().stack_switcher.set_opacity(0.0)
+            switcher_widget.set_opacity(0.0)
+            switcher_widget.set_sensitive(False)
         else:
-            Gio.Application.get_default().stack_switcher.set_opacity(1.0)
+            switcher_widget.set_opacity(1.0)
+            switcher_widget.set_sensitive(True)
 
         self.sidePage.stack.set_visible_child_full(mode, transition)
 


### PR DESCRIPTION
When hiding the stack switcher we need to set both the opacity and sensitivity. Otherwise the buttons can still be clicked even when they are hidden.

Fixes: https://github.com/linuxmint/cinnamon/issues/12115