### PR TITLE
extensions: Make register/unregisterTrayIconReplacement multi-instance compatible.

### DIFF
--- a/files/usr/share/cinnamon/applets/a11y@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/a11y@cinnamon.org/applet.js
@@ -39,7 +39,7 @@ class CinnamonA11YApplet extends Applet.TextIconApplet {
 
         try {
             this.metadata = metadata;
-            Main.systrayManager.registerTrayIconReplacement("a11y", metadata.uuid);
+            Main.systrayManager.registerTrayIconReplacement("a11y", metadata.uuid, this.instance_id);
 
             this.set_applet_icon_symbolic_name("xsi-accessibility");
             this.set_applet_tooltip(_("Accessibility"));
@@ -247,7 +247,7 @@ class CinnamonA11YApplet extends Applet.TextIconApplet {
     }
 
     on_applet_removed_from_panel() {
-        Main.systrayManager.unregisterTrayIconReplacement(this.metadata.uuid);
+        Main.systrayManager.unregisterTrayIconReplacement(this.metadata.uuid, this.instance_id);
     }
 }
 

--- a/files/usr/share/cinnamon/applets/keyboard@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/keyboard@cinnamon.org/applet.js
@@ -60,8 +60,8 @@ class CinnamonKeyboardApplet extends Applet.Applet {
 
         try {
             this.metadata = metadata;
-            Main.systrayManager.registerTrayIconReplacement("keyboard", metadata.uuid);
-            Main.systrayManager.registerTrayIconReplacement("input-method", metadata.uuid);
+            Main.systrayManager.registerTrayIconReplacement("keyboard", metadata.uuid, this.instance_id);
+            Main.systrayManager.registerTrayIconReplacement("input-method", metadata.uuid, this.instance_id);
 
             this.menuManager = new PopupMenu.PopupMenuManager(this);
             this.menu = new Applet.AppletPopupMenu(this, orientation);
@@ -354,7 +354,7 @@ class CinnamonKeyboardApplet extends Applet.Applet {
 
     on_applet_removed_from_panel() {
         this._signalManager.disconnectAllSignals();
-        Main.systrayManager.unregisterTrayIconReplacement(this.metadata.uuid);
+        Main.systrayManager.unregisterTrayIconReplacement(this.metadata.uuid, this.instance_id);
     }
 };
 

--- a/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
@@ -1803,8 +1803,8 @@ CinnamonNetworkApplet.prototype = {
 
         try {
             this.metadata = metadata;
-            Main.systrayManager.registerTrayIconReplacement("network", metadata.uuid);
-            Main.systrayManager.registerTrayIconReplacement("nm-applet", metadata.uuid);
+            Main.systrayManager.registerTrayIconReplacement("network", metadata.uuid, this.instance_id);
+            Main.systrayManager.registerTrayIconReplacement("nm-applet", metadata.uuid, this.instance_id);
 
             this.menuManager = new PopupMenu.PopupMenuManager(this);
             this.menu = new Applet.AppletPopupMenu(this, orientation);
@@ -2669,7 +2669,7 @@ CinnamonNetworkApplet.prototype = {
     },
 
     on_applet_removed_from_panel: function() {
-        Main.systrayManager.unregisterTrayIconReplacement(this.metadata.uuid);
+        Main.systrayManager.unregisterTrayIconReplacement(this.metadata.uuid, this.instance_id);
         Main.keybindingManager.removeXletHotKey(this, "network-open");
         if (this._periodicTimeoutId){
             Mainloop.source_remove(this._periodicTimeoutId);

--- a/files/usr/share/cinnamon/applets/network@cinnamon.org/metadata.json
+++ b/files/usr/share/cinnamon/applets/network@cinnamon.org/metadata.json
@@ -1,5 +1,6 @@
 {
  "uuid": "network@cinnamon.org",
+ "max-instances": -1,
  "name": "Network Manager",
  "description": "Network manager applet",
  "icon": "cs-network"

--- a/files/usr/share/cinnamon/applets/on-screen-keyboard@cinnamon.org/metadata.json
+++ b/files/usr/share/cinnamon/applets/on-screen-keyboard@cinnamon.org/metadata.json
@@ -1,5 +1,6 @@
 {
  "uuid": "on-screen-keyboard@cinnamon.org",
+ "max-instances": -1,
  "name": "On-Screen keyboard",
  "icon": "cinnamon-virtual-keyboard",
  "description": "A Cinnamon applet to launch the on-screen keyboard"

--- a/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
@@ -244,8 +244,8 @@ class CinnamonPowerApplet extends Applet.TextIconApplet {
 
         this.settings = new Settings.AppletSettings(this, metadata.uuid, instanceId);
 
-        Main.systrayManager.registerTrayIconReplacement("power", metadata.uuid);
-        Main.systrayManager.registerTrayIconReplacement("battery", metadata.uuid);
+        Main.systrayManager.registerTrayIconReplacement("power", metadata.uuid, this.instance_id);
+        Main.systrayManager.registerTrayIconReplacement("battery", metadata.uuid, this.instance_id);
 
         this.menuManager = new PopupMenu.PopupMenuManager(this);
         this.menu = new Applet.AppletPopupMenu(this, orientation);
@@ -732,7 +732,7 @@ class CinnamonPowerApplet extends Applet.TextIconApplet {
     }
 
     on_applet_removed_from_panel() {
-        Main.systrayManager.unregisterTrayIconReplacement(this.metadata.uuid);
+        Main.systrayManager.unregisterTrayIconReplacement(this.metadata.uuid, this.instance_id);
 
         if (!this._profilesProxy)
             return;

--- a/files/usr/share/cinnamon/applets/power@cinnamon.org/metadata.json
+++ b/files/usr/share/cinnamon/applets/power@cinnamon.org/metadata.json
@@ -1,5 +1,6 @@
 {
  "uuid": "power@cinnamon.org",
+ "max-instances": -1,
  "name": "Power Manager",
  "description": "Cinnamon power management applet",
  "icon": "cs-power"

--- a/files/usr/share/cinnamon/applets/slideshow@cinnamon.org/metadata.json
+++ b/files/usr/share/cinnamon/applets/slideshow@cinnamon.org/metadata.json
@@ -1,5 +1,6 @@
 {
 "uuid":"slideshow@cinnamon.org",
+"max-instances": -1,
 "name":"Slideshow Controls",
 "description":"Basic controls for the Cinnamon slideshow",
 "icon":"preferences-desktop-wallpaper"

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -1744,15 +1744,15 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
 
     registerSystrayIcons() {
         for (let i = 0; i < players_with_seek_support.length; i++) {
-            Main.systrayManager.registerTrayIconReplacement(players_with_seek_support[i], this.metadata.uuid);
+            Main.systrayManager.registerTrayIconReplacement(players_with_seek_support[i], this.metadata.uuid, this.instance_id);
         }
         for (let i = 0; i < players_without_seek_support.length; i++) {
-            Main.systrayManager.registerTrayIconReplacement(players_without_seek_support[i], this.metadata.uuid);
+            Main.systrayManager.registerTrayIconReplacement(players_without_seek_support[i], this.metadata.uuid, this.instance_id);
         }
     }
 
     unregisterSystrayIcons() {
-        Main.systrayManager.unregisterTrayIconReplacement(this.metadata.uuid);
+        Main.systrayManager.unregisterTrayIconReplacement(this.metadata.uuid, this.instance_id);
     }
 }
 

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/metadata.json
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/metadata.json
@@ -1,5 +1,6 @@
 {
  "uuid": "sound@cinnamon.org",
+ "max-instances": -1,
  "name": "Sound",
  "description": "A Cinnamon applet to control sound and music",
  "icon": "cs-sound"

--- a/files/usr/share/cinnamon/applets/xrandr@cinnamon.org/metadata.json
+++ b/files/usr/share/cinnamon/applets/xrandr@cinnamon.org/metadata.json
@@ -1,5 +1,6 @@
 {
  "uuid": "xrandr@cinnamon.org",
+ "max-instances": -1,
  "name": "Display",
  "description": "XRandR monitor control applet",
  "icon": "cs-display",

--- a/files/usr/share/cinnamon/desklets/photoframe@cinnamon.org/metadata.json
+++ b/files/usr/share/cinnamon/desklets/photoframe@cinnamon.org/metadata.json
@@ -1,5 +1,6 @@
 {
  "uuid": "photoframe@cinnamon.org",
+ "max-instances": -1,
  "name": "Digital photo frame",
  "description": "A digital photo frame desklet",
  "icon": "folder-pictures",

--- a/js/ui/systray.js
+++ b/js/ui/systray.js
@@ -32,24 +32,30 @@ SystrayManager.prototype = {
      * registerTrayIconReplacement:
      * @role (string): The systray icon name as reported in the logs.
      * @uuid (string): The uuid of the applet, desklet, or extension.
+     * @instanceId (int): Optional instance id for multi-instance support.
      *
-     * Registers the uuid to replace a tray icon identified by the role
+     * Registers the uuid to replace a tray icon identified by the role.
      */
-    registerTrayIconReplacement: function(role, uuid) {
-        this._roles.push({role: role.toLowerCase(), uuid: uuid});
+    registerTrayIconReplacement: function(role, uuid, instanceId) {
+        this._roles.push({role: role.toLowerCase(), uuid: uuid, instanceId: instanceId});
         this.emit("changed");
     },
 
     /**
      * unregisterTrayIconReplacement:
      * @uuid (string): The uuid of the applet, desklet, or extension.
+     * @instanceId (int): Optional instance id. If provided, only entries
+     * matching both uuid and instanceId are removed. If omitted, all
+     * entries for the uuid are removed.
      *
-     * Unregisters the any roles claimed by uuid.
+     * Unregisters any roles claimed by uuid (and optionally instanceId).
      */
-    unregisterTrayIconReplacement: function(uuid) {
+    unregisterTrayIconReplacement: function(uuid, instanceId) {
         for (let i = this._roles.length - 1; i >= 0; i--) {
             if (this._roles[i].uuid == uuid) {
-                this._roles.splice(i, 1);
+                if (instanceId === undefined || this._roles[i].instanceId === instanceId) {
+                    this._roles.splice(i, 1);
+                }
             }
         }
         this.emit("changed");


### PR DESCRIPTION
Most applets are already compatible, mark them so. Remaining ones
are:
- notifications (https://github.com/linuxmint/cinnamon/pull/13248)
- legacy systray applet.

Only a couple of third-party applets make use of the tray-icon-
replacement functions.

- The network applet sends its own notifications currently, and we'd
  end up with multiples. Possibly some of the network code can be
  put in a shared class/instance.