### PR TITLE
GWL: Set reasonable min width for panel item ...

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -340,7 +340,7 @@ class AppGroup {
         const [labelMinSize, labelNaturalSize] = this.label.get_preferred_width(forHeight);
         // The label text starts in the center of the icon, so we should allocate the space
         // needed for the icon plus the space needed for(label - icon/2)
-        alloc.min_size = 1 * global.ui_scale;
+        alloc.min_size = this.iconSize * global.ui_scale;
 
         const {appId} = this.groupState;
 


### PR DESCRIPTION
 ... in case application icon is missing.

Fixes: https://github.com/linuxmint/cinnamon/issues/12307