### PR TITLE
panel.js: always show panel when highlighted

### DIFF
--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -2087,6 +2087,7 @@ Panel.prototype = {
         this._hidden = false;
         this._disabled = false;
         this._panelEditMode = false;
+        this._highlighted = false;
         this._autohideSettings = null;
         this._destroyed = false;
         this._positionChanged = false;
@@ -2405,8 +2406,8 @@ Panel.prototype = {
 
         this.actor.change_style_pseudo_class('highlight', highlight);
 
-        if (highlight)
-            this.peekPanel();
+        this._highlighted = highlight;
+        this._updatePanelVisibility();
     },
 
     /**
@@ -3685,7 +3686,7 @@ Panel.prototype = {
      * true = autohide, false = always show, intel = Intelligent
      */
     _updatePanelVisibility: function() {
-        if (this._panelEditMode || this._peeking || this._panelHasOpenMenus())
+        if (this._panelEditMode || this._highlighted || this._peeking || this._panelHasOpenMenus())
             this._shouldShow = true;
         else {
             switch (this._autohideSettings) {


### PR DESCRIPTION
When panel is set to auto hide and panel settings (or applet settings) is opened, the panel shows for 1.5 seconds before hiding. I think that the need to show the highlighted panel while other panel settings are being changed outweighs the need to demonstrate the effect of the auto hide option.

Cf. https://github.com/linuxmint/cinnamon/pull/8659