### PR TITLE
endSessionDialog: Fix hibernate action

### DIFF
--- a/js/ui/endSessionDialog.js
+++ b/js/ui/endSessionDialog.js
@@ -165,7 +165,10 @@ class EndSessionDialog extends ModalDialog.ModalDialog {
                 if (canHibernate) {
                     this.addButton({
                         label: _("Hibernate"),
-                        action: this._dialogProxy.HibernateRemote.bind(this._dialogProxy)
+                        action: () => {
+                            this._dialogProxy.HibernateRemote();
+                            this.close();
+                        }
                     });
                 }
 


### PR DESCRIPTION
closes https://github.com/linuxmint/cinnamon/issues/12664

### Before the fix

https://github.com/user-attachments/assets/c06dbff1-8742-4d47-a732-032622af5cfd

Another issue that happens due to this, since the dialog stays open for longer and active is that as you can see in the video, I can click the other options and even the hibernate option more than once, which since the hibernation stores the state can lead to the system firing these actions (like a reboot) unecessarily (and unatended too likely) after the hibernation is resumed, like happened here:

https://github.com/user-attachments/assets/c014f0e2-cb30-4256-9018-7d6d522edabb

### After the fix

https://github.com/user-attachments/assets/a6e84f4c-ff32-4451-b17d-d00d549b9dc7

This was tested in a computer with LMDE 7. 
