### PR TITLE
messageTray.js: Check for pending notifications after showing a ...

### DIFF
--- a/js/ui/messageTray.js
+++ b/js/ui/messageTray.js
@@ -1072,7 +1072,10 @@ MessageTray.prototype = {
             opacity: 0,
             duration: ANIMATION_TIME,
             mode: Clutter.AnimationMode.EASE_OUT_QUAD,
-            onComplete: () => this._hideNotificationCompleted()
+            onComplete: () => {
+                this._hideNotificationCompleted();
+                this._updateState();
+            }
         });
     },
 


### PR DESCRIPTION
... notification.

Notifications received while a notification was being shown were not being shown and were left pending. 

Fixes https://github.com/linuxmint/cinnamon/issues/13293