### PR TITLE
cinnamon theme: fix expo-workspaces-name-entry

### DIFF
--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -2009,6 +2009,7 @@ StScrollBar StButton#vhandle:hover {
     selected-color: black;
     caret-color: rgb(128, 128, 128);
     caret-size: 1px;
+    min-width: 80px;
     height: 1.4em;
     box-shadow: inset 0px 2px 4px rgba(0,0,0,0.6);
 }

--- a/data/theme/cinnamon.css
+++ b/data/theme/cinnamon.css
@@ -2009,10 +2009,8 @@ StScrollBar StButton#vhandle:hover {
     selected-color: black;
     caret-color: rgb(128, 128, 128);
     caret-size: 1px;
-    width: 250px;
-    height: 1em;
+    height: 1.4em;
     box-shadow: inset 0px 2px 4px rgba(0,0,0,0.6);
-    text-align: center;
 }
 
 .expo-workspaces-name-entry#selected {


### PR DESCRIPTION
remove fixed width and adjust height.

before:

![Screenshot from 2024-04-27 04-38-35](https://github.com/linuxmint/cinnamon/assets/58893963/6a41d1f4-ef15-4776-8a7d-4341269d9bbc)

After:

![Screenshot from 2024-04-27 04-41-07](https://github.com/linuxmint/cinnamon/assets/58893963/600164e7-4f22-4d65-afdd-0eda22540880)

