### PR TITLE
cinnamon-settings: add 'Gnome Left' option to Windows buttons layout

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_windows.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_windows.py
@@ -43,6 +43,7 @@ class Module:
                 button_options.append([":minimize,maximize,close", _("Right")])
                 button_options.append(["close,maximize,minimize:", _("Left")])
             button_options.append([":close", _("Gnome")])
+            button_options.append(["close:", _("Gnome Left")])
             button_options.append(["close:minimize,maximize", _("Classic Mac")])
 
             widget = GSettingsComboBox(_("Buttons layout"), "org.cinnamon.desktop.wm.preferences", "button-layout", button_options, size_group=size_group)


### PR DESCRIPTION
solves #13226

<img width="1602" height="1264" alt="image" src="https://github.com/user-attachments/assets/36b262d9-84ca-4f8c-831d-d733781731d0" />
