### PR TITLE
theme: Fix rounding and spacing in GWL window previews

### DIFF
--- a/data/theme/cinnamon-sass/widgets/_windowlist.scss
+++ b/data/theme/cinnamon-sass/widgets/_windowlist.scss
@@ -47,6 +47,7 @@
 
   &-thumbnail-menu {
     border: 1px solid $borders_color;
+    margin: 6px;
     background-color: $bg_color;
     border-radius: $base_border_radius;
     box-shadow: 0 0 6px 0 $shadow_color;
@@ -56,6 +57,10 @@
     .item-box {
       padding: 10px;
       spacing: 4px;
+      border-radius: 0;
+
+      &:first-child { border-radius: $base_border_radius 0 0 $base_border_radius; }
+      &:last-child { border-radius: 0 $base_border_radius $base_border_radius 0; }
 
       &:outlined {
         border: 2px solid transparentize($fg_color, 0.5);


### PR DESCRIPTION
Fixes rounding in window previews when hovered. Also add a margin to give the window preview the same distance from the panel as menus.

https://github.com/linuxmint/mint22.1-beta/issues/23