### PR TITLE
notifications@cinnamon.org - Avoid redundant update_list calls during clear all

### DIFF
--- a/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
@@ -243,14 +243,15 @@ class CinnamonNotificationsApplet extends Applet.TextIconApplet {
     }
 
     _clear_all() {
-        let count = this.notifications.length;
-        if (count > 0) {
-            for (let i = count-1; i >=0; i--) {
-                this._notificationbin.remove_actor(this.notifications[i].actor);
-                this.notifications[i].destroy(NotificationDestroyedReason.DISMISSED);
-            }
-        }
+        let toDestroy = this.notifications.slice();
+
+        // Clear tracking state first so destroy handlers skip redundant work.
         this.notifications = [];
+        this._notificationbin.remove_all_children();
+
+        for (let notification of toDestroy) {
+            notification.destroy(NotificationDestroyedReason.DISMISSED);
+        }
         this.update_list();
     }
 


### PR DESCRIPTION
## Problem

When clearing all notifications, each `notification.destroy()` triggers the destroy signal handler, which calls `update_list()` individually. With N notifications, this results in N+1 calls to `update_list()`, each recalculating urgency, updating icons/labels, reordering children, and requesting a relayout. When the notification count gets high, there is a noticeable hang when it clears all notifications. 50 notifications took 6.5 seconds to clear (see screenshot below).

## Fix

Added a `_clearing` flag that causes the destroy handler to skip `update_list()` during bulk clear. The single `update_list()` call at the end of `_clear_all()` handles final state. Wrapped in try/finally to guarantee the flag resets if a destroy call throws.                                                                                  

## Testing

Tested on Cinnamon 6.6.7 by triggering 50 notifications and clearing all. Verified via Looking Glass:

** Before: **
<img width="631" height="43" alt="image" src="https://github.com/user-attachments/assets/a480e507-4b41-4752-a50d-387ff81d7257" />

** After: **
<img width="592" height="39" alt="image" src="https://github.com/user-attachments/assets/bc5413c4-881f-4f16-8372-64b27dad61e6" />

Also verified:
  - Clear all updates tray icon and count correctly
  - Individual notification dismiss still updates the list