### PR TITLE
menu applet: remove 'force show panel' config toggle

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1247,7 +1247,6 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         this._pathCompleter.set_dirs_only(false);
         this.contextMenu = null;
         this.lastSelectedCategory = null;
-        this.settings.bind("force-show-panel", "forceShowPanel");
 
         this.orderDirty = false;
 
@@ -1280,9 +1279,6 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
     _updateKeybinding() {
         Main.keybindingManager.addXletHotKey(this, "overlay-key", this.overlayKey, () => {
             if (!Main.overview.visible && !Main.expo.visible) {
-                if (this.forceShowPanel && !this.isOpen) {
-                    this.panel.peekPanel();
-                }
                 this.menu.toggle_with_options(this.enableAnimation);
             }
         });

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/settings-schema.json
@@ -25,7 +25,7 @@
         "behavior-panel" : {
             "type" : "section",
             "title" : "Panel",
-            "keys" : ["overlay-key", "activate-on-hover", "hover-delay", "force-show-panel", "enable-animation"]
+            "keys" : ["overlay-key", "activate-on-hover", "hover-delay", "enable-animation"]
         },
         "appearance-menu" : {
             "type" : "section",
@@ -216,12 +216,6 @@
     "type" : "switch",
     "default" : true,
     "description": "Enable autoscrolling in application list"
- },
- "force-show-panel" : {
-    "type" : "switch",
-    "default" : true,
-    "description": "Force the panel to be visible when opening the menu",
-    "tooltip": "Opening the menu will also show the main panel (which may be auto-hidden)."
  },
 "activate-on-hover" : {
     "type" : "switch",


### PR DESCRIPTION
Ability to keep the panel hidden was removed in https://github.com/linuxmint/cinnamon/pull/11779/changes so the toggle is now redundant.

fixes: https://github.com/linuxmint/cinnamon/issues/13367 and https://github.com/linuxmint/cinnamon/issues/12536