### PR TITLE
menu@cinnamon.org: check category icon exists

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -812,7 +812,10 @@ class CategoryButton extends SimpleMenuItem {
             size = 16;
             symbolic = true;
             if (typeof icon !== 'string')
-                icon = icon.get_names()[0]
+                if (icon?.get_names)
+                    icon = icon.get_names()[0];
+                else
+                    icon = "";
             if (icon.startsWith("applications-") || icon === "folder-recent")
                 icon = "xsi-" + icon;
             else if (icon == "xapp-user-favorites")


### PR DESCRIPTION
as user defined categories can have no defined icon.

Fixes: #13257