### PR TITLE
Keep panel usable over fullscreened window when menu applet is opened by shortcut key

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1205,7 +1205,6 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         this._pathCompleter.set_dirs_only(false);
         this.contextMenu = null;
         this.lastSelectedCategory = null;
-        this.settings.bind("force-show-panel", "forceShowPanel");
 
         this.orderDirty = false;
 
@@ -1238,9 +1237,6 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
     _updateKeybinding() {
         Main.keybindingManager.addHotKey("overlay-key-" + this.instance_id, this.overlayKey, () => {
             if (!Main.overview.visible && !Main.expo.visible) {
-                if (this.forceShowPanel && !this.isOpen) {
-                    this.panel.peekPanel();
-                }
                 this.menu.toggle_with_options(this.enableAnimation);
             }
         });

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/settings-schema.json
@@ -25,7 +25,7 @@
         "behavior-panel" : {
             "type" : "section",
             "title" : "Panel",
-            "keys" : ["overlay-key", "activate-on-hover", "hover-delay", "force-show-panel", "enable-animation"]
+            "keys" : ["overlay-key", "activate-on-hover", "hover-delay", "enable-animation"]
         },
         "appearance-menu" : {
             "type" : "section",
@@ -228,12 +228,6 @@
     "default" : true,
     "description": "Enable autoscrolling in application list",
     "tooltip": "Choose whether or not to enable smooth autoscrolling in the application list."
- },
- "force-show-panel" : {
-    "type" : "switch",
-    "default" : true,
-    "description": "Force the panel to be visible when opening the menu",
-    "tooltip": "Opening the menu will also show the main panel (which may be auto-hidden)."
  },
 "activate-on-hover" : {
     "type" : "switch",

--- a/js/ui/modalDialog.js
+++ b/js/ui/modalDialog.js
@@ -485,7 +485,7 @@ var InfoOSD = class {
             this.actor.add(label);
         }
         Main.layoutManager.addChrome(this.actor, {
-            visibleInFullscreen: false,
+            visibleInFullscreen: true,
             affectsInputRegion: false
         });
     }

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -3728,16 +3728,12 @@ Panel.prototype = {
         }
 
         const focusedWindow = global.display.get_focus_window();
-        if (focusedWindow && focusedWindow.is_fullscreen() && focusedWindow.get_monitor() === this.monitorIndex
-            && this._panelHasOpenMenus()) {
-            // An applet has been opened by shortcut key over a fullscreened window so remove
-            // focus from fullscreened window so that chrome remains visible until fullscreened
-            // window is focused again by user.
-            this._focusDesktop();
-        } else if (focusedWindow && focusedWindow.get_monitor() !== this.monitorIndex
-            && global.display.get_monitor_in_fullscreen(this.monitorIndex) && this._panelHasOpenMenus()) {
-            // Focused window is on other monitor but this monitor has a fullscreened window so
-            // remove focus from other window so that chrome remains visible until a window is focused
+        if (this._panelHasOpenMenus() && focusedWindow &&
+            (focusedWindow.get_monitor() === this.monitorIndex && focusedWindow.is_fullscreen() ||
+            focusedWindow.get_monitor() !== this.monitorIndex && global.display.get_monitor_in_fullscreen(this.monitorIndex))) {
+            // An applet has been opened by shortcut key either over a focused fullscreened window or on a monitor with a 
+            // fullscreened window (while focused window is on a different monitor), so focus desktop on current monitor
+            // so that chrome (panel) remains visible and usable until the fullscreened window is again focused by user.
             this._focusDesktop();
         }
         


### PR DESCRIPTION
... until fullscreened window is refocused by user. Also remove force-show-panel option from menu@cinnamon.org

depends on: #12929, #12958

fixes: #11658, #8849, #10230

Also fixes bug mentioned in #11087
>If I quickly flick my mouse downward towards the bottom panel that's hidden and then move the mouse away, before the panel has even been fully revealed, it will remain in the visible state until I move my mouse down over it and then move my mouse away from it.

Fixes other bugs where autohide panel hides when mouse is still on panel. e.g. open any applet by clicking on it's panel icon, then click elsewhere on panel to close applet, panel hides. (mentioned in #12962)