### PR TITLE
Menu applet: fix menu sidebar radius

### DIFF
--- a/data/theme/cinnamon-sass/_common.scss
+++ b/data/theme/cinnamon-sass/_common.scss
@@ -1,6 +1,7 @@
 $base_padding: 6px;
 $base_margin: 4px;
 $base_border_radius: 8px;
+$larger_border_radius: $base_border_radius * 2;
 
 $modal_dialog_radius: 18px;
 

--- a/data/theme/cinnamon-sass/widgets/_alttab.scss
+++ b/data/theme/cinnamon-sass/widgets/_alttab.scss
@@ -6,7 +6,7 @@
 .switcher-list {
   background-color: $panel_bg;
   border: 1px solid $borders_color;
-  border-radius: $base_border_radius * 2;
+  border-radius: $larger_border_radius;
   box-shadow: 0 0 6px 0 $shadow_color;
   padding: $base_padding * 3;
 
@@ -52,7 +52,7 @@
     background-gradient-direction: horizontal;
     background-gradient-start: transparentize($panel_bg, 0.0);
     background-gradient-end: transparentize($panel_bg, 1.0);
-    border-radius: $base_border_radius * 2;
+    border-radius: $larger_border_radius;
     border-radius-topright: 0px;
     border-radius-bottomright: 0px;
     width: 60px;
@@ -62,7 +62,7 @@
     background-gradient-direction: horizontal;
     background-gradient-start: transparentize($panel_bg, 1.0);
     background-gradient-end: transparentize($panel_bg, 0.0);
-    border-radius: $base_border_radius * 2;
+    border-radius: $larger_border_radius;
     border-radius-topleft: 0px;
     border-radius-bottomleft: 0px;
     width: 60px;

--- a/data/theme/cinnamon-sass/widgets/_deprecated.scss
+++ b/data/theme/cinnamon-sass/widgets/_deprecated.scss
@@ -1,7 +1,6 @@
 // OLD MENU - Used by some of the menu spices
 
 $menu_outer_padding: 9px;
-$menu_outer_border_radius: $base_border_radius * 1.25;
 
 %start_menu_button {
   padding: $base_padding;

--- a/data/theme/cinnamon-sass/widgets/_menus.scss
+++ b/data/theme/cinnamon-sass/widgets/_menus.scss
@@ -11,7 +11,7 @@ $menuitem_border_radius: $base_border_radius * 1;
 .popup-menu-content {
   padding: $base_padding;
   background-color: $bg_color;
-  border-radius: $base_border_radius * 2;
+  border-radius: $larger_border_radius;
   border: 1px solid $borders_color;
   box-shadow: 0 0 6px $shadow_color;
 }
@@ -102,7 +102,7 @@ $menuitem_border_radius: $base_border_radius * 1;
 .popup-combo-menu {
   padding: $base_padding;
   background-color: $bg_color;
-  border-radius: $base_border_radius * 1.25;
+  border-radius: $larger_border_radius;
   border: 1px solid $borders_color;
   box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.2);
 }

--- a/data/theme/cinnamon-sass/widgets/_startmenu.scss
+++ b/data/theme/cinnamon-sass/widgets/_startmenu.scss
@@ -23,7 +23,6 @@
 $appmenu_small_padding: 5px;
 $appmenu_padding: 10px;
 $appmenu_large_padding: 15px;
-$appmenu_radius: $base_border_radius * 1.25;
 
 %appmenu_button {
   padding: $base_padding;
@@ -73,7 +72,7 @@ $appmenu_radius: $base_border_radius * 1.25;
   &-sidebar {
     padding: $appmenu_padding 0px;
     background-color: $base_color;
-    border-radius: $appmenu_radius 0 0 $appmenu_radius;
+    border-radius: $larger_border_radius 0 0 $larger_border_radius;
     border-right-width: 1px;
     border-color: $borders_color;
 


### PR DESCRIPTION
$appmenu_radius (used for sidebar only) should match popup-menu-content radius ($base_border_radius * 2) so that left and right sides of menu applet are the same.

Fixes https://github.com/linuxmint/mint22.3-beta/issues/80

@JosephMcc 