### PR TITLE
nightlight: Add schedule mode option 'always'

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_nightlight.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_nightlight.py
@@ -58,7 +58,7 @@ class Module:
 
             size_group = Gtk.SizeGroup.new(Gtk.SizeGroupMode.HORIZONTAL)
 
-            options = ["auto", _("Automatic")], ["manual", _("Specify start and end times")]
+            options = ["auto", _("Automatic")], ["manual", _("Specify start and end times")], ["always", _("Keep always on")]
             widget = GSettingsComboBox(_("Schedule"), COLOR_SCHEMA, "night-light-schedule-mode", options, size_group=size_group)
             section.add_row(widget)
             section.need_separator = False


### PR DESCRIPTION
This is more user-friendly than having to tweak the start and stop times, for everyone who wants to have it permanently enabled.

Depends on:
https://github.com/linuxmint/cinnamon-settings-daemon/pull/408

![night-light-screenshot_80p](https://github.com/user-attachments/assets/a2dcf78f-5228-47cb-92f1-ae71babacfa2)
