### PR TITLE
add a new date and time display applet

### DIFF
--- a/files/usr/share/cinnamon/applets/datetime_display@cinnamon.org/.placeholder
+++ b/files/usr/share/cinnamon/applets/datetime_display@cinnamon.org/.placeholder
@@ -1,0 +1,2 @@
+# This is a placeholder file to create the directory.
+# It can be removed later if not needed.

--- a/files/usr/share/cinnamon/applets/datetime_display@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/datetime_display@cinnamon.org/applet.js
@@ -1,0 +1,53 @@
+const Applet = imports.ui.applet;
+const GLib = imports.gi.GLib;
+const Lang = imports.lang;
+const Settings = imports.ui.settings;
+
+class DateTimeDisplayApplet extends Applet.TextApplet {
+    constructor(orientation, panel_height, instance_id) {
+        super(orientation, panel_height, instance_id);
+
+        this.settings = new Settings.AppletSettings(this, "datetime_display@cinnamon.org", instance_id);
+        this.settings.bindProperty(Settings.BindingDirection.IN, "dateFormat", "dateFormat", this.on_settings_changed, null);
+        this.settings.bindProperty(Settings.BindingDirection.IN, "timeFormat", "timeFormat", this.on_settings_changed, null);
+
+        this.update_ui();
+        this.update_loop_id = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, 1, Lang.bind(this, this.update_ui));
+    }
+
+    on_applet_removed_from_panel() {
+        if (this.update_loop_id) {
+            GLib.source_remove(this.update_loop_id);
+            this.update_loop_id = 0;
+        }
+    }
+
+    on_settings_changed() {
+        this.update_ui();
+    }
+
+    update_ui() {
+        let displayDate = "";
+        if (this.dateFormat) {
+            displayDate = GLib.DateTime.new_now_local().format(this.dateFormat);
+        }
+
+        let displayTime = "";
+        if (this.timeFormat) {
+            displayTime = GLib.DateTime.new_now_local().format(this.timeFormat);
+        }
+
+        let displayText = displayDate;
+        if (displayDate && displayTime) {
+            displayText += " " + displayTime;
+        } else if (displayTime) {
+            displayText = displayTime;
+        }
+
+        this.set_applet_label(displayText);
+    }
+}
+
+function main(metadata, orientation, panel_height, instance_id) {
+    return new DateTimeDisplayApplet(orientation, panel_height, instance_id);
+}

--- a/files/usr/share/cinnamon/applets/datetime_display@cinnamon.org/icons/.placeholder
+++ b/files/usr/share/cinnamon/applets/datetime_display@cinnamon.org/icons/.placeholder
@@ -1,0 +1,2 @@
+# This is a placeholder file to create the directory.
+# It can be removed later if not needed.

--- a/files/usr/share/cinnamon/applets/datetime_display@cinnamon.org/icons/datetime_display_icon.svg
+++ b/files/usr/share/cinnamon/applets/datetime_display@cinnamon.org/icons/datetime_display_icon.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg id="svg3219" width="48" height="48" version="1.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <defs id="defs3221">
+  <linearGradient id="linearGradient2877" x1="25.058" x2="25.058" y1="47.028" y2="39.999" gradientUnits="userSpaceOnUse">
+   <stop id="stop3704" style="stop-opacity:0" offset="0"/>
+   <stop id="stop3710" offset=".5"/>
+   <stop id="stop3706" style="stop-opacity:0" offset="1"/>
+  </linearGradient>
+  <radialGradient id="radialGradient2875" cx="4.993" cy="43.5" r="2.5" gradientTransform="matrix(2.0038 0 0 1.4 -20.012 -104.4)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient3688"/>
+  <linearGradient id="linearGradient3688">
+   <stop id="stop3690" offset="0"/>
+   <stop id="stop3692" style="stop-opacity:0" offset="1"/>
+  </linearGradient>
+  <radialGradient id="radialGradient2873" cx="4.993" cy="43.5" r="2.5" gradientTransform="matrix(2.0038 0 0 1.4 27.988 -17.4)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient3688"/>
+  <linearGradient id="linearGradient2462" x1="24" x2="24" y1="44" y2="3.8905" gradientTransform="translate(0 .96744)" gradientUnits="userSpaceOnUse">
+   <stop id="stop3106" style="stop-color:#787878" offset="0"/>
+   <stop id="stop3108" style="stop-color:#aaa" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient2460" x1="19.36" x2="19.36" y1="16.138" y2="44.984" gradientUnits="userSpaceOnUse">
+   <stop id="stop3602" style="stop-color:#f4f4f4" offset="0"/>
+   <stop id="stop3604" style="stop-color:#dbdbdb" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient2457" x1="24" x2="24" y1="44" y2="3.899" gradientTransform="translate(0 .96744)" gradientUnits="userSpaceOnUse">
+   <stop id="stop2492" style="stop-color:#791235" offset="0"/>
+   <stop id="stop2494" style="stop-color:#dd3b27" offset="1"/>
+  </linearGradient>
+  <radialGradient id="radialGradient2455" cx="12.063" cy="11.394" r="20" gradientTransform="matrix(1.5296e-8 1.1116 -1.5963 0 35.053 .93151)" gradientUnits="userSpaceOnUse">
+   <stop id="stop3359" style="stop-color:#f89b7e" offset="0"/>
+   <stop id="stop3361" style="stop-color:#e35d4f" offset=".39679"/>
+   <stop id="stop3363" style="stop-color:#c6262e" offset="1"/>
+  </radialGradient>
+  <linearGradient id="linearGradient2452" x1="24" x2="24" y1="5" y2="43" gradientTransform="translate(9.5367e-6 .96744)" gradientUnits="userSpaceOnUse">
+   <stop id="stop3310-1-4" style="stop-color:#fff" offset="0"/>
+   <stop id="stop3312-5-3" style="stop-color:#fff;stop-opacity:0" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient2448" x1="23.415" x2="23.415" y1="16" y2="20" gradientTransform="matrix(1 0 0 .75 0 4)" gradientUnits="userSpaceOnUse">
+   <stop id="stop3512" offset="0"/>
+   <stop id="stop3514" style="stop-opacity:0" offset="1"/>
+  </linearGradient>
+  <radialGradient id="radialGradient3560" cx="14" cy="4.9179" r="2" gradientTransform="matrix(1.455 -2.6431e-8 5e-8 2.2747 -6.3697 -6.839)" gradientUnits="userSpaceOnUse" spreadMethod="reflect" xlink:href="#linearGradient3520"/>
+  <linearGradient id="linearGradient3520">
+   <stop id="stop3522" style="stop-color:#f2f2f2" offset="0"/>
+   <stop id="stop3524" style="stop-color:#999" offset="1"/>
+  </linearGradient>
+  <radialGradient id="radialGradient3562" cx="14" cy="4.9179" r="2" gradientTransform="matrix(1.455 -2.6431e-8 5e-8 2.2747 13.63 -6.839)" gradientUnits="userSpaceOnUse" spreadMethod="reflect" xlink:href="#linearGradient3520"/>
+ </defs>
+ <g id="layer1">
+  <g id="g2036" transform="matrix(1.1 0 0 .44444 -2.4 25.111)">
+   <g id="g3712" transform="matrix(1.0526 0 0 1.2857 -1.2632 -13.429)" style="opacity:.4">
+    <rect id="rect2801" x="38" y="40" width="5" height="7" style="fill:url(#radialGradient2873)"/>
+    <rect id="rect3696" transform="scale(-1)" x="-10" y="-47" width="5" height="7" style="fill:url(#radialGradient2875)"/>
+    <rect id="rect3700" x="10" y="40" width="28" height="7" style="fill:url(#linearGradient2877)"/>
+   </g>
+  </g>
+  <rect id="rect5505" x="4.5" y="5.4674" width="39" height="39" rx="2.2322" ry="2.2322" style="fill:url(#linearGradient2460);stroke-linecap:round;stroke-linejoin:round;stroke:url(#linearGradient2462)"/>
+  <path id="rect2424" d="m6.7188 5.4688c-1.2366 0-2.2188 0.9821-2.2188 2.2188v7.8125h39v-7.8125c0-1.2366-0.9821-2.2188-2.2188-2.2188h-34.562z" style="fill:url(#radialGradient2455);stroke:url(#linearGradient2457)"/>
+  <rect id="rect6741" x="5.5" y="6.4674" width="37" height="37" rx="1.3652" ry="1.3652" style="fill:none;opacity:.4;stroke-linecap:round;stroke-linejoin:round;stroke:url(#linearGradient2452)"/>
+  <rect id="rect3508" x="4" y="16" width="40" height="3" rx="0" ry="0" style="fill:url(#linearGradient2448);opacity:.3"/>
+  <g id="g3541">
+   <rect id="rect3497" x="12" y="2" width="4" height="11" rx="1.8086" ry="1.5304" style="fill:#fff;opacity:.4"/>
+   <rect id="rect3493" x="12" y="7.6919" width="4" height="4.3081" rx="1.5869" ry="1.5869" style="fill:#cc3429"/>
+   <rect id="rect3483" x="12" y="1" width="4" height="10" rx="1.8086" ry="1.3912" style="fill:url(#radialGradient3560)"/>
+  </g>
+  <g id="g3536">
+   <rect id="rect3526" x="32" y="2" width="4" height="11" rx="1.8086" ry="1.5304" style="fill:#fff;opacity:.4"/>
+   <rect id="rect3528" x="32" y="7.6919" width="4" height="4.3081" rx="1.5869" ry="1.5869" style="fill:#cc3429"/>
+   <rect id="rect3530" x="32" y="1" width="4" height="10" rx="1.8086" ry="1.3912" style="fill:url(#radialGradient3562)"/>
+  </g>
+ </g>
+ <text id="text7623" transform="scale(1.0065 .99356)" x="10.312376" y="39.944809" style="fill:#4d4d4d;font-family:Arial;font-size:24.768px;font-weight:bold" xml:space="preserve"><tspan id="tspan7625" x="10.312376" y="39.944809" style="fill:#4d4d4d">28</tspan></text>
+</svg>

--- a/files/usr/share/cinnamon/applets/datetime_display@cinnamon.org/metadata.json
+++ b/files/usr/share/cinnamon/applets/datetime_display@cinnamon.org/metadata.json
@@ -1,0 +1,17 @@
+{
+  "uuid": "datetime_display@cinnamon.org",
+  "name": "Date and Time Display",
+  "description": "A simple applet to display the current date and time with customizable format.",
+  "icon": "datetime_display_icon",
+  "version": "1.0.0",
+  "cinnamon-version": [ "5.0" ],
+  "multiversion": false,
+  "developer": "Jules",
+  "developer_url": "",
+  "website": "",
+  "max-instances": -1,
+  "orientation": "horizontal",
+  "prevent-decorations": false,
+  "default_width": 200,
+  "default_height": 30
+}

--- a/files/usr/share/cinnamon/applets/datetime_display@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/datetime_display@cinnamon.org/settings-schema.json
@@ -1,0 +1,14 @@
+{
+  "dateFormat": {
+    "type": "string",
+    "default": "%Y-%m-%d",
+    "description": "Date Format",
+    "tooltip": "Enter the date format string (e.g., %Y-%m-%d, %A %B %e, %x)"
+  },
+  "timeFormat": {
+    "type": "string",
+    "default": "%H:%M:%S",
+    "description": "Time Format",
+    "tooltip": "Enter the time format string (e.g., %H:%M:%S, %I:%M %p, %X)"
+  }
+}

--- a/files/usr/share/cinnamon/applets/datetime_display@cinnamon.org/stylesheet.css
+++ b/files/usr/share/cinnamon/applets/datetime_display@cinnamon.org/stylesheet.css
@@ -1,0 +1,23 @@
+/* Basic styling for the Date and Time Display Applet */
+
+.applet-box {
+    /* padding: 2px 5px; */ /* Example padding */
+    /* color: #ffffff; */ /* Example text color, assuming a dark panel */
+    /* font-weight: bold; */
+}
+
+.applet-icon {
+    /* margin-right: 5px; */ /* Space between icon and text */
+    /* icon-size: 1em; */   /* Adjust icon size relative to font */
+}
+
+.applet-label {
+    /* Specific styling for the text part of the applet */
+    /* font-size: 0.9em; */
+}
+
+/* Add more specific styles as needed */
+/* For example, if you add a calendar popup: */
+/* .calendar-popup { ... } */
+/* .calendar-day { ... } */
+/* .calendar-day-today { ... } */


### PR DESCRIPTION
this applet displays the current date and time on the panel. You can customize the date and time format strings through the applet's settings.

the applet consists of:
- metadata.json: defines the applet's properties.
- applet.js: contains the javaScript logic for displaying and updating the date/time.
- settings-schema.json: defines the configurable settings for date and time formats.
- icons/datetime_display_icon.svg: the icon for the applet.