### PR TITLE
Grouped window list: Add option to only list windows from the current monitor

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/settings-schema.json
@@ -30,7 +30,8 @@
         "scroll-behavior",
         "left-click-action",
         "middle-click-action",
-        "show-all-workspaces"
+        "show-all-workspaces",
+        "list-monitor-windows"
       ]
     },
     "appButtonsSection": {
@@ -148,6 +149,11 @@
     "type": "checkbox",
     "default": false,
     "description": "Show windows from all workspaces"
+  },
+  "list-monitor-windows": {
+    "type": "checkbox",
+    "default": true,
+    "description": "Only list windows from the current monitor"
   },
   "enable-app-button-dragging": {
     "type": "checkbox",


### PR DESCRIPTION
Hi :)

I added an old feature to show only active applications on the current monitor which was deleted in [https://github.com/linuxmint/cinnamon/commit/ef4610cd8963c87eb12dc8dcf717a9e6ca1dbd78#diff-10f95e2348d1571d611014de1fa17308](commit)
Now allows to toggle between showing only current monitor applications or showing all apps from all monitors. This PR is related to this topic #8802 