### PR TITLE
windowManager: Give the resize popup it's own style class

### DIFF
--- a/data/theme/cinnamon-sass/widgets/_osd.scss
+++ b/data/theme/cinnamon-sass/widgets/_osd.scss
@@ -92,5 +92,5 @@ $ws_dot_inactive: $ws_indicator_height / 6;
 .resize-popup {
   @extend %osd_base;
 
-  padding: $base_padding;
+  padding: $base_padding * 2;
 }

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -204,10 +204,14 @@ var ResizePopup = GObject.registerClass(
 class ResizePopup extends St.Widget {
     _init() {
         super._init({ layout_manager: new Clutter.BinLayout() });
-        this._label = new St.Label({ style_class: 'info-osd',
-                                     x_align: Clutter.ActorAlign.CENTER,
-                                     y_align: Clutter.ActorAlign.CENTER,
-                                     x_expand: true, y_expand: true });
+        this._label = new St.Label({
+            style_class: 'resize-popup',
+            important: true,
+            x_align: Clutter.ActorAlign.CENTER,
+            y_align: Clutter.ActorAlign.CENTER,
+            x_expand: true,
+            y_expand: true
+        });
         this.add_child(this._label);
         Main.uiGroup.add_actor(this);
     }


### PR DESCRIPTION
Reusing the info-osd class is convenient but doesn't always give what we want. Add a unique style class to allow theming this independently