### PR TITLE
Add grouped window list notification count functionality

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -1083,7 +1083,7 @@ class AppGroup {
     resetNotificationCount() {
         if (this.groupState.willUnmount) return;
     
-        this.groupState.set({ notificationCount : 0 });
+        this.groupState.set({ notificationCount: 0 });
         this.showBadge();
     }
 

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/constants.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/constants.js
@@ -18,6 +18,11 @@ const constants = {
         Title: 3,
         Focused: 4
     },
+    CountNumbers: {
+        None: 1,
+        Window: 2,
+        Notification: 3
+    },
     FavType: {
         favorites: 0,
         pinnedApps: 1,

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/settings-schema.json
@@ -185,9 +185,14 @@
     }
   },
   "number-display": {
-    "type": "checkbox",
-    "default": true,
-    "description": "Show window count numbers"
+    "type": "combobox",
+    "default": 2,
+    "description": "Show count numbers",
+    "options": {
+      "None": 1,
+      "Window": 2,
+      "Notification": 3
+    }
   },
   "enable-app-button-dragging": {
     "type": "checkbox",


### PR DESCRIPTION
This feature allows users to see a notification badge on the grouped window list applet:
- current badge UI element was reused
- builtin message tray is used to be notified if an app got a notification
- "Show window count numbers" setting was changed to comobox
- extracted badge logic into a method where it's decided if the badge is shown, when is shown and what number to show



This is how settings combobox looks:
![count_numbers_setting](https://github.com/user-attachments/assets/baac3c28-127a-4139-8311-c7b8ce98c8c4)

And this indicates that I have a notification (because in settings I have "Show count numbers" = "Notification"):
![image](https://github.com/user-attachments/assets/9de6b751-dcda-4f90-b4fe-fd26786cd5d0)


Once I select "Show count numbers" = "Window" in settings combobox, it behaves as previous implementation, showing window count:
![image](https://github.com/user-attachments/assets/a941f170-3f24-4859-a9f0-37d4e9404da3)


