### PR TITLE
cornerbar applet: add shift + click actions settings

### DIFF
--- a/files/usr/share/cinnamon/applets/cornerbar@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/cornerbar@cinnamon.org/applet.js
@@ -22,7 +22,9 @@ class CinnamonBarApplet extends Applet.Applet {
         this.settings.bind("peek-opacity", "peek_opacity");
         this.settings.bind("peek-blur", "peek_blur");
         this.settings.bind("click-action", "click_action");
+        this.settings.bind("shift-click-action", "shift_click_action");
         this.settings.bind("middle-click-action", "middle_click_action");
+        this.settings.bind("shift-middle-click-action", "shift_middle_click_action");
         this.settings.bind("scroll-behavior", "scroll_behavior");
 
         this.signals = new SignalManager.SignalManager(null);
@@ -220,11 +222,17 @@ class CinnamonBarApplet extends Applet.Applet {
     }
 
     on_applet_clicked(event) {
-        this.perform_action(this.click_action);
+        let modifiers = Cinnamon.get_event_state(event);
+        let shift_pressed = (modifiers & Clutter.ModifierType.SHIFT_MASK);
+        let action = shift_pressed ? this.shift_click_action : this.click_action;
+        this.perform_action(action);
     }
 
     on_applet_middle_clicked(event) {
-        this.perform_action(this.middle_click_action);
+        let modifiers = Cinnamon.get_event_state(event);
+        let shift_pressed = (modifiers & Clutter.ModifierType.SHIFT_MASK);
+        let action = shift_pressed ? this.shift_middle_click_action : this.middle_click_action;
+        this.perform_action(action);
     }
 
     perform_action(action) {

--- a/files/usr/share/cinnamon/applets/cornerbar@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/cornerbar@cinnamon.org/applet.js
@@ -9,6 +9,7 @@ const PopupMenu = imports.ui.popupMenu;
 const SignalManager = imports.misc.signalManager;
 const Mainloop = imports.mainloop;
 const Tweener = imports.ui.tweener;
+const Cinnamon = imports.gi.Cinnamon;
 
 const SCROLL_DELAY = 200;
 

--- a/files/usr/share/cinnamon/applets/cornerbar@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/cornerbar@cinnamon.org/settings-schema.json
@@ -14,10 +14,10 @@
             "Show the window selector (Scale)": "show_scale"
         }
     },
-    "shift-click-action": {
+    "middle-click-action": {
         "type": "combobox",
-        "description": "Shift + click action",
-        "default": "show_expo",
+        "description": "Middle click action",
+        "default": "show_desklets",
         "options" : {
             "Show the desktop": "show_desktop",
             "Show the desklets": "show_desklets",
@@ -25,10 +25,10 @@
             "Show the window selector (Scale)": "show_scale"
         }
     },
-    "middle-click-action": {
+    "shift-click-action": {
         "type": "combobox",
-        "description": "Middle click action",
-        "default": "show_desklets",
+        "description": "Shift + click action",
+        "default": "show_expo",
         "options" : {
             "Show the desktop": "show_desktop",
             "Show the desklets": "show_desklets",

--- a/files/usr/share/cinnamon/applets/cornerbar@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/cornerbar@cinnamon.org/settings-schema.json
@@ -14,10 +14,32 @@
             "Show the window selector (Scale)": "show_scale"
         }
     },
+    "shift-click-action": {
+        "type": "combobox",
+        "description": "Shift + click action",
+        "default": "show_expo",
+        "options" : {
+            "Show the desktop": "show_desktop",
+            "Show the desklets": "show_desklets",
+            "Show the workspace selector (Expo)": "show_expo",
+            "Show the window selector (Scale)": "show_scale"
+        }
+    },
     "middle-click-action": {
         "type": "combobox",
         "description": "Middle click action",
         "default": "show_desklets",
+        "options" : {
+            "Show the desktop": "show_desktop",
+            "Show the desklets": "show_desklets",
+            "Show the workspace selector (Expo)": "show_expo",
+            "Show the window selector (Scale)": "show_scale"
+        }
+    },
+    "shift-middle-click-action": {
+        "type": "combobox",
+        "description": "Shift + middle click action",
+        "default": "show_scale",
         "options" : {
             "Show the desktop": "show_desktop",
             "Show the desklets": "show_desklets",


### PR DESCRIPTION
Allow to set different actions on `shift + click` and `shift + middle click` actions.