### PR TITLE
debian/control: Add IBus runtime dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -64,6 +64,7 @@ Depends:
  gir1.2-graphene-1.0,
  gir1.2-gsound-1.0,
  gir1.2-gtkclutter-1.0,
+ gir1.2-ibus-1.0,
  gir1.2-ical-3.0,
  gir1.2-keybinder-3.0,
  gir1.2-meta-muffin-0.0 (>= 5.3),


### PR DESCRIPTION
As part of the libraries loaded in files like js/ui/keyboardManager.js:3, IBus is required in order to successfully launch the session.