### PR TITLE
make the shutdown dialog default action configurable

### DIFF
--- a/js/ui/endSessionDialog.js
+++ b/js/ui/endSessionDialog.js
@@ -60,6 +60,7 @@ class EndSessionDialog extends ModalDialog.ModalDialog {
         this._inhibited = false;
         this._settings = new Gio.Settings({ schema_id: 'org.cinnamon.SessionManager' });
         this._currentTime = this._settings.get_int('quit-time-delay');
+        this._shutdownDefaultActions = this._settings.get_strv("shutdown-dialog-default-actions");
         this._progressTimerId = 0;
         this._defaultAction = null;
 
@@ -154,6 +155,15 @@ class EndSessionDialog extends ModalDialog.ModalDialog {
 
                 break;
             case DialogMode.SHUTDOWN:
+                const allowedShutdownDefaultActions = {
+                    "cancel": true,
+                    "shutdown": canStop,
+                    "restart": canRestart,
+                    "suspend": canSuspend,
+                    "hibernate": canHibernate
+                };
+                let shutdownDefaultAction = this._shutdownDefaultActions.filter(a => allowedShutdownDefaultActions[a])[0];
+
                 [button, buttonAction] = this._addCancel();
 
                 if (canSuspend) {

--- a/js/ui/endSessionDialog.js
+++ b/js/ui/endSessionDialog.js
@@ -103,12 +103,13 @@ class EndSessionDialog extends ModalDialog.ModalDialog {
         }
     }
 
-    _addCancel() {
+    _addCancel(buttonIsDefault=false) {
         this.addButton({
             label: _("Cancel"),
             action: () => {
                 this._dialogProxy.CancelRemote();
             },
+            default: buttonIsDefault,
             key: Clutter.KEY_Escape
         });
     }

--- a/js/ui/endSessionDialog.js
+++ b/js/ui/endSessionDialog.js
@@ -104,14 +104,17 @@ class EndSessionDialog extends ModalDialog.ModalDialog {
     }
 
     _addCancel(buttonIsDefault=false) {
-        this.addButton({
+        let buttonAction = () => {
+            this._dialogProxy.CancelRemote();
+        };
+        let button = this.addButton({
             label: _("Cancel"),
-            action: () => {
-                this._dialogProxy.CancelRemote();
-            },
+            action: buttonAction,
             default: buttonIsDefault,
             key: Clutter.KEY_Escape
         });
+
+        return [button, buttonAction];
     }
 
     _getCapabilities(result, error) {

--- a/js/ui/endSessionDialog.js
+++ b/js/ui/endSessionDialog.js
@@ -128,7 +128,7 @@ class EndSessionDialog extends ModalDialog.ModalDialog {
 
         var [canSwitchUser, canStop, canRestart, canHybridSleep, canSuspend, canHibernate, canLogout] = result[0];
         var content = null;
-        let button;
+        let button, buttonAction;
 
         switch(this._mode) {
             case DialogMode.LOGOUT:
@@ -154,41 +154,45 @@ class EndSessionDialog extends ModalDialog.ModalDialog {
 
                 break;
             case DialogMode.SHUTDOWN:
-                this._addCancel();
+                [button, buttonAction] = this._addCancel();
 
                 if (canSuspend) {
-                    this.addButton({
+                    buttonAction = () => {
+                        this._dialogProxy.SuspendRemote();
+                        this.close();
+                    };
+                    button = this.addButton({
                         label: _("Suspend"),
-                        action: () => {
-                            this._dialogProxy.SuspendRemote();
-                            this.close();
-                        },
+                        action: buttonAction
                     });
                 }
 
                 if (canHibernate) {
-                    this.addButton({
+                    buttonAction = this._dialogProxy.HibernateRemote.bind(this._dialogProxy);
+                    button = this.addButton({
                         label: _("Hibernate"),
-                        action: this._dialogProxy.HibernateRemote.bind(this._dialogProxy)
+                        action: buttonAction
                     });
                 }
 
                 if (canRestart) {
-                    this.addButton({
+                    buttonAction = this._dialogProxy.RestartRemote.bind(this._dialogProxy);
+                    button = this.addButton({
                         label: _("Restart"),
-                        action: this._dialogProxy.RestartRemote.bind(this._dialogProxy),
+                        action: buttonAction
                     });
                 }
 
                 if (canStop) {
-                    this._defaultAction = this._dialogProxy.ShutdownRemote.bind(this._dialogProxy);
+                    buttonAction = this._dialogProxy.ShutdownRemote.bind(this._dialogProxy);
                     button = this.addButton({
                         label: _("Shut Down"),
-                        action: this._defaultAction,
+                        action: buttonAction,
                         destructive_action: true,
                         default: true,
                     });
                     button.grab_key_focus();
+                    this._defaultAction = buttonAction;
                 }
 
                 this._messageDialogContent.title = _("Shut Down");

--- a/js/ui/endSessionDialog.js
+++ b/js/ui/endSessionDialog.js
@@ -129,7 +129,7 @@ class EndSessionDialog extends ModalDialog.ModalDialog {
 
         var [canSwitchUser, canStop, canRestart, canHybridSleep, canSuspend, canHibernate, canLogout] = result[0];
         var content = null;
-        let button, buttonAction;
+        let button, buttonAction, buttonIsDefault;
 
         switch(this._mode) {
             case DialogMode.LOGOUT:
@@ -164,45 +164,71 @@ class EndSessionDialog extends ModalDialog.ModalDialog {
                 };
                 let shutdownDefaultAction = this._shutdownDefaultActions.filter(a => allowedShutdownDefaultActions[a])[0];
 
-                [button, buttonAction] = this._addCancel();
+                buttonIsDefault = (shutdownDefaultAction == "cancel");
+                [button, buttonAction] = this._addCancel(buttonIsDefault);
+                if (buttonIsDefault) {
+                    button.grab_key_focus();
+                    this._defaultAction = buttonAction;
+                }
 
                 if (canSuspend) {
+                    buttonIsDefault = (shutdownDefaultAction == "suspend");
                     buttonAction = () => {
                         this._dialogProxy.SuspendRemote();
                         this.close();
                     };
                     button = this.addButton({
                         label: _("Suspend"),
-                        action: buttonAction
+                        action: buttonAction,
+                        default: buttonIsDefault
                     });
+                    if (buttonIsDefault) {
+                        button.grab_key_focus();
+                        this._defaultAction = buttonAction;
+                    }
                 }
 
                 if (canHibernate) {
+                    buttonIsDefault = (shutdownDefaultAction == "hibernate");
                     buttonAction = this._dialogProxy.HibernateRemote.bind(this._dialogProxy);
                     button = this.addButton({
                         label: _("Hibernate"),
-                        action: buttonAction
+                        action: buttonAction,
+                        default: buttonIsDefault
                     });
+                    if (buttonIsDefault) {
+                        button.grab_key_focus();
+                        this._defaultAction = buttonAction;
+                    }
                 }
 
                 if (canRestart) {
+                    buttonIsDefault = (shutdownDefaultAction == "restart");
                     buttonAction = this._dialogProxy.RestartRemote.bind(this._dialogProxy);
                     button = this.addButton({
                         label: _("Restart"),
-                        action: buttonAction
+                        action: buttonAction,
+                        default: buttonIsDefault
                     });
+                    if (buttonIsDefault) {
+                        button.grab_key_focus();
+                        this._defaultAction = buttonAction;
+                    }
                 }
 
                 if (canStop) {
+                    buttonIsDefault = (shutdownDefaultAction == "shutdown");
                     buttonAction = this._dialogProxy.ShutdownRemote.bind(this._dialogProxy);
                     button = this.addButton({
                         label: _("Shut Down"),
                         action: buttonAction,
                         destructive_action: true,
-                        default: true,
+                        default: buttonIsDefault
                     });
-                    button.grab_key_focus();
-                    this._defaultAction = buttonAction;
+                    if (buttonIsDefault) {
+                        button.grab_key_focus();
+                        this._defaultAction = buttonAction;
+                    }
                 }
 
                 this._messageDialogContent.title = _("Shut Down");


### PR DESCRIPTION
Hey there.

This requires https://github.com/linuxmint/cinnamon-session/pull/188 to be in place.

It basically makes the shutdown dialog's default action configurable, considering also that an action may not be available at all (which is why the setting is a list of strings, rather than e.g. a single enum).

I'd really be happy if this feature was accepted, I'd be longing for it since years (and finally crossed my laziness threshold ^^).

Please review (I'm not really a JS guy and completely new to Cinnamon's codebase).

Thanks,
Chris.