### PR TITLE
ListSettingsWidget: allow item edit only if edit button is visible

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/TreeListWidgets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/TreeListWidgets.py
@@ -241,7 +241,8 @@ class List(SettingsWidget):
             self.move_down_button.set_sensitive(True)
 
     def on_row_activated(self, *args):
-        self.edit_item()
+        if "edit" not in self.hidden_buttons:
+            self.edit_item()
 
     def add_item(self, *args):
         data = self.open_add_edit_dialog()


### PR DESCRIPTION
This fixes a bug where a user can edit a settings widget list item via double click when the _Edit_ button is hidden.

The intent of hiding the _Edit_ button is to prevent edits. This keeps the UI behavior consistent.

An example xlet using this is [Direct@claudiux](https://github.com/linuxmint/cinnamon-spices-applets/tree/master/Direct%40claudiux).