### PR TITLE
cornerbar: Properly filter windows not to transparentize on peek blur/opacity effects

### DIFF
--- a/files/usr/share/cinnamon/applets/cornerbar@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/cornerbar@cinnamon.org/applet.js
@@ -13,7 +13,7 @@ const Tweener = imports.ui.tweener;
 
 const SCROLL_DELAY = 200;
 
-const WINDOWN_TYPES_FILTER_TRANSPARENCY = [
+const PEEK_TRANSPARENCY_FILTER_TYPES = [
     Meta.WindowType.DESKTOP,
     Meta.WindowType.DOCK,
 ];
@@ -132,7 +132,7 @@ class CinnamonBarApplet extends Applet.Applet {
                         let window = windows[i].meta_window;
                         let compositor = windows[i];
 
-                        if (!WINDOWN_TYPES_FILTER_TRANSPARENCY.includes(window.get_window_type())) {
+                        if (!PEEK_TRANSPARENCY_FILTER_TYPES.includes(window.get_window_type())) {
                             if (this.peek_blur) {
                                 if (!compositor.eff)
                                     compositor.eff = new Clutter.BlurEffect();

--- a/files/usr/share/cinnamon/applets/cornerbar@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/cornerbar@cinnamon.org/applet.js
@@ -13,6 +13,11 @@ const Tweener = imports.ui.tweener;
 
 const SCROLL_DELAY = 200;
 
+const WINDOWN_TYPES_FILTER_TRANSPARENCY = [
+    Meta.WindowType.DESKTOP,
+    Meta.WindowType.DOCK,
+];
+
 class CinnamonBarApplet extends Applet.Applet {
     constructor(orientation, panel_height, instance_id) {
         super(orientation, panel_height, instance_id);
@@ -127,7 +132,7 @@ class CinnamonBarApplet extends Applet.Applet {
                         let window = windows[i].meta_window;
                         let compositor = windows[i];
 
-                        if (window.get_window_type() !== Meta.WindowType.DESKTOP) {
+                        if (!WINDOWN_TYPES_FILTER_TRANSPARENCY.includes(window.get_window_type())) {
                             if (this.peek_blur) {
                                 if (!compositor.eff)
                                     compositor.eff = new Clutter.BlurEffect();

--- a/files/usr/share/cinnamon/applets/cornerbar@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/cornerbar@cinnamon.org/applet.js
@@ -1,6 +1,7 @@
 const Applet = imports.ui.applet;
 const GLib = imports.gi.GLib;
 const St = imports.gi.St;
+const Meta = imports.gi.Meta;
 const Lang = imports.lang;
 const Clutter = imports.gi.Clutter;
 const Main = imports.ui.main;
@@ -126,7 +127,7 @@ class CinnamonBarApplet extends Applet.Applet {
                         let window = windows[i].meta_window;
                         let compositor = windows[i];
 
-                        if (window.get_title() !== "Desktop") {
+                        if (window.get_window_type() !== Meta.WindowType.DESKTOP) {
                             if (this.peek_blur) {
                                 if (!compositor.eff)
                                     compositor.eff = new Clutter.BlurEffect();

--- a/files/usr/share/cinnamon/applets/cornerbar@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/cornerbar@cinnamon.org/settings-schema.json
@@ -27,7 +27,7 @@
     },
     "scroll-behavior": {
         "type": "combobox",
-        "default": "none",
+        "default": "nothing",
         "description": "Scroll wheel behavior",
         "options": {
             "Nothing": "nothing",


### PR DESCRIPTION
To filter the desktop window from the others that should have been opacified and blurred, previously, the window title was being used to check if the name of the window was or was not equal to "Desktop", that won't work for all localizations because the title of the window "Desktop" will be translated to another thing in other languages (e.g. "Área de Trabalho" in Portuguese), so the filtering would not work.

This PR proposes instead to check the window type, which is a more reliable method to check whether the window is a desktop window.

\+ Also filter **dock** type windows (like **plank** or **latte**) they shouldn't be transparent as well on peek