### PR TITLE
power: Add suspend option to battery-critical actions

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_power.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_power.py
@@ -642,6 +642,7 @@ def get_available_options(up_client):
     ]
 
     critical_options = [
+        ("suspend", _("Suspend")),
         ("shutdown", _("Shut down immediately")),
         ("hibernate", _("Hibernate")),
         ("nothing", _("Do nothing"))


### PR DESCRIPTION
some say that including "suspend" in the set of available battery critical actions is dangerous: power might ran out during suspend and machine state would be lost.

however:

- the really dangerous action is "do nothing", and it is still allowed in the UI. suspend might loose state, but is way way safer than "do nothing": suspend will flush all caches to disks, making sure that all recently saved data is persistent. it also forwards filesystems to a point where -though still mounted- they are effectively clean: filesystems are guaranteed to be in a sane state on-disk, even if they do not journal. running out of power during suspend is infinitely more "graceful" and safe than running out of power while the CPU is running: the latter is allowed, but the former is not. go figure...
  - possible dangerous bugs in SSD firmware will also be sidestepped, as SSDs will be sleeping during the power off event.

- suspend can loose state, yes, but this can happen any time the user suspends. if suspending, the system will *not* wake up and do the critical action (eg, shutdown) when power is critical. by this token, suspend should never be allowed then. but we allow it because it makes sense: we assume users know what they are doing.

- the current UI has a bug by which, if the user chooses suspend in dconf (as i do; i also elevate the critical trigger percentage), the UI shows the setting as blank and corrupts it immediately if the user simply touches it. the bug was reported here: https://github.com/linuxmint/cinnamon/issues/11983. this PR fixes that issue (for suspend only, the most likely trigger by far). there are other ways to fix this (discussed in the bug report), but over a year passed and no fixes were proposed, so i propose merging this.

thank you!