### PR TITLE
Update Debian .deb control file

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -116,7 +116,8 @@ Recommends:
  gnome-themes-extra | gnome-themes-standard,
  gnome-online-accounts-gtk,
  touchegg,
- wget | curl,
+ wget,
+ curl,
 Suggests: cinnamon-doc
 Provides: notification-daemon, x-window-manager, polkit-1-auth-agent
 Description: Modern Linux desktop

--- a/debian/control
+++ b/debian/control
@@ -89,7 +89,6 @@ Depends:
  metacity,
  nemo,
  network-manager-gnome [linux-any],
- policykit-1-gnome,
  python3,
  python3-dbus,
  python3-distro,
@@ -104,7 +103,6 @@ Depends:
  python3-tinycss2,
  python3-tz,
  streamer,
- wget,
  xapps-common (>= 2.5.0),
  xdg-desktop-portal-gtk,
  xdg-desktop-portal-xapp,
@@ -118,6 +116,7 @@ Recommends:
  gnome-themes-extra | gnome-themes-standard,
  gnome-online-accounts-gtk,
  touchegg,
+ wget | curl,
 Suggests: cinnamon-doc
 Provides: notification-daemon, x-window-manager, polkit-1-auth-agent
 Description: Modern Linux desktop


### PR DESCRIPTION
This pull request fixes issue #12649, since policykit-1-gnome is deprecated and replaced in this new version. Also changed wget from a required package to recommended package because cinnamon can run properly without wget. Also adding curl to recommended package since it is more common to see installers using curl than wget.