### PR TITLE
notificationDaemon: Fix handling of `image-path` hint

### DIFF
--- a/js/ui/notificationDaemon.js
+++ b/js/ui/notificationDaemon.js
@@ -477,7 +477,7 @@ NotificationDaemon.prototype = {
                 if (image_path.substr(0, 7) != 'file://') {
                     image_path = GLib.filename_to_uri(image_path);
                 }
-                image = St.TextureCache.get_default().load_uri_async(image_path, null),
+                image = St.TextureCache.get_default().load_uri_async(image_path,
                                                                      notification.IMAGE_SIZE,
                                                                      notification.IMAGE_SIZE);
             }

--- a/js/ui/notificationDaemon.js
+++ b/js/ui/notificationDaemon.js
@@ -475,7 +475,7 @@ NotificationDaemon.prototype = {
                 let image_path = hints['image-path'];
                 // Convert filepaths to file URIs but leave file URIs untouched
                 if (image_path.substr(0, 7) != 'file://') {
-                    image_path = GLib.filename_to_uri(image_path);
+                    image_path = GLib.filename_to_uri(image_path, null);
                 }
                 image = St.TextureCache.get_default().load_uri_async(image_path,
                                                                      notification.IMAGE_SIZE,

--- a/js/ui/notificationDaemon.js
+++ b/js/ui/notificationDaemon.js
@@ -472,7 +472,12 @@ NotificationDaemon.prototype = {
                 image = St.TextureCache.get_default().load_from_raw(data, hasAlpha,
                                                                     width, height, rowStride, notification.IMAGE_SIZE);
             } else if (hints['image-path']) {
-                image = St.TextureCache.get_default().load_uri_async(GLib.filename_to_uri(hints['image-path'], null),
+                let image_path = hints['image-path'];
+                // Convert filepaths to file URIs but leave file URIs untouched
+                if (image_path.substr(0, 7) != 'file://') {
+                    image_path = GLib.filename_to_uri(image_path);
+                }
+                image = St.TextureCache.get_default().load_uri_async(image_path, null),
                                                                      notification.IMAGE_SIZE,
                                                                      notification.IMAGE_SIZE);
             }


### PR DESCRIPTION
This pull request addresses issue #12777 by adding a check to avoid passing an already valid file URI to `GLib.filename_to_uri`.