### PR TITLE
Update classicSwitcher.js

### DIFF
--- a/js/ui/appSwitcher/classicSwitcher.js
+++ b/js/ui/appSwitcher/classicSwitcher.js
@@ -582,6 +582,7 @@ SwitcherList.prototype = {
     },
 
     _onItemClicked: function (index) {
+        this._itemEntered(index);
         this._itemActivated(index);
     },
 


### PR DESCRIPTION
Describe bug: When you click on the icon on pressed alt+tab - active became focused icon, but not you clicked.
This PR will fix this small bug.