### PR TITLE
expo.js: Force expo to show on the monitor that the mouse is on

### DIFF
--- a/js/ui/expo.js
+++ b/js/ui/expo.js
@@ -195,22 +195,22 @@ Expo.prototype = {
         // when it is next shown.
         this.hide();
 
-        let primary = Main.layoutManager.primaryMonitor;
+        let current = Main.layoutManager.currentMonitor;
         let rtl = (St.Widget.get_default_direction () == St.TextDirection.RTL);
 
         let contentY = 0;
-        let contentHeight = primary.height;
+        let contentHeight = current.height;
 
-        this._group.set_position(primary.x, primary.y);
-        this._group.set_size(primary.width, primary.height);
+        this._group.set_position(current.x, current.y);
+        this._group.set_size(current.width, current.height);
 
         this._gradient.set_position(0, 0);
-        this._gradient.set_size(primary.width, primary.height);
+        this._gradient.set_size(current.width, current.height);
 
         this._coverPane.set_position(0, 0);
-        this._coverPane.set_size(primary.width, contentHeight);
+        this._coverPane.set_size(current.width, contentHeight);
 
-        let viewWidth = primary.width - this._spacing;
+        let viewWidth = current.width - this._spacing;
         let viewHeight = contentHeight - 2 * this._spacing;
         let viewY = contentY + this._spacing;
         let viewX = rtl ? 0 : this._spacing;
@@ -224,34 +224,34 @@ Expo.prototype = {
         this._windowCloseArea.width = node.get_length('width');
 
         this._expo.actor.set_position(0, 0);
-        this._expo.actor.set_size((primary.width - buttonWidth), primary.height);
+        this._expo.actor.set_size((current.width - buttonWidth), current.height);
 
-        let buttonY = (primary.height - buttonHeight) / 2;
+        let buttonY = (current.height - buttonHeight) / 2;
 
-        this._addWorkspaceButton.set_position((primary.width - buttonWidth), buttonY);
-        this._addWorkspaceButton.set_size(buttonWidth, buttonHeight); 
+        this._addWorkspaceButton.set_position((current.width - buttonWidth), buttonY);
+        this._addWorkspaceButton.set_size(buttonWidth, buttonHeight);
         if (this._addWorkspaceButton.get_theme_node().get_background_image() == null)
-            this._addWorkspaceButton.set_style('background-image: url("/usr/share/cinnamon/theme/add-workspace.png");'); 
+            this._addWorkspaceButton.set_style('background-image: url("/usr/share/cinnamon/theme/add-workspace.png");');
 
-        this._windowCloseArea.set_position((primary.width - this._windowCloseArea.width) / 2 , primary.height);
+        this._windowCloseArea.set_position((current.width - this._windowCloseArea.width) / 2 , current.height);
         this._windowCloseArea.set_size(this._windowCloseArea.width, this._windowCloseArea.height);
         this._windowCloseArea.raise_top();
     },
 
     _showCloseArea : function() {
-        let primary = Main.layoutManager.primaryMonitor;
+        let current = Main.layoutManager.currentMonitor;
         this._windowCloseArea.show();
         this._windowCloseArea.ease({
-            y: primary.height - this._windowCloseArea.height,
+            y: current.height - this._windowCloseArea.height,
             duration: Main.animations_enabled ? ANIMATION_TIME : 0,
             mode: Clutter.AnimationMode.EASE_OUT_QUAD
         });
     },
 
     _hideCloseArea : function() {
-        let primary = Main.layoutManager.primaryMonitor;
+        let current = Main.layoutManager.currentMonitor;
         this._windowCloseArea.ease({
-            y: primary.height,
+            y: current.height,
             duration: Main.animations_enabled ? ANIMATION_TIME : 0,
             mode: Clutter.AnimationMode.EASE_OUT_QUAD
         });
@@ -319,15 +319,15 @@ Expo.prototype = {
             Main.layoutManager.monitors.forEach(function(monitor,index) {
                 let clone = clones[index];
                 clone.ease({
-                    x: Main.layoutManager.primaryMonitor.x + activeWorkspaceActor.allocation.x1,
-                    y: Main.layoutManager.primaryMonitor.y + activeWorkspaceActor.allocation.y1,
-                    scale_x: activeWorkspaceActor.get_scale()[0] , 
-                    scale_y: activeWorkspaceActor.get_scale()[1], 
+                    x: Main.layoutManager.currentMonitor.x + activeWorkspaceActor.allocation.x1,
+                    y: Main.layoutManager.currentMonitor.y + activeWorkspaceActor.allocation.y1,
+                    scale_x: activeWorkspaceActor.get_scale()[0] ,
+                    scale_y: activeWorkspaceActor.get_scale()[1],
                     duration: Main.animations_enabled ? ANIMATION_TIME : 0,
                     mode: Clutter.AnimationMode.EASE_OUT_QUAD,
                     onUpdate: (t, timeIndex) => {
-                        clone.get_transition("x")?.set_to(Main.layoutManager.primaryMonitor.x + activeWorkspaceActor.allocation.x1);
-                        clone.get_transition("y")?.set_to(Main.layoutManager.primaryMonitor.y + activeWorkspaceActor.allocation.y1);
+                        clone.get_transition("x")?.set_to(Main.layoutManager.currentMonitor.x + activeWorkspaceActor.allocation.x1);
+                        clone.get_transition("y")?.set_to(Main.layoutManager.currentMonitor.y + activeWorkspaceActor.allocation.y1);
                         clone.get_transition("scale-x")?.set_to(activeWorkspaceActor.get_scale()[0]);
                         clone.get_transition("scale-y")?.set_to(activeWorkspaceActor.get_scale()[1]);
                     },
@@ -436,7 +436,7 @@ Expo.prototype = {
 
             let clone = new Clutter.Clone({source: activeWorkspaceActor});
             cover.add_actor(clone);
-            clone.set_position(Main.layoutManager.primaryMonitor.x + activeWorkspaceActor.allocation.x1, Main.layoutManager.primaryMonitor.y + activeWorkspaceActor.allocation.y1);
+            clone.set_position(Main.layoutManager.currentMonitor.x + activeWorkspaceActor.allocation.x1, Main.layoutManager.currentMonitor.y + activeWorkspaceActor.allocation.y1);
             clone.set_clip(monitor.x, monitor.y, monitor.width, monitor.height);
             clone.set_scale(activeWorkspaceActor.get_scale()[0], activeWorkspaceActor.get_scale()[1]);
 


### PR DESCRIPTION
This PR helps users with multiple monitors. Currently, the expo mode only shows on the dedicated primary monitor. In my opinion it should follow the mouse for multi-monitor users, since it's a good assumption that the user is looking at the monitor where their mouse cursor is currently at. Tested and works with multiple monitors and behaves properly with only one monitor.

Below is a video from VirtualBox (with two virtual monitors) where I showcase the expo functionality launching on the screen where the mouse is:

https://github.com/user-attachments/assets/d746f9a8-859b-4a4c-bacd-413afaa95f11

Below is only a single monitor being used (via VirtualBox):

https://github.com/user-attachments/assets/ad243f58-ce44-4226-a672-c51a92fa888f



