### PR TITLE
cs_panel.py: Error handling for panels on unavailable monitors

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_panel.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_panel.py
@@ -326,7 +326,9 @@ class Module:
             panel_id, monitor_id, position = def_.split(":")
             monitor_id = int(monitor_id)
 
-            if self.id_or_monitor_position_used(already_defined_panels, monitor_layout, panel_id, monitor_id, position):
+            if monitor_id >= n_mons:
+                print("cs_panel: Ignoring panel definition with a monitor out of range: (ID: %s, Monitor: %d, Position: %s)" % (panel_id, monitor_id, position))
+            elif self.id_or_monitor_position_used(already_defined_panels, monitor_layout, panel_id, monitor_id, position):
                 removals.append(def_)
                 continue
 


### PR DESCRIPTION
If a panel definition exists for an inactive monitor, launching the panels settings menu will fail.

In `id_or_monitor_position_used` we check if a position is used by going through monitor_layout[monitor_id]. This can result in an index out of range error if the length of monitor_layout is not greater than monitor_id. See https://github.com/linuxmint/cinnamon/issues/12378 and https://github.com/linuxmint/cinnamon/issues/12397.

To reproduce:
1. Go to the display settings menu and disable a monitor with a panel (or simply unplug a monitor with a panel)
2. Attempt to launch the panels settings menu

This implementation does not remove the panel definition and it will still be available when the monitor is re-attached.