### PR TITLE
Update control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -89,7 +89,6 @@ Depends:
  metacity,
  nemo,
  network-manager-gnome [linux-any],
- policykit-1-gnome,
  python3,
  python3-dbus,
  python3-distro,


### PR DESCRIPTION
This pull request fixes issue https://github.com/linuxmint/cinnamon/issues/12649, since policykit-1-gnome is deprecated and replaced in this new version.