### PR TITLE
FIX: keyboard layout switching while search is focused (#13428)

### DIFF
--- a/js/ui/expoThumbnail.js
+++ b/js/ui/expoThumbnail.js
@@ -16,6 +16,7 @@ const PointerTracker = imports.misc.pointerTracker;
 const SignalManager = imports.misc.signalManager;
 const GridNavigator = imports.misc.gridNavigator;
 const WindowUtils = imports.misc.windowUtils;
+const Util = imports.misc.util;
 
 // The maximum size of a thumbnail is 1/8 the width and height of the screen
 let MAX_THUMBNAIL_SCALE = 0.9;
@@ -499,6 +500,12 @@ ExpoWorkspaceThumbnail.prototype = {
     },
     
     onTitleKeyPressEvent: function(actor, event) {
+        // Handle keyboard layout switching (Alt+Shift, etc.) before other key handling
+        let layoutResult = Util.handleKeyboardLayoutSwitchingInTextEntry(actor, event);
+        if (layoutResult !== null) {
+            return layoutResult;
+        }
+
         this.undoTitleEdit = false;
         let symbol = event.get_key_symbol();
         if (symbol === Clutter.KEY_Return ||

--- a/js/ui/keyringPrompt.js
+++ b/js/ui/keyringPrompt.js
@@ -41,6 +41,14 @@ class KeyringDialog extends ModalDialog.ModalDialog {
         });
         CinnamonEntry.addContextMenu(this._passwordEntry);
         this._passwordEntry.clutter_text.connect('activate', this._onPasswordActivate.bind(this));
+        // Handle keyboard layout switching (Alt+Shift, etc.)
+        this._passwordEntry.clutter_text.connect('key-press-event', (actor, event) => {
+            let layoutResult = Util.handleKeyboardLayoutSwitchingInTextEntry(actor, event);
+            if (layoutResult !== null) {
+                return layoutResult;
+            }
+            return Clutter.EVENT_PROPAGATE;
+        });
         this.prompt.bind_property('password-visible',
             this._passwordEntry, 'visible', GObject.BindingFlags.SYNC_CREATE);
         passwordBox.add_child(this._passwordEntry);
@@ -52,6 +60,14 @@ class KeyringDialog extends ModalDialog.ModalDialog {
         });
         CinnamonEntry.addContextMenu(this._confirmEntry);
         this._confirmEntry.clutter_text.connect('activate', this._onConfirmActivate.bind(this));
+        // Handle keyboard layout switching (Alt+Shift, etc.)
+        this._confirmEntry.clutter_text.connect('key-press-event', (actor, event) => {
+            let layoutResult = Util.handleKeyboardLayoutSwitchingInTextEntry(actor, event);
+            if (layoutResult !== null) {
+                return layoutResult;
+            }
+            return Clutter.EVENT_PROPAGATE;
+        });
         this.prompt.bind_property('confirm-visible',
             this._confirmEntry, 'visible', GObject.BindingFlags.SYNC_CREATE);
         passwordBox.add_child(this._confirmEntry);

--- a/js/ui/networkAgent.js
+++ b/js/ui/networkAgent.js
@@ -15,6 +15,7 @@ const Main = imports.ui.main;
 const MessageTray = imports.ui.messageTray;
 const ModalDialog = imports.ui.modalDialog;
 const CinnamonEntry = imports.ui.cinnamonEntry;
+const Util = imports.misc.util;
 
 const VPN_UI_GROUP = 'VPN Plugin UI';
 
@@ -71,6 +72,14 @@ class NetworkSecretDialog extends ModalDialog.ModalDialog {
                 }
 
                 secret.entry.clutter_text.connect('activate', this._onOk.bind(this));
+                // Handle keyboard layout switching (Alt+Shift, etc.)
+                secret.entry.clutter_text.connect('key-press-event', (actor, event) => {
+                    let layoutResult = Util.handleKeyboardLayoutSwitchingInTextEntry(actor, event);
+                    if (layoutResult !== null) {
+                        return layoutResult;
+                    }
+                    return Clutter.EVENT_PROPAGATE;
+                });
                 secret.entry.clutter_text.connect('text-changed', () => {
                     secret.value = secret.entry.get_text();
                     if (secret.validate)

--- a/js/ui/polkitAuthenticationAgent.js
+++ b/js/ui/polkitAuthenticationAgent.js
@@ -256,6 +256,14 @@ var AuthenticationDialog = GObject.registerClass({
         });
         CinnamonEntry.addContextMenu(this._passwordEntry);
         this._passwordEntry.clutter_text.connect('activate', this._onEntryActivate.bind(this));
+        // Handle keyboard layout switching (Alt+Shift, etc.)
+        this._passwordEntry.clutter_text.connect('key-press-event', (actor, event) => {
+            let layoutResult = Util.handleKeyboardLayoutSwitchingInTextEntry(actor, event);
+            if (layoutResult !== null) {
+                return layoutResult;
+            }
+            return Clutter.EVENT_PROPAGATE;
+        });
         this._passwordEntry.bind_property('reactive',
             this._passwordEntry.clutter_text, 'editable',
             GObject.BindingFlags.SYNC_CREATE);

--- a/js/ui/runDialog.js
+++ b/js/ui/runDialog.js
@@ -198,6 +198,12 @@ class RunDialog extends ModalDialog.ModalDialog {
      }
 
     _onKeyPress(o, e) {
+        // Handle keyboard layout switching (Alt+Shift, etc.) before other key handling
+        let layoutResult = Util.handleKeyboardLayoutSwitchingInTextEntry(o, e);
+        if (layoutResult !== null) {
+            return layoutResult;
+        }
+
         let symbol = e.get_key_symbol();
         if (symbol === Clutter.KEY_Return || symbol === Clutter.KEY_KP_Enter) {
             if (o.get_text().trim() == "") {


### PR DESCRIPTION
Keyboard layout switching doesn't work when Cinnamon text fields are focused. Keybindings like Alt+Shift or Super+Space have no effect because text entry key event handlers stop event propagation.

**Extended scope:** 
This fix now covers ALL (hopefully) Cinnamon text entries, not just the menu:
- Menu search field
- Alt+F2 run dialog
- Expo workspace renaming
- Polkit authentication dialog (sudo passwords)
- Network password dialog (WiFi/VPN)
- Keyring password prompt

But please this should be double checked - these are system critical fields, i dont feel enough experienced to be shure i checked every possible caveat here.


The fix has two parts:

1. **For custom keybindings** (like switch-input-source), invoke the keybinding callback before stopping event propagation
2. **For modifier-only keys** (Alt, Shift, Ctrl, Super), allow the event to propagate so XKB-based layout switching can work

The Implementation
- Created reusable helper function `handleKeyboardLayoutSwitchingInTextEntry()` in `util.js`
- Respects Input Methods (has_preedit check for CJK languages)
- Performance optimized (Set-based lookup)
- Extended modifier list (Hyper, Meta keys)

This should allow users to switch keyboard layouts while typing in any Cinnamon text field.

#### Root Cause in my point of view

- Commit 6a5105420 (Dec 15) moved `switch-input-source` from `global.display` to `KeybindingManager`
- Commit 05e68dd2c (Dec 12) blocked keybindings in text entries to prevent duplicate events
- Components must now explicitly invoke KeybindingManager for layout switching

Tests done:

Tested on Linux Mint 22.3 Cinnamon 6.6.6 with US + DE layouts:

- ✅ Menu search field
- ✅ Alt+F2 run dialog
- ✅ Expo workspace renaming
- ✅ Polkit authentication (sudo)
- ✅ Keyring prompt

Fixes #13428, #13513, #13407