### PR TITLE
[WIP] Support for org.freedesktop.Application

### DIFF
--- a/src/cinnamon-app.h
+++ b/src/cinnamon-app.h
@@ -85,6 +85,19 @@ gboolean cinnamon_app_launch (CinnamonApp     *app,
                            char        **startup_id,
                            GError      **error);
 
+void cinnamon_app_activate_action (CinnamonApp            *app,
+                                const char          *action_name,
+                                GVariant            *parameter,
+                                guint                timestamp,
+                                int                  workspace,
+                                GCancellable        *cancellable,
+                                GAsyncReadyCallback  callback,
+                                gpointer             user_data);
+gboolean
+cinnamon_app_activate_action_finish (CinnamonApp      *app,
+                                  GAsyncResult  *result,
+                                  GError       **error);
+
 gboolean cinnamon_app_launch_offloaded (CinnamonApp     *app,
                            guint         timestamp,
                            GList        *uris,

--- a/src/cinnamon-global.c
+++ b/src/cinnamon-global.c
@@ -1427,7 +1427,9 @@ cinnamon_global_app_launched_cb (GAppLaunchContext *context,
  * Return value: (transfer full): A new #GAppLaunchContext
  */
 GAppLaunchContext *
-cinnamon_global_create_app_launch_context (CinnamonGlobal *global)
+cinnamon_global_create_app_launch_context (CinnamonGlobal *global,
+                                           guint32      timestamp,
+                                           int          workspace)
 {
   MetaWorkspaceManager *workspace_manager = global->workspace_manager;
   MetaStartupNotification *sn;
@@ -1437,10 +1439,15 @@ cinnamon_global_create_app_launch_context (CinnamonGlobal *global)
   sn = meta_display_get_startup_notification (global->meta_display);
   context = meta_startup_notification_create_launcher (sn);
 
-  meta_launch_context_set_timestamp (context, cinnamon_global_get_current_time (global));
+  if (timestamp == 0)
+    timestamp = cinnamon_global_get_current_time (global);
+  meta_launch_context_set_timestamp (context, timestamp);
 
-  ws = meta_workspace_manager_get_active_workspace (workspace_manager);
-  meta_launch_context_set_workspace (context, ws);
+  if (workspace > -1)
+    {
+      ws = meta_workspace_manager_get_workspace_by_index (workspace_manager, workspace);
+      meta_launch_context_set_workspace (context, ws);
+    }
 
   g_signal_connect (context,
                     "launched",

--- a/src/cinnamon-global.h
+++ b/src/cinnamon-global.h
@@ -114,7 +114,9 @@ void cinnamon_global_run_at_leisure (CinnamonGlobal          *global,
 void     cinnamon_global_sync_pointer              (CinnamonGlobal  *global);
 
 GAppLaunchContext *
-         cinnamon_global_create_app_launch_context (CinnamonGlobal  *global);
+         cinnamon_global_create_app_launch_context (CinnamonGlobal  *global,
+                                                    guint32      timestamp,
+                                                    int          workspace);
 
 void     cinnamon_global_notify_error              (CinnamonGlobal  *global,
                                                  const char   *msg,


### PR DESCRIPTION
This implements support for org.freedesktop.Application D-Bus interface to call ActivateAction and pass activation token to the app. This is necessary for this to work https://github.com/linuxmint/muffin/pull/725 Unfortunately, I have a very poor understanding of how JS code works in Cinnamon, so I need help to implement the necessary interfaces.

Relevant MR's from GNOME Shell: https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/3198
                                                              https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/3199