### PR TITLE
desklet-photoframe: change image size to guarantee keeping the ratio

### DIFF
--- a/files/usr/share/cinnamon/desklets/photoframe@cinnamon.org/desklet.js
+++ b/files/usr/share/cinnamon/desklets/photoframe@cinnamon.org/desklet.js
@@ -153,17 +153,9 @@ class CinnamonPhotoFrameDesklet extends Desklet.Desklet {
         image.disconnect(image._notif_id);
 
         let height, width;
-        let imageRatio = image.width / image.height;
-        let frameRatio = this.width / this.height;
-
-        if (imageRatio > frameRatio) {
-            width = this.width;
-            height = this.width / imageRatio;
-        } else {
-            height = this.height;
-            width = this.height * imageRatio;
-        }
-
+        let ratio = Math.min(this.width/image.width,this.height/image.height);
+        width = ratio*image.width;
+        height = ratio*image.height;
         image.set_size(width, height);
     }
 


### PR DESCRIPTION
Currently, sometimes the images get squeezed, when in line 161 height is bigger than the height of the desklet and then the ratio isn't kept. Now this doesn't happen, as we always guarantee that the aspect ratio is kept and both height and width of the image stay smaller than the one of the desklet. See https://stackoverflow.com/questions/3971841/how-to-resize-images-proportionally-keeping-the-aspect-ratio for more details