### PR TITLE
NEW: menu: Add option to hide categories icons

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -838,32 +838,34 @@ class CategoryButton extends SimpleMenuItem {
             categoryId: categoryId,
         });
 
-        let size = applet.categoryIconSize;
-        if (applet.symbolicCategoryIcons) {
-            symbolic = true;
-            if (typeof icon !== 'string')
-                if (icon?.get_names)
-                    icon = icon.get_names()[0];
+        if (applet.showCategoryIcons) {
+            let size = applet.categoryIconSize;
+            if (applet.symbolicCategoryIcons) {
+                symbolic = true;
+                if (typeof icon !== 'string')
+                    if (icon?.get_names)
+                        icon = icon.get_names()[0];
+                    else
+                        icon = "";
+                if (icon.startsWith("applications-") || icon === "folder-recent")
+                    icon = "xsi-" + icon;
+                else if (icon == "xapp-user-favorites")
+                    icon = "xsi-user-favorites-symbolic";
+                else if (icon == "preferences-system")
+                    icon = "xsi-applications-administration";
+                else if (icon == "preferences-desktop")
+                    icon = "xsi-applications-preferences";
+                else if (icon == "wine")
+                    icon = "xsi-applications-wine";
                 else
-                    icon = "";
-            if (icon.startsWith("applications-") || icon === "folder-recent")
-                icon = "xsi-" + icon;
-            else if (icon == "xapp-user-favorites")
-                icon = "xsi-user-favorites-symbolic";
-            else if (icon == "preferences-system")
-                icon = "xsi-applications-administration";
-            else if (icon == "preferences-desktop")
-                icon = "xsi-applications-preferences";
-            else if (icon == "wine")
-                icon = "xsi-applications-wine";
-            else
-                icon = "xsi-applications-other";
-        }
+                    icon = "xsi-applications-other";
+            }
 
-        if (typeof icon === 'string')
-            this.addIcon(size, icon, null, symbolic);
-        else if (icon)
-            this.addIcon(size, null, icon, symbolic);
+            if (typeof icon === 'string')
+                this.addIcon(size, icon, null, symbolic);
+            else if (icon)
+                this.addIcon(size, null, icon, symbolic);
+        }
 
         this.addLabel(this.name, 'appmenu-category-button-label');
 
@@ -1175,6 +1177,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         this.settings.bind("menu-icon-size", "menuIconSize", this._updateIconAndLabel);
         this.settings.bind("menu-label", "menuLabel", this._updateIconAndLabel);
         this.settings.bind("overlay-key", "overlayKey", this._updateKeybinding);
+        this.settings.bind("show-category-icons", "showCategoryIcons", () => this.queueRefresh(REFRESH_ALL_MASK));
         this.settings.bind("symbolic-category-icons", "symbolicCategoryIcons", () => this.queueRefresh(REFRESH_ALL_MASK));
         this.settings.bind("category-icon-size", "categoryIconSize", () => this.queueRefresh(REFRESH_ALL_MASK));
         this.settings.bind("category-hover", "categoryHover", this._updateCategoryHover);

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/settings-schema.json
@@ -30,7 +30,7 @@
         "appearance-menu" : {
             "type" : "section",
             "title" : "Options",
-            "keys" : ["search-position", "system-position", "show-description", "symbolic-category-icons", "category-icon-size",
+            "keys" : ["search-position", "system-position", "show-description", "show-category-icons", "symbolic-category-icons", "category-icon-size",
                       "application-icon-size", "sidebar-icon-size", "sidebar-max-width",
                       "reset-menu-size-button"]
         },
@@ -83,10 +83,16 @@
     "description" : "Text",
     "dependency" : "menu-custom"
  },
+ "show-category-icons" : {
+    "type" : "switch",
+    "default" : true,
+    "description" : "Show categories icons"
+ },
  "symbolic-category-icons" : {
     "type" : "switch",
     "default" : true,
-    "description" : "Use symbolic icons for categories"
+    "description" : "Use symbolic icons for categories",
+    "dependency" : "show-category-icons"
  },
  "category-icon-size" : {
     "type": "spinbutton",
@@ -95,7 +101,8 @@
     "max" : 48,
     "step" : 1,
     "units" : "px",
-    "description" : "Categories icon size"
+    "description" : "Categories icon size",
+    "dependency" : "show-category-icons"
  },
  "application-icon-size" : {
     "type": "spinbutton",


### PR DESCRIPTION
Fixes #13368

The old Cinnamon menu had an option to completely hide category icons, but the new menu only allows switching between symbolic and colorful icons. This restores the missing feature.

Added a new "Show categories icons" toggle in the menu settings. When disabled, category buttons display only text without any icons. The existing "Use symbolic icons" and "Categories icon size" options become inactive (grayed out) when icons are hidden.

This gives users the option for a cleaner, more minimalist menu appearance.