### PR TITLE
Backport: PopupResizeHandler return correct popup size bugfix

### DIFF
--- a/js/ui/applet.js
+++ b/js/ui/applet.js
@@ -1064,8 +1064,8 @@ var PopupResizeHandler = class PopupResizeHandler {
         let [stageX, stageY] = event.get_coords();
         this._drag_start_position = {x: stageX, y: stageY};
         this._drag_start_size = {width: this.actor.width, height: this.actor.height};
-        this._init_user_width = this._get_user_width();
-        this._init_user_height = this._get_user_height();
+        this._init_user_width = this._new_user_width = this._get_user_width();
+        this._init_user_height = this._new_user_height = this._get_user_height();
 
         return true;
     }


### PR DESCRIPTION
Backport of PR #12804 to the 6.4-maintenance branch.

## Summary
Cherry-pick of commit 0df121fed from master. This fix was merged in May 2025 
but was never backported to 6.4.x.

## The Bug
When clicking on the menu resize edge without actually moving the mouse 
(click and release), `_new_user_width` and `_new_user_height` were 
uninitialized, causing the menu to shrink unexpectedly.

## The Fix
Initialize these values at the start of the drag operation, ensuring correct 
sizes are returned even without mouse movement.

Fixes: #12972 (for 6.4.x users)
Related: #12803, #12804

Credit: @fredcw (original fix author)