### PR TITLE
Don't crash on start-up if polkit encounters a dbus error

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -89,7 +89,6 @@ Depends:
  metacity,
  nemo,
  network-manager-gnome [linux-any],
- policykit-1-gnome,
  python3,
  python3-dbus,
  python3-distro,

--- a/js/ui/polkitAuthenticationAgent.js
+++ b/js/ui/polkitAuthenticationAgent.js
@@ -40,6 +40,7 @@ const CinnamonEntry = imports.ui.cinnamonEntry;
 const PopupMenu = imports.ui.popupMenu;
 const UserWidget = imports.ui.userWidget;
 const Util = imports.misc.util;
+const Main = imports.ui.main;
 
 const DIALOG_ICON_SIZE = 64;
 const DELAYED_RESET_TIMEOUT = 200;
@@ -523,5 +524,22 @@ var AuthenticationAgent = class {
 }
 
 function init() {
-    let agent = new AuthenticationAgent();
+    try {
+        let agent = new AuthenticationAgent();
+    } catch(err) {
+        if(!(err instanceof Error)) {
+            err = new Error(err);
+        }
+
+        log('polkitAuthenticationAgent: init error ' + err);
+
+        let icon = new St.Icon({ icon_name: 'dialog-warning',
+                                 icon_type: St.IconType.FULLCOLOR,
+                                 icon_size: 36 });
+
+        Main.warningNotify(_('Unable to start Cinnamon PolicyKit Agent'), err.message +
+                           "\n\n" +
+                           _("If you have another PolicyKit Agent configured to autostart, it should be disabled."),
+                           icon);
+    }
 }


### PR DESCRIPTION
From #12272

Don't crash if the agent doesn't start properly. If another agent happens to be running, this will throw a DBus exception. I figured popping a notification would be most appropriate, since the user may have another agent configured to auto-start.
```
(cinnamon:9337): Gjs-CRITICAL **: 13:47:05.571: JS ERROR: Polkit.Error: GDBus.Error:org.freedesktop.PolicyKit1.Error.Failed: An authentication agent already exists for the given subject
_init@/usr/share/cinnamon/js/ui/polkitAuthenticationAgent.js:332:22
AuthenticationAgent@/usr/share/cinnamon/js/ui/polkitAuthenticationAgent.js:323:10
init@/usr/share/cinnamon/js/ui/polkitAuthenticationAgent.js:392:17
start@/usr/share/cinnamon/js/ui/main.js:433:31
@<main>:1:47
```
This was my best guess at how to handle this. I wasn't sure if it belonged in `polkitAuthenticationAgent.js` or in `main.js`.