### PR TITLE
PopupSliderMenuItem: Don't track the hover state

### DIFF
--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -657,7 +657,10 @@ var PopupAlternatingMenuItem = class PopupAlternatingMenuItem extends PopupBaseM
 
 var PopupSliderMenuItem = class PopupSliderMenuItem extends PopupBaseMenuItem {
     _init(value) {
-        super._init.call(this, { activate: false });
+        super._init.call(this, {
+            activate: false,
+            hover: false,
+        });
 
         this._signals.connect(this.actor, 'key-press-event', Lang.bind(this, this._onKeyPressEvent));
 


### PR DESCRIPTION
Most of the time this just makes the sliders look poor. The menu item itself isn't really doing anything on click. It just makes more sense not to apply a hover style on these items.