### PR TITLE
Add a warning message about monitor freezing with Coverflow and Timeline

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_windows.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_windows.py
@@ -166,6 +166,7 @@ class Module:
             ]
             widget = GSettingsComboBox(_("Alt-Tab switcher style"), "org.cinnamon", "alttab-switcher-style", alttab_styles)
             settings.add_row(widget)
+            settings.add_note("When using Coverflow (3D) or Timeline (3D) as an Alt-Tab switcher style with multiple monitors, monitor freezing may occur.")
 
             widget = GSettingsSwitch(_("Display the alt-tab switcher on the primary monitor instead of the active one"), "org.cinnamon", "alttab-switcher-enforce-primary-monitor")
             settings.add_row(widget)


### PR DESCRIPTION
Use of multiple screens with Coverflow (3D) or Timeline (3D) settings may cause screen freezing (Bug #9993). Other forum posts also suggest a similar issue.
This commit introduces a note to the System Settings > Windows setting under the Alt-Tab tab that use of Coverflow (3D) or Timeline (3D) may cause monitor freezing.

[This post](https://forums.linuxmint.com/viewtopic.php?t=341496) outlines that the bug likely originates in Coverflow, the problems with troubleshooting it, and the bug report (#9993) which has been closed as not planned.

I had the exact same thing happen with monitor freezing while using Coverflow, and no freezing when it is turned off. I propose a warning note in the settings configuration to alert new users that this may occur.