### PR TITLE
polkitAuthenticationAgent.js: Ensure Cinnamon is part of the correct login session when registering.

### DIFF
--- a/js/misc/gnomeSession.js
+++ b/js/misc/gnomeSession.js
@@ -75,6 +75,7 @@ var SessionManagerIface = '\
        <method name="GetInhibitors"> \
            <arg type="ao" name="inhibitors" direction="out"/> \
        </method> \
+       <method name="RestartCinnamonLauncher" /> \
        <signal name="InhibitorAdded"> \
            <arg type="o" name="id" direction="out"/> \
        </signal> \
@@ -82,6 +83,7 @@ var SessionManagerIface = '\
            <arg type="o" name="id" direction="out"/> \
        </signal> \
        <property name="InhibitedActions" type="u" access="read"/> \
+       <property name="SessionId" type="s" access="read"/> \
     </interface> \
 </node>';
 

--- a/src/cinnamon-polkit-authentication-agent.c
+++ b/src/cinnamon-polkit-authentication-agent.c
@@ -87,12 +87,14 @@ cinnamon_polkit_authentication_agent_init (CinnamonPolkitAuthenticationAgent *ag
 {
 }
 
-void
+gchar *
 cinnamon_polkit_authentication_agent_register (CinnamonPolkitAuthenticationAgent *agent,
                                             GError                        **error_out)
 {
   GError *error = NULL;
   PolkitSubject *subject;
+  gchar *session_id = NULL;
+
   subject = polkit_unix_session_new_for_process_sync (getpid (),
                                                       NULL, /* GCancellable* */
                                                       &error);
@@ -104,6 +106,7 @@ cinnamon_polkit_authentication_agent_register (CinnamonPolkitAuthenticationAgent
       goto out;
     }
 
+  session_id = g_strdup (polkit_unix_session_get_session_id (POLKIT_UNIX_SESSION (subject)));
   agent->handle = polkit_agent_listener_register (POLKIT_AGENT_LISTENER (agent),
                                                   POLKIT_AGENT_REGISTER_FLAGS_NONE,
                                                   subject,
@@ -117,6 +120,8 @@ cinnamon_polkit_authentication_agent_register (CinnamonPolkitAuthenticationAgent
 
   if (subject != NULL)
     g_object_unref (subject);
+
+  return session_id;
 }
 
 static void

--- a/src/cinnamon-polkit-authentication-agent.h
+++ b/src/cinnamon-polkit-authentication-agent.h
@@ -27,7 +27,7 @@ CinnamonPolkitAuthenticationAgent *cinnamon_polkit_authentication_agent_new (voi
 
 void                            cinnamon_polkit_authentication_agent_complete (CinnamonPolkitAuthenticationAgent *agent,
                                                                             gboolean                        dismissed);
-void                            cinnamon_polkit_authentication_agent_register (CinnamonPolkitAuthenticationAgent *agent,
+gchar *                         cinnamon_polkit_authentication_agent_register (CinnamonPolkitAuthenticationAgent *agent,
                                                                             GError                        **error_out);
 void                            cinnamon_polkit_authentication_agent_unregister (CinnamonPolkitAuthenticationAgent *agent);
 


### PR DESCRIPTION
Compare Cinnamon's session id with cinnamon-session's (which should never change), and have cinnamon-session restart us if there is a mismatch.

Ref: #12669, #12728.

See: https://github.com/linuxmint/cinnamon-session/pull/184.