### PR TITLE
Add "Share pinned windows with all window lists" option for Grouped Window List applet

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/settings-schema.json
@@ -31,7 +31,8 @@
         "left-click-action",
         "middle-click-action",
         "show-all-workspaces",
-        "window-display-settings"
+        "window-display-settings",
+        "share-pinned-windows"
       ]
     },
     "hotKeysSection": {
@@ -138,6 +139,11 @@
       "Only from monitors without a window list": 1,
       "From all monitors": 2
     }
+  },
+  "share-pinned-windows": {
+    "type": "checkbox",
+    "default": false,
+    "description": "Share pinned windows with all window lists"
   },
   "cycleMenusHotkey": {
     "type": "keybinding",


### PR DESCRIPTION
This optional feature (disabled by default) allows the user to share pinned windows in a window list with all other window lists.
- When enabled, all other window lists will gain the pinned windows of the sharing window list. 
- Adding or removing pins from the shared window list will update all other window lists.
- Pins in other window lists that are not in a sharing window list are unaffected.

![image](https://github.com/user-attachments/assets/d66bdd20-7780-4fa9-9905-69e92a0dbf97)

