### PR TITLE
Fix jxl file previews in cs_background.py

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_backgrounds.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_backgrounds.py
@@ -609,7 +609,7 @@ class PixCache(object):
                         os.remove(cache_filename)
 
                 if not loaded:
-                    if mimetype in ("image/svg+xml", "image/avif"):
+                    if mimetype in ("image/svg+xml", "image/avif", "image/jxl"):
                         # rasterize svg with Gdk-Pixbuf and convert to PIL Image
                         tmp_pix = GdkPixbuf.Pixbuf.new_from_file(filename)
                         mode = "RGBA" if tmp_pix.props.has_alpha else "RGB"


### PR DESCRIPTION
The gnome-backgrounds project uses jxl files for many backgrounds. 

https://gitlab.gnome.org/GNOME/gnome-backgrounds

Unfortunately the Cinnamon Backgrounds module doesn't render these correctly. Causing blank sections for many of the Backgrounds. The python `Image.open` call doesn't support them yet, even with libjxl installed.

This patch merely adds support for `image/jxl` files and makes sure they render correctly.
