### PR TITLE
Fix an issue preventing reloading/upgrading multi-instance applets

### DIFF
--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -37,8 +37,12 @@ var clipboard = [];
 var promises = [];
 
 function initEnabledApplets() {
+   // Load each unique Applet UUID, ignoring duplicates due to multiple instances
     for (let i = 0; i < definitions.length; i++) {
-        promises.push(Extension.loadExtension(definitions[i].uuid, Extension.Type.APPLET))
+        let uuid = definitions[i].uuid;
+        if (definitions.findIndex( (e) => e.uuid === uuid) === i) {
+            promises.push(Extension.loadExtension(uuid, Extension.Type.APPLET));
+        }
     }
     return Promise.all(promises).then(function() {
         Main.cinnamonDBusService.EmitXletsLoadedComplete();


### PR DESCRIPTION
When reloading an applet (i.e after updating the applet) it will fail to restart if there is more than one instance of the applet in the list of applet definitions. The restart fails because of an issue during the initial Cinnamon startup in the initEnabledApplets() function where it calls loadExtension() concurrently for each element in the applet definitions array. The definitions array has multiple entries for applets with multiple instances. This causes duplicated entries in the Extensions.extensions array (which was intended to have only one entry for each spice) because the protection against duplicate entries is executing concurrently, causing most concurrent tasks to see the same empty extensions array resulting in the duplicate check being ineffective.

How does duplicate entries in the extensions array cause the reload to fail: During the reload process we call unloadExtension() where we remove one entry from the extensions array, using forgetExtension(), leaving any duplicates still in the array. When we finish the reload process by calling loadExtension() to restart the Applet, we execute the Extension constructor which calls getExtension() to make sure the extension is not already running. Here it finds one of the duplicate extension array elements and aborts creating a new Applet thinking that the Applet is already running. This is how we fail to restart any of the Applet instances on reload.

This fix avoids the problem by changing initEnabledApplets() so that it will only call loadExtension() once for each unique uuid in the definitions array.