### PR TITLE
FIX: Add overflow hidden to user avatar to prevent clipping issues

### DIFF
--- a/js/ui/userWidget.js
+++ b/js/ui/userWidget.js
@@ -124,7 +124,8 @@ class Avatar extends St.Bin {
             this.add_style_class_name('user-avatar');
             this.style = `
                 background-image: url("${iconFile}");
-                background-size: cover;`;
+                background-size: cover;
+                overflow: hidden;`;
         } else {
             this.style = null;
             this.child = new St.Icon({


### PR DESCRIPTION
Prevents portrait images from leaking outside the circular avatar bounds.

Fixes: linuxmint/cinnamon#13422