### PR TITLE
FIX: util module import to prevent name collisions

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/KeybindingWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/KeybindingWidgets.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 from gi.repository import Gtk, Gdk, GObject
-import util
+from bin import util
 
 print("KeybindingWidgets session type: %s" % util.get_session_type())
 

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/SettingsWidgets.py
@@ -11,7 +11,7 @@ from xapp.SettingsWidgets import SettingsWidget, SettingsLabel
 from xapp.GSettingsWidgets import PXGSettingsBackend
 from ChooserButtonWidgets import DateChooserButton, TimeChooserButton
 from KeybindingWidgets import ButtonKeybinding
-import util
+from bin import util
 
 import KeybindingTable
 

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/XkbSettings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/XkbSettings.py
@@ -3,7 +3,7 @@
 from gi.repository import Gio, Gtk, CinnamonDesktop, Pango, GLib
 
 from xapp.SettingsWidgets import SettingsSection
-import util
+from bin import util
 import subprocess
 
 class XkbSettingsEditor(SettingsSection):

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_sound.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_sound.py
@@ -6,7 +6,7 @@ gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, Cvc, Gdk, GdkPixbuf, Gio, Pango
 from SettingsWidgets import SidePage, GSettingsSoundFileChooser
 from xapp.GSettingsWidgets import *
-import util
+from bin import util
 
 CINNAMON_SOUNDS = "org.cinnamon.sounds"
 CINNAMON_DESKTOP_SOUNDS = "org.cinnamon.desktop.sound"


### PR DESCRIPTION
This PR addresses issue #13490 where cinnamon-settings fails to start with an AttributeError: module 'util' has no attribute 'get_session_type'.

The root cause appears to be the use of bare import util statements in four files, which can be shadowed by any util.py file present in the user's working directory or Python path.

I was able to reproduce this issue by placing an empty util.py in the home directory – this caused the exact error reported in the issue. After applying the fix, cinnamon-settings launched correctly even with the conflicting file present.

**Changes**
Changed` import util` to `from bin import util` in:

- bin/KeybindingWidgets.py
- bin/SettingsWidgets.py
- bin/XkbSettings.py
- modules/cs_sound.py

This aligns these files with the import pattern already used throughout the codebase (e.g., cinnamon-settings.py, cs_keyboard.py, cs_info.py, cs_general.py, etc.).

**Tested**
Tested in Linux Mint 22.3 VM:

- cinnamon-settings launches without errors
- Sound settings module loads correctly
- Keyboard settings with XKB options tab works

While this issue may be relatively rare in practice (requiring a conflicting util.py in the user's environment), using explicit imports is more robust in my point of view and i think consistent with the rest of the codebase.