### PR TITLE
menu: Fix misclick on user avatar area when resizing the menu

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -2407,13 +2407,13 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         this.userBox = new St.BoxLayout({
             style_class: 'appmenu-sidebar-user-box',
             vertical: true,
-            reactive: true
+            reactive: false
         });
 
         let user = AccountsService.UserManager.get_default().get_user(GLib.get_user_name());
         this.userIcon = new UserWidget.UserWidget(user, Clutter.Orientation.VERTICAL, false);
-
-        this.userBox.connect('button-press-event', () => {
+        this.userIcon.set_reactive(true);
+        this.userIcon.connect('button-press-event', () => {
             this.menu.toggle();
             Util.spawnCommandLine("cinnamon-settings user");
         });


### PR DESCRIPTION
Issue demonstrated in the video:


https://github.com/user-attachments/assets/bf59978b-1461-4bcb-b0f5-cd4dd7e8cad7