### PR TITLE
UPD: Clarify bookmarks toggle description in menu applet

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/settings-schema.json
@@ -154,7 +154,8 @@
  "show-bookmarks" : {
     "type" : "switch",
     "default" : true,
-    "description" : "Other bookmarks"
+    "description" : "Custom folders and bookmarks",
+    "tooltip" : "Show custom folders pinned in Nemo (including Templates, if pinned)"
  },
  "system-position" : {
       "type": "combobox",


### PR DESCRIPTION
Changed "Other bookmarks" to "Custom folders and bookmarks" with tooltip explaining it includes all user-pinned folders from Nemo (including Templates, if pinned).

This makes it clearer that the toggle controls ALL custom bookmarks, not just "other" ones, addressing user confusion (including me).

Related: linuxmint/cinnamon#13414