### PR TITLE
Fix autohide panel bugs

### DIFF
--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -2090,6 +2090,7 @@ Panel.prototype = {
         this._destroyed = false;
         this._positionChanged = false;
         this._monitorsChanged = false;
+        this._mouseEntered = null;
         this._signalManager = new SignalManager.SignalManager(null);
         this.height = 0;
         this.margin_top = 0;
@@ -2371,7 +2372,6 @@ Panel.prototype = {
 
         return;
     },
-
 
     peekPanel: function() {
         if (!this._hidden || this._peeking)
@@ -2972,7 +2972,7 @@ Panel.prototype = {
         if (this._positionChanged) {
             panelChanged = true;
             this._positionChanged = false;
-            this._hidden = false;
+            this._showPanel();
         }
 
         // if the monitors changed, force update in case the position needs updating
@@ -3666,6 +3666,8 @@ Panel.prototype = {
 
         for (let i = 0; i < global.menuStack.length; i++) {
             let menu = global.menuStack[i];
+            if (menu.customStyleClass && menu.customStyleClass.includes("thumbnail"))
+                continue;
             if (menu.getPanel() === this.actor) {
                 return true;
             }
@@ -3684,6 +3686,8 @@ Panel.prototype = {
      * true = autohide, false = always show, intel = Intelligent
      */
     _updatePanelVisibility: function() {
+        this._mouseEntered = this._mouseOnPanel();
+
         if (this._panelEditMode || this._highlighted || this._peeking || this._panelHasOpenMenus())
             this._shouldShow = true;
         else {
@@ -3774,30 +3778,31 @@ Panel.prototype = {
     },
 
     _enterPanel: function(actor=null, event=null) {
-        this._mouseEntered = true;
-        this._updatePanelVisibility();
+        if (!this._mouseEntered) {
+            this._updatePanelVisibility();
+        }
     },
 
     _leavePanel:function(actor=null, event=null) {
-        if (event !== null && this._eventOnPanelStrip(...event.get_coords())) {
-            return;
+        // Panel gives false leave-event's when mouse is still on panel so we determine this._mouseEntered
+        // manually with this._mouseOnPanel() in this._updatePanelVisibility()
+        
+        if (this._mouseEntered) {
+            this._updatePanelVisibility();
+            if (this.isHideable() && event !== null && this._mouseOnPanel()) {
+                // Since we get false leave-event's and reported mouse position is often still
+                // on panel even if left, we check again a short while later to make sure.
+                setTimeout(this._updatePanelVisibility.bind(this), 250);
+            }
         }
-
-        this._mouseEntered = false;
-        this._updatePanelVisibility();
     },
 
-    _eventOnPanelStrip: function(x, y) {
-        switch (this.panelPosition) {
-            case PanelLoc.top:
-                return y === this.monitor.y;
-            case PanelLoc.bottom:
-                return y === this.monitor.y + this.monitor.height - 1;
-            case PanelLoc.left:
-                return x === this.monitor.x;
-            case PanelLoc.right:
-                return x === this.monitor.x + this.monitor.width - 1;
-        }
+    _mouseOnPanel: function() {
+        this.actor.sync_hover();
+        const [x, y] = global.get_pointer();
+
+        return (this.actor.x <= x && x <= this.actor.x + this.actor.width &&
+            this.actor.y <= y && y <= this.actor.y + this.actor.height);
     },
 
     /**
@@ -3808,7 +3813,6 @@ Panel.prototype = {
      */
     disable: function() {
         this._disabled = true;
-        this._leavePanel();
         this.actor.ease({
             opacity: 0,
             duration: AUTOHIDE_ANIMATION_TIME,
@@ -3900,18 +3904,14 @@ Panel.prototype = {
 
     /**
      * _hidePanel:
-     * @force (boolean): whether or not to force the hide.
      *
-     * This hides the panel unless this._shouldShow is false. This behaviour is
-     * overridden if the @force argument is set to true. However, the panel
-     * will always not be hidden if a menu is open, regardless of the value of
-     * @force.
+     * This hides the panel.
      */
-    _hidePanel: function(force) {
+    _hidePanel: function() {
         if (this._destroyed) return;
         this._showHideTimer = 0;
 
-        if ((this._shouldShow && !force) || this._panelHasOpenMenus()) return;
+        if (this._hidden) return;
 
         // setup panel tween - slide out the monitor edge leaving one pixel
         // if horizontal panel, animation on y. if vertical, animation on x.
@@ -3964,7 +3964,7 @@ Panel.prototype = {
     },
 
     getIsVisible: function() {
-        return !this._hidden;
+        return !this._hidden || this._shouldShow;
     },
 
     resetDNDZones: function() {


### PR DESCRIPTION
Fixes bug mentioned in #11087
>If I quickly flick my mouse downward towards the bottom panel that's hidden and then move the mouse away, before the panel has even been fully revealed, it will remain in the visible state until I move my mouse down over it and then move my mouse away from it.

Fixes other bugs where autohide panel hides when mouse is still on panel. e.g. open any applet by clicking on it's panel icon, then click elsewhere on panel to close applet, panel hides. (mentioned in #12962)