### PR TITLE
_ibus-popup.scss: Do not darken un-selected candidates

### DIFF
--- a/data/theme/cinnamon-sass/widgets/_ibus-popup.scss
+++ b/data/theme/cinnamon-sass/widgets/_ibus-popup.scss
@@ -25,8 +25,8 @@ $popover_arrow_height: 12px;
 .candidate-box {
   padding: 0.3em 0.5em 0.3em 0.5em;
   border-radius: $base_border_radius;
-  color: darken($fg_color,50%);
-  &:selected,&:hover { background-color: $lighter_bg_color; color: $fg_color; }
+  color: $fg_color;
+  &:selected,&:hover { background-color: $lighter_bg_color; }
 }
 
 .candidate-page-button-box {


### PR DESCRIPTION
When I type Chinese via Pinyin, I scan all the candidates at the same time and do the selection using keyboard 1-9 (without any usages of mouse) so it is important to make all candidates clear to read soon as they appear... :joy:

Here are some screenshots:

<details><summary>Before the change ...</summary>

<img width="1088" height="524" alt="cinnamon-ibus-before" src="https://github.com/user-attachments/assets/301affe9-fcc2-4d51-88be-2669a0908c34" />

</details>

<details><summary>... Hey the popup is actually much smaller on the screen!</summary>

<img width="3200" height="2000" alt="popup" src="https://github.com/user-attachments/assets/452caf73-996b-4b4d-bca8-5c2b2b49e5b8" />


</details>



<details><summary>After the change</summary>

<img width="1150" height="556" alt="cinnamon-ibus-after" src="https://github.com/user-attachments/assets/319b8e1c-b83b-43c2-b99a-be401f38ccef" />

</details>



<details><summary>This is the builtin Pinyin IME on Microsoft Windows 11</summary>

<img width="1390" height="344" alt="windows-ime" src="https://github.com/user-attachments/assets/da139ab9-2bf1-45cb-a113-caace383703b" />

<img width="1377" height="323" alt="windows-ime-dark" src="https://github.com/user-attachments/assets/71056882-78ef-4b04-96dc-0cd04f5f8fab" />


</details>
