### PR TITLE
theme: Fix missing text on virtual keyboard

### DIFF
--- a/data/theme/cinnamon-sass/widgets/_keyboard.scss
+++ b/data/theme/cinnamon-sass/widgets/_keyboard.scss
@@ -13,8 +13,9 @@
   &-key {
     @extend %button;
 
-    min-height: 30px;
-    min-width: 30px;
+    min-height: 2em;
+    min-width: 2em;
+    padding: 0;
     font-size: 1.2em;
     font-weight: bold;
 
@@ -23,7 +24,10 @@
 
   &-subkeys {
     padding: $base_padding;
-    -arrow-border-radius: $borders_color;
+    -arrow-background-color: $bg_color;
+    -arrow-border-width: 1px;
+    -arrow-border-radius: $base_border_radius;
+    -arrow-border-color: lighten($borders_color, 10%);
     -arrow-base: 20px;
     -arrow-rise: 10px;
     -boxpointer-gap: 0;


### PR DESCRIPTION
Use em to set the button size. This allows the size to adjust when the keyboard size is changed. Also fix the boxpointer menu that holds the subkeys.

Fixes: https://github.com/linuxmint/mint22.1-beta/issues/25