### PR TITLE
input sources: Allow a default xkb layout to be configured for Ibus input methods that support it.

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/input-sources-list.ui
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/input-sources-list.ui
@@ -142,6 +142,205 @@
       </object>
     </child>
   </object>
+  <object class="GtkDialog" id="ibus_config_dialog">
+    <property name="can-focus">False</property>
+    <property name="border-width">12</property>
+    <property name="title" translatable="yes">Configure Input Method</property>
+    <property name="default-width">450</property>
+    <property name="type-hint">dialog</property>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">12</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="can-focus">False</property>
+            <child>
+              <object class="GtkButton" id="ibus_config_close_button">
+                <property name="label" translatable="yes">Close</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="ibus_config_name_label">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">center</property>
+            <property name="xalign">0</property>
+            <attributes>
+              <attribute name="weight" value="bold"/>
+              <attribute name="scale" value="1.2"/>
+            </attributes>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkFrame">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label-xalign">0</property>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="margin-start">12</property>
+                <property name="margin-end">12</property>
+                <property name="margin-top">12</property>
+                <property name="margin-bottom">12</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">12</property>
+                <child>
+                  <object class="GtkLabel" id="ibus_config_explanation_label">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label" translatable="yes">By default, this input method uses whichever keyboard layout was active before switching to it. You can override this to always use a specific layout.</property>
+                    <property name="wrap">True</property>
+                    <property name="max-width-chars">50</property>
+                    <property name="xalign">0</property>
+                    <style>
+                      <class name="dim-label"/>
+                    </style>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Layout:</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="ibus_config_layout_label">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="hexpand">True</property>
+                        <property name="ellipsize">end</property>
+                        <property name="xalign">0</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkButton" id="ibus_config_change_layout_button">
+                        <property name="label" translatable="yes">Change</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="ibus_config_clear_override_button">
+                        <property name="label" translatable="yes">Reset</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+              </object>
+            </child>
+            <child type="label">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Keyboard Layout</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="ibus_config_engine_settings_button">
+            <property name="label" translatable="yes">Engine Settings</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
   <object class="GtkImage" id="image1">
     <property name="visible">True</property>
     <property name="can-focus">False</property>

--- a/js/ui/keyboardManager.js
+++ b/js/ui/keyboardManager.js
@@ -16,6 +16,7 @@ DESKTOP_INPUT_SOURCES_SCHEMA = 'org.cinnamon.desktop.input-sources';
 KEY_INPUT_SOURCES = 'sources';
 KEY_KEYBOARD_OPTIONS = 'xkb-options';
 KEY_PER_WINDOW = 'per-window';
+KEY_SOURCE_LAYOUTS = 'source-layouts';
 
 var INPUT_SOURCE_TYPE_XKB = 'xkb';
 var INPUT_SOURCE_TYPE_IBUS = 'ibus';
@@ -176,7 +177,7 @@ var KeyboardManager = class {
 };
 
 var InputSource = class {
-    constructor(type, id, displayName, shortName, flagName, xkbLayout, variant, prefs, index) {
+    constructor(type, id, displayName, shortName, flagName, xkbLayout, variant, prefs, index, layoutOverride) {
         this.type = type;
         this.id = id;
         this.displayName = displayName;
@@ -187,6 +188,7 @@ var InputSource = class {
         this.xkbLayout = xkbLayout;
         this.variant = variant;
         this.preferences = prefs;
+        this._layoutOverride = layoutOverride;
 
         this.properties = null;
 
@@ -207,6 +209,10 @@ var InputSource = class {
     }
 
     _getXkbId() {
+        // Use layout override if set
+        if (this._layoutOverride)
+            return this._layoutOverride;
+
         let engineDesc = IBusManager.getIBusManager().getEngineDesc(this.id);
         if (!engineDesc)
             return this.id;
@@ -411,6 +417,7 @@ var InputSourceSettings = class {
         this._settings.connect('changed::%s'.format(KEY_INPUT_SOURCES), this._emitInputSourcesChanged.bind(this));
         this._settings.connect('changed::%s'.format(KEY_KEYBOARD_OPTIONS), this._emitKeyboardOptionsChanged.bind(this));
         this._settings.connect('changed::%s'.format(KEY_PER_WINDOW), this._emitPerWindowChanged.bind(this));
+        this._settings.connect('changed::%s'.format(KEY_SOURCE_LAYOUTS), this._emitInputSourcesChanged.bind(this));
 
         let sources = this._settings.get_value(KEY_INPUT_SOURCES);
         if (sources.n_children() == 0) {
@@ -462,6 +469,10 @@ var InputSourceSettings = class {
 
     get perWindow() {
         return this._settings.get_boolean(KEY_PER_WINDOW);
+    }
+
+    get sourceLayouts() {
+        return this._settings.get_value(KEY_SOURCE_LAYOUTS).deep_unpack();
     }
 };
 Signals.addSignalMethods(InputSourceSettings.prototype);
@@ -731,17 +742,34 @@ var InputSourceManager = class {
         }
 
         let inputSourcesDupeTracker = {};
+        let sourceLayouts = this._settings.sourceLayouts;
 
         for (let i = 0; i < infosList.length; i++) {
-            let is = new InputSource(infosList[i].type,
-                                     infosList[i].id,
-                                     infosList[i].displayName,
-                                     infosList[i].shortName,
-                                     infosList[i].flagName,
-                                     infosList[i].xkbLayout,
-                                     infosList[i].variant,
-                                     infosList[i].prefs,
-                                     i);
+            let info = infosList[i];
+            let layoutOverride = null;
+
+            // Only apply layout overrides for IBus engines that use "default" layout
+            if (info.type == INPUT_SOURCE_TYPE_IBUS && info.id in sourceLayouts) {
+                let engineDesc = this._ibusManager.getEngineDesc(info.id);
+                let engineLayout = engineDesc ? engineDesc.get_layout() : null;
+
+                if (!engineLayout || engineLayout == 'default') {
+                    layoutOverride = sourceLayouts[info.id];
+                } else {
+                    global.logWarning('Ignoring layout override for IBus engine "%s": engine requires layout "%s"'.format(info.id, engineLayout));
+                }
+            }
+
+            let is = new InputSource(info.type,
+                                     info.id,
+                                     info.displayName,
+                                     info.shortName,
+                                     info.flagName,
+                                     info.xkbLayout,
+                                     info.variant,
+                                     info.prefs,
+                                     i,
+                                     layoutOverride);
             is.connect('activate', this.activateInputSource.bind(this));
 
             let key = is.shortName;


### PR DESCRIPTION
By default, the last-used layout (or en-us) is used when switching to a mozc or m17n-based im. This can be overridden at the time of their activation.

Add a setting, and repurpose the 'configure' button in the keyboard layout settings to show a dialog that will allow the user to choose a default layout, as well as launch that engine's configuration program if one is available.

This will be disabled for engines whose default layout is not 'default' (chewing, hangul, sunpinyin, libthai).

Depends on https://github.com/linuxmint/cinnamon-desktop/pull/263

ref:
https://forums.linuxmint.com/viewtopic.php?t=461850

<img width="776" height="632" alt="image" src="https://github.com/user-attachments/assets/ae72d762-9dfe-4e3d-8686-f901b0d5342e" />

