### PR TITLE
osdWindow.js: adding text display of the level and a small increase in the icon

### DIFF
--- a/data/theme/cinnamon-sass/widgets/_osd.scss
+++ b/data/theme/cinnamon-sass/widgets/_osd.scss
@@ -20,7 +20,7 @@ $ws_dot_inactive: $ws_indicator_height / 6;
   & > * { spacing: $base_padding * 2; }
 
   StIcon {
-    icon-size: 32px;
+    icon-size: 44px;
   }
 
   StLabel {
@@ -43,6 +43,14 @@ $ws_dot_inactive: $ws_indicator_height / 6;
   .level-bar {
     border-radius: $base_border_radius;
     background-color: $fg_color;
+  }
+
+  .level-text {
+   min-width: 44px;
+   text-align: right;
+
+   &:ltr { margin-right: 0px; }
+   &:rtl { margin-left: 0px; }
   }
 }
 

--- a/js/ui/osdWindow.js
+++ b/js/ui/osdWindow.js
@@ -64,6 +64,12 @@ class OsdWindow extends Clutter.Actor {
         });
         this._hbox.add_child(this._vbox);
 
+        this._leveltext = new St.Label({
+            style_class: 'level-text',
+            y_align: Clutter.ActorAlign.CENTER,
+        });
+        this._hbox.add_child(this._leveltext);
+
         this._label = new St.Label();
         this._vbox.add_child(this._label);
 
@@ -90,7 +96,9 @@ class OsdWindow extends Clutter.Actor {
 
     setLevel(value) {
         this._level.visible = value != null;
+        this._leveltext.visible = this._level.visible;
         if (this._level.visible) {
+            this._leveltext.text = "%d%%".format(value);
             value = value / 100;
             if (this.visible)
                 this._level.ease_property('value', value, {


### PR DESCRIPTION
In my opinion, the volume percentage display in Cinnamon v.6.2.x was very convenient and I would like to bring it back. Also, media buttons are more often used on devices like TVs, so it would be better to make the icon a little bigger.

![Voff](https://github.com/user-attachments/assets/dd9678bb-e003-434b-bc70-cbcc7dcddd59)
![V25](https://github.com/user-attachments/assets/fa5d97fe-ec87-4560-be44-aaa235be2894)
![V100](https://github.com/user-attachments/assets/fcd687c8-9e1b-49f3-ae32-644f8115cb34)

Before:
![Vprev](https://github.com/user-attachments/assets/36ecdb74-f10b-4626-9950-3a248bf356c2)
