### PR TITLE
spices: Fix theme update and improve spice removal process

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
@@ -174,14 +174,15 @@ class Spice_Harvester(GObject.Object):
 
         if self.themes:
             self.install_folder = f'{home}/.themes/'
-            old_install_folder = os.path.join(GLib.get_user_data_dir(), 'themes')
-            self.spices_directories = (self.install_folder, old_install_folder)
+            old_install_folder = os.path.join(home, ".local/share/cinnamon/themes")
+            legacy_install_folder = os.path.join(GLib.get_user_data_dir(), 'themes')
+            self.spices_directories = (self.install_folder, old_install_folder, legacy_install_folder)
         elif self.actions:
             actions = 'nemo/actions/'
             self.install_folder = f'{home}/.local/share/{actions}'
             sys_dirs = [x + f'/{actions}' for x in GLib.get_system_data_dirs()]
             sys_dirs.append(self.install_folder)
-            self.spices_directories = (sys_dirs)
+            self.spices_directories = tuple(sys_dirs)
         else:
             self.install_folder = f'{home}/.local/share/cinnamon/{self.collection_type}s/'
             self.spices_directories = (f'/usr/share/cinnamon/{self.collection_type}s/', self.install_folder)
@@ -738,13 +739,12 @@ class Spice_Harvester(GObject.Object):
                                        os.path.join(locale_dir, f'{uuid}.mo')],
                                        check=True)
 
-        # Create install folder on demand
-        if not os.path.exists(self.install_folder):
-            subprocess.run(["/usr/bin/mkdir", "-p", self.install_folder], check=True)
+        os.makedirs(self.install_folder, mode=0o755, exist_ok=True)
 
         dest = os.path.join(self.install_folder, uuid)
-        if os.path.exists(dest):
-            shutil.rmtree(dest)
+
+        self._remove_spice_from_all_directories(uuid)
+
         if self.actions and os.path.exists(dest + '.nemo_action'):
             os.remove(dest + '.nemo_action')
         if not self.actions:
@@ -807,20 +807,29 @@ class Spice_Harvester(GObject.Object):
                     shutil.rmtree(os.path.join(settings_dir, uuid))
                 if os.path.exists(os.path.join(old_settings_dir, uuid)):
                     shutil.rmtree(os.path.join(old_settings_dir, uuid))
-            for folder in self.spices_directories:
-                shutil.rmtree(os.path.join(folder, uuid), ignore_errors=True)
+
+            self._remove_spice_from_all_directories(uuid)
+
             if self.actions:
                 disabled_list = self.settings.get_strv(self.enabled_key)
                 uuid_name = f"{uuid}.nemo_action"
                 if uuid_name in disabled_list:
                     disabled_list.remove(uuid_name)
                     self.settings.set_strv(self.enabled_key, disabled_list)
-                try:
-                    os.remove(os.path.join(folder, f'{uuid}.nemo_action'))
-                except FileNotFoundError:
-                    pass
         except Exception as error:
             self.errorMessage(_("A problem occurred while removing %s.") % job['uuid'], str(error))
+
+    def _remove_spice_from_all_directories(self, uuid):
+        for directory in self.spices_directories:
+            dest = os.path.join(directory, uuid)
+            if os.path.isdir(dest):
+                shutil.rmtree(dest, ignore_errors=True)
+            if self.actions:
+                action_file = os.path.join(directory, f"{uuid}.nemo_action")
+                try:
+                    os.remove(action_file)
+                except FileNotFoundError:
+                    pass
 
     def update_all(self):
         """ applies all available updates"""

--- a/python3/cinnamon/harvester.py
+++ b/python3/cinnamon/harvester.py
@@ -20,7 +20,7 @@ import gi
 gi.require_version('Gtk', '3.0')
 gi.require_version('Gdk', '3.0')
 gi.require_version('Gio', '2.0')
-from gi.repository import Gdk, Gtk, Gio, GLib
+from gi.repository import Gdk, GdkPixbuf, Gtk, Gio, GLib
 
 from . import logger
 from . import proxygsettings
@@ -37,33 +37,46 @@ try:
 except:
     pass
 
+home = os.path.expanduser("~")
+locale_inst = f'{home}/.local/share/locale'
+settings_dir = os.path.join(GLib.get_user_config_dir(), 'cinnamon', 'spices')
+
 URL_SPICES_HOME = "https://cinnamon-spices.linuxmint.com"
 
 SPICE_MAP = {
     "applet": {
         "url": URL_SPICES_HOME + "/json/applets.json",
         "enabled-schema": "org.cinnamon",
-        "enabled-key": "enabled-applets"
+        "enabled-key": "enabled-applets",
+        "install-folders": (os.path.join(home, ".local/share/cinnamon/applets"),)
     },
     "desklet": {
         "url": URL_SPICES_HOME + "/json/desklets.json",
         "enabled-schema": "org.cinnamon",
-        "enabled-key": "enabled-desklets"
+        "enabled-key": "enabled-desklets",
+        "install-folders": (os.path.join(home, ".local/share/cinnamon/desklets"),)
     },
     "extension": {
         "url": URL_SPICES_HOME + "/json/extensions.json",
         "enabled-schema": "org.cinnamon",
-        "enabled-key": "enabled-extensions"
+        "enabled-key": "enabled-extensions",
+        "install-folders": (os.path.join(home, ".local/share/cinnamon/extensions"),)
     },
     "action": {
         "url": URL_SPICES_HOME + "/json/actions.json",
         "enabled-schema": "org.nemo.plugins",
-        "enabled-key": "disabled-actions"
+        "enabled-key": "disabled-actions",
+        "install-folders": (os.path.join(home, ".local/share/nemo/actions"),)
     },
     "theme": {
         "url": URL_SPICES_HOME + "/json/themes.json",
         "enabled-schema": "org.cinnamon.theme",
-        "enabled-key": "name"
+        "enabled-key": "name",
+        "install-folders": (
+            os.path.join(home, ".themes"),
+            os.path.join(GLib.get_user_data_dir(), "themes"),
+            os.path.join(home, ".local/share/cinnamon/themes"),
+        )
     }
 }
 
@@ -71,9 +84,6 @@ TIMEOUT_DOWNLOAD_JSON = 15
 TIMEOUT_DOWNLOAD_THUMB = 60
 TIMEOUT_DOWNLOAD_ZIP = 120
 
-home = os.path.expanduser("~")
-locale_inst = f'{home}/.local/share/locale'
-settings_dir = os.path.join(GLib.get_user_config_dir(), 'cinnamon', 'spices')
 
 activity_logger = logger.ActivityLogger()
 
@@ -164,13 +174,8 @@ class Harvester:
 
         self.index_file = os.path.join(self.cache_folder, "index.json")
 
-        self.install_folder = f"{home}/.local/share/nemo/actions" if self.actions else os.path.join(home, ".local/share/cinnamon", f"{self.spice_type}s")
-
-        if self.themes:
-            old_install_folder = f'{home}/.themes/'
-            self.spices_directories = (old_install_folder, self.install_folder)
-        else:
-            self.spices_directories = (self.install_folder, )
+        self.spices_directories = SPICE_MAP[self.spice_type]["install-folders"]
+        self.install_folder = self.spices_directories[0]
 
         self.disabled = not self.anything_installed()
 
@@ -308,6 +313,8 @@ class Harvester:
                     subdirectory = os.path.join(directory, uuid)
                     if uuid.endswith('.nemo_action'):
                         continue
+                    if uuid in self.meta_map:
+                        continue
                     # For actions, ignore any other normal files, an action may place other support scripts in here.
                     if self.actions and not os.path.isdir(subdirectory):
                         continue
@@ -433,11 +440,11 @@ class Harvester:
                                        os.path.join(locale_dir, f'{uuid}.mo')],
                                        check=True)
 
+        os.makedirs(self.install_folder, mode=0o755, exist_ok=True)
+
+        self._remove_spice_from_all_directories(uuid)
+
         dest = os.path.join(self.install_folder, uuid)
-        if os.path.exists(dest):
-            shutil.rmtree(dest)
-        if self.actions and os.path.exists(dest + '.nemo_action'):
-            os.remove(dest + '.nemo_action')
         if not self.actions:
             shutil.copytree(folder, dest)
         else:
@@ -464,6 +471,18 @@ class Harvester:
 
         with open(meta_path, "w+", encoding='utf-8') as f:
             json.dump(md, f, indent=4)
+
+    def _remove_spice_from_all_directories(self, uuid):
+        for directory in self.spices_directories:
+            dest = os.path.join(directory, uuid)
+            if os.path.isdir(dest):
+                shutil.rmtree(dest, ignore_errors=True)
+            if self.actions:
+                action_file = os.path.join(directory, f"{uuid}.nemo_action")
+                try:
+                    os.remove(action_file)
+                except FileNotFoundError:
+                    pass
 
     def write_to_log(self, uuid, action):
         new_version = "<none>"


### PR DESCRIPTION
Theme updates (when using **mintupdate**) were having issues due to it installing updated themes to `~/.local/share/cinnamon/themes` instead of the current path used to load themes, which is `~/.themes`, so theme updates weren't actually having an effect. I've also made updates to guarantee that removed themes are removed from all their possible directories (to clean leftovers of the updates in the wrong directories).