### PR TITLE
Make dummy panel visible on fullscreened monitors

### DIFF
--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -1290,7 +1290,7 @@ PanelDummy.prototype = {
 
         this.actor = new Cinnamon.GenericContainer({style_class: "panel-dummy", reactive: true, track_hover: true, important: true});
 
-        Main.layoutManager.addChrome(this.actor, { addToWindowgroup: false });
+        Main.layoutManager.addChrome(this.actor, { addToWindowgroup: false, visibleInFullscreen: true });
         //
         // layouts set to be full width horizontal panels, and vertical panels set to use as much available space as is left
         //


### PR DESCRIPTION
Show all available panel positions when moving a panel or selecting position of new panel.