### PR TITLE
Dnd.js: Revert bug workaround

### DIFF
--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -17,7 +17,6 @@ const Signals = imports.signals;
 const Gettext = imports.gettext;
 const Cinnamon = imports.gi.Cinnamon;
 const SignalManager = imports.misc.signalManager;
-const Dnd = imports.ui.dnd;
 
 var AllowedLayout = {  // the panel layout that an applet is suitable for
     VERTICAL: 'vertical',
@@ -1059,11 +1058,6 @@ var PopupResizeHandler = class PopupResizeHandler {
             return false;
 
         //---Start drag------
-
-        if (Dnd.currentGrabActor != null) { //workaround for issue github.com/linuxmint/cinnamon/issues/11123
-            Dnd.currentGrabActor.fakeRelease();
-        }
-
         this._grabEvents(event);
         this.resizingInProgress = true;
 

--- a/js/ui/dnd.js
+++ b/js/ui/dnd.js
@@ -46,8 +46,6 @@ var currentDraggable = null;
 var dragMonitors = [];
 var targetMonitors = [];
 
-var currentGrabActor = null; //This is used by class PopupResizeHandler in ui/applet.js as a workaround to issue github.com/linuxmint/cinnamon/issues/11123
-
 function _getEventHandlerActor() {
     if (!eventHandlerActor) {
         eventHandlerActor = new Clutter.Actor({ width: 0, height: 0 });
@@ -156,7 +154,6 @@ var _Draggable = new Lang.Class({
         this.drag_device.grab(this.actor);
         this._onEventId = this.actor.connect('event',
                                              Lang.bind(this, this._onEvent));
-        currentGrabActor = this;
     },
 
     _ungrabActor: function(event) {
@@ -171,7 +168,6 @@ var _Draggable = new Lang.Class({
 
         this.actor.disconnect(this._onEventId);
         this._onEventId = null;
-        currentGrabActor = null;
     },
 
     _grabEvents: function(event) {


### PR DESCRIPTION
Revert a workaround added in commit https://github.com/linuxmint/cinnamon/pull/11688/commits/c5af58b2d4ccc4258494bf7127e8097a9fb92aef that prevented a dnd bug https://github.com/linuxmint/cinnamon/pull/11665#issuecomment-1557253018

The original bug https://github.com/linuxmint/cinnamon/issues/11123 that caused this bug has now been fixed so this workaround is no longer needed.

Edit: btw, this doesn't necessarily have to be merged for cinnamon 6.2 as the workaround now effectively doesn't do anything.