### PR TITLE
sound-applet: Fix mute/unmute toggle when clicking volume icon (#13053)

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -107,6 +107,16 @@ class VolumeSlider extends PopupMenu.PopupSliderMenuItem {
             this.icon = new St.Icon({icon_name: this.app_icon, icon_type: St.IconType.FULLCOLOR, icon_size: 16});
         }
 
+        this.icon.reactive = true;
+        this.icon.track_hover = true;
+        this.icon.connect('button-press-event', (actor, event) => {
+            if (this.stream && event.get_button() === 1) {
+                this.stream.change_is_muted(!this.stream.is_muted);
+                return Clutter.EVENT_STOP;
+            }
+            return Clutter.EVENT_PROPAGATE;
+        });
+
         this.removeActor(this._slider);
         this.addActor(this.icon, {span: 0});
         this.addActor(this._slider, {span: -1, expand: true});


### PR DESCRIPTION
This PR fixes an issue where clicking the speaker icon in the Cinnamon sound applet popup would only mute audio but not restore/unmute it.

Before: Clicking the icon muted sound, but subsequent clicks had no effect.

After: Clicking the icon now correctly toggles between mute and unmute.

Steps to test

Build and restart Cinnamon (Alt+F2 → r → Enter).

Open the sound applet from the panel.

Click the speaker icon next to the volume slider:

First click → mutes audio.

Second click → unmutes audio.

Related issue

Fixes #13053