### PR TITLE
[WIP] screensaver: make unlock dialog vertically layout with rounded user picture

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_user.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_user.py
@@ -212,7 +212,7 @@ class Module:
 
             face_path = os.path.join(self.accountService.get_home_dir(), ".face")
 
-            pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(path, 255, -1)
+            pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(path, -1, -1)
             pixbuf.savev(face_path, "png")
             self.accountService.set_icon_file(path)
             self.face_button.set_picture_from_file(path)


### PR DESCRIPTION
make unlock dialog vertically layout with rounded user picture
note: there is an illustrated image for the change in [#486](https://github.com/linuxmint/cinnamon-screensaver/issues/486)

closes: [#486](https://github.com/linuxmint/cinnamon-screensaver/issues/486)
related: [#487](https://github.com/linuxmint/cinnamon-screensaver/pull/487)