### PR TITLE
dialog.js: Fix spelling

### DIFF
--- a/data/theme/cinnamon-sass/widgets/_dialogs.scss
+++ b/data/theme/cinnamon-sass/widgets/_dialogs.scss
@@ -82,7 +82,7 @@
     text-align: center;
     @extend %title_2;
 
-    &.leightweight { @extend %title_4; }
+    &.lightweight { @extend %title_4; }
   }
 
   .message-dialog-description { text-align: center; }

--- a/js/ui/dialog.js
+++ b/js/ui/dialog.js
@@ -244,7 +244,7 @@ var MessageDialogContent = GObject.registerClass({
 
             this._updateTitleStyleLater = Meta.later_add(Meta.LaterType.BEFORE_REDRAW, () => {
                 this._updateTitleStyleLater = 0;
-                this._title.add_style_class_name('leightweight');
+                this._title.add_style_class_name('lightweight');
                 return GLib.SOURCE_REMOVE;
             });
         }
@@ -257,7 +257,7 @@ var MessageDialogContent = GObject.registerClass({
 
         _setLabel(this._title, title);
 
-        this._title.remove_style_class_name('leightweight');
+        this._title.remove_style_class_name('lightweight');
         this._updateTitleStyle();
 
         this.notify('title');


### PR DESCRIPTION
Fix spelling error in class name.

related: https://github.com/linuxmint/mint-themes/pull/486

At least I assume it's a mistake?