### PR TITLE
Fix battery status logic for CHARGING and PENDING_CHARGE states

### DIFF
--- a/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
@@ -445,6 +445,9 @@ class CinnamonPowerApplet extends Applet.TextIconApplet {
                 status = ngettext("Charging - %d minute until fully charged", "Charging - %d minutes until fully charged", minutes).format(minutes);
             }
         }
+        else if (state == UPDeviceState.PENDING_CHARGE) {
+            status = _("Pending charge");
+        }
         else if (state == UPDeviceState.FULLY_CHARGED) {
             status = _("Fully charged");
         }


### PR DESCRIPTION
Fixed issue #13686 

Previously, PENDING_CHARGE was unreachable due to duplicated condition checks. This separates the logic so both states are handled correctly (i hope).