### PR TITLE
GWL: Add generic icon for apps with no icon

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -300,6 +300,22 @@ class AppGroup {
             });
         }
 
+        if (icon instanceof St.Icon) {
+            let gicon = icon.get_gicon();
+            if (gicon?.get_names) {
+                let iconTheme = Gtk.IconTheme.get_default();
+                let hasAnyIcon = gicon.get_names()
+                    .some(name => iconTheme.lookup_icon(name, icon.icon_size, 0));
+                if (!hasAnyIcon) {
+                    icon = new St.Icon({
+                        icon_name: 'application-x-executable',
+                        icon_size: this.iconSize,
+                        icon_type: St.IconType.FULLCOLOR
+                    });
+                }
+            }
+        }
+
         const oldChild = this.iconBox.get_child();
         this.iconBox.set_child(icon);
 


### PR DESCRIPTION
This ensures there is an panel icon (`application-x-executable`) where there is no themed icon available for the app.

This is the same method used in the menu applet: https://github.com/linuxmint/cinnamon/commit/e83f778631e2636f4ddc235f46c24aee54ca645f

Fixes https://github.com/linuxmint/mint22.3-beta/issues/11 and https://github.com/linuxmint/cinnamon/issues/12307