### PR TITLE
sound@cinnamon.org: Prevent Muffin from showing up in volume mixer (Fixes: #11847)

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -455,9 +455,12 @@ class StreamMenuSection extends PopupMenu.PopupMenuSection {
             iconName = "audio-x-generic";
         }
 
-        let slider = new VolumeSlider(applet, stream, name, iconName);
-        slider._slider.style = "min-width: 6em;";
-        this.addMenuItem(slider);
+        // Prevent Muffin from spawning sound streams
+        if (name !== "Muffin") {
+            let slider = new VolumeSlider(applet, stream, name, iconName);
+            slider._slider.style = "min-width: 6em;";
+            this.addMenuItem(slider);
+        }
     }
 }
 


### PR DESCRIPTION
**Closes #11847**

This patch prevents application "Muffin" (Cinnamon's window manager) from showing up in the volume mixer of the `sound@cinnamon.org` applet when scrolling up and down with the middle mouse wheel.

Tested and working on X11/Wayland on the following versions:
- LMDE 6 (Cinnamon version: 6.0.4)
- Linux Mint 21.3 (Cinnamon version: 6.0.4)
- Latest git version of Cinnamon (compiled using mint-dev-tools)