### PR TITLE
Fix SyntaxWarning in GtkSettingsEditor._get_keyfile

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/CinnamonGtkSettings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/CinnamonGtkSettings.py
@@ -40,7 +40,7 @@ class GtkSettingsEditor:
             keyfile.load_from_file(self._path, 0)
         except:
             pass
-        finally:
+
             return keyfile
 
     def get_boolean(self, key):


### PR DESCRIPTION
Move return statement out of finally block to eliminate SyntaxWarning. 
The finally block served no cleanup purpose and has been removed.