### PR TITLE
Have alt+tab show windows from the current monitor only

### DIFF
--- a/data/org.cinnamon.gschema.xml
+++ b/data/org.cinnamon.gschema.xml
@@ -431,6 +431,11 @@
       <summary>Enforce displaying the alt-tab switcher on the primary monitor instead of the active one</summary>
     </key>
 
+    <key type="b" name="alttab-switcher-show-current-monitor">
+      <default>false</default>
+      <summary>Show windows from current monitor only</summary>
+    </key>  
+
     <key type="b" name="alttab-minimized-aware">
     <default>true</default>
       <summary>Move minimized windows to the end of the appSwitcher</summary>

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_windows.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_windows.py
@@ -179,5 +179,8 @@ class Module:
             widget = GSettingsSwitch(_("Show windows from all workspaces"), "org.cinnamon", "alttab-switcher-show-all-workspaces")
             settings.add_row(widget)
 
+            widget = GSettingsSwitch(_("Show windows from current monitor"), "org.cinnamon", "alttab-switcher-show-current-monitor")
+            settings.add_row(widget)
+
             widget = GSettingsSwitch(_("Warp mouse pointer to the new focused window"), "org.cinnamon", "alttab-switcher-warp-mouse-pointer")
             settings.add_row(widget)

--- a/js/ui/appSwitcher/appSwitcher.js
+++ b/js/ui/appSwitcher/appSwitcher.js
@@ -64,6 +64,13 @@ function getWindowsForBinding(binding) {
 
     windows = windows.filter(Main.isInteresting);
 
+    //Switch between windows on the current monitor only
+    let showCurrentMonitorOnly = global.settings.get_boolean("alttab-switcher-show-current-monitor");
+
+    if (showCurrentMonitorOnly) {
+        windows = windows.filter(w => w.get_monitor() === global.screen.get_current_monitor())
+    }
+
     switch (binding.get_name()) {
         case 'switch-panels':
         case 'switch-panels-backward':


### PR DESCRIPTION
The purpose is to provide an option for Alt+tab to show windows from the current monitor only. 

As referenced in [this issue. ](https://github.com/linuxmint/cinnamon/issues/4330#issuecomment-558173425), 
Credit to @delchiaro for providing the solution of editing the `appSwitcher.js`, I just figured that with Multi monitor setups being quite common it would be very useful to have this option in the panel. For myself the lack of it was frustrating.
 
The option "Show windows from current monitor only" is added to the System Settings -> Windows -> Alt+tab window.

![Screenshot from 2025-01-20 23-28-52](https://github.com/user-attachments/assets/0633830c-e24a-4da1-8608-a770115f6c8c)
 
