### PR TITLE
menu: Fix input method key event handling

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1718,6 +1718,11 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
             return Clutter.EVENT_STOP;
         }
 
+        if (this.searchEntryText.has_preedit()) {
+            // There is an uncommitted text in the search box, let the input method to handle this.
+            return Clutter.EVENT_PROPAGATE;
+        }
+
         let ctrlKey = modifierState & Clutter.ModifierType.CONTROL_MASK;
 
         // If a context menu is open, hijack keyboard navigation and concentrate on the context menu.


### PR DESCRIPTION
When typing something into the search box, key events should be propagated to the input method.

Fixes: linuxmint/mint22.3-beta#60