### PR TITLE
sound@cinnamon.org: Play volume change sound after changing volume via dragging volume slider

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -94,6 +94,9 @@ class VolumeSlider extends PopupMenu.PopupSliderMenuItem {
         this.tooltip = new Tooltips.Tooltip(this.actor, this.tooltipText);
 
         this.connect("value-changed", () => this._onValueChanged());
+        if (tooltip === _("Volume")) {
+            this.connect("drag-end", () => this._onDragEnd());
+        }
 
         this.app_icon = app_icon;
         if (this.app_icon == null) {
@@ -158,6 +161,12 @@ class VolumeSlider extends PopupMenu.PopupSliderMenuItem {
             this.applet._notifyVolumeChange(this.stream);
     }
 
+    _onDragEnd() {
+        if (this.stream) {
+            this.applet._notifyVolumeChange(this.stream);
+        }
+    }
+
     _onScrollEvent(actor, event) {
         let direction = event.get_scroll_direction();
 
@@ -183,7 +192,6 @@ class VolumeSlider extends PopupMenu.PopupSliderMenuItem {
             this._value = Math.max(0, Math.min(this._value + delta/this.applet._volumeMax*this.applet._volumeNorm, 1));
             this._slider.queue_repaint();
             this.emit('value-changed', this._value);
-            this.emit('drag-end');
             return true;
         }
         return false;


### PR DESCRIPTION
Fixes https://github.com/linuxmint/cinnamon/issues/9472

Featured added to `sound150@claudiux` spice applet https://github.com/linuxmint/cinnamon-spices-applets/pull/6573

Original issue was requesting feature be added to `sound@cinnamon.org` applet - porting feature from `sound150@claudiux` spice applet.

Users migrating from other operating systems might expect that changing the volume slider would play an audible tone to indicate how loud the volume is. Right now, the only ways to get this tone to play from the applet are to use the keyboard or mouse scroll wheel. This adds another option for users who prefer to use mouse/touch screen or don't have a mouse wheel to hear how loud the volume is.