### PR TITLE
Fixed bug which causes this._panelZoneSizes is null error

### DIFF
--- a/files/usr/share/cinnamon/applets/keyboard@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/keyboard@cinnamon.org/applet.js
@@ -244,7 +244,7 @@ class CinnamonKeyboardApplet extends Applet.TextIconApplet {
             this.desktop_settings.connect("changed::keyboard-layout-show-flags", _syncConfig);
             this.desktop_settings.connect("changed::keyboard-layout-use-upper", _syncConfig);
             this.desktop_settings.connect("changed::keyboard-layout-prefer-variant-names", _syncConfig);
-            global.settings.connect('changed::' + PANEL_EDIT_MODE_KEY, () => this._onPanelEditModeChanged());
+            this.panelEditModeHandler = global.settings.connect('changed::' + PANEL_EDIT_MODE_KEY, () => this._onPanelEditModeChanged());
 
             this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
             this.menu.addAction(_("Show Keyboard Layout"), () => {
@@ -454,7 +454,7 @@ class CinnamonKeyboardApplet extends Applet.TextIconApplet {
 
     on_applet_removed_from_panel() {
         this._controller.applet_removed();
-
+        global.settings.disconnect(this.panelEditModeHandler);
         Main.systrayManager.unregisterTrayIconReplacement(this.metadata.uuid);
     }
 };

--- a/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
@@ -38,7 +38,7 @@ class CinnamonNotificationsApplet extends Applet.TextIconApplet {
 
         // Events
         Main.messageTray.connect('notify-applet-update', Lang.bind(this, this._notification_added));
-        global.settings.connect('changed::' + PANEL_EDIT_MODE_KEY, Lang.bind(this, this._on_panel_edit_mode_changed));
+        this.panelEditModeHandler = global.settings.connect('changed::' + PANEL_EDIT_MODE_KEY, Lang.bind(this, this._on_panel_edit_mode_changed));
 
         // States
         this._blinking = false;
@@ -53,6 +53,7 @@ class CinnamonNotificationsApplet extends Applet.TextIconApplet {
     on_applet_removed_from_panel () {
         Main.keybindingManager.removeHotKey("notification-open-" + this.instance_id);
         Main.keybindingManager.removeHotKey("notification-clear-" + this.instance_id);
+        global.settings.disconnect(this.panelEditModeHandler);
     }
 
     _openMenu() {

--- a/files/usr/share/cinnamon/applets/printers@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/printers@cinnamon.org/applet.js
@@ -30,7 +30,7 @@ class CinnamonPrintersApplet extends Applet.TextIconApplet {
         this.settings = new Settings.AppletSettings(this, metadata.uuid, instance_id);
         this.settings.bind('show-icon', 'show_icon', this.update);
 
-        global.settings.connect('changed::' + PANEL_EDIT_MODE_KEY, Lang.bind(this, this._on_panel_edit_mode_changed));
+        this.panelEditModeHandler = global.settings.connect('changed::' + PANEL_EDIT_MODE_KEY, Lang.bind(this, this._on_panel_edit_mode_changed));
 
         this.jobsCount = 0;
         this.printersCount = 0;
@@ -56,6 +56,7 @@ class CinnamonPrintersApplet extends Applet.TextIconApplet {
 
     on_applet_removed_from_panel() {
         this.settings.finalize();
+        global.settings.disconnect(this.panelEditModeHandler);
     }
 
     _on_panel_edit_mode_changed () {


### PR DESCRIPTION
Occurred when toggling panel edit mode when these applets were removed from a panel and that panel was removed.

Applets were still listening for panel-edit-mode changed signal and not garbage collected.