### PR TITLE
cs_startup: fix custom commands with spaces in path

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_startup.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_startup.py
@@ -899,6 +899,8 @@ class AppDialog(Gtk.Dialog):
 
         if response == Gtk.ResponseType.ACCEPT:
             name = chooser.get_filename()
+            if " " in name:
+                name = '"' + name + '"'
             self.command_entry.set_text(name)
 
         chooser.destroy()


### PR DESCRIPTION
Automatically add quotes if selected filepath contains spaces.

fixes https://github.com/linuxmint/cinnamon-settings-daemon/issues/363
