### PR TITLE
dnd: guard against disposed dragActor in _onAnimationComplete and _dragComplete

### DIFF
--- a/js/ui/dnd.js
+++ b/js/ui/dnd.js
@@ -647,6 +647,14 @@ var _Draggable = new Lang.Class({
     },
 
     _onAnimationComplete : function (dragActor, eventTime) {
+        if (dragActor.is_finalized()) {
+            global.unset_cursor();
+            this.emit('drag-end', eventTime, false);
+            this._animationInProgress = false;
+            if (!this._buttonDown)
+                this._dragComplete();
+            return;
+        }
         if (this._dragOrigParent) {
             global.reparentActor (dragActor, this._dragOrigParent);
             dragActor.set_scale(this._dragOrigScale, this._dragOrigScale);
@@ -663,7 +671,7 @@ var _Draggable = new Lang.Class({
     },
 
     _dragComplete: function() {
-        if (this._dragOrigParent)
+        if (this._dragOrigParent && this._dragActor && !this._dragActor.is_finalized())
             Cinnamon.util_set_hidden_from_pick(this._dragActor, false);
 
         this._ungrabEvents();


### PR DESCRIPTION
## Summary

Fixes #13235

When Expo closes via hot corner, it creates and destroys `Clutter.Group` (overridden as `fake_group` in `overrides.js`) actors during the close animation. If a drag is in progress at that moment, `dnd.js` still holds a reference to the now-disposed actor in `this._dragActor`. When the drag ends, `_onAnimationComplete` and `_dragComplete` attempt to access the finalized GObject, triggering Gjs-CRITICAL errors and a CPU spin that freezes the desktop.

- Add `is_finalized()` check in `_onAnimationComplete` to bail out gracefully when the drag actor has been destroyed by C code before the animation completed
- Add `is_finalized()` guard in `_dragComplete` before calling `util_set_hidden_from_pick` on the drag actor

Tested on Linux Mint 22.3 / Cinnamon 6.6.7 with dual monitors and NVIDIA RTX 3050. No new `fake_group` disposed errors in `~/.xsession-errors` after fix, where previously they appeared consistently when using hot corners to trigger Expo.

Note: this fix was developed with AI assistance (Claude).