### PR TITLE
Cinnamon: Adds hidden-buttons to list in applet settings

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py
@@ -33,7 +33,8 @@ JSON_SETTINGS_PROPERTIES_MAP = {
     "icon_categories"  : "icon_categories",
     "default_category" : "default_category",
     "show-seconds"     : "show_seconds",
-    "show-buttons"     : "show_buttons"
+    "show-buttons"     : "show_buttons",
+    "hidden-buttons"   : "hidden_buttons"
 }
 
 OPERATIONS = ['<=', '>=', '<', '>', '!=', '=']

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/TreeListWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/TreeListWidgets.py
@@ -101,10 +101,11 @@ class List(SettingsWidget):
     bind_dir = None
 
     def __init__(self, label=None, columns=None, height=200, size_group=None, \
-                 dep_key=None, tooltip="", show_buttons=True):
+                 dep_key=None, tooltip="", show_buttons=True, hidden_buttons=[]):
         super(List, self).__init__(dep_key=dep_key)
         self.columns = columns
         self.show_buttons = show_buttons
+        self.hidden_buttons = hidden_buttons
 
         self.set_orientation(Gtk.Orientation.VERTICAL)
         self.set_spacing(0)
@@ -201,11 +202,16 @@ class List(SettingsWidget):
             self.move_down_button.set_tooltip_text(_("Move selected entry down"))
             self.move_down_button.connect("clicked", self.move_item_down)
             self.move_down_button.set_sensitive(False)
-            button_toolbar.insert(self.add_button, 0)
-            button_toolbar.insert(self.remove_button, 1)
-            button_toolbar.insert(self.edit_button, 2)
-            button_toolbar.insert(self.move_up_button, 3)
-            button_toolbar.insert(self.move_down_button, 4)
+            if "+" not in self.hidden_buttons:
+                button_toolbar.insert(self.add_button, 0)
+            if "-" not in self.hidden_buttons:
+                button_toolbar.insert(self.remove_button, 1)
+            if "edit" not in self.hidden_buttons:
+                button_toolbar.insert(self.edit_button, 2)
+            if "up" not in self.hidden_buttons:
+                button_toolbar.insert(self.move_up_button, 3)
+            if "down" not in self.hidden_buttons:
+                button_toolbar.insert(self.move_down_button, 4)
 
         self.content_widget.get_selection().connect("changed", self.update_button_sensitivity)
         self.content_widget.set_activate_on_single_click(False)


### PR DESCRIPTION
Example in a `settings-schema.json` file:

```
"myList": {
        "type": "list",
        "default": [],
        "columns":  [
            {"id": "id", "title": "Name", "type": "string", "expand-width": true}
        ],
        "show-buttons": true,
        "hidden-buttons": ["+", "-", "edit"],
        "description": "My list"
    },
```

The "hidden-buttons" is an array that is [] (empty) by default.

This array can contain these values:

- "+"
- "-"
- "edit"
- "up"
- "down"

With the example above:  "hidden-buttons": ["+", "-", "edit"], the user can not add, remove or edit rows to the list; the user only can move the items of the list.

<img width="225" height="200" alt="image" src="https://github.com/user-attachments/assets/45e17311-97f6-4de4-8b51-281140dc1ef6" />

TODO: Update documentation.