### PR TITLE
chore: Rename 'Linux Kernel' to 'Kernel' in system info

### DIFF
--- a/cinnamon.pot
+++ b/cinnamon.pot
@@ -4748,7 +4748,7 @@ msgid "Cinnamon Version"
 msgstr ""
 
 #: files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py:120
-msgid "Linux Kernel"
+msgid "Kernel"
 msgstr ""
 
 #: files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py:121

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
@@ -117,7 +117,7 @@ def createSystemInfos():
                     break # No need to continue reading the file once we have found PRETTY_NAME
     if 'CINNAMON_VERSION' in os.environ:
         infos.append((_("Cinnamon Version"), os.environ['CINNAMON_VERSION']))
-    infos.append((_("Linux Kernel"), platform.release()))
+    infos.append((_("Kernel"), platform.release()))
     infos.append((_("Processor"), processorName))
     if memunit == "kB":
         infos.append((_("Memory"), '%.1f %s' % ((float(memsize)/(1024*1024)), _("GiB"))))


### PR DESCRIPTION
Given that Cinnamon already supports various types of UNIX operating systems, it should not be restricted to depend solely on the Linux kernel.