### PR TITLE
Fix: Panel shifts when clock seconds change (#13336)

### DIFF
--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
@@ -22,6 +22,10 @@ class CinnamonCalendarApplet extends Applet.TextApplet {
     constructor(orientation, panel_height, instance_id) {
         super(orientation, panel_height, instance_id);
 
+        // Use tabular figures to prevent panel shifting when clock updates (issue #13336)
+        // This ensures all digits have equal width (e.g., "1" same width as "0")
+        this._applet_label.set_style('font-feature-settings: "tnum"');
+
         this.setAllowedLayout(Applet.AllowedLayout.BOTH);
 
         try {


### PR DESCRIPTION
Use tabular figures (font-feature-settings: "tnum") for the clock label to ensure all digits have equal width. This prevents the panel from shifting when the time changes (e.g., from "9:59" to "10:00" or when seconds update). I think its 

Fixes linuxmint/cinnamon#13336