### PR TITLE
main.js: Don't import NetworkAgent unless nm_agent support is enabled.

### DIFF
--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -112,7 +112,6 @@ const KeyringPrompt = imports.ui.keyringPrompt;
 const RunDialog = imports.ui.runDialog;
 const Layout = imports.ui.layout;
 const LookingGlass = imports.ui.lookingGlass;
-const NetworkAgent = imports.ui.networkAgent;
 const NotificationDaemon = imports.ui.notificationDaemon;
 const WindowAttentionHandler = imports.ui.windowAttentionHandler;
 const CinnamonDBus = imports.ui.cinnamonDBus;
@@ -450,7 +449,7 @@ function start() {
     // NM Agent
     if (Config.BUILT_NM_AGENT) {
         if (global.settings.get_boolean("enable-nm-agent")) {
-            networkAgent = new NetworkAgent.NetworkAgent();
+            networkAgent = new imports.ui.networkAgent.NetworkAgent();
             global.log('NetworkManager agent: enabled')
         } else {
             global.log('NetworkManager agent: disabled by settings')


### PR DESCRIPTION
When networkmanager is not present, `imports.gi.NM` will raise an exception and cause cinnamon to die.

```
(cinnamon:1886): Cjs-CRITICAL **: 23:43:31.458: JS ERROR: Error: Requiring NM, version none: Typelib file for namespace 'NM' (any version) not found
@/usr/share/cinnamon/js/ui/networkAgent.js:7:12
@/usr/share/cinnamon/js/ui/main.js:115:22
@/usr/share/cinnamon/js/misc/util.js:19:14
overrideGObject@/usr/share/cinnamon/js/ui/overrides.js:29:32
init@/usr/share/cinnamon/js/ui/overrides.js:14:5
init@/usr/share/cinnamon/js/ui/environment.js:450:15
@<main>:1:24

** Message: 23:43:31.458: Execution of main.js threw exception: Script <main> threw an exception
```