### PR TITLE
popupMenu.js: Simplify the menu animation

### DIFF
--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -222,7 +222,7 @@ class ResizePopup extends St.Widget {
 });
 
 var WindowManager = class WindowManager {
-        MENU_ANIMATION_TIME = 0.1;
+        MENU_ANIMATION_TIME = 0.15;
         WORKSPACE_ANIMATION_TIME = 0.15;
         TILE_PREVIEW_ANIMATION_TIME = 0.15;
         SIZE_CHANGE_ANIMATION_TIME = 0.12;


### PR DESCRIPTION
Currently the menu animates a distance of 1/10 the menus height/width. This leads to some menus having a bit different animation then others. Switch to using a hard coded distance instead. With the smaller distance we can also now remove the set_clip() that is being used. That hurts performance, especially on HiDpi. That was being updated on every update of the tween. It also clips out any box shadow that the theme is using on the menu as a side effect.

With the smaller amount of translation happening in the menu, slow down the speed of the animation just a bit. This results in the overall animation looking very similar to how it did before.