### PR TITLE
GWL: Refresh all workspaces when change group/ungroup option

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -295,7 +295,7 @@ class GroupedWindowListApplet extends Applet.Applet {
 
     bindSettings() {
         const settingsProps = [
-            {key: 'group-apps', value: 'groupApps', cb: this.refreshCurrentWorkspace},
+            {key: 'group-apps', value: 'groupApps', cb: this.refreshAllWorkspaces},
             {key: 'scroll-behavior', value: 'scrollBehavior', cb: null},
             {key: 'left-click-action', value: 'leftClickAction', cb: null},
             {key: 'middle-click-action', value: 'middleClickAction', cb: null},


### PR DESCRIPTION
Fixes bug where other workspaces are not updated when "group windows by application" option is changed