### PR TITLE
Fix OSD fading out when updated during hide animation

### DIFF
--- a/js/ui/osdWindow.js
+++ b/js/ui/osdWindow.js
@@ -110,6 +110,8 @@ class OsdWindow extends Clutter.Actor {
         if (!this._icon.gicon)
             return;
 
+        this.remove_transition('opacity');
+
         if (!this.visible) {
             Meta.disable_unredirect_for_display(global.display);
             super.show();
@@ -121,6 +123,8 @@ class OsdWindow extends Clutter.Actor {
                 duration: FADE_TIME,
                 mode: Clutter.AnimationMode.EASE_OUT_QUAD,
             });
+        } else {
+            this.opacity = 255;
         }
 
         if (this._hideTimeoutId)


### PR DESCRIPTION
Fixes the issue of pressing a key during osd fade out and the content updating but the window still disappearing, removed transition and set opacity to 255 at each show() call to handle that.

you can test with a shell script to press caps lock every 1.5 seconds.