### PR TITLE
Use Polkit agent for X11 sessions

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -85,7 +85,6 @@ Depends:
  metacity,
  nemo,
  network-manager-gnome [linux-any],
- policykit-1-gnome,
  python3,
  python3-dbus,
  python3-distro,

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -430,9 +430,7 @@ function start() {
     _initUserSession();
     screenRecorder = new ScreenRecorder.ScreenRecorder();
 
-    if (Meta.is_wayland_compositor()) {
-        PolkitAuthenticationAgent.init();
-    }
+    PolkitAuthenticationAgent.init();
 
     _startDate = new Date();
 

--- a/js/ui/polkitAuthenticationAgent.js
+++ b/js/ui/polkitAuthenticationAgent.js
@@ -35,6 +35,7 @@ const PolkitAgent = imports.gi.PolkitAgent;
 const ModalDialog = imports.ui.modalDialog;
 const CinnamonEntry = imports.ui.cinnamonEntry;
 const UserWidget = imports.ui.userWidget;
+const Main = imports.ui.main;
 
 const DIALOG_ICON_SIZE = 64;
 
@@ -389,5 +390,22 @@ AuthenticationAgent.prototype = {
 }
 
 function init() {
-    let agent = new AuthenticationAgent();
+    try {
+        let agent = new AuthenticationAgent();
+    } catch(err) {
+        if(!(err instanceof Error)) {
+            err = new Error(err);
+        }
+
+        log('polkitAuthenticationAgent: init error ' + err);
+
+        let icon = new St.Icon({ icon_name: 'dialog-warning',
+                                 icon_type: St.IconType.FULLCOLOR,
+                                 icon_size: 36 });
+
+        Main.warningNotify(_('Unable to start Cinnamon PolicyKit Agent'), err.message +
+                           "\n\n" +
+                           _("If you have another PolicyKit Agent configured to autostart, it should be disabled."),
+                           icon);
+    }
 }


### PR DESCRIPTION
This simplifies packaging since we don't need to worry if an external polkit agent is needed. This is currently a draft since I understand upstream may not be ready for this change yet. But I'm creating this now so I can reference it in Gentoo packaging.

Also, don't crash if the agent doesn't start properly. If another agent happens to be running, this will throw a DBus exception. I figured popping a notification would be most appropriate, since the user may have another agent configured to auto-start.
```
(cinnamon:9337): Gjs-CRITICAL **: 13:47:05.571: JS ERROR: Polkit.Error: GDBus.Error:org.freedesktop.PolicyKit1.Error.Failed: An authentication agent already exists for the given subject
_init@/usr/share/cinnamon/js/ui/polkitAuthenticationAgent.js:332:22
AuthenticationAgent@/usr/share/cinnamon/js/ui/polkitAuthenticationAgent.js:323:10
init@/usr/share/cinnamon/js/ui/polkitAuthenticationAgent.js:392:17
start@/usr/share/cinnamon/js/ui/main.js:433:31
@<main>:1:47
```