### PR TITLE
[menu@cinnamon.org] Replace "Uninstall" context menu item with "App Info"

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/appUtils.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/appUtils.js
@@ -1,5 +1,7 @@
 const Cinnamon = imports.gi.Cinnamon;
 const CMenu = imports.gi.CMenu;
+const Gio = imports.gi.Gio;
+const Util = imports.misc.util;
 
 let appsys = Cinnamon.AppSystem.get_default();
 
@@ -115,3 +117,68 @@ function loadDirectory(dir, top_dir, apps) {
     }
     return has_entries;
 }
+
+function _launchMintinstall(pkgName) {
+    Util.spawn(["mintinstall", "show", pkgName]);
+}
+
+// launch mintinstall on app page
+function launchMintinstallForApp(app) {
+    if (app.get_is_flatpak()) {
+        const pkgName = app.get_flatpak_app_id();
+        _launchMintinstall(pkgName);
+    } else {
+        const filePath = app.desktop_file_path;
+        if (!filePath) return;
+        
+        const proc = Gio.Subprocess.new(
+            ['dpkg', '-S', filePath],
+            Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE
+        );
+        proc.communicate_utf8_async(null, null, (obj, res) => {
+            try {
+                let [success, stdout, stderr] = obj.communicate_utf8_finish(res);
+                if (success && stdout) {
+                    const foundPkg = stdout.split(':')[0].trim();
+                    _launchMintinstall(foundPkg);
+                }
+            } catch (e) {
+                global.logError("dpkg check failed: " + e.message);
+            }
+        });
+    }
+}
+
+function _launchPamac(pkgName) {
+    Util.spawn(["pamac-manager", `--details=${pkgName}`]);
+}
+
+// launch pamac-manager on app page
+function launchPamacForApp(app) {
+    if (app.get_is_flatpak()) {
+        // pamac-manager doesn't open on page of flatpak apps even if flatpak
+        // is enabled but let's launch it anyway so user can search for it.
+        const pkgName = app.get_flatpak_app_id();
+        _launchPamac(pkgName);
+    } else {
+        const filePath = app.desktop_file_path;
+        if (!filePath) return;
+        
+        const proc = Gio.Subprocess.new(
+            ['pacman', '-Qqo', filePath],
+            Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE
+        );
+        proc.communicate_utf8_async(null, null, (obj, res) => {
+            try {
+                let [success, stdout, stderr] = obj.communicate_utf8_finish(res);
+                if (success && stdout) {
+                    const foundPkg = stdout.trim();
+                    _launchPamac(foundPkg);
+                }
+            } catch (e) {
+                global.logError("pacman check failed: " + e.message);
+            }
+        });
+    }
+}
+

--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -430,11 +430,16 @@ class ApplicationContextMenuItem extends ContextMenuItem {
                 this._action = "add_to_favorites";
                 closeMenu = false;
                 break;
+            case "app_info":
+                if (this._button.applet._mintinstallAvailable) {
+                    AppUtils.launchMintinstallForApp(this._button.app);
+                } else if (this._button.applet._pamacManagerAvailable) {
+                    AppUtils.launchPamacForApp(this._button.app);
+                }
+                closeMenu = true;
+                break;
             case "app_properties":
                 Util.spawnCommandLine("cinnamon-desktop-editor -mlauncher -o" + GLib.shell_quote(this._button.app.get_app_info().get_filename()));
-                break;
-            case "uninstall":
-                Util.spawnCommandLine("/usr/bin/cinnamon-remove-application '" + this._button.app.get_app_info().get_filename() + "'");
                 break;
             case "offload_launch":
                 try {
@@ -534,13 +539,17 @@ class GenericApplicationButton extends SimpleMenuItem {
 
         const appinfo = this.app.get_app_info();
 
-        if (appinfo.get_filename() != null) {
-            menuItem = new ApplicationContextMenuItem(this, _("Properties"), "app_properties", "xsi-document-properties-symbolic");
-            menu.addMenuItem(menuItem);
+        if (this.applet._pamacManagerAvailable || this.applet._mintinstallAvailable) {
+            const filePath = this.app.desktop_file_path;
+            // Software managers usually only know of system installed apps.
+            if (!filePath.startsWith("/home/") && !filePath.includes("cinnamon-settings")) {
+                menuItem = new ApplicationContextMenuItem(this, _("App Info"), "app_info", "xsi-dialog-information-symbolic");
+                menu.addMenuItem(menuItem);
+            }
         }
 
-        if (this.applet._canUninstallApps) {
-            menuItem = new ApplicationContextMenuItem(this, _("Uninstall"), "uninstall", "xsi-edit-delete");
+        if (appinfo.get_filename() != null) {
+            menuItem = new ApplicationContextMenuItem(this, _("Properties"), "app_properties", "xsi-document-properties-symbolic");
             menu.addMenuItem(menuItem);
         }
 
@@ -1346,7 +1355,8 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         this._activeActor = null;
         this._knownApps = new Set(); // Used to keep track of apps that are already installed, so we can highlight newly installed ones
         this._appsWereRefreshed = false;
-        this._canUninstallApps = GLib.file_test("/usr/bin/cinnamon-remove-application", GLib.FileTest.EXISTS);
+        this._pamacManagerAvailable = GLib.find_program_in_path("pamac-manager");
+        this._mintinstallAvailable = GLib.find_program_in_path("mintinstall");
         this.RecentManager = DocInfo.getDocManager();
         this.privacy_settings = new Gio.Settings( {schema_id: PRIVACY_SCHEMA} );
         this.noRecentDocuments = true;


### PR DESCRIPTION
"Uninstall" calls cinnamon-remove-application, a simple mint only script. Replace with "App Info" to open mintinstall or pamac-manager (many arch based distros) on the app details page so user can view an app's details and optionally uninstall using the OS's software manager. Other distro's GUI software managers could optionally be added later.

Requires: https://github.com/linuxmint/mintinstall/pull/492

Replaces: https://github.com/linuxmint/cinnamon/pull/13527