### PR TITLE
FIX: Prevent crash when window icon texture is null (#13461)

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -293,7 +293,9 @@ class AppGroup {
             } else {
                 icon = this.groupState.app.create_icon_texture(this.iconSize);
             }
-        } else {
+        }
+
+        if (!icon) {
             icon = new St.Icon({
                 icon_name: 'application-default-icon',
                 icon_type: St.IconType.FULLCOLOR,

--- a/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/window-list@cinnamon.org/applet.js
@@ -818,9 +818,13 @@ class AppMenuButton {
 
         let icon = this.app ?
             this.app.create_icon_texture_for_window(this.icon_size, this.metaWindow) :
-            new St.Icon({ icon_name: 'application-default-icon',
+            null;
+
+        if (!icon) {
+            icon = new St.Icon({ icon_name: 'application-default-icon',
                 icon_type: St.IconType.FULLCOLOR,
                 icon_size: this.icon_size });
+        }
 
         let old_child = this._iconBox.get_child();
         this._iconBox.set_child(icon);


### PR DESCRIPTION
Fixes #13461

Cinnamon crashes when using WebApps (e.g. WhatsApp installed from Brave Browser) after the app has been running for a while.

When muffin emits a notify::icon signal during idle_update_icon(), the window-list applets call create_icon_texture_for_window() which can return null in race conditions (e.g., when a WebApp window is being destroyed or its icon is unavailable).

Previously, this null value was passed directly to set_child(), causing a SIGSEGV in _clutter_actor_queue_only_relayout(self=0x0).

This fix adds a null check after create_icon_texture_for_window() and falls back to a default icon, preventing the crash. 

Tried it with that fix - no crash detected.

Affected applets:

[window-list@cinnamon.org](mailto:window-list@cinnamon.org)
[grouped-window-list@cinnamon.org](mailto:grouped-window-list@cinnamon.org)