### PR TITLE
cs_windows.py: Add Traditional button layout option

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_windows.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_windows.py
@@ -45,6 +45,7 @@ class Module:
             button_options.append([":close", _("Gnome")])
             button_options.append(["close:", _("Gnome Left")])
             button_options.append(["close:minimize,maximize", _("Classic Mac")])
+            button_options.append(["menu:minimize,maximize,close", _("Traditional")])
 
             widget = GSettingsComboBox(_("Buttons layout"), "org.cinnamon.desktop.wm.preferences", "button-layout", button_options, size_group=size_group)
             settings.add_row(widget)


### PR DESCRIPTION
This is equal to the "Right" button layout plus a menu button on the left side.