### PR TITLE
dnd.js: Fix window freeze on rapid taskbar clicks

### DIFF
--- a/js/ui/dnd.js
+++ b/js/ui/dnd.js
@@ -139,6 +139,12 @@ var _Draggable = new Lang.Class({
         if (Tweener.getTweenCount(actor))
             return false;
 
+        // Clean up any existing grab before starting a new one (fixes #13462)
+        // This prevents pointer grabs from accumulating during rapid clicks
+        if (this._onEventId) {
+            this._ungrabActor(event);
+        }
+
         this._buttonDown = true;
         this._grabActor(event);
 


### PR DESCRIPTION
Fixes #13462

## Problem

When users click rapidly on taskbar icons, windows can become unresponsive - clicks inside the window content have no effect until the user clicks on the title bar or maximizes/minimizes the window.

## Root Cause

The issue is in `js/ui/dnd.js` in the `_onButtonPress` handler. When a button press event occurs, the code calls `_grabActor()` to grab the pointer for potential drag operations. However, if another click happens before the previous grab is properly released (which can happen during rapid clicking), the grabs accumulate and the pointer gets stuck in a grabbed state.

## Solution

Before starting a new grab in `_onButtonPress`, check if there's already an existing grab (`this._onEventId` is set) and clean it up first by calling `_ungrabActor()`. This ensures only one grab is active at a time and prevents the accumulation that causes the freeze.

## Changes

- Added cleanup logic in `_onButtonPress` to release any existing grab before creating a new one
- This is a minimal, targeted fix that doesn't change the overall drag-and-drop behavior

## Testing

- Rapid clicking on taskbar icons no longer causes window freezes
- Normal drag-and-drop operations still work correctly
- Window switching via taskbar clicks works as expected