### PR TITLE
Menu editor fixes

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-menu-editor/cme/MainWindow.py
+++ b/files/usr/share/cinnamon/cinnamon-menu-editor/cme/MainWindow.py
@@ -77,6 +77,7 @@ class MainWindow(object):
         self.popup_menu.show_all()
 
         self.cut_copy_buffer = None
+        self.item_to_cut = None
         self.file_id = None
         self.last_tree = None
         self.main_window = self.tree.get_object('mainwindow')
@@ -352,7 +353,11 @@ class MainWindow(object):
             return
         if not isinstance(item, CMenu.TreeEntry):
             return
-        (self.cut_copy_buffer, self.file_id) = self.editor.cutItem(item)
+        (self.cut_copy_buffer, self.file_id) = self.editor.copyItem(item)
+
+        # Update focus to menu tree view, which will activate paste button and deselect copied item
+        self.on_menu_tree_cursor_changed(self.tree.get_object('menu_tree'))
+        self.item_to_cut = item
 
     def on_edit_copy_activate(self, menu):
         item_tree = self.tree.get_object('item_tree')
@@ -366,6 +371,7 @@ class MainWindow(object):
 
         # Update focus to menu tree view, which will activate paste button and deselect copied item
         self.on_menu_tree_cursor_changed(self.tree.get_object('menu_tree'))
+        self.item_to_cut = None
 
     def on_edit_paste_activate(self, menu):
         item_tree = self.tree.get_object('item_tree')
@@ -380,6 +386,10 @@ class MainWindow(object):
             return
         if self.cut_copy_buffer is not None:
             success = self.editor.pasteItem(self.cut_copy_buffer, item, self.file_id)
+
+            if success and self.item_to_cut:
+                self.editor.deleteItem(self.item_to_cut)
+
             if success:
                 self.cut_copy_buffer = None
                 self.file_id = None

--- a/files/usr/share/cinnamon/cinnamon-menu-editor/cme/MenuEditor.py
+++ b/files/usr/share/cinnamon/cinnamon-menu-editor/cme/MenuEditor.py
@@ -251,15 +251,12 @@ class MenuEditor(object):
         copy_buffer.load_from_file(file_path, util.KEY_FILE_FLAGS)
         return copy_buffer, None
 
-    def cutItem(self, item):
-        copy_buffer, file_id = self.copyItem(item)
-        file_id = self.deleteItem(item)
-        return copy_buffer, file_id
-
     def pasteItem(self, cut_copy_buffer, menu, file_id = None):
         try:
             path = self.getPath(menu)
-            util.fillKeyFile(cut_copy_buffer, dict(Hidden=False, NoDisplay=False))
+            # Paste item only into target category
+            kwargs = dict(Hidden=False, NoDisplay=False, Categories=";".join(path)+";")
+            util.fillKeyFile(cut_copy_buffer, kwargs)
             name = util.getNameFromKeyFile(cut_copy_buffer)
             if file_id is None:
                 file_id = util.getUniqueFileId(name.replace(os.sep, '-'), '.desktop')


### PR DESCRIPTION
Hello, this PR fixes some issues (see bottom) related to cutting/pasting/deleting items in the `cinnamon-menu-editor`.


Sorry for the very long description, but it took me a long time to (sort of) understand this application, so I think I should provide a detailed description so that more people can easier understand/review these changes. 

### Changelog and explanation

#### Commit 4b0f5cb9e5f9c7aa1cad2669275f7e52e54d5464:

This commit fixes bad UX when copying items. Whenever user clicks on the "Copy" button no visual changes occur, despite the fact that the application places the item into a buffer. This might lead the user to think that copying "doesn't work". Pasting will only activate when user selects a category from the left menu. 

To fix this I've added one line to the `on_edit_copy_activate()` function. This line simulates user reopening the category that is currently open -> the one where copying occured. This will cause the currently selected items to deselect and will activate the "Paste" button, which will provide necessary UI feedback to the user. This issue was mention in the https://github.com/linuxmint/cinnamon/issues/9293#issuecomment-3067325479


#### Commit dbc7fe6fc2c7249e65b7589ec4346509453db1d7

This commit fixes two cutting/pasting bugs. First of all the current "cut" functionality is not really a cut. It just copies an item and immediately removes it, which is not how cutting should work. Items shouldn't be deleted until they're pasted somewhere. This commit fixes this through the introduction of a new variable `self.item_to_cut`, which indicates that cutting is (not) in progress.

This commit also fixed issues with duplicate cutting, by that I mean the incorrect behavior that occurs whenever cutting non-user-made items, which causes the same item to appear where its supposed to be pasted (correct), but also in its original category (incorrect duplicate). This is only worsened by fact that deleting either of these duplicated causes both to be deleted. This is caused by the fact that the pasted item is XML `<Include>`ed into the target category, but it is also displayed in the original one, because of the `Categories` `.desktop` property.

My fix https://github.com/linuxmint/cinnamon/commit/dbc7fe6fc2c7249e65b7589ec4346509453db1d7#diff-c98f55b82ed859a581afcbd203640e9e8dd29811a0cfd3db9d133c99f1becbdcR257 to this works by altering how items are pasted. Instead of just pasting the item I think it's also required to alter its `Categories` attribute in the `.desktop` file. My code basically just overrides the default `Categories` (which cause the duplication), with the category name of where the item was pasted into. 

For example, the calculator app is by default in `Categories=GNOME;GTK;Utility;Calculator;`, after the paste into "Graphics" my code would transform `.desktop` of the pasted item to `Categories=Graphics;`. 

Unfortunately recent changes from https://github.com/linuxmint/cinnamon/commit/a692d520ce79a536e088e7aaa1aefce63d83c94b#diff-04e819d30a3cd74ec4ed5faf25823f7121c8043dc21dbe9ecfa9231b2e7e19e7R54 are unexpectedly causing more issues here, because this also makes the editor add an additional (unneeded) localized property for ex. `Categories[en_US]=Graphics;`. While this is incorrect behavior I don't think it would cause any issues for now. I figured I should leave this alone and let maintainers make a decision, because I'm sure you know better than me. 


### Issues which this PR is based on
In my opinion this PR closes
* https://github.com/linuxmint/cinnamon/issues/10581
* https://github.com/linuxmint/cinnamon/issues/10140
* https://github.com/linuxmint/cinnamon/issues/10139