### PR TITLE
placesManager.js: Add mounts with no associated volume.

### DIFF
--- a/js/ui/placesManager.js
+++ b/js/ui/placesManager.js
@@ -465,6 +465,15 @@ PlacesManager.prototype = {
             }
         }
 
+        /* add mounts that have no volume (/etc/mtab mounts, ftp, sftp,...) */
+        let mounts = this._volumeMonitor.get_mounts();
+        for(let i = 0; i < mounts.length; i++) {
+            if(mounts[i].get_volume())
+                continue;
+
+            this._addMount(mounts[i]);
+        }
+
         /* We emit two signals, one for a generic 'all places' update
          * and the other for one specific to mounts. We do this because
          * clients like PlaceDisplay may only care about places in general


### PR DESCRIPTION
This reverts part of af72ce04265. While it likely doesn't affect anything in core Cinnamon (changing what isRemovable() checks would probably keep these mounts hidden anyhow), other applets might choose to display these.

See linuxmint/nemo#3670.

Ref:
linuxmint/mint22.3-beta#67.