### PR TITLE
JsonSettingsWidgets.py: Trigger xlet settings update when settings ...

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/JsonSettingsWidgets.py
@@ -196,6 +196,8 @@ class JSONSettingsHandler(object):
                 self.do_key_update(key)
 
         self.save_settings()
+        if self.notify_callback:
+            self.notify_callback(self, "", "")
 
     def do_key_update(self, key):
         if key in self.bindings:
@@ -224,6 +226,8 @@ class JSONSettingsHandler(object):
             else:
                 print(f"Skipping key {key}: the key does not exist in {filepath} or has no value")
         self.save_settings()
+        if self.notify_callback:
+            self.notify_callback(self, "", "")
 
     def save_to_file(self, filepath):
         if os.path.exists(filepath):


### PR DESCRIPTION
... options "Reset to defaults" and "Import from a file" are used. This is needed because the file monitor was removed from `settings.js` in commit https://github.com/linuxmint/cinnamon/pull/12819/changes/7cbcabb36e094ed493b0c3d0746648e116b3143f

This fixes a bug where the xlet settings were not updated in the xlet after choosing options "Reset to defaults" and "Import from a file" in the xlet settings config dialog causing them to have no effect.