### PR TITLE
panel.js: Only pick reactive actors on validating right click target

### DIFF
--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -2680,7 +2680,7 @@ Panel.prototype = {
         if (event.get_button() == 3) {  // right click
             try {
                 let [x, y] = event.get_coords();
-                let target = global.stage.get_actor_at_pos(Clutter.PickMode.ALL, x, y);
+                let target = global.stage.get_actor_at_pos(Clutter.PickMode.REACTIVE, x, y);
 
                 // NB test on parent fails with centre aligned vertical box, but works for the test against the actor
                 if (this._context_menu._getMenuItems().length > 0 &&


### PR DESCRIPTION
The goal is to fix https://github.com/linuxmint/cinnamon-spices-extensions/issues/749 for the extension mouse-click-effects.

The extension allows the user to put an icon below its cursor pointer to perform animations or follow the cursor pointer.

I use a **St.Icon** with the **reactive** attribute **set to false** but still it is interfering when right-clicking the panel to open the panel menu, though this does not happen when right-clicking an applet to open the applet menu.

When receiving a right-click event the panel verifies if the click target was indeed the panel directly or another component before showing the menu (I suppose to avoid opening when right-clicking applets), for that, it will pick the actor in the position of the click, but even though the **St.Icon** I have it is unreactive it's being picked unnecessarily, with this PR I changed it only to pick REACTIVE actors, preventing non-reactive actors from being considered in this process.