### PR TITLE
Change session type from Application to XSession

### DIFF
--- a/data/xsessions/cinnamon.desktop.in
+++ b/data/xsessions/cinnamon.desktop.in
@@ -4,5 +4,5 @@ Comment=This session logs you into Cinnamon
 Exec=cinnamon-session-cinnamon
 TryExec=@bindir@/cinnamon
 Icon=
-Type=Application
+Type=XSession
 

--- a/data/xsessions/cinnamon2d.desktop.in
+++ b/data/xsessions/cinnamon2d.desktop.in
@@ -4,7 +4,7 @@ Comment=This session logs you into Cinnamon (using software rendering)
 Exec=cinnamon-session-cinnamon2d
 TryExec=@bindir@/cinnamon2d
 Icon=
-Type=Application
+Type=XSession
 X-Ubuntu-Gettext-Domain=cinnamon
 X-GNOME-Provides=cinnamon2d
 


### PR DESCRIPTION
This fixes an issue with DisplayLink monitors not working on Cinnamon, as EVDI will not initialize them if it is not an XSession. This is also the proper type anyway. https://codesearch.debian.net/search?q=Type%3DXSession