### PR TITLE
Modified sound@cinnamon.org to autoexpand "Output device" category.

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -1070,6 +1070,7 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
         this._applet_context_menu.addMenuItem(this._selectOutputDeviceItem);
         this._outputApplicationsMenu.actor.hide();
         this._selectOutputDeviceItem.actor.hide();
+        this._selectOutputDeviceItem.menu.open();
 
         this._inputSection = new PopupMenu.PopupMenuSection();
         this._inputVolumeSection = new VolumeSlider(this, null, _("Microphone"), null);

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -1072,19 +1072,23 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
         this._applet_context_menu.addMenuItem(this._selectOutputDeviceItem);
         this._outputApplicationsMenu.actor.hide();
         this._selectOutputDeviceItem.actor.hide();
-        this._outputApplicationsMenu.menu.connect('open-state-changed', (menu, open) => {
-            if (this.alwaysExpandApplications && !open && this._outputApplicationsMenu.actor.visible)
-                menu.open();
+        this._applet_context_menu.connect('open-state-changed', (menu, open) => {
+            if (open) {
+                if (this.alwaysExpandApplications && this._outputApplicationsMenu.actor.visible)
+                    this._outputApplicationsMenu.menu.open();
+                if (this.alwaysExpandOutputDevice && this._selectOutputDeviceItem.actor.visible)
+                    this._selectOutputDeviceItem.menu.open();
+            }
         });
-        if (this.alwaysExpandApplications)
-            this._outputApplicationsMenu.menu.open();
-        else
-            this._outputApplicationsMenu.menu.close();
+        this._outputApplicationsMenu.actor.connect('notify::visible', () => {
+            if (this.alwaysExpandApplications && this._outputApplicationsMenu.actor.visible)
+                this._outputApplicationsMenu.menu.open();
+        });
 
-        if (this.alwaysExpandOutputDevice)
-            this._selectOutputDeviceItem.menu.open();
-        else
-            this._selectOutputDeviceItem.menu.close();
+        this._selectOutputDeviceItem.actor.connect('notify::visible', () => {
+            if (this.alwaysExpandOutputDevice && this._selectOutputDeviceItem.actor.visible)
+                this._selectOutputDeviceItem.menu.open();
+        });
 
         this._inputSection = new PopupMenu.PopupMenuSection();
         this._inputVolumeSection = new VolumeSlider(this, null, _("Microphone"), null);

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -988,6 +988,8 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
 
         this.settings.bind("keyOpen", "keyOpen", this._setKeybinding);
         this.settings.bind("alwaysShowMuteInput", "alwaysShowMuteInput", this.on_settings_changed);
+        this.settings.bind("alwaysExpandApplications", "alwaysExpandApplications", this.on_settings_changed);
+        this.settings.bind("alwaysExpandOutputDevice", "alwaysExpandOutputDevice", this.on_settings_changed);                
 
         this.settings.bind("tooltipShowVolume", "tooltipShowVolume", this.on_settings_changed);
         this.settings.bind("tooltipShowPlayer", "tooltipShowPlayer", this.on_settings_changed);
@@ -1070,7 +1072,19 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
         this._applet_context_menu.addMenuItem(this._selectOutputDeviceItem);
         this._outputApplicationsMenu.actor.hide();
         this._selectOutputDeviceItem.actor.hide();
-        this._selectOutputDeviceItem.menu.open();
+        this._outputApplicationsMenu.menu.connect('open-state-changed', (menu, open) => {
+            if (this.alwaysExpandApplications && !open && this._outputApplicationsMenu.actor.visible)
+                menu.open();
+        });
+        if (this.alwaysExpandApplications)
+            this._outputApplicationsMenu.menu.open();
+        else
+            this._outputApplicationsMenu.menu.close();
+
+        if (this.alwaysExpandOutputDevice)
+            this._selectOutputDeviceItem.menu.open();
+        else
+            this._selectOutputDeviceItem.menu.close();
 
         this._inputSection = new PopupMenu.PopupMenuSection();
         this._inputVolumeSection = new VolumeSlider(this, null, _("Microphone"), null);

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -1080,15 +1080,6 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
                     this._selectOutputDeviceItem.menu.open();
             }
         });
-        this._outputApplicationsMenu.actor.connect('notify::visible', () => {
-            if (this.alwaysExpandApplications && this._outputApplicationsMenu.actor.visible)
-                this._outputApplicationsMenu.menu.open();
-        });
-
-        this._selectOutputDeviceItem.actor.connect('notify::visible', () => {
-            if (this.alwaysExpandOutputDevice && this._selectOutputDeviceItem.actor.visible)
-                this._selectOutputDeviceItem.menu.open();
-        });
 
         this._inputSection = new PopupMenu.PopupMenuSection();
         this._inputVolumeSection = new VolumeSlider(this, null, _("Microphone"), null);

--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/settings-schema.json
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/settings-schema.json
@@ -26,6 +26,18 @@
         "tooltip": "Always show the 'Mute input' switch in the context menu.",
         "default": false
     },
+    "alwaysExpandApplications": {
+        "type": "switch",
+        "description": "Always expand applications",
+        "tooltip": "Always expand the 'Applications' list in the context menu.",
+        "default": false
+    },
+    "alwaysExpandOutputDevice": {
+        "type": "switch",
+        "description": "Always expand output devices",
+        "tooltip": "Always expand the 'Output device' list in the context menu.",
+        "default": true
+    },
     "_knownPlayers": {
         "type": "generic",
         "default": ["banshee", "vlc", "rhythmbox"]


### PR DESCRIPTION
The Linux Mint `sound@cinnamon.org` applet doesn't display the system's output devices by default when a user right clicks on the applet to open the context menu.

This change modifies it so that the category `Output device` is already expanded and doesn't hide what audio devices the user's system has which should make their discovery easier.