### PR TITLE
Adds toggle switch to on-screen-keyboard@cinnamon.org (Closes #11974)

### DIFF
--- a/files/usr/share/cinnamon/applets/on-screen-keyboard@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/on-screen-keyboard@cinnamon.org/applet.js
@@ -1,6 +1,7 @@
 const Applet = imports.ui.applet;
 const Gio = imports.gi.Gio;
 const Lang = imports.lang;
+const PopupMenu = imports.ui.popupMenu;
 const Main = imports.ui.main;
 
 class CinnamonOnScreenKeyboardApplet extends Applet.IconApplet {
@@ -8,11 +9,24 @@ class CinnamonOnScreenKeyboardApplet extends Applet.IconApplet {
         super(orientation, panel_height, instanceId);
         this.settings = new Gio.Settings({ schema_id: 'org.cinnamon.desktop.a11y.applications' });
         this.settings.connect('changed::screen-keyboard-enabled', Lang.bind(this, this.update_status));
+
+        this.keyboard_switch = new PopupMenu.PopupSwitchMenuItem(
+            _("Enable on-screen keyboard"),
+            this.settings.get_boolean("screen-keyboard-enabled"),
+            null);
+        this._applet_context_menu.addMenuItem(this.keyboard_switch);
+        this.keyboard_switch.connect(
+            "toggled",
+            Lang.bind(this,
+                function(item, state) {this.settings.set_boolean("screen-keyboard-enabled", state)}));
+        this._applet_context_menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+
         this.update_status();
     }
 
     on_applet_clicked(event) {
         Main.virtualKeyboard.toggle();
+        this.keyboard_switch.setToggleState(true);
     }
 
     update_status() {


### PR DESCRIPTION
This adds a toggle switch to the context menu of the `on-screen-keyboard@cinnamon.org` applet. This switch enables and (more importantly) disables the on-board keyboard.