### PR TITLE
cinnamon-window-tracker.c (wayland): Connect to MetaWindow::shown

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -947,10 +947,6 @@ class AppGroup {
         if (metaWindow) {
             this.signals.connect(metaWindow, 'notify::title', (...args) => this.onWindowTitleChanged(...args));
             this.signals.connect(metaWindow, 'notify::appears-focused', (...args) => this.onFocusWindowChange(...args));
-            this.signals.connect(metaWindow, 'notify::gtk-application-id', (w) => this.onAppChange(w));
-            this.signals.connect(metaWindow, 'notify::wm-class', (w) => this.onAppChange(w));
-            this.signals.connect(metaWindow, 'unmanaged', (w) => this.onAppChange(w));
-
             this.signals.connect(metaWindow, 'notify::icon', (w) => this.setIcon(w));
 
             if (metaWindow.progress !== undefined) {
@@ -992,8 +988,6 @@ class AppGroup {
 
         this.signals.disconnect('notify::title', metaWindow);
         this.signals.disconnect('notify::appears-focused', metaWindow);
-        this.signals.disconnect('notify::gtk-application-id', metaWindow);
-        this.signals.disconnect('notify::wm-class', metaWindow);
 
         this.groupState.metaWindows.splice(refWindow, 1);
 
@@ -1017,13 +1011,6 @@ class AppGroup {
                 cb(this.groupState.appId, this.groupState.isFavoriteApp);
             }
         }
-    }
-
-    onAppChange(metaWindow) {
-        if (!this.workspaceState) return;
-
-        this.workspaceState.trigger('windowRemoved', metaWindow);
-        this.workspaceState.trigger('windowAdded', metaWindow);
     }
 
     onWindowTitleChanged(metaWindow, refresh) {

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -293,6 +293,7 @@ class GroupedWindowListApplet extends Applet.Applet {
         this.signals.connect(global.settings, 'changed::panel-edit-mode', (...args) => this.on_panel_edit_mode_changed(...args));
         this.signals.connect(Main.themeManager, 'theme-set', (...args) => this.refreshCurrentWorkspace(...args));
         this.signals.connect(Main.messageTray, 'notify-applet-update', this._onNotificationReceived.bind(this));
+        this.signals.connect(this.tracker, 'window-app-changed', (...args) => this._onWindowAppChanged(...args));
     }
 
     bindSettings() {
@@ -1019,8 +1020,18 @@ class GroupedWindowListApplet extends Applet.Applet {
             currentWorkspace.windowRemoved(currentWorkspace.metaWorkspace, metaWindow);
             return;
         }
-        
+
         currentWorkspace.windowAdded(currentWorkspace.metaWorkspace, metaWindow);
+    }
+
+    _onWindowAppChanged(tracker, metaWindow) {
+        if (!metaWindow) return;
+
+        this.workspaces.forEach(workspace => {
+            if (!workspace) return;
+            workspace.windowRemoved(workspace.metaWorkspace, metaWindow);
+            workspace.windowAdded(workspace.metaWorkspace, metaWindow);
+        });
     }
 
     onUIScaleChange() {

--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -816,11 +816,18 @@ class AppMenuButton {
     setIcon() {
         this.icon_size = this._applet.icon_size;
 
-        let icon = this.app ?
-            this.app.create_icon_texture_for_window(this.icon_size, this.metaWindow) :
-            new St.Icon({ icon_name: 'application-default-icon',
+        let icon;
+        if (this.app) {
+            if (this.app.is_window_backed()) {
+                icon = this.app.create_icon_texture_for_window(this.icon_size, this.metaWindow);
+            } else {
+                icon = this.app.create_icon_texture(this.icon_size);
+            }
+        } else {
+            icon = new St.Icon({ icon_name: 'application-default-icon',
                 icon_type: St.IconType.FULLCOLOR,
                 icon_size: this.icon_size });
+        }
 
         let old_child = this._iconBox.get_child();
         this._iconBox.set_child(icon);
@@ -1240,7 +1247,14 @@ class CinnamonWindowListApplet extends Applet.Applet {
     }
 
     _onWindowAppChanged(tracker, metaWindow) {
-        this._refreshItemByMetaWindow(metaWindow);
+        let window = this._windows.find(win => (win.metaWindow == metaWindow));
+
+        if (window) {
+            window.app = window._getApp();
+            window.appId = window.app ? window.app.get_id() : null;
+            window.setIcon();
+            window.setDisplayTitle();
+        }
     }
 
     _onWindowSkipTaskbarChanged(display, metaWindow) {


### PR DESCRIPTION
Wayland windows don't necessary have all app-association info attached at creation (x11 windows do since they're dispatched from the server), and the window-tracker won't be able to create a CinnamonApp association immediately. The most obvious sign of this currently is the window-list applet not consistently displaying icons, particularly when a window first appears.

- Connect to the 'shown' signal on wayland client windows that fail other lookups and get a dummy/window-backed CinnamonApp initially, and update the app association when it is received.
- Update the window-list applet to re-check its own app association when the window-tracker signals.
- Remove redundant signals from gwl, and connect to the tracker's window-app-changed signal instead.


ref: https://github.com/linuxmint/wayland/issues/154