### PR TITLE
layout.js: Fix the work area for MonitorConstraint

### DIFF
--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -157,12 +157,14 @@ var MonitorConstraint = GObject.registerClass({
                 switch (i) {
                     case 0:
                         rect.y += panel.actor.get_height();
+                        rect.height -= panel.actor.get_height();
                         break;
                     case 1:
                         rect.height -= panel.actor.get_height();
                         break;
                     case 2:
                         rect.x += panel.actor.get_width();
+                        rect.width -= panel.actor.get_width();
                         break;
                     case 3:
                         rect.width -= panel.actor.get_width();


### PR DESCRIPTION
The work area was being improperly calculated for panels placed on the top or right side of the screen.

Closes: https://github.com/linuxmint/cinnamon/issues/12540