### PR TITLE
Prepare for GLib 2.86.0 typelib break

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_default.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_default.py
@@ -307,10 +307,10 @@ class DefaultTerminalButton(Gtk.AppChooserButton):
 
         while self.this_item is not None and count_up < len(apps):
             self.this_item = apps[count_up]
-            cat_val = Gio.DesktopAppInfo.get_categories(self.this_item)
-            exec_val = Gio.DesktopAppInfo.get_string(self.this_item, "Exec")
-            name_val = Gio.DesktopAppInfo.get_string(self.this_item, "Name")
-            icon_val = Gio.DesktopAppInfo.get_string(self.this_item, "Icon")
+            cat_val = GioUnix.DesktopAppInfo.get_categories(self.this_item)
+            exec_val = GioUnix.DesktopAppInfo.get_string(self.this_item, "Exec")
+            name_val = GioUnix.DesktopAppInfo.get_string(self.this_item, "Name")
+            icon_val = GioUnix.DesktopAppInfo.get_string(self.this_item, "Icon")
             # terminals don't have mime types, so we check for "TerminalEmulator" under the "Category" key in desktop files
             if cat_val is not None and "TerminalEmulator" in cat_val:
                 # this crazy if statement makes sure remaining desktop file info is not empty, then prevents root terminals from showing, then prevents repeating terminals from trying to being added which leave a blank space and Gtk-WARNING's
@@ -364,11 +364,11 @@ class DefaultCalculatorButton(Gtk.AppChooserButton):
 
         while self.this_item is not None and count_up < len(apps):
             self.this_item = apps[count_up]
-            cat_val = Gio.DesktopAppInfo.get_categories(self.this_item)
-            exec_val = Gio.DesktopAppInfo.get_string(self.this_item, "Exec")
-            name_val = Gio.DesktopAppInfo.get_string(self.this_item, "Name")
-            icon_val = Gio.DesktopAppInfo.get_string(self.this_item, "Icon")
-            comment_val = Gio.DesktopAppInfo.get_string(self.this_item, "Comment")
+            cat_val = GioUnix.DesktopAppInfo.get_categories(self.this_item)
+            exec_val = GioUnix.DesktopAppInfo.get_string(self.this_item, "Exec")
+            name_val = GioUnix.DesktopAppInfo.get_string(self.this_item, "Name")
+            icon_val = GioUnix.DesktopAppInfo.get_string(self.this_item, "Icon")
+            comment_val = GioUnix.DesktopAppInfo.get_string(self.this_item, "Comment")
             #calculators don't have mime types, so we check for "Calculator" under the "Category" key in desktop files
             if (cat_val is not None and "Calculator" in cat_val) or \
                (exec_val is not None and "alculator" in exec_val.lower()) or \

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -78,6 +78,7 @@
 
 const Clutter = imports.gi.Clutter;
 const Gio = imports.gi.Gio;
+const GioUnix = imports.gi.GioUnix;
 const GLib = imports.gi.GLib;
 const Gtk = imports.gi.Gtk;
 const Mainloop = imports.mainloop;
@@ -312,7 +313,7 @@ function start() {
     // Chain up async errors reported from C
     global.connect('notify-error', function (global, msg, detail) { notifyError(msg, detail); });
 
-    Gio.DesktopAppInfo.set_desktop_env('X-Cinnamon');
+    GioUnix.DesktopAppInfo.set_desktop_env('X-Cinnamon');
 
     Clutter.get_default_backend().set_input_method(new InputMethod.InputMethod());
 

--- a/meson.build
+++ b/meson.build
@@ -37,7 +37,7 @@ atk = dependency('atk-bridge-2.0')
 gio = dependency('gio-2.0', version: '>= 2.36.0')
 gio_unix = dependency('gio-unix-2.0')
 gl = dependency('gl')
-glib_version = '2.52.0'
+glib_version = '2.79.2'
 glib = dependency('glib-2.0', version: '>= ' + glib_version)
 gtk = dependency('gtk+-3.0', version: '>= 3.12.0')
 muffin = dependency('libmuffin-0', version: '>= 5.2.0')


### PR DESCRIPTION
In newest glib GioUnix symbols are not anymore exposed in GioUnix, while cjs should use https://github.com/linuxmint/cjs/pull/131 it's still better to use GioUnix all the times.

~~More importantly though, when scanning the cinnamon headers, GioUnix-2.0 should be used or the APIs exposing `GDesktopAppInfo` won't work or they will be broken.~~ (this should not be  a problem here since you actually use `GMenuDesktopAppInfo` instead which is not exposed by `GioUnix`)

~~It's not included here, but it's *highly* recommended to now depend on GLib 2.86.0, or at least communicate clearly to distributors that they **must** recompile cinnamon on GLib 2.86.0 (and with these patches) to get it working with newer GLib version (or well with the newest gio introspection typelibs).~~