### PR TITLE
FIX: Fix clock rendering artifacts on time update

### DIFF
--- a/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/calendar@cinnamon.org/applet.js
@@ -274,6 +274,8 @@ class CinnamonCalendarApplet extends Applet.TextApplet {
         }
 
         this.set_applet_label(label_string);
+        // Force relayout to fix rendering artifacts when clock updates (issue #13441)
+        this.actor.queue_relayout();
 
         let dateFormattedTooltip = this.clock.get_clock_for_format(DATE_FORMAT_FULL).capitalize();
         if (this.use_custom_format) {


### PR DESCRIPTION
Forces actor relayout after clock label update to prevent rendering artifacts 
(ghost pixels from previous digits remaining on screen).

**Tests**
- Tested in VM with Linux Mint 22.3 Cinnamon 6.6.5
- Observed clock transitions before/after fix
- Fix successfully prevents visual artifacts during time updates


The fix calls `this.actor.queue_relayout()` after `set_applet_label()` 
to ensure complete redraw of the clock actor.

Fixes #13441