### PR TITLE
Notifications applet: add option to show newest notifications first

### DIFF
--- a/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
@@ -27,6 +27,7 @@ class CinnamonNotificationsApplet extends Applet.TextIconApplet {
         this.settings.bind("keyOpen", "keyOpen", this._setKeybinding);
         this.settings.bind("keyClear", "keyClear", this._setKeybinding);
         this.settings.bind("showNotificationCount", "showNotificationCount", this.update_list);
+        this.settings.bind("showNewestFirst", "showNewestFirst", this.update_list);
         this._setKeybinding();
 
         // Layout
@@ -166,6 +167,7 @@ class CinnamonNotificationsApplet extends Applet.TextIconApplet {
                 this.actor.show();
                 this.clear_action.actor.show();
                 this.set_applet_label(count.toString());
+                this._reorderNotifications();
                 // Find max urgency and derive list icon.
                 let max_urgency = -1;
                 for (let i = 0; i < count; i++) {
@@ -222,6 +224,25 @@ class CinnamonNotificationsApplet extends Applet.TextIconApplet {
         }
         this.notifications = [];
         this.update_list();
+    }
+
+    _reorderNotifications() {
+        let orderedNotifications = this.notifications.slice();
+
+        if (this.showNewestFirst) {
+            orderedNotifications.reverse();
+        }
+
+        // Remove all children without destroying them.
+        let children = this._notificationbin.get_children();
+        for (let i = 0; i < children.length; i++) {
+            this._notificationbin.remove_child(children[i]);
+        }
+
+        // Add them back in desired order.
+        for (let i = 0; i < orderedNotifications.length; i++) {
+            this._notificationbin.add_child(orderedNotifications[i].actor);
+        }
     }
 
     _show_hide_tray() { // Show or hide the notification tray.

--- a/files/usr/share/cinnamon/applets/notifications@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/notifications@cinnamon.org/settings-schema.json
@@ -24,6 +24,11 @@
         "default": true,
         "description": "Show the number of notifications"
     },
+    "showNewestFirst": {
+        "type": "switch",
+        "default": false,
+        "description": "Show newest notifications first"
+    },
     "section3": {
         "type": "section",
         "description": "Keyboard shortcuts"


### PR DESCRIPTION
This PR introduces a new setting to allow users to choose the order in which notifications are displayed in the applet. By default, notifications are shown oldest-to-newest, but with this change, users can optionally reverse the list and see the newest notifications first.

Some users prefer to have the most recent notifications appear at the top of the list. The current implementation always appends new notifications at the bottom, which can be inconvenient when many notifications are present.

Related idea - https://github.com/orgs/linuxmint/discussions/831

<details>
  <summary>New switch (default is off):</summary>
  <img width="800" height="628" alt="Notifications_001" src="https://github.com/user-attachments/assets/1ba6090a-4c7a-461c-9ff2-529ecf0772f5" />
  </details>

<details>
  <summary>Off:</summary>
  <img width="726" height="520" alt="Selection_060" src="https://github.com/user-attachments/assets/a86ae027-0a9f-42b2-b4d5-1e02037108ce" />
  </details>
<details>
  <summary>On:</summary>
  <img width="726" height="520" alt="Selection_061" src="https://github.com/user-attachments/assets/3295b5c4-0395-4bdd-a450-7970b73f4219" />
  </details>