### PR TITLE
Hide icon themes that marked as 'Hidden'

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
@@ -148,6 +148,8 @@ class Module:
             if os.path.exists(path):
                 try:
                     for line in list(open(path)):
+                        if line.startswith("Hidden=true"):
+                            break
                         if line.startswith("Directories="):
                             valid.append(directory)
                             break


### PR DESCRIPTION
The icon theme specification provides this property for themes that are not supposed to be visible to the user.

Reference: https://specifications.freedesktop.org/icon-theme/latest/#file_formats