### PR TITLE
wrong app id in calc search provider example

### DIFF
--- a/docs/search-providers-examples/calc@cinnamon.org/search_provider.js
+++ b/docs/search-providers-examples/calc@cinnamon.org/search_provider.js
@@ -12,7 +12,7 @@ function perform_search(pattern){
 
         let awns = (Math.round(solution * 10000) / 10000).toString();
         if (awns != pattern) {
-            let default_icon_app = Cinnamon.AppSystem.get_default().lookup_app("galculator.desktop");
+            let default_icon_app = Cinnamon.AppSystem.get_default().lookup_app("org.gnome.Calculator.desktop");
             let result = {
                 id: awns,
                 label: _("Solution: %s").format(awns),


### PR DESCRIPTION
The app id in the calc search provider is no longer valide. The new id is `org.gnome.Calculator.desktop`