### PR TITLE
Slightly wider end-session-dialog

### DIFF
--- a/data/theme/cinnamon-sass/widgets/_dialogs.scss
+++ b/data/theme/cinnamon-sass/widgets/_dialogs.scss
@@ -56,7 +56,7 @@
 // End session dialog
 
 .end-session-dialog {
-  width: 40em;
+  width: 45em;
 
   .dialog-content-box { spacing: 0; }
 


### PR DESCRIPTION
Visually, it is almost unnoticeable, but the button labels in many other languages ​​will now fit completely.