### PR TITLE
Fixed menu editor freezing on right-clicking categories on the left menu

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-menu-editor/cme/MainWindow.py
+++ b/files/usr/share/cinnamon/cinnamon-menu-editor/cme/MainWindow.py
@@ -507,8 +507,7 @@ class MainWindow(object):
             event_time = 0
             menu_tree.grab_focus()
             menu_tree.set_cursor(path, menu_tree.get_columns()[0], 0)
-        popup = self.tree.get_object('edit_menu')
-        popup.popup(None, None, None, None, button, event_time)
+        self.popup_menu.popup(None, None, None, None, button, event_time)
         #without this shift-f10 won't work
         return True
 


### PR DESCRIPTION
Hello, 

This fixes https://github.com/linuxmint/mint22.3-beta/issues/42

It seems that after deleting the `edit_menu` .ui element the code was only partially updated and the reference to the old `edit_menu` was left in the `on_menu_tree_popup_menu()` function, which executes on (right)-clicking the category buttons.