### PR TITLE
pointerTracker: fix ny coordinate using nx in get_real_pointer_position

### DIFF
--- a/js/misc/pointerTracker.js
+++ b/js/misc/pointerTracker.js
@@ -83,7 +83,7 @@ var PointerSwitcher = class {
         const monitor = Main.layoutManager.monitors[index];
 
         let real_x = (nx * monitor.width) + monitor.x;
-        let real_y = (nx * monitor.height) + monitor.y;
+        let real_y = (ny * monitor.height) + monitor.y;
 
         return [real_x, real_y];
     }


### PR DESCRIPTION
Fixes a copy-paste bug in get_real_pointer_position where ny was 
mistakenly using nx, causing incorrect Y positioning when using 
pointer-next/previous-monitor shortcuts.

Note: unrelated to #13716, found while investigating it.