### PR TITLE
Menu applet: add workaround for tearing bug on categories scroll

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -2742,8 +2742,11 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         this.categoriesBox = new St.BoxLayout({ style_class: 'menu-categories-box',
                                                 vertical: true,
                                                 accessible_role: Atk.Role.LIST });
+        // Add additional box with 0 padding as a workaround to bug github.com/linuxmint/cinnamon/issues/11760
+        this.categoriesBugfixBox = new St.BoxLayout({ style: 'padding: 0px; margin: 0px; spacing: 0px;' });
+        this.categoriesBugfixBox.add_actor(this.categoriesBox);
         this.categoriesScrollBox = new St.ScrollView({ style_class: 'vfade menu-applications-scrollbox' });
-        this.categoriesScrollBox.add_actor(this.categoriesBox);
+        this.categoriesScrollBox.add_actor(this.categoriesBugfixBox);
         this.categoriesScrollBox.set_policy(St.PolicyType.NEVER, St.PolicyType.AUTOMATIC);
         this.categoriesScrollBox.set_clip_to_allocation(true);
 


### PR DESCRIPTION
This isn't a fix but a workaround for #11760

I tried the same for the applications box which has the same problem (though much less common) but it causes the app buttons to be too short which I don't know how to fix.