### PR TITLE
dialog.js: add style class dialog-button-box

### DIFF
--- a/js/ui/dialog.js
+++ b/js/ui/dialog.js
@@ -65,6 +65,7 @@ class Dialog extends St.Widget {
         });
 
         this.buttonLayout = new St.Widget ({
+            style_class: "dialog-button-box",
             layout_manager: new Clutter.BoxLayout({
                 homogeneous: true,
                 spacing: 12,


### PR DESCRIPTION
Allow themes to style the dialog buttonlayout. This is a replacement for the old modal-dialog-button-box class style. Without it, themes like Numix-Cinnamon-Transparent, New-Minty, and Vertex-Maia will not be able to style the button box separately.

![Numix-Cinnamon-Transparent](https://github.com/user-attachments/assets/db8f927e-23b2-4e4b-b946-d3c9c4d477b2)

![Vertex-Maia](https://github.com/user-attachments/assets/2c363b93-291a-4efb-9947-61afdc5f1bee)
