### PR TITLE
Add a custom layout option for window buttons

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_windows.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_windows.py
@@ -45,7 +45,7 @@ class Module:
             button_options.append([":close", _("Gnome")])
             button_options.append(["close:minimize,maximize", _("Classic Mac")])
 
-            widget = GSettingsComboBox(_("Buttons layout"), "org.cinnamon.desktop.wm.preferences", "button-layout", button_options, size_group=size_group)
+            widget = CustomButtonLayoutSelector(_("Buttons layout"), "org.cinnamon.desktop.wm.preferences", "button-layout", button_options, size_group=size_group)
             settings.add_row(widget)
 
             settings = page.add_section(_("Actions"))
@@ -194,3 +194,165 @@ class Module:
             settings.add_row(switch)
             switch = GSettingsSwitch(_("Maximize, instead of tile, when dragging a window to the top edge"), "org.cinnamon.muffin", "tile-maximize")
             settings.add_reveal_row(switch, "org.cinnamon.muffin", "edge-tiling")
+
+class CustomButtonLayoutSelector(Gtk.Box):
+    def __init__(self, description, schema_name, key_name, predefined_options, size_group=None):
+        super().__init__(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+
+        self.description = description 
+        self.settings = Gio.Settings(schema_name)
+        self.key_name = key_name
+        self.predefined_options = predefined_options 
+        self.custom_sentinel_value = "___CUSTOM_LAYOUT_SENTINEL___" 
+
+        self.updating_ui_from_gsettings = False
+
+        self.combo = Gtk.ComboBoxText()
+        if size_group:
+            size_group.add_widget(self.combo)
+
+        for value, text in self.predefined_options:
+            self.combo.append(value, text)
+        self.combo.append(self.custom_sentinel_value, _("Custom"))
+
+        self.pack_start(self.combo, True, True, 0)
+
+        self.entry_revealer = Gtk.Revealer()
+        self.entry_revealer.set_transition_type(Gtk.RevealerTransitionType.SLIDE_DOWN)
+        self.entry_revealer.set_transition_duration(200)
+
+        self.custom_entry = Gtk.Entry()
+        self.custom_entry.set_placeholder_text(_("e.g., menu:minimize,maximize,close"))
+        self.custom_entry.set_tooltip_text(_("Define custom button layout. \n"
+                                             "Format: left_side: 'buttons:', right_side: ':buttons'. \n"
+                                             "Available buttons: close, minimize, maximize, menu. \n"
+                                             "Examples: menu,maximize:close or :close,minimize \n"
+                                             "Leave one side empty for buttons only on one side, e.g., :close or close: \n"
+                                             "Press 'Enter' key to validate button layout." ))
+        self.entry_revealer.add(self.custom_entry)
+        self.pack_start(self.entry_revealer, True, True, 0)
+
+        # Add a label for error messages
+        self.error_label = Gtk.Label()
+        self.error_label.set_no_show_all(True)
+        self.error_label.get_style_context().add_class('error-label')
+        self.pack_start(self.error_label, True, True, 0)
+
+        self.combo.connect("changed", self._on_combo_changed)
+        self.custom_entry.connect("activate", self._on_entry_submit)
+        self.custom_entry.connect("focus-out-event", self._on_entry_submit_on_focus_out)
+        self.custom_entry.connect("changed", self._on_entry_changed)
+
+        self.settings_handler_id = self.settings.connect(f"changed::{self.key_name}", self._on_settings_changed)
+
+        self._load_initial_state()
+
+    def _load_initial_state(self):
+        # Temporarily block to avoid issues during init.
+        # Signal might be emitted if value is coerced by GSettings during get_string if not already cached.
+        # if self.settings_handler_id is not None: # Check if handler ID exists
+        #     self.settings.block_signal_handler(self.settings_handler_id)
+        
+        self._update_ui_from_settings_value(self.settings.get_string(self.key_name))
+        
+        # if self.settings_handler_id is not None: # Check if handler ID exists
+        #     self.settings.unblock_signal_handler(self.settings_handler_id)
+
+    def _update_ui_from_settings_value(self, current_value):
+        self.updating_ui_from_gsettings = True
+
+        found_predefined = False
+        for val, _text in self.predefined_options:
+            if val == current_value:
+                self.combo.set_active_id(val)
+                self.entry_revealer.set_reveal_child(False)
+                found_predefined = True
+                break
+        
+        if not found_predefined:
+            self.combo.set_active_id(self.custom_sentinel_value)
+            self.custom_entry.set_text(current_value if current_value is not None else "")
+            self.entry_revealer.set_reveal_child(True)
+            
+        self.updating_ui_from_gsettings = False
+
+    def _on_settings_changed(self, settings_obj, key):
+        if self.updating_ui_from_gsettings:
+            return 
+        
+        current_value = settings_obj.get_string(key)
+        self._update_ui_from_settings_value(current_value)
+
+    def _on_combo_changed(self, combo):
+        if self.updating_ui_from_gsettings:
+            return
+
+        active_id = combo.get_active_id()
+        if active_id is None:
+            return
+
+        if active_id == self.custom_sentinel_value:
+            self.entry_revealer.set_reveal_child(True)
+        else:
+            self.entry_revealer.set_reveal_child(False)
+            # if self.settings_handler_id is not None:
+            #     self.settings.block_signal_handler(self.settings_handler_id)
+            self.settings.set_string(self.key_name, active_id)
+            # if self.settings_handler_id is not None:
+            #     self.settings.unblock_signal_handler(self.settings_handler_id)
+
+    def _validate_layout(self, layout_string):
+        valid_buttons = ['close', 'minimize', 'maximize', 'menu']
+        parts = layout_string.split(':')
+        if len(parts) != 2:
+            return False, _("Invalid format. Must contain exactly one ':'")
+        
+        for part in parts:
+            if part:
+                buttons = part.split(',')
+                invalid_buttons = [btn for btn in buttons if btn not in valid_buttons]
+                if invalid_buttons:
+                    return False, _("Invalid buttons: ") + ", ".join(invalid_buttons)
+        return True, ""
+
+    def _show_error(self, error_message):
+        self.custom_entry.get_style_context().add_class('error')
+        self.error_label.set_text(error_message)
+        self.error_label.show()
+
+    def _clear_error(self):
+        self.custom_entry.get_style_context().remove_class('error')
+        self.error_label.set_text("")
+        self.error_label.hide()
+
+    def _on_entry_changed(self, entry):
+        self._clear_error()
+
+    def _submit_custom_entry_value(self):
+        if self.updating_ui_from_gsettings:
+            return False
+
+        if self.combo.get_active_id() == self.custom_sentinel_value:
+            new_layout_string = self.custom_entry.get_text()
+            is_valid, error_message = self._validate_layout(new_layout_string)
+            
+            if not is_valid:
+                self._show_error(error_message)
+                return False
+            
+            self._clear_error()
+            self.settings.set_string(self.key_name, new_layout_string)
+        return False
+
+    def _on_entry_submit(self, entry):
+        self._submit_custom_entry_value()
+
+    def _on_entry_submit_on_focus_out(self, entry, event):
+        self._submit_custom_entry_value()
+        return False
+
+    def do_destroy(self):
+        if hasattr(self, 'settings_handler_id') and self.settings_handler_id is not None:
+            self.settings.disconnect(self.settings_handler_id)
+        # Gtk.Box.do_destroy(self) # Call chain automatically for GObject subclasses
+        super().do_destroy()


### PR DESCRIPTION
- In the cs_windows module, users can now add a custom layout for window buttons.
- Error message if an invalid layout is added
- Tooltip with examples