### PR TITLE
fix(actions): don't use pull_request_target

### DIFF
--- a/.github/workflows/pattern-checker.yml
+++ b/.github/workflows/pattern-checker.yml
@@ -1,7 +1,7 @@
 name: Pattern Check
 
 on:
-    pull_request_target:
+    pull_request:
         branches: [ master ]
 
 permissions:
@@ -14,7 +14,7 @@ jobs:
 
         steps:
             - name: Checkout github-actions
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   repository: linuxmint/github-actions
                   path: _github-actions


### PR DESCRIPTION
# Why
`pull_request_target` is insecure.

# What
Don't use pull_request_target.
Update and pin action.

# Context
https://research.jfrog.com/post/part-1-pull-request-target-exploitation/#:~:text=pull%5Frequest%5Ftarget,-%2C%20where

See its usage here: https://github.com/linuxmint/cinnamon/actions?query=event%3Apull_request_target.

## TODO
Remove all instances of https://github.com/search?q=org%3Alinuxmint+pull_request_target&type=code.
Update description in https://github.com/linuxmint/github-actions/blob/master/install-deps/action.yml#L6.

All actions in the org need to be updated, pinned.
Workflows in https://github.com/linuxmint should be completly rethinked.

Tests welcome.