### PR TITLE
fix users and groups falsely claiming that dots are allowed in usernames

### DIFF
--- a/cinnamon.pot
+++ b/cinnamon.pot
@@ -2355,7 +2355,7 @@ msgid ""
 "The username must consist of only:\n"
 "    - lower case letters (a-z)\n"
 "    - numerals (0-9)\n"
-"    - '.', '-', and '_' characters"
+"    - '-' and '_' characters"
 msgstr ""
 
 #: files/usr/share/cinnamon/cinnamon-settings-users/cinnamon-settings-users.py:379

--- a/files/usr/share/cinnamon/cinnamon-settings-users/cinnamon-settings-users.py
+++ b/files/usr/share/cinnamon/cinnamon-settings-users/cinnamon-settings-users.py
@@ -373,7 +373,7 @@ class NewUserDialog(Gtk.Dialog):
             self.username_entry.connect("changed", self._on_info_changed)
 
             label = Gtk.Label()
-            label.set_markup(_("The username must consist of only:\n    - lower case letters (a-z)\n    - numerals (0-9)\n    - '.', '-', and '_' characters"))
+            label.set_markup(_("The username must consist of only:\n    - lower case letters (a-z)\n    - numerals (0-9)\n    - '-' and '_' characters"))
 
             table = DimmedTable()
             table.add_labels([_("Account Type"), _("Full Name"), _("Username")])


### PR DESCRIPTION
fix users and groups falsely claiming that dots are allowed in usernames