### PR TITLE
power_applet: rearrange battery label, so the percentage is on left

### DIFF
--- a/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
@@ -191,7 +191,7 @@ class DeviceItem extends PopupMenu.PopupBaseMenuItem {
         let statusLabel = null;
 
         if (battery_level == UPDeviceLevel.NONE) {
-            this.label = new St.Label({ text: "%s %d%%".format(description, Math.round(percentage)) });
+            this.label = new St.Label({ text: "%d%% %s".format(Math.round(percentage), description) });
             statusLabel = new St.Label({ text: "%s".format(status), style_class: 'popup-inactive-menu-item' });
         } else {
             this.label = new St.Label({ text: "%s".format(description) });


### PR DESCRIPTION
old: `<battery logo> <battery name> <percentage>`
new: `<battery logo> <percentage>\t<battery name>`

example for the new result:
<img width="736" height="549" alt="image" src="https://github.com/user-attachments/assets/d96d83b2-2a2c-4d07-8198-5887e868723c" />

This is make it easier to see the percentage as it is beside the battery logo

solved #13261