### PR TITLE
fix high cpu usage in shortcut view

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_keyboard.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_keyboard.py
@@ -447,7 +447,6 @@ class Module:
             self.cat_tree.connect("cursor-changed", self.onCategoryChanged)
             self.cat_tree.connect("button-release-event", self.onCategorySelected)
             self.cat_tree.connect("key-release-event", self.onCategorySelected)
-            self.cat_tree.connect("row-activated", self.onCategoryChanged)
             self.cat_tree.connect("map", self.categoryHighlightOnMap)
             self.cat_tree.connect("focus-in-event", self.categoryHighlightOnMap)
             self.cat_tree.connect("unmap", self.categoryHighlightUnmap)


### PR DESCRIPTION
Fixes  #12807 

I found a related log entry for the issue:
> TypeError: Module.onCategoryChanged() takes 2 positional arguments but 4 were given

The  [row-activated signal](https://docs.gtk.org/gtk3/signal.TreeView.row-activated.html)  expects a callback with four parameters. 
However, `onCategoryChanged()` only accepts two, which likely led to the unexpected behavior and resulting CPU spike.
After removing the signal connection, the issue no longer occurs.

Note: This bug is also present in Linux Mint 22.