### PR TITLE
cinnamon-settings: Add sidePage name to titlebar when entering

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/cinnamon-settings.py
@@ -190,6 +190,8 @@ class MainWindow(Gio.Application):
         if not user_action:
             self.window.set_title(sidePage.name)
             self.window.set_icon_name(sidePage.icon)
+        else:
+            self.window.set_title(_("System Settings") + " > " + sidePage.name)
 
         if sidePage.stack:
             self.stack_switcher.set_stack(sidePage.stack)


### PR DESCRIPTION
Implementation of https://github.com/orgs/linuxmint/discussions/767

Currently, when you enter a setting module from Cinnamon Settings, the title bar always says "System Settings" - no matter which setting you're in. The settings module doesn't have an indicator which setting you're in either. 

![Screenshot from 2025-01-29 06-28-14](https://github.com/user-attachments/assets/705b4836-7441-4b0e-ae8e-f6c51a7315bc)

This behavior is different from when you enter the setting directly via a .desktop file or `cinnamon-settings module` from the terminal.

![Screenshot from 2025-01-29 06-29-07](https://github.com/user-attachments/assets/f3a5553c-c71b-40a7-aa8b-7207d2cb570e)

This PR adds the settings module name to the window title when you navigate into it.

![Screenshot from 2025-01-29 06-31-30](https://github.com/user-attachments/assets/2516d28b-d71c-4aac-9fe3-cb6c060fb1e1)