### PR TITLE
croco: Use g_string_free() return value

### DIFF
--- a/src/st/croco/cr-additional-sel.c
+++ b/src/st/croco/cr-additional-sel.c
@@ -323,8 +323,7 @@ cr_additional_sel_to_string (CRAdditionalSel const * a_this)
         }
 
         if (str_buf) {
-                result = (guchar *) str_buf->str;
-                g_string_free (str_buf, FALSE);
+                result = (guchar *) g_string_free (str_buf, FALSE);
                 str_buf = NULL;
         }
 
@@ -422,8 +421,7 @@ cr_additional_sel_one_to_string (CRAdditionalSel const *a_this)
         }
 
         if (str_buf) {
-                result = (guchar *) str_buf->str;
-                g_string_free (str_buf, FALSE);
+                result = (guchar *) g_string_free (str_buf, FALSE);
                 str_buf = NULL;
         }
 

--- a/src/st/croco/cr-attr-sel.c
+++ b/src/st/croco/cr-attr-sel.c
@@ -168,8 +168,7 @@ cr_attr_sel_to_string (CRAttrSel const * a_this)
         }
 
         if (str_buf) {
-                result = (guchar *) str_buf->str;
-                g_string_free (str_buf, FALSE);
+                result = (guchar *) g_string_free (str_buf, FALSE);
         }
 
         return result;

--- a/src/st/croco/cr-declaration.c
+++ b/src/st/croco/cr-declaration.c
@@ -539,8 +539,7 @@ cr_declaration_to_string (CRDeclaration const * a_this, gulong a_indent)
                 }
         }
         if (stringue && stringue->str) {
-                result = stringue->str;
-                g_string_free (stringue, FALSE);
+                result = g_string_free (stringue, FALSE);
         }
         return result;
 
@@ -586,8 +585,7 @@ cr_declaration_list_to_string (CRDeclaration const * a_this, gulong a_indent)
                         break;
         }
         if (stringue && stringue->str) {
-                result = (guchar *) stringue->str;
-                g_string_free (stringue, FALSE);
+                result = (guchar *) g_string_free (stringue, FALSE);
         }
 
         return result;
@@ -639,8 +637,7 @@ cr_declaration_list_to_string2 (CRDeclaration const * a_this,
                         break;
         }
         if (stringue && stringue->str) {
-                result = (guchar *) stringue->str;
-                g_string_free (stringue, FALSE);
+                result = (guchar *) g_string_free (stringue, FALSE);
         }
 
         return result;

--- a/src/st/croco/cr-fonts.c
+++ b/src/st/croco/cr-fonts.c
@@ -196,8 +196,7 @@ cr_font_family_to_string (CRFontFamily const * a_this,
                                                 &stringue);
 
         if (status == CR_OK && stringue) {
-                result = (guchar *) stringue->str;
-                g_string_free (stringue, FALSE);
+                result = (guchar *) g_string_free (stringue, FALSE);
                 stringue = NULL;
 
         } else {

--- a/src/st/croco/cr-parsing-location.c
+++ b/src/st/croco/cr-parsing-location.c
@@ -126,8 +126,7 @@ cr_parsing_location_to_string (CRParsingLocation const *a_this,
 					a_this->byte_offset) ;
 	}
 	if (result->len) {
-		str = result->str ;
-		g_string_free (result, FALSE) ;
+		str = g_string_free (result, FALSE) ;
 	} else {
 		g_string_free (result, TRUE) ;
 	}

--- a/src/st/croco/cr-pseudo.c
+++ b/src/st/croco/cr-pseudo.c
@@ -107,8 +107,7 @@ cr_pseudo_to_string (CRPseudo const * a_this)
         }
 
         if (str_buf) {
-                result = (guchar *) str_buf->str;
-                g_string_free (str_buf, FALSE);
+                result = (guchar *) g_string_free (str_buf, FALSE);
                 str_buf = NULL;
         }
 

--- a/src/st/croco/cr-rgb.c
+++ b/src/st/croco/cr-rgb.c
@@ -273,8 +273,7 @@ cr_rgb_to_string (CRRgb const * a_this)
         }
 
         if (str_buf) {
-                result = (guchar *) str_buf->str;
-                g_string_free (str_buf, FALSE);
+                result = (guchar *) g_string_free (str_buf, FALSE);
         }
 
         return result;

--- a/src/st/croco/cr-selector.c
+++ b/src/st/croco/cr-selector.c
@@ -171,8 +171,7 @@ cr_selector_to_string (CRSelector const * a_this)
         }
 
         if (str_buf) {
-                result = (guchar *) str_buf->str;
-                g_string_free (str_buf, FALSE);
+                result = (guchar *) g_string_free (str_buf, FALSE);
                 str_buf = NULL;
         }
 

--- a/src/st/croco/cr-simple-sel.c
+++ b/src/st/croco/cr-simple-sel.c
@@ -152,8 +152,7 @@ cr_simple_sel_to_string (CRSimpleSel const * a_this)
         }
 
         if (str_buf) {
-                result = (guchar *) str_buf->str;
-                g_string_free (str_buf, FALSE);
+                result = (guchar *) g_string_free (str_buf, FALSE);
                 str_buf = NULL;
         }
 
@@ -194,8 +193,7 @@ cr_simple_sel_one_to_string (CRSimpleSel const * a_this)
         }
 
         if (str_buf) {
-                result = (guchar *) str_buf->str;
-                g_string_free (str_buf, FALSE);
+                result = (guchar *) g_string_free (str_buf, FALSE);
                 str_buf = NULL;
         }
 

--- a/src/st/croco/cr-statement.c
+++ b/src/st/croco/cr-statement.c
@@ -623,12 +623,8 @@ cr_statement_ruleset_to_string (CRStatement const * a_this, glong a_indent)
                 cr_utils_dump_n_chars2 (' ', stringue, a_indent);
         }
         g_string_append (stringue, "}");
-        result = stringue->str;
+        result = g_string_free (stringue, FALSE);
 
-        if (stringue) {
-                g_string_free (stringue, FALSE);
-                stringue = NULL;
-        }
         if (tmp_str) {
                 g_free (tmp_str);
                 tmp_str = NULL;
@@ -679,8 +675,7 @@ cr_statement_font_face_rule_to_string (CRStatement const * a_this,
                 g_string_append (stringue, "\n}");
         }
         if (stringue) {
-                result = stringue->str ;
-                g_string_free (stringue, FALSE) ;
+                result = g_string_free (stringue, FALSE);
                 stringue = NULL ;
         }
         return result ;
@@ -726,8 +721,7 @@ cr_statement_charset_to_string (CRStatement const *a_this,
                 }
         }
         if (stringue) {
-                str = stringue->str ;
-                g_string_free (stringue, FALSE) ;
+                str = g_string_free (stringue, FALSE);
         }
         return str ;
 }
@@ -780,8 +774,7 @@ cr_statement_at_page_rule_to_string (CRStatement const *a_this,
                 }
                 g_string_append (stringue, "\n}\n");
         }
-        result = stringue->str ;
-        g_string_free (stringue, FALSE) ;
+        result = g_string_free (stringue, FALSE) ;
         stringue = NULL ;
         return result ;
 }
@@ -842,8 +835,7 @@ cr_statement_media_rule_to_string (CRStatement const *a_this,
                 g_string_append (stringue, "\n}");
         }
         if (stringue) {
-                str = stringue->str ;
-                g_string_free (stringue, FALSE) ;
+                str = g_string_free (stringue, FALSE) ;
         }
         return str ;
 }
@@ -905,8 +897,7 @@ cr_statement_import_rule_to_string (CRStatement const *a_this,
                 g_string_append (stringue, " ;");
         }
         if (stringue) {
-                str = stringue->str ;
-                g_string_free (stringue, FALSE) ;
+                str = g_string_free (stringue, FALSE) ;
                 stringue = NULL ;
         }
         return str ;
@@ -2565,8 +2556,7 @@ cr_statement_list_to_string (CRStatement const *a_this, gulong a_indent)
                         str = NULL ;
                 }                
         }
-        str = stringue->str ;
-        g_string_free (stringue, FALSE) ;
+        str = g_string_free (stringue, FALSE) ;
         return str ;
 }
 

--- a/src/st/croco/cr-stylesheet.c
+++ b/src/st/croco/cr-stylesheet.c
@@ -82,8 +82,7 @@ cr_stylesheet_to_string (CRStyleSheet const *a_this)
 		}
         }
 	if (stringue) {
-		str = stringue->str ;
-		g_string_free (stringue, FALSE) ;
+		str = g_string_free (stringue, FALSE) ;
 		stringue = NULL ;
 	}
 	return str ;

--- a/src/st/croco/cr-term.c
+++ b/src/st/croco/cr-term.c
@@ -462,8 +462,7 @@ cr_term_to_string (CRTerm const * a_this)
         }
 
         if (str_buf) {
-                result =(guchar *) str_buf->str;
-                g_string_free (str_buf, FALSE);
+                result = (guchar *) g_string_free (str_buf, FALSE);
                 str_buf = NULL;
         }
 
@@ -659,8 +658,7 @@ cr_term_one_to_string (CRTerm const * a_this)
         }
 
         if (str_buf) {
-                result = (guchar *) str_buf->str;
-                g_string_free (str_buf, FALSE);
+                result = (guchar *) g_string_free (str_buf, FALSE);
                 str_buf = NULL;
         }
 


### PR DESCRIPTION
croco: Use g_string_free() return value
glib now warns if the return value is not used, so use the API as
intended instead of assigning the character data separately before
freeing the GString.

Based on:  https://github.com/GNOME/gnome-shell/commit/e86a0b32c2dd199daa9d9bd80349705f0ae391a7