### PR TITLE
Show "wired with a padlock" or "wireless with a padlock" icons when a VPN is connected

### DIFF
--- a/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
@@ -2443,6 +2443,27 @@ CinnamonNetworkApplet.prototype = {
                 this._setIcon('network-vpn');
                 this.set_applet_tooltip(_("Connected to WIREGUARD"));
             }
+            for (let i = 0; i < this._activeConnections.length; i++) {
+                const a = this._activeConnections[i];
+                if (a._section === NMConnectionCategory.VPN && a.state === NM.ActiveConnectionState.ACTIVATING) {
+                    this._setIcon('network-vpn-acquiring');
+                    this.set_applet_tooltip(_("Connecting to the VPN..."));
+                    break;
+                }
+                else if (a._section === NMConnectionCategory.VPN && a.state === NM.ActiveConnectionState.ACTIVATED) {
+                    let iconName = 'network-vpn';
+                    if (mc._section == NMConnectionCategory.WIRELESS) {
+                        const dev = mc._primaryDevice;
+                        if (dev) {
+                            const ap = dev.device.active_access_point;
+                            iconName = 'network-wireless-signal-' + signalToIcon(ap.strength) + '-secure-symbolic';
+                        }
+                    }
+                    this._setIcon(iconName);
+                    this.set_applet_tooltip(_("Connected to the VPN"));
+                    break;
+                }
+            }
         }
         catch (e) {
             global.logError(e);


### PR DESCRIPTION
Replace default network connection icons with ones with a padlock when a user is connecting/connected to a VPN. This allows to quickly check if a VPN is connected by the appearance of a network connection icon.

This should resolve linuxmint/cinnamon#5527

![image](https://github.com/linuxmint/cinnamon/assets/1595560/77e73fb5-1a93-4b74-803f-faa0c9c3b1b3)
![image](https://github.com/linuxmint/cinnamon/assets/1595560/052aa5c5-7904-4740-9190-47cc78d0b4b9)
