### PR TITLE
Fix option for only showing printer applet "while printing".

### DIFF
--- a/files/usr/share/cinnamon/applets/printers@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/printers@cinnamon.org/applet.js
@@ -175,7 +175,7 @@ class CinnamonPrintersApplet extends Applet.TextIconApplet {
                     //Cancel Job
                     out = out.split(/\n/);
                     this.jobsCount = out.length - 1;
-                    Util.spawn_async(['/usr/bin/lpq', '-a'], Lang.bind(this, function(out2) {
+                    Util.spawn_async(['/usr/bin/lpstat', '-o'], Lang.bind(this, function(out2) {
                         out2 = out2.replace(/\n/g, ' ').split(/\s+/);
                         let sendJobs = [];
                         for(var n = 0; n < out.length - 1; n++) {


### PR DESCRIPTION
If `lpq` isn't available, `Util.spawn_async` silently fails and the code to hide the printer applet never gets called. All the other `Util.spawn_async` in the printer applet use `lpstat` instead which can also show the number of print jobs.