### PR TITLE
placesManager.js: Go back to having isRemovable() call can_unmount().

### DIFF
--- a/js/ui/placesManager.js
+++ b/js/ui/placesManager.js
@@ -105,7 +105,7 @@ PlaceDeviceInfo.prototype = {
     },
 
     isRemovable: function() {
-        return this._mount.can_eject();
+        return this._mount.can_unmount();
     },
 
     remove: function() {


### PR DESCRIPTION
There isn't enough consistency between various removable device types and filesystems to be able to rely on can_eject() here.

ref:
https://github.com/linuxmint/cinnamon/issues/13370