### PR TITLE
theme: Fix a warning when opening the sound applet

### DIFF
--- a/data/theme/cinnamon-sass/widgets/_applets.scss
+++ b/data/theme/cinnamon-sass/widgets/_applets.scss
@@ -127,7 +127,7 @@ $applet_padding: 6px;
       width: 16px;
       height: 16px;
 
-      StIcon { icon-size: 1.2 em;}
+      StIcon { icon-size: 1.2em;}
     }
   }
 


### PR DESCRIPTION
This fixes constant "length values must specify a unit" spam when opening the sound applet.