### PR TITLE
Fix: User avatar not updating in menu (#13489)

### DIFF
--- a/js/ui/userWidget.js
+++ b/js/ui/userWidget.js
@@ -5,6 +5,8 @@
 
 const Atk = imports.gi.Atk;
 const Clutter = imports.gi.Clutter;
+const GdkPixbuf = imports.gi.GdkPixbuf;
+const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
 const St = imports.gi.St;
@@ -12,6 +14,13 @@ const St = imports.gi.St;
 const Params = imports.misc.params;
 
 var AVATAR_ICON_SIZE = 64;
+
+// Directory for cached avatar copies (to bypass St's image caching)
+// Using ~/.cache for persistence across reboots
+const AVATAR_CACHE_DIR = GLib.build_filenamev([GLib.get_user_cache_dir(), 'cinnamon', 'avatars']);
+
+// Maximum dimensions for avatar images (AccountsService has size limits)
+const MAX_AVATAR_SIZE = 512;
 
 var Avatar = GObject.registerClass(
 class Avatar extends St.Bin {
@@ -106,6 +115,86 @@ class Avatar extends St.Bin {
         this.update();
     }
 
+    // Get a cache-busted path for the icon file
+    // This copies (and optionally resizes) the file to ~/.cache to bypass St's image cache
+    _getCacheBustedIconPath(iconFile) {
+        // Only needed for AccountsService icons (same path, changing content)
+        if (!iconFile.startsWith('/var/lib/AccountsService/icons/'))
+            return iconFile;
+
+        try {
+            // Ensure cache directory exists
+            let cacheDir = Gio.File.new_for_path(AVATAR_CACHE_DIR);
+            if (!cacheDir.query_exists(null)) {
+                cacheDir.make_directory_with_parents(null);
+            }
+
+            // Get file modification time for cache-busting
+            let file = Gio.File.new_for_path(iconFile);
+            let info = file.query_info('time::modified', Gio.FileQueryInfoFlags.NONE, null);
+            let mtime = info.get_modification_date_time().to_unix();
+
+            // Get username from path
+            let username = GLib.path_get_basename(iconFile);
+
+            // Create unique filename with timestamp
+            let cachedPath = GLib.build_filenamev([AVATAR_CACHE_DIR, `${username}-${mtime}`]);
+
+            // Check if cached file already exists
+            let cachedFile = Gio.File.new_for_path(cachedPath);
+            if (!cachedFile.query_exists(null)) {
+                // Clean up old cached files for this user
+                this._cleanOldCachedAvatars(username, cachedPath);
+
+                // Load image with GdkPixbuf to check dimensions
+                let pixbuf = GdkPixbuf.Pixbuf.new_from_file(iconFile);
+                let width = pixbuf.get_width();
+                let height = pixbuf.get_height();
+
+                // If image is larger than MAX_AVATAR_SIZE, resize it
+                if (width > MAX_AVATAR_SIZE || height > MAX_AVATAR_SIZE) {
+                    // Calculate aspect-preserving dimensions
+                    let scale = Math.min(MAX_AVATAR_SIZE / width, MAX_AVATAR_SIZE / height);
+                    let newWidth = Math.floor(width * scale);
+                    let newHeight = Math.floor(height * scale);
+
+                    // Resize and save
+                    let scaledPixbuf = pixbuf.scale_simple(newWidth, newHeight, GdkPixbuf.InterpType.BILINEAR);
+                    scaledPixbuf.savev(cachedPath, 'png', [], []);
+                } else {
+                    // Image is small enough, just copy it
+                    file.copy(cachedFile, Gio.FileCopyFlags.OVERWRITE, null, null);
+                }
+            }
+
+            return cachedPath;
+        } catch (e) {
+            global.logError(`[UserWidget] Failed to create cached avatar: ${e}`);
+            return iconFile;
+        }
+    }
+
+    // Remove old cached avatars for a user (keep only the current one)
+    _cleanOldCachedAvatars(username, keepPath) {
+        try {
+            let cacheDir = Gio.File.new_for_path(AVATAR_CACHE_DIR);
+            let enumerator = cacheDir.enumerate_children('standard::name', Gio.FileQueryInfoFlags.NONE, null);
+            let info;
+            while ((info = enumerator.next_file(null)) !== null) {
+                let name = info.get_name();
+                if (name.startsWith(username + '-')) {
+                    let filePath = GLib.build_filenamev([AVATAR_CACHE_DIR, name]);
+                    if (filePath !== keepPath) {
+                        let file = Gio.File.new_for_path(filePath);
+                        file.delete(null);
+                    }
+                }
+            }
+        } catch (e) {
+            // Ignore cleanup errors
+        }
+    }
+
     update() {
         let iconFile = null;
         if (this._user) {
@@ -120,10 +209,12 @@ class Avatar extends St.Bin {
             this._iconSize * scaleFactor);
 
         if (iconFile) {
+            // Use cache-busted path to bypass St's image caching
+            let displayPath = this._getCacheBustedIconPath(iconFile);
             this.child = null;
             this.add_style_class_name('user-avatar');
             this.style = `
-                background-image: url("${iconFile}");
+                background-image: url("${displayPath}");
                 background-size: cover;`;
         } else {
             this.style = null;


### PR DESCRIPTION
After some research i think this fixes two related issues when changing user profile pictures:

1. **Image caching problem**: When selecting a custom image from files, the menu avatar wouldn't update without restarting Cinnamon. This was caused by St's CSS background-image caching - AccountsService copies all custom images to the same path (/var/lib/AccountsService/icons/<user>), so the URL stays identical while only the file content changes.

2. **Size limit**: AccountsService rejects images larger than ~1MB with a silent error, preventing large photos from being set as avatars.

**Solution:**

- userWidget.js: Implements cache-busting by copying AccountsService icons to ~/.cache/cinnamon/avatars/<user>-<mtime> with unique timestamps, forcing St to reload the image. Also resizes oversized images as fallback.

- cs_user.py: Resizes large images (>512px) before passing to AccountsService, preventing rejection. Also fixes existing bug where original path was used instead of the resized .face file.

Tested with images up to 9600x6000 (5.4MB) - now displays correctly without Cinnamon restart. I hope this will help. 
Looking for Feedback.