### PR TITLE
Call on_applet_reloaded() for all instances of an Applet

### DIFF
--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -122,7 +122,6 @@ function prepareExtensionReload(extension) {
             if (!applet) continue;
             global.log(`Reloading applet: ${extension.uuid}/${applet_id}`);
             applet.on_applet_reloaded();
-            return;
         }
     }
 }


### PR DESCRIPTION
When reloading an Applet that has more than one instance, the on_applet_reloaded() function is only called on the first Applet in the definitions array that matches the UUID. This fix allows the loop to continue through all Applet definitions and call on_applet_reloaded() for all Applet instances matching the UUID.