### PR TITLE
FIX: Add default home folders to search results (#13402)

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -712,6 +712,35 @@ class SearchProviderResultButton extends SimpleMenuItem {
     }
 }
 
+class PlaceSearchResultButton extends SimpleMenuItem {
+    constructor(applet, place) {
+        super(applet, {
+            name: place.name,
+            type: 'search-result',
+            styleClass: 'appmenu-application-button',
+            place: place,
+        });
+
+        this.icon = place.iconFactory(applet.applicationIconSize);
+        if (this.icon)
+            this.addActor(this.icon);
+        else
+            this.addIcon(applet.applicationIconSize, 'folder');
+
+        this.addLabel(this.name, 'appmenu-application-button-label');
+    }
+
+    activate() {
+        this.place.launch();
+        this.applet.menu.close();
+    }
+
+    destroy() {
+        delete this.place;
+        super.destroy();
+    }
+}
+
 class PlaceButton extends SimpleMenuItem {
     constructor(applet, place) {
         let selectedAppId = place.idDecoded.substr(place.idDecoded.indexOf(':') + 1);
@@ -1217,6 +1246,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         this._applicationsButtons = [];
         this._favoriteAppButtons = [];
         this._placesButtons = [];
+        this._searchablePlaces = [];
         this._transientButtons = [];
         this.recentButton = null;
         this._recentButtons = [];
@@ -2129,50 +2159,61 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
 
         //Load places again
         this._placesButtons = [];
+        // Store all default places for search (independent of show* settings)
+        this._searchablePlaces = [];
 
         let places = [...Main.placesManager.getDefaultPlaces(), ...Main.placesManager.getBookmarks()];
         for (let place of places) {
             let path = place.idDecoded.replace("bookmark:file://", "")
+            let isDefaultPlace = true;
+            let showInSidebar = true;
+
             switch (path) {
                 case "special:home":
-                    if (!this.showHome)
-                        continue;
+                    showInSidebar = this.showHome;
                     break;
                 case "special:desktop":
-                     if (!this.showDesktop)
-                        continue;
+                    showInSidebar = this.showDesktop;
                     break;
                 case GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_DOWNLOAD):
-                    if (!this.showDownloads)
-                        continue;
+                    showInSidebar = this.showDownloads;
                     break;
                 case GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_DOCUMENTS):
-                    if (!this.showDocuments)
-                        continue;
+                    showInSidebar = this.showDocuments;
                     break;
                 case GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_MUSIC):
-                    if (!this.showMusic)
-                        continue;
+                    showInSidebar = this.showMusic;
                     break;
                 case GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_PICTURES):
-                    if (!this.showPictures)
-                        continue;
+                    showInSidebar = this.showPictures;
                     break;
                 case GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_VIDEOS):
-                    if (!this.showVideos)
-                        continue;
+                    showInSidebar = this.showVideos;
                     break;
                 default:
-                    if (!this.showBookmarks)
-                        continue;
+                    // Bookmarks are not default places
+                    isDefaultPlace = false;
+                    showInSidebar = this.showBookmarks;
                     break;
             }
-            let button = new PlaceButton(this, place);
-            this._placesButtons.push(button);
-            this.placesBox.add(button.actor, {
-                y_align: St.Align.END,
-                y_fill: false
-            });
+
+            // Always add default places to searchable list
+            if (isDefaultPlace) {
+                this._searchablePlaces.push({
+                    place: place,
+                    searchString: AppUtils.decomp_string(place.name).replace(/\s/g, '')
+                });
+            }
+
+            // Only add to sidebar if setting is enabled
+            if (showInSidebar) {
+                let button = new PlaceButton(this, place);
+                this._placesButtons.push(button);
+                this.placesBox.add(button.actor, {
+                    y_align: St.Align.END,
+                    y_fill: false
+                });
+            }
         }
         this.placesBox.queue_relayout();
 
@@ -2995,6 +3036,17 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         buttons = [...buttons, ...result];
 
         this._displayButtons(null, buttons, acResultButtons);
+
+        // Search all default places (independent of sidebar visibility settings)
+        let regexpPattern = new RegExp(Util.escapeRegExp(pattern));
+        for (let placeInfo of this._searchablePlaces) {
+            let res = placeInfo.searchString.match(regexpPattern);
+            if (res) {
+                let button = new PlaceSearchResultButton(this, placeInfo.place);
+                this._searchProviderButtons.push(button);
+                this.applicationsBox.add_actor(button.actor);
+            }
+        }
 
         if (buttons.length || acResultButtons.length) {
             this.appBoxIter.reloadVisible();


### PR DESCRIPTION
Fixes #13402

Users expect to find default home folders (Downloads, Documents, Pictures, Music, Videos, Desktop, Home) when searching in the menu, but currently they only appear if they're enabled in the sidebar settings.

This fix separates search functionality from sidebar visibility. Default home folders are now always searchable regardless of the show* settings. The settings only control whether folders appear in the sidebar, not whether they're searchable.

Changes:

- Added PlaceSearchResultButton class for place search results
- Added _searchablePlaces array containing all default places
- Modified _refreshPlaces to populate searchable places independently of sidebar visibility
- Modified _searchAppSystem to search through _searchablePlaces and display results