### PR TITLE
[NEXT] st-label: Don't guard against NULL text

### DIFF
--- a/src/st/st-label.c
+++ b/src/st/st-label.c
@@ -352,7 +352,6 @@ st_label_set_text (StLabel     *label,
   ClutterText *ctext;
 
   g_return_if_fail (ST_IS_LABEL (label));
-  g_return_if_fail (text != NULL);
 
   priv = label->priv;
   ctext = CLUTTER_TEXT (priv->label);


### PR DESCRIPTION
NULL is allowed for the underlying clutter_text, so there is no real reason to guard against this. This also cleans up spammy warnings when using g_object_bind to set/update the labels.