### PR TITLE
Be compatible with GIRepository-1.0 and 2.0.

### DIFF
--- a/js/misc/config.js.in
+++ b/js/misc/config.js.in
@@ -8,3 +8,5 @@ var PACKAGE_VERSION = '@PACKAGE_VERSION@';
 var BUILT_NM_AGENT = @BUILT_NM_AGENT@;
 /* libexec directory */
 var LIBEXECDIR = '@LIBEXECDIR@';
+
+var USE_GIR20 = @USE_GIR20@;

--- a/meson.build
+++ b/meson.build
@@ -25,18 +25,25 @@ dbus = dependency('dbus-1')
 servicedir = dbus.get_variable(pkgconfig: 'session_bus_services_dir', pkgconfig_define: ['datadir', datadir])
 
 # dependencies
-cjs = dependency('cjs-1.0', version: '>= 4.8.0')
+cjs = dependency('cjs-1.0', version: '>= 115.0')
 clutter = dependency('muffin-clutter-0')
 cmenu = dependency('libcinnamon-menu-3.0', version: '>= 4.8.0')
 cogl = dependency('muffin-cogl-0')
 cogl_path = dependency('muffin-cogl-path-0')
 gcr = dependency('gcr-base-3', version: '>= 3.7.5')
 gdkx11 = dependency('gdk-x11-3.0')
-gi = dependency('gobject-introspection-1.0', version: '>= 0.9.2')
 polkit = dependency('polkit-agent-1', version: '>= 0.100')
 atk = dependency('atk-bridge-2.0')
 gio = dependency('gio-2.0', version: '>= 2.36.0')
 gio_unix = dependency('gio-unix-2.0')
+
+use_gir20 = false
+if cjs.version().version_compare('>= 139.9')
+  gi = dependency('girepository-2.0', version: '>= 2.36.0')
+  use_gir20 = true
+else
+  gi = dependency('gobject-introspection-1.0', version: '>= 0.9.2')
+endif
 gl = dependency('gl')
 glib_version = '2.79.2'
 glib = dependency('glib-2.0', version: '>= ' + glib_version)
@@ -110,6 +117,7 @@ cinnamon_conf = configuration_data()
 cinnamon_conf.set_quoted('VERSION', version)
 cinnamon_conf.set_quoted('GETTEXT_PACKAGE', meson.project_name().to_lower())
 cinnamon_conf.set('BUILT_NM_AGENT', internal_nm_agent)
+cinnamon_conf.set10('USE_GIR20', use_gir20)
 
 have_mallinfo = cc.has_function('mallinfo', prefix: '#include <malloc.h>')
 if have_mallinfo
@@ -209,6 +217,7 @@ config_js_conf.set('PACKAGE_NAME', meson.project_name().to_lower())
 config_js_conf.set('PACKAGE_VERSION', version)
 config_js_conf.set10('BUILT_NM_AGENT', internal_nm_agent)
 config_js_conf.set('LIBEXECDIR', join_paths(prefix, libexecdir))
+config_js_conf.set10('USE_GIR20', use_gir20)
 
 configure_file(
     input: 'js/misc/config.js.in',
@@ -216,7 +225,6 @@ configure_file(
     configuration: config_js_conf,
     install_dir: 'share/cinnamon/js/misc/'
 )
-
 
 excluded_files = []
 if get_option('exclude_info_settings')

--- a/src/cinnamon-generic-container.c
+++ b/src/cinnamon-generic-container.c
@@ -19,7 +19,6 @@
 
 #include <clutter/clutter.h>
 #include <gtk/gtk.h>
-#include <girepository.h>
 
 static void cinnamon_generic_container_iface_init (ClutterContainerIface *iface);
 

--- a/src/cinnamon-global-private.h
+++ b/src/cinnamon-global-private.h
@@ -2,6 +2,8 @@
 #ifndef __CINNAMON_GLOBAL_PRIVATE_H__
 #define __CINNAMON_GLOBAL_PRIVATE_H__
 
+#include "config.h"
+
 #include <errno.h>
 #include <math.h>
 #include <stdarg.h>
@@ -10,7 +12,13 @@
 
 #include "cinnamon-global.h"
 #include <gio/gio.h>
+
+#if USE_GIR20
+#include <girepository/girepository.h>
+#else
 #include <girepository.h>
+#endif
+
 #include <meta/meta-plugin.h>
 
 

--- a/src/cinnamon-global.c
+++ b/src/cinnamon-global.c
@@ -1,7 +1,5 @@
 /* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
 
-#include "config.h"
-
 #include <fcntl.h>
 
 #include "cinnamon-global-private.h"
@@ -358,7 +356,7 @@ cinnamon_global_class_init (CinnamonGlobalClass *klass)
                                    g_param_spec_object ("stage",
                                                         "Stage",
                                                         "Stage holding the desktop scene graph",
-                                                        CLUTTER_TYPE_ACTOR,
+                                                        CLUTTER_TYPE_STAGE,
                                                         G_PARAM_READABLE));
   g_object_class_install_property (gobject_class,
                                    PROP_STAGE_INPUT_MODE,

--- a/src/cinnamon-tray-manager.c
+++ b/src/cinnamon-tray-manager.c
@@ -4,7 +4,6 @@
 
 #include <clutter/clutter.h>
 #include <clutter/x11/clutter-x11.h>
-#include <girepository.h>
 #include <gtk/gtk.h>
 #include <meta/display.h>
 #include <meta/util.h>

--- a/src/main.c
+++ b/src/main.c
@@ -11,7 +11,13 @@
 #include <clutter/clutter.h>
 #include <dbus/dbus-shared.h>
 #include <glib/gi18n-lib.h>
+
+#if USE_GIR20
+#include <girepository/girepository.h>
+#else
 #include <girepository.h>
+#endif
+
 #include <meta/main.h>
 #include <meta/meta-plugin.h>
 #include <meta/prefs.h>
@@ -369,16 +375,30 @@ main (int argc, char **argv)
   cinnamon_a11y_init ();
   cinnamon_perf_log_init ();
 
+#if USE_GIR20
+  g_autoptr (GIRepository) repo = NULL;
+  repo = gi_repository_dup_default ();
+
+  gi_repository_prepend_search_path (repo, CINNAMON_PKGLIBDIR);
+  gi_repository_prepend_search_path (repo, MUFFIN_TYPELIB_DIR);
+#else
   g_irepository_prepend_search_path (CINNAMON_PKGLIBDIR);
   g_irepository_prepend_search_path (MUFFIN_TYPELIB_DIR);
+#endif
 
   /* We need to explicitly add the directories where the private libraries are
    * installed to the GIR's library path, so that they can be found at runtime
    * when linking using DT_RUNPATH (instead of DT_RPATH), which is the default
    * for some linkers (e.g. gold) and in some distros (e.g. Debian).
    */
+
+#if USE_GIR20
+  gi_repository_prepend_library_path (repo, CINNAMON_PKGLIBDIR);
+  gi_repository_prepend_library_path (repo, MUFFIN_TYPELIB_DIR);
+#else
   g_irepository_prepend_library_path (CINNAMON_PKGLIBDIR);
   g_irepository_prepend_library_path (MUFFIN_TYPELIB_DIR);
+#endif
 
   /* Disable debug spew from various libraries */
   g_log_set_handler ("Cvc", G_LOG_LEVEL_DEBUG,

--- a/src/st/st-entry.c
+++ b/src/st/st-entry.c
@@ -1179,12 +1179,12 @@ st_entry_set_text (StEntry     *entry,
  * Returns: (transfer none): the #ClutterText used by #StEntry. The entry is
  * owned by the #StEntry and should not be unref'ed by the application.
  */
-ClutterActor*
+ClutterText *
 st_entry_get_clutter_text (StEntry *entry)
 {
   g_return_val_if_fail (ST_ENTRY (entry), NULL);
 
-  return entry->priv->entry;
+  return (ClutterText *) entry->priv->entry;
 }
 
 /**

--- a/src/st/st-entry.h
+++ b/src/st/st-entry.h
@@ -68,7 +68,7 @@ StWidget *            st_entry_new              (const gchar *text);
 const gchar *         st_entry_get_text         (StEntry     *entry);
 void                  st_entry_set_text         (StEntry     *entry,
                                                  const gchar *text);
-ClutterActor*         st_entry_get_clutter_text (StEntry     *entry);
+ClutterText *         st_entry_get_clutter_text (StEntry     *entry);
 
 void                  st_entry_set_hint_text    (StEntry     *entry,
                                                  const gchar *text);

--- a/src/st/st-label.c
+++ b/src/st/st-label.c
@@ -388,12 +388,12 @@ st_label_set_text (StLabel     *label,
  * Returns: (transfer none): ethe #ClutterText used by #StLabel. The label
  * is owned by the #StLabel and should not be unref'ed by the application.
  */
-ClutterActor*
+ClutterText *
 st_label_get_clutter_text (StLabel *label)
 {
   g_return_val_if_fail (ST_IS_LABEL (label), NULL);
 
-  return label->priv->label;
+  return (ClutterText *) label->priv->label;
 }
 
 

--- a/src/st/st-label.h
+++ b/src/st/st-label.h
@@ -64,7 +64,7 @@ StWidget *     st_label_new              (const gchar *text);
 const gchar *  st_label_get_text         (StLabel     *label);
 void           st_label_set_text         (StLabel     *label,
                                           const gchar *text);
-ClutterActor * st_label_get_clutter_text (StLabel     *label);
+ClutterText * st_label_get_clutter_text (StLabel     *label);
 
 G_END_DECLS
 

--- a/src/st/st-password-entry.c
+++ b/src/st/st-password-entry.c
@@ -141,10 +141,10 @@ clutter_text_password_char_cb (GObject    *object,
                                gpointer    user_data)
 {
   StPasswordEntry *entry = ST_PASSWORD_ENTRY (user_data);
-  ClutterActor *clutter_text;
+  ClutterText *clutter_text;
 
   clutter_text = st_entry_get_clutter_text (ST_ENTRY (entry));
-  if (clutter_text_get_password_char (CLUTTER_TEXT (clutter_text)) == 0)
+  if (clutter_text_get_password_char (clutter_text) == 0)
     st_password_entry_set_password_visible (entry, TRUE);
   else
     st_password_entry_set_password_visible (entry, FALSE);
@@ -154,7 +154,7 @@ static void
 st_password_entry_init (StPasswordEntry *entry)
 {
   StPasswordEntryPrivate *priv;
-  ClutterActor *clutter_text;
+  ClutterText *clutter_text;
 
   priv = entry->priv = st_password_entry_get_instance_private (entry);
 
@@ -167,7 +167,7 @@ st_password_entry_init (StPasswordEntry *entry)
   priv->show_peek_icon = TRUE;
 
   clutter_text = st_entry_get_clutter_text (ST_ENTRY (entry));
-  clutter_text_set_password_char (CLUTTER_TEXT (clutter_text), BULLET);
+  clutter_text_set_password_char (clutter_text, BULLET);
 
   g_signal_connect (clutter_text, "notify::password-char",
                     G_CALLBACK (clutter_text_password_char_cb), entry);
@@ -243,7 +243,7 @@ st_password_entry_set_password_visible (StPasswordEntry *entry,
                                         gboolean         value)
 {
   StPasswordEntryPrivate *priv;
-  ClutterActor *clutter_text;
+  ClutterText *clutter_text;
 
   g_return_if_fail (ST_IS_PASSWORD_ENTRY (entry));
 
@@ -256,12 +256,12 @@ st_password_entry_set_password_visible (StPasswordEntry *entry,
   clutter_text = st_entry_get_clutter_text (ST_ENTRY (entry));
   if (priv->password_visible)
     {
-      clutter_text_set_password_char (CLUTTER_TEXT (clutter_text), 0);
+      clutter_text_set_password_char (clutter_text, 0);
       st_icon_set_icon_name (ST_ICON (priv->peek_password_icon), "xsi-view-conceal-symbolic");
     }
   else
     {
-      clutter_text_set_password_char (CLUTTER_TEXT (clutter_text), BULLET);
+      clutter_text_set_password_char (clutter_text, BULLET);
       st_icon_set_icon_name (ST_ICON (priv->peek_password_icon), "xsi-view-reveal-symbolic");
     }
 


### PR DESCRIPTION
ref:
https://github.com/linuxmint/cjs/pull/135

I've fixed a few warnings, but  some remain....
```
Type GITypeInfo of property XApp.StatusIconInterface::icon-name does not match type GITypeInfo of first argument of setter complete_scroll. Falling back to slow path
Type GITypeInfo of property XApp.StatusIconInterface::label does not match type GITypeInfo of first argument of setter complete_scroll. Falling back to slow path
Type GITypeInfo of property XApp.StatusIconInterface::tooltip-text does not match type GITypeInfo of first argument of setter complete_scroll. Falling back to slow path
...
...
```

These seem like false-positives, though - it's comparing unrelated elements. I think it's a bug in gobject-introspection (well, glib now)