### PR TITLE
Fix battery status logic for CHARGING and PENDING_CHARGE states

### DIFF
--- a/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
@@ -448,7 +448,7 @@ class CinnamonPowerApplet extends Applet.TextIconApplet {
         else if (state == UPDeviceState.FULLY_CHARGED) {
             status = _("Fully charged");
         }
-        else if (state == UPDeviceState.FULLY_CHARGED) {
+        else if (state == UPDeviceState.PENDING_CHARGE) {
             status = _("Pending charge");
         }
         else if (state == UPDeviceState.DISCHARGING) {

--- a/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
@@ -448,6 +448,9 @@ class CinnamonPowerApplet extends Applet.TextIconApplet {
         else if (state == UPDeviceState.FULLY_CHARGED) {
             status = _("Fully charged");
         }
+        else if (state == UPDeviceState.FULLY_CHARGED) {
+            status = _("Pending charge");
+        }
         else if (state == UPDeviceState.DISCHARGING) {
             if (time == 0) {
                 status = _("Using battery power");


### PR DESCRIPTION
Fixed issue #13686

Previously, PENDING_CHARGE was unreachable due to duplicated condition checks. This separates the logic so both states are handled correctly (i hope).