### PR TITLE
st-bin: Remove unused foreach implementation

### DIFF
--- a/src/st/st-bin.c
+++ b/src/st/st-bin.c
@@ -85,16 +85,6 @@ st_bin_remove (ClutterContainer *container,
 }
 
 static void
-st_bin_foreach (ClutterContainer *container,
-                ClutterCallback   callback,
-                gpointer          user_data)
-{
-  StBinPrivate *priv = ST_BIN (container)->priv;
-
-  callback (priv->child, user_data);
-}
-
-static void
 clutter_container_iface_init (ClutterContainerIface *iface)
 {
   iface->add = st_bin_add;


### PR DESCRIPTION
Based on: https://github.com/GNOME/gnome-shell/commit/a9a3687ea02c7af7c208f5b06df7e86d3313cc49

fixes this warning

```
../src/st/st-bin.c:88:1: warning: ‘st_bin_foreach’ defined but not used [-Wunused-function]
   88 | st_bin_foreach (ClutterContainer *container,
      | ^~~~~~~~~~~~~~
```