### PR TITLE
fix infinite max desklet instances

### DIFF
--- a/js/ui/settings.js
+++ b/js/ui/settings.js
@@ -971,7 +971,7 @@ DeskletSettings.prototype = {
     },
 
     _get_is_multi_instance_xlet: function(uuid) {
-        return Extension.get_max_instances(uuid) > 1;
+        return Extension.get_max_instances(uuid) != 1;
     }
 };
 


### PR DESCRIPTION

I think I may have figured out why setting "max-instances": "-1" in desklets causes the settings to become inaccessible. [#1326](https://github.com/linuxmint/cinnamon-spices-desklets/issues/1326)

I tested the change on my system and can now open the settings again. However, I can create more instances than allowed by "max-instances". This still needs to be fixed.
