### PR TITLE
Fix crash when attempting to report an error in the UI with details

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
@@ -846,7 +846,7 @@ class Spice_Harvester(GObject.Object):
         esc = html.escape(markup)
         dialog.set_markup(esc)
         dialog.show_all()
-        _ = dialog.run()
+        dialog.run()
         dialog.destroy()
 
     def errorMessage(self, msg, detail=None):


### PR DESCRIPTION
Ref #12354.

Assignment to `_` was almost certainly unintended in the line `_ = dialog.run()`, and has been removed.

As is, the code forced `_` to be recognized as a local (see https://stackoverflow.com/questions/370357); in the case where a non-`None` value is passed, this would mean that `_` is used before assignment.

Context implies that `_` is supposed to be a globally defined function, but further implies that the result from `dialog.run` *should not* replace that value.

Most likely, the original code was assigning to `_` for debugging purposes (i.e. so that the local value could be examined in a debugger), and the name collision was unintended.