### PR TITLE
Fixed an xlet-settings issue causing invalid callback/signal triggers with some setting types

### DIFF
--- a/js/ui/settings.js
+++ b/js/ui/settings.js
@@ -668,12 +668,14 @@ XletSettingsBase.prototype = {
 
             // Each row of the list needs to be checked
             equal = Object.keys(value).every(row => {
-                if(value[row].length === oldValue[row].length) {
+                if (value[row].length === oldValue[row].length) {
                     return Object.keys(value[row]).every(
                         key => oldValue[row].hasOwnProperty(key)
                         && value[row][key] === oldValue[row][key]
                     );
-                };
+                } else {
+                    return false;
+                }
             });    
               
         } else {


### PR DESCRIPTION
Hello, this PR closes #13151. I fixed a problem described in the linked issue. I've also found that this problem comes up with the `list` setting type. 

Issue was caused by an improper condition checking whether the setting was changed or not. More specifically, for three setting types: `datechooser`, `timechooser` and `list` it would always evalute them as changed, because the condition `if (value == oldValue) continue;` is always false for them. This causes these setting types to always fire their respective callbacks every time any other setting is changed.

My solution implements a new function `_isValueChanged()`, which checks whether the setting was actually changed. The implementation seems a bit too complex for what it does, but I don't think there's a different way. I'm pretty sure JS doesn't have a good, robust, builtin way of checking whether any two object have the same keys/values, so I think it's necessary to implement such functionality separately for every unique setting type.    


