### PR TITLE
[sound@cinnamon.org] Prevents Cvc.MixerControl from being loaded more than once

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -1137,6 +1137,9 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
 
         for(let i in this._players)
             this._players[i].destroy();
+
+        if (this._control)
+            this._control.close();
     }
 
     on_applet_clicked(event) {


### PR DESCRIPTION
Fixes #12180