### PR TITLE
extensions: Fix auto-enable on download

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
@@ -773,10 +773,11 @@ class Spice_Harvester(GObject.Object):
 
     def _install_finished(self, job):
         uuid = job['uuid']
-        if self.get_enabled(uuid) and self._proxy:
-            self._proxy.ReloadXlet('(ss)', uuid, self.collection_type.upper())
-        else:
-            self.send_proxy_signal('ReloadXlet', '(ss)', uuid, self.collection_type.upper())
+        if self.get_enabled(uuid):
+            if self._proxy:
+                self._proxy.ReloadXlet('(ss)', uuid, self.collection_type.upper())
+            else:
+                self.send_proxy_signal('ReloadXlet', '(ss)', uuid, self.collection_type.upper())
 
     def uninstall(self, uuid):
         """ uninstalls and removes the given extension"""


### PR DESCRIPTION
The extension reload signal was being triggered automatically in the end of the installation process, but this only should apply if the extension was already enabled before (maybe after an update of an already installed extension I guess).

fixes https://github.com/linuxmint/cinnamon/issues/12075