### PR TITLE
Make InfoOSD visible on fullscreened monitors

### DIFF
--- a/js/ui/modalDialog.js
+++ b/js/ui/modalDialog.js
@@ -485,7 +485,7 @@ var InfoOSD = class {
             this.actor.add(label);
         }
         Main.layoutManager.addChrome(this.actor, {
-            visibleInFullscreen: false,
+            visibleInFullscreen: true,
             affectsInputRegion: false
         });
     }


### PR DESCRIPTION
Current InfoOSD's are "Restarting cinnamon", "Select position of new panel. Esc to cancel.", and "Select new position of panel. Esc to cancel.". 