### PR TITLE
modalDialog.js: Add some support for old themes

### DIFF
--- a/js/ui/modalDialog.js
+++ b/js/ui/modalDialog.js
@@ -105,6 +105,8 @@ var ModalDialog = GObject.registerClass({
         this.dialogLayout = new Dialog.Dialog(this.backgroundStack, params.styleClass);
         this.contentLayout = this.dialogLayout.contentLayout;
         this.buttonLayout = this.dialogLayout.buttonLayout;
+        this.dialogLayout._dialog.add_style_class_name("modal-dialog"); // temporarily add some support for old themes
+        this.buttonLayout.add_style_class_name("modal-dialog-button-box"); // temporarily add some support for old themes
 
         this.openAndCloseTime = 100;
         let enableRadialEffect = true;
@@ -188,7 +190,9 @@ var ModalDialog = GObject.registerClass({
     }
 
     addButton(buttonInfo) {
-        return this.dialogLayout.addButton(buttonInfo);
+        const button = this.dialogLayout.addButton(buttonInfo);
+        button.add_style_class_name("modal-dialog-button"); // temporarily add some support for old themes
+        return button;
     }
 
     _fadeOpen() {


### PR DESCRIPTION
@clefebvre @JosephMcc 

The new cinnamon modal dialogs break almost all existing cinnamon themes apart from cinnamon and Mint-Y, most of which will likely never be updated rendering most cinnamon themes effectively obsolete. To mitigate this, albeit somewhat imperfectly, some small support for old themes could be added. This could give more time for theme authors to update their themes (including Mint-L and Mint-X) and could be removed at a later time.

Here is a representative selection of themes showing how this added support would look including some of the most popular cinnamon themes in cinnamon spices. All these themes would otherwise have the default cinnamon theme dialog: 

Mint-X:
![Mint-X](https://github.com/user-attachments/assets/27879e97-b60b-4df7-b957-26de562d0f97)
Mint-L
![Mint-L](https://github.com/user-attachments/assets/69f6d859-f1a1-4244-81aa-ddff6a14bdb4)
[Cinnamox-Aubergine
![Cinnamox-Aubergine](https://github.com/user-attachments/assets/ed57328e-d5e8-421d-91f6-c476f93ab77f)
Numix-Cinnamon-Transparent
![Numix-Cinnamon-Transparent](https://github.com/user-attachments/assets/9bc4ae3c-f044-4178-80a2-414dd14499c6)
CBlack
![CBlack](https://github.com/user-attachments/assets/ed9c569d-c3af-4160-bc81-3d96b0d4edcc)
New-Minty
![New-Minty](https://github.com/user-attachments/assets/0f4fd48e-e6f5-43ce-83e6-b3fa66f6f850)
qob
![qob](https://github.com/user-attachments/assets/69295658-4a65-4f14-a98d-d96496a0f9c5)
Carta
![Carta](https://github.com/user-attachments/assets/df8d2dfd-3caa-417f-8c9c-cfd26444898f)
Vertex-Maia (Manjaro default theme)
![Vertex-Maia](https://github.com/user-attachments/assets/fe856b0f-7734-4135-8169-a6efba44d64e)
Orchis-Light (dark background instead of light):
![Orchis-Light](https://github.com/user-attachments/assets/189d127a-a640-48a8-b7ea-ce7a5ed9d926)
Eleganse-dark:
![Eleganse-dark](https://github.com/user-attachments/assets/34510922-edb7-471a-bd65-5f70fc8d7bbb)
Adapta-Nokto:
![Adapta-Nokto](https://github.com/user-attachments/assets/b92a29c9-0006-4c2c-a81d-789c76dd8299)
Adapta and Adapta-Nokto would otherwise have transparent backgrounds:
![Adapta-Nokto_wo](https://github.com/user-attachments/assets/e67ce174-b9df-448b-a554-eaef9a41605f)
