### PR TITLE
Fix image not showing in notification when notifications are set to show at bottom of screen.

### DIFF
--- a/js/ui/messageTray.js
+++ b/js/ui/messageTray.js
@@ -1009,19 +1009,10 @@ MessageTray.prototype = {
             let getBottomPositionY = () => {
                 return this._monitor.y + this._monitor.height - this._notificationBin.height - bottomGap;
             };
-            let shouldReturn = false;
-            let initialY = getBottomPositionY();
             // For multi-line notifications, the correct height will not be known until the notification is done animating,
-            // so this will set _notificationBin.y when queue-redraw is emitted, and return early if the  height decreases
-            // to prevent unnecessary property setting.
+            // so this will set _notificationBin.y when queue-redraw is emitted.
             this.bottomPositionSignal = this._notificationBin.connect('queue-redraw', () => {
-                if (shouldReturn) {
-                    return;
-                }
                 this._notificationBin.y = getBottomPositionY();
-                if (initialY > this._notificationBin.y) {
-                    shouldReturn = true;
-                }
             });
         }
 


### PR DESCRIPTION
It seems that merely reading the `height` property of StBin before `queue-redraw` signal causes the image in the notification to disappear. This fixes the issue but whether it fixes the real cause of the bug, I'm not sure - I don't know if accessing the height property of StBin before `queue-redraw` is allowed or not supposed to have any side effects.

Fixes: https://github.com/linuxmint/cinnamon/issues/12613