### PR TITLE
workspace-switcher@cinnamon.org: Workspaces will be always displayed as empty when they are

### DIFF
--- a/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/workspace-switcher@cinnamon.org/applet.js
@@ -266,8 +266,8 @@ class SimpleButton extends WorkspaceButton {
         }
         else {
             this.actor.remove_style_pseudo_class('outlined');
-            this.update();
         }
+        this.update();
     }
 
     shade(used) {


### PR DESCRIPTION
Workspace switcher: Workspaces will be always displayed as empty when they are, in the “Simple buttons” display mode.

Fixes #12809