### PR TITLE
[power@cinnamon.org] Add support for more battery device labels and icons

### DIFF
--- a/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
@@ -19,6 +19,7 @@ const {
     DeviceKind: UPDeviceKind,
     DeviceLevel: UPDeviceLevel,
     DeviceState: UPDeviceState,
+    Device: UPDevice
 } = UPowerGlib
 
 function deviceLevelToString(level) {
@@ -39,6 +40,9 @@ function deviceLevelToString(level) {
 }
 
 function deviceKindToString(kind) {
+    // By default we use .replaceAll('-', ' ') and .capitalize() to make the
+    // UPowerGlib.kind_to_string() result more friendly, but we also handle a
+    // few special cases here where that does't provide an optimal result.
     switch (kind) {
         case UPDeviceKind.LINE_POWER:
             return _("AC adapter");
@@ -46,24 +50,24 @@ function deviceKindToString(kind) {
             return _("Laptop battery");
         case UPDeviceKind.UPS:
             return _("UPS");
-        case UPDeviceKind.MONITOR:
-            return _("Monitor");
-        case UPDeviceKind.MOUSE:
-            return _("Mouse");
-        case UPDeviceKind.KEYBOARD:
-            return _("Keyboard");
         case UPDeviceKind.PDA:
             return _("PDA");
         case UPDeviceKind.PHONE:
             return _("Cell phone");
-        case UPDeviceKind.MEDIA_PLAYER:
-            return _("Media player");
-        case UPDeviceKind.TABLET:
-            return _("Tablet");
-        case UPDeviceKind.COMPUTER:
-            return _("Computer");
-        default:
-            return _("Unknown");
+        case UPDeviceKind.BLUETOOTH_GENERIC:
+            return _("Bluetooth device");
+        default: {
+            try {
+                return _(
+                    UPDevice
+                        .kind_to_string(kind)
+                        .replaceAll('-', ' ')
+                        .capitalize()
+                );
+            } catch {
+                return _("Unknown");
+            }
+        }
     }
 }
 
@@ -84,6 +88,20 @@ function deviceKindToIcon(kind, icon) {
             return ("computer");
         case UPDeviceKind.GAMING_INPUT:
             return ("input-gaming");
+        case UPDeviceKind.TOUCHPAD:
+            return ("input-touchpad");
+        case UPDeviceKind.HEADSET:
+            return ("audio-headset");
+        case UPDeviceKind.SPEAKERS:
+            return ("audio-speakers");
+        case UPDeviceKind.HEADPHONES:
+            return ("audio-headphones");
+        case UPDeviceKind.PRINTER:
+            return ("printer");
+        case UPDeviceKind.SCANNER:
+            return ("scanner");
+        case UPDeviceKind.CAMERA:
+            return ("camera-photo");
         default:
             if (icon) {
                 return icon;


### PR DESCRIPTION
I have a device that shows up in UPower as a `HEADSET`, which wasn't one of the enumerated device types in the power applet so it showed up as "Unknown" with a generic battery icon. When I went to add support for the headset, I noticed this comment:

https://github.com/linuxmint/cinnamon/blob/8d97e5689f7bea670fb8882d54f48f91e33f04bf/files/usr/share/cinnamon/applets/power%40cinnamon.org/applet.js#L16

So instead of adding only the `HEADSET` device type, I've added `UPowerGlib` introspection and used `UPDevice.kind_to_string(kind)` so now any device type should get a reasonable label. I've also added icons for several more device types.

I've also renamed a few variables to be consistent with the `DeviceKind` terminology used by `UPowerGlib` (instead of `DeviceType`)