### PR TITLE
Set clip_to_allocation to true for menu and notification applets

### DIFF
--- a/docs/applets-examples/finder@cinnamon.org/applet.js
+++ b/docs/applets-examples/finder@cinnamon.org/applet.js
@@ -260,6 +260,7 @@ MyApplet.prototype =
             });
             this._scrollBox.add_actor(this._container);
             this._scrollBox.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC);
+            this._scrollBox.set_clip_to_allocation(true);
             this._scrollBox.set_auto_scrolling(true);
 
             this.searchEntryText = this.searchEntry.clutter_text;

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -2730,6 +2730,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         this.categoriesScrollBox = new St.ScrollView({ style_class: 'vfade menu-applications-scrollbox' });
         this.categoriesScrollBox.add_actor(this.categoriesBox);
         this.categoriesScrollBox.set_policy(St.PolicyType.NEVER, St.PolicyType.AUTOMATIC);
+        this.categoriesScrollBox.set_clip_to_allocation(true);
 
         this.categoriesApplicationsBox.actor.add(this.categoriesScrollBox);
 
@@ -2738,6 +2739,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         this.applicationsScrollBox = new St.ScrollView({ style_class: 'vfade menu-applications-scrollbox'});
         this.applicationsScrollBox.add_actor(this.applicationsBox);
         this.applicationsScrollBox.set_policy(St.PolicyType.NEVER, St.PolicyType.AUTOMATIC);
+        this.applicationsScrollBox.set_clip_to_allocation(true);
 
         let vscroll = this.applicationsScrollBox.get_vscroll_bar();
         vscroll.connect('scroll-start',
@@ -2763,6 +2765,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         this.favoritesBox = new FavoritesBox().actor;
         this.favoritesScrollBox = new St.ScrollView({ y_align: St.Align.START, style_class: 'vfade menu-favorites-scrollbox' });
         this.favoritesScrollBox.set_policy(St.PolicyType.NEVER, St.PolicyType.AUTOMATIC);
+        this.favoritesScrollBox.set_clip_to_allocation(true);
         this.favoritesScrollBox.add_actor(this.favoritesBox);
 
         this.left_box.add(this.favoritesScrollBox, { expand: true });

--- a/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
@@ -98,6 +98,7 @@ class CinnamonNotificationsApplet extends Applet.TextIconApplet {
         this._maincontainer.add(this.scrollview);
         this.scrollview.add_actor(this._notificationbin);
         this.scrollview.set_policy(St.PolicyType.NEVER, St.PolicyType.AUTOMATIC);
+        this.scrollview.set_clip_to_allocation(true);
 
         let vscroll = this.scrollview.get_vscroll_bar();
         vscroll.connect('scroll-start', Lang.bind(this, function() {


### PR DESCRIPTION
This prevents the view from being clicked/selected when outside of the visible viewing pane.

Closes #11123