### PR TITLE
Prevent context menu from closing when favorites add/remove is clicked

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -406,7 +406,9 @@ class ApplicationContextMenuItem extends PopupMenu.PopupBaseMenuItem {
                 } else return true;
         }
         this._appButton.applet.toggleContextMenu(this._appButton);
-        this._appButton.applet.menu.close();
+        if (this._action !== "add_to_favorites" && this._action !== "remove_from_favorites") {
+            this._appButton.applet.menu.close();
+        }
         return false;
     }
 


### PR DESCRIPTION
This partially fixes #12881 and #8773.

### Issue
menu@cinnamon closes whenever something is selected from the `contextMenu`. Including `add/remove favorite` button.

![menufavclosebug](https://github.com/user-attachments/assets/0cba9c9b-a00e-4496-8773-78455ae3bfa1)

### Considerations
As well as I believe the menu should not be closed when something is added or removed from the favorites, I am not so sure about the other actions like `add to desktop` or `add to panel`. Should we keep the experience consistent and close the menu for all options, or should we have special cases for `favorite`, just like I've added here?

This is more like a design choice. I would be happy to implement whatever the decision is.
Another point to consider if we should keep `contextMenu` open or close it after every operation. I left it as it is, so it closes, but this requires some discussion with the design team, I suppose.

### Fix
Basically, wrapped the close action with an if statement to prevent it from closing the menu for favorite operations.
![menufavclosebugfix](https://github.com/user-attachments/assets/d855b8ab-beda-488b-8016-b44ee8bef893)

I would appreciate any feedback.