### PR TITLE
Optionally install wayland session files

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -16,11 +16,10 @@ desktop_conf.set('bindir', join_paths(prefix, bindir))
 desktop_conf.set('libexecdir', join_paths(prefix, libexecdir))
 desktop_conf.set('VERSION', meson.project_version())
 
-desktop_files = [
-  'cinnamon.desktop',
-  'cinnamon-wayland.desktop',
-  'cinnamon2d.desktop',
-]
+desktop_files = ['cinnamon.desktop', 'cinnamon2d.desktop']
+if get_option('wayland')
+    desktop_files += ['cinnamon-wayland.desktop']
+endif
 
 foreach desktop_file : desktop_files
     desktop = configure_file(
@@ -40,7 +39,9 @@ foreach desktop_file : desktop_files
 endforeach
 
 subdir('xdg-portal')
-subdir('wayland_sessions')
+if get_option('wayland')
+    subdir('wayland_sessions')
+endif
 subdir('xsessions')
 subdir('services')
 

--- a/meson.build
+++ b/meson.build
@@ -165,10 +165,15 @@ else
     session_conf.set('REQUIRED', '')
 endif
 
-foreach file : ['cinnamon.session', 'cinnamon2d.session', 'cinnamon-wayland.session']
+session_files = ['cinnamon.session', 'cinnamon2d.session']
+if get_option('wayland')
+    session_files += ['cinnamon-wayland.session']
+endif
+
+foreach session_file : session_files
     configure_file(
-        input: file + '.in',
-        output: file,
+        input: session_file + '.in',
+        output: session_file,
         configuration: session_conf,
         install_dir: join_paths(prefix, datadir, 'cinnamon-session', 'sessions'),
     )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -23,4 +23,9 @@ option('py3modules_dir',
     value : '',
     description: 'Where to install python3 modules'
 )
+option('wayland',
+    type : 'boolean',
+    value : true,
+    description: 'Enable wayland support'
+)
 


### PR DESCRIPTION
Add options to disable installing wayland session and xdg-portal files. Cinnamon shouldn't advertise having wayland sessions if the rest of the packages are built without wayland support.

I didn't see a good option for handling `cinnamon-session-cinnamon` without a more significant refactor. But fortunately `cinnamon-session` aborts with an obvious error message
```
$ cinnamon-session-cinnamon --wayland
cinnamon-session-binary[25984]: CRITICAL: t+0.00369s: Unable to start session: Failed to load session "cinnamon-wayland"
```