### PR TITLE
[Next] Move sass compilation to its own custom target

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -11,8 +11,7 @@ install_subdir(
     'theme',
     exclude_files: [
         'theme-changelog.txt',
-        'meson.build',
-        'parse-sass.sh'
+        'meson.build'
     ],
     exclude_directories: ['cinnamon-sass'],
     install_dir: pkgdatadir,

--- a/data/theme/cinnamon-sass/meson.build
+++ b/data/theme/cinnamon-sass/meson.build
@@ -1,0 +1,11 @@
+sassc = find_program('pysassc', 'sassc')
+
+custom_target(
+  'cinnamon_css',
+  input: 'cinnamon.scss',
+  output: 'cinnamon.css',
+  command: [sassc, '@INPUT@', '@OUTPUT@'],
+  build_always_stale: true,
+  install: true,
+  install_dir: join_paths(pkgdatadir, 'theme')
+)

--- a/data/theme/meson.build
+++ b/data/theme/meson.build
@@ -1,3 +1,1 @@
-sassc = find_program('pysassc')
-
-run_command('parse-sass.sh', check: true)
+subdir('cinnamon-sass')

--- a/data/theme/parse-sass.sh
+++ b/data/theme/parse-sass.sh
@@ -1,3 +1,0 @@
-#! /bin/bash
-
-pysassc ./cinnamon-sass/cinnamon.scss cinnamon.css


### PR DESCRIPTION
`run_command` runs silently and the build log does not indicate that the command was run, or what the command was, so it's not great for build debugging. On the other hand, `custom_target` logs as a normal build target.
```
[9/113] /usr/bin/pysassc ../cinnamon-6.4.3/data/theme/cinnamon-sass/cinnamon.scss data/theme/cinnamon-sass/cinnamon.css
```

`run_command` also states that it runs in an unspecified directory, so the current script is relying on undocumented implementation/platform specific behavior. Rather than updating the script to ensure it runs in the proper directory, `custom_target` does this for us (and handles installs since it enforces the source/build separation).

Also support both pysassc and sassc (which was the reason I was in here in the first place X_X). The only difference between the two is some decimal precision.
```patch
--- a/data/theme/cinnamon-sass/cinnamon.css (pysassc)
+++ b/data/theme/cinnamon-sass/cinnamon.css (sassc)
@@ -994,13 +994,13 @@ StScrollBar StButton#hhandle {
     spacing: 12px; }
   .workspace-switch-osd-indicator {
     background-color: rgba(255, 255, 255, 0.5);
-    padding: 2.66667px;
-    margin: 13.33333px;
+    padding: 2.6666666667px;
+    margin: 13.3333333333px;
     border-radius: 32px; }
     .workspace-switch-osd-indicator:active {
       background-color: #3584e4;
-      padding: 5.33333px;
-      margin: 10.66667px; }
+      padding: 5.3333333333px;
+      margin: 10.6666666667px; }
 
 .monitor-label {
   border-radius: 0;
```
Theoretically this could also add dart-sass ('sass') to the list of programs, but that has more differences  (like outputting `rgb(x, y, z)` values instead of hex, and over 100 deprecation warnings). While [py]sassc/libsass are deprecated, I'm not advocating for a migration to dart-sass (yet) since Gentoo doesn't package dart, and I'm not signing up to maintain that.