### PR TITLE
extension.js: Put back "notifications" role removed in commit ...

### DIFF
--- a/js/ui/appletManager.js
+++ b/js/ui/appletManager.js
@@ -25,6 +25,7 @@ var appletsLoaded = false;
 
 // FIXME: This role stuff is checked in extension.js, why not move checks from here to there?
 var Roles = {
+    NOTIFICATIONS: 'notifications',
     PANEL_LAUNCHER: 'panellauncher',
     WINDOW_ATTENTION_HANDLER: 'windowattentionhandler',
     WINDOW_LIST: 'windowlist'

--- a/js/ui/extension.js
+++ b/js/ui/extension.js
@@ -104,6 +104,7 @@ var Type = {
     }),
     APPLET: _createExtensionType("Applet", "applets", AppletManager, {
         roles: {
+            notifications: null,
             windowlist: null,
             windowattentionhandler: null,
             panellauncher: null,
@@ -112,6 +113,7 @@ var Type = {
     }),
     DESKLET: _createExtensionType("Desklet", "desklets", DeskletManager, {
         roles: {
+            notifications: null,
             windowlist: null,
             windowattentionhandler: null
         }


### PR DESCRIPTION
... https://github.com/linuxmint/cinnamon/commit/1c995f606972dddd339d6dfbc13dc908bdf757cb

While the "notifications" role is no longer used in cinnamon 6.6, removing the named role in `extension.js` prevents 3rd party applets from loading if the role is listed in the 3rd party's metadata.json file. While the 3rd party applet can be versioned to adapt to the changes in cinnamon 6.6, the metadata.json file cannot. Therefore the applet should not be prevented from loading even though the "notifications" role is no longer used in cinnamon.

Fixes https://github.com/linuxmint/cinnamon-spices-applets/issues/8114