### PR TITLE
environment: Use cjs smart GObject GTypeName computation

### DIFF
--- a/js/ui/environment.js
+++ b/js/ui/environment.js
@@ -289,6 +289,8 @@ function init() {
         St.Widget.set_default_direction(St.TextDirection.RTL);
     }
 
+    GObject.gtypeNameBasedOnJSPath = true;
+
     // Miscellaneous monkeypatching
     _patchContainerClass(St.BoxLayout);
     _patchContainerClass(St.Table);


### PR DESCRIPTION
Make cjs to compute the GType name for registered GObject-derived classes using the file basename and the first directory name, so that we can avoid name clashing, and ensure that no xlet will break cinnamon by registering a name that is already used (by cinnamon or by any other extension).