### PR TITLE
croco: Remove unused and dodgy function

### DIFF
--- a/src/st/croco/cr-selector.c
+++ b/src/st/croco/cr-selector.c
@@ -50,20 +50,6 @@ cr_selector_new (CRSimpleSel * a_simple_sel)
         return result;
 }
 
-CRSelector *
-cr_selector_parse_from_buf (const guchar * a_char_buf, enum CREncoding a_enc)
-{
-        CRParser *parser = NULL;
-
-        g_return_val_if_fail (a_char_buf, NULL);
-
-        parser = cr_parser_new_from_buf ((guchar*)a_char_buf, strlen ((const char *) a_char_buf),
-                                         a_enc, FALSE);
-        g_return_val_if_fail (parser, NULL);
-
-        return NULL;
-}
-
 /**
  * cr_selector_append:
  *

--- a/src/st/croco/cr-selector.h
+++ b/src/st/croco/cr-selector.h
@@ -70,9 +70,6 @@ struct _CRSelector
 
 CRSelector* cr_selector_new (CRSimpleSel *a_sel_expr) ;
 
-CRSelector * cr_selector_parse_from_buf (const guchar * a_char_buf,
-					 enum CREncoding a_enc) ;
-
 CRSelector* cr_selector_append (CRSelector *a_this, CRSelector *a_new) ;
 
 CRSelector* cr_selector_append_simple_sel (CRSelector *a_this,


### PR DESCRIPTION
The function creates a parser object that is never used nor
freed, then always returns NULL.

Luckily it's unused, so just remove it.

Based on:  https://github.com/GNOME/gnome-shell/commit/3220005eea236f07c80ae0c04a76b64a24dc4fac