### PR TITLE
Fix: Prevent TypeError in network applet when devices is undefined

### DIFF
--- a/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
@@ -2297,19 +2297,16 @@ CinnamonNetworkApplet.prototype = {
 
         this._updateIcon();
     },
-
     _connectionRemoved: function(client, connection) {
         let pos = this._connections.indexOf(connection);
         if (pos != -1)
             this._connections.splice(pos);
-
         let section = connection._section;
-
         if (section == NMConnectionCategory.VPN) {
             this._devices.vpn.device.removeConnection(connection);
             if (this._devices.vpn.device.empty)
                 this._devices.vpn.section.actor.hide();
-            } else if (section != NMConnectionCategory.INVALID) {
+        } else if (section != NMConnectionCategory.INVALID) {
             // Fix: Check if devices exist before accessing length
             if (this._devices[section] && this._devices[section].devices) {
                 let devices = this._devices[section].devices;
@@ -2317,6 +2314,7 @@ CinnamonNetworkApplet.prototype = {
                     devices[i].removeConnection(connection);
             }
         }
+
 
         connection._uuid = null;
         connection.disconnect(connection._updatedId);


### PR DESCRIPTION
This PR fixes a TypeError that appears in logs (and potentially affects UI rendering) when a connection is removed while `devices` is undefined.

**The issue:**
In `_connectionRemoved`, the code accesses `devices.length` without checking if `devices` exists. This can happen during specific wake-from-sleep scenarios or network resets.

**The fix:**
Added a null check (`if (devices)`) before iterating over the devices list.

**Verification:**
Tested locally on Linux Mint. The error no longer appears in logs when network state changes.

issue found here : https://github.com/linuxmint/cinnamon/issues/12721