### PR TITLE
cs_keyboard.py: Skip invalid bindings

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_keyboard.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_keyboard.py
@@ -535,9 +535,12 @@ class Module:
                     home = os.path.expanduser("~")
                     gettext.bindtextdomain(name, f"{home}/.local/share/locale")
                     gettext.textdomain(name)
-                    with open(f"{home}/.local/share/cinnamon/{_type}/{name}/metadata.json", encoding="utf-8") as metadata:
-                        json_data = json.load(metadata)
-                        category_label = gettext.gettext(_(json_data["name"]))
+                    try:
+                        with open(f"{home}/.local/share/cinnamon/{_type}/{name}/metadata.json", encoding="utf-8") as metadata:
+                            json_data = json.load(metadata)
+                            category_label = gettext.gettext(_(json_data["name"]))
+                    except FileNotFoundError:
+                        continue
                 if not _id:
                     cat_label = category_label if category_label else name
                     CATEGORIES.append([cat_label, name, "spices", None, properties])


### PR DESCRIPTION
It is possible to remove Spices manually by removing the associated directories rather than using the appropriate module. This results in the bindings still being stored internally. When loading the Keyboard module and this scenario has occurred, it results in a failure due to the matching files having been removed. We leave the mappings internally so that if the matching Spice is reinstalled, the previous settings will be retained.