### PR TITLE
menu@cinnamon.org: Fix keyboard layout switching when menu is open

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1804,6 +1804,16 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
 
     _onMenuKeyPress(actor, event) {
         let symbol = event.get_key_symbol();
+
+        // Allow layout switching (Caps_Lock / ISO_Next_Group) when menu is open
+        if (symbol === Clutter.KEY_ISO_Next_Group ||
+            symbol === Clutter.KEY_ISO_Prev_Group ||
+            symbol === Clutter.KEY_Caps_Lock) {
+            let inputSourceManager = imports.ui.keyboardManager.getInputSourceManager();
+            inputSourceManager._modifiersSwitcher(false);
+            return Clutter.EVENT_STOP;
+        }
+
         let item_actor;
         this.appBoxIter.reloadVisible();
         this.catBoxIter.reloadVisible();


### PR DESCRIPTION
When the menu applet is open, the search entry captures all key events, preventing keyboard layout switching via Caps Lock (grp:caps_toggle) or other XKB layout switch keys. The ISO_Next_Group/ISO_Prev_Group keysyms generated by XKB are consumed by the search field instead of triggering the layout switch.

Handle these keysyms explicitly in _onMenuKeyPress by calling the input source manager's switcher directly and stopping event propagation.