### PR TITLE
window-list: Remove indicators for minimized and tiled windows from window names

### DIFF
--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -524,12 +524,6 @@ class AppMenuButton {
         if (this._tooltip && this._applet.windowHover != "nothing" && this._tooltip.set_text)
             this._tooltip.set_text(title);
 
-        if (this.metaWindow.minimized) {
-            title = "["+ title +"]";
-        } else if (this.metaWindow.tile_mode != Meta.TileMode.NONE && this.metaWindow.tile_mode != Meta.TileMode.MAXIMIZED) {
-            title = "|"+ title;
-        }
-
         this._label.set_text(title);
     }
 


### PR DESCRIPTION
Hi!

This adds an option to remove the `[ ]` and `|` indicators on minimized/tiled windows (I'm not personally a fan, was also confusing figuring out why these were being added at first).

Setting:

![settings](https://github.com/linuxmint/cinnamon/assets/37175276/81c30393-e928-420a-b16c-52651a0e199e)

Cheers