### PR TITLE
Update appGroup.js

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -354,7 +354,7 @@ class AppGroup {
                     labelNaturalSize + iconNaturalSize + 6 : 0;
                 alloc.natural_size = Math.min(iconNaturalSize + Math.max(max, labelNaturalSize), MAX_BUTTON_WIDTH * global.ui_scale);
             } else {
-                alloc.natural_size = iconNaturalSize + 6 * global.ui_scale;
+                alloc.natural_size = iconNaturalSize + 10 * global.ui_scale;
             }
         } else {
             alloc.natural_size = this.state.trigger('getPanelHeight');


### PR DESCRIPTION
Make taskbar app icon button width the same as the "Menu" applet button width, for consistency.

Ever since Mint 21.x the app icon buttons have slimmed down so much that the buttons look like upright rectangles and not the 4:3-ish square buttons one would expect, like the "Menu" applet. It's even more obvious since both the "Menu" and "Grouped window list" applets are sitting right next to each other.

I propose this change to make both applet buttons the exact same width for a more consistent and pleasant look.