### PR TITLE
Fix nm-applet requirement in meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -164,9 +164,9 @@ install_subdir(
 
 session_conf = configuration_data()
 if have_networkmanager
-    session_conf.set('REQUIRED', '')
-else
     session_conf.set('REQUIRED', 'nm-applet;')
+else
+    session_conf.set('REQUIRED', '')
 endif
 
 session_files = ['cinnamon.session', 'cinnamon2d.session']


### PR DESCRIPTION
The logic was swapped in 16cf990 which is incorrect.
So require nm-applet when have_networkmanager is true, i. e. disable_networkmanager is false. Not vice versa.