### PR TITLE
gwl: Avoid adding the window again after removal

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/workspace.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/workspace.js
@@ -239,8 +239,10 @@ class Workspace {
         && this.state.monitorWatchList.indexOf(metaWindow.get_monitor()) > -1;
     }
 
-    windowWorkspaceChanged(display, metaWorkspace, metaWindow) {
-        this.windowAdded(metaWindow, metaWorkspace);
+    windowWorkspaceChanged(display, metaWindow, metaWorkspace) {
+        // If the window is removed the metaWorkspace will be null, in that
+        // case we wouldn't want to add the window again.
+        if (metaWorkspace) this.windowAdded(metaWorkspace, metaWindow);
     }
 
     windowAdded(metaWorkspace, metaWindow, app, isFavoriteApp) {


### PR DESCRIPTION
This was triggering when using the show window in all workspaces option and was leading the app group representation to an irregular state where removed windows would still be counted and show irresponsible thumbnails.