### PR TITLE
appswitcher: Fix Alt+Shift+Tab (#13717)

### DIFF
--- a/js/ui/appSwitcher/appSwitcher.js
+++ b/js/ui/appSwitcher/appSwitcher.js
@@ -341,8 +341,13 @@ AppSwitcher.prototype = {
         let state = mods & this._modifierMask;
 
         if (state == 0) {
-            if (this._initialDelayTimeoutId !== 0)
-                this._currentIndex = (this._currentIndex + 1) % this._windows.length;
+            if (this._initialDelayTimeoutId !== 0) {
+                let name = this._binding ? this._binding.get_name() : '';
+                if (name.includes('backward'))
+                    this._currentIndex = (this._currentIndex - 1 + this._windows.length) % this._windows.length;
+                else
+                    this._currentIndex = (this._currentIndex + 1) % this._windows.length;
+            }
             this._activateSelected();
         }
 

--- a/js/ui/appSwitcher/appSwitcher.js
+++ b/js/ui/appSwitcher/appSwitcher.js
@@ -341,8 +341,13 @@ AppSwitcher.prototype = {
         let state = mods & this._modifierMask;
 
         if (state == 0) {
-            if (this._initialDelayTimeoutId !== 0)
-                this._currentIndex = (this._currentIndex + 1) % this._windows.length;
+            if (this._initialDelayTimeoutId !== 0) {
+                let backward = this._binding.is_reversed();
+                if (backward)
+                    this._currentIndex = (this._currentIndex - 1 + this._windows.length) % this._windows.length;
+                else
+                    this._currentIndex = (this._currentIndex + 1) % this._windows.length;
+            }
             this._activateSelected();
         }
 

--- a/js/ui/appSwitcher/appSwitcher3D.js
+++ b/js/ui/appSwitcher/appSwitcher3D.js
@@ -55,7 +55,7 @@ AppSwitcher3D.prototype = {
 
     _show: function() {
         this._enableMonitorFix();
-        
+        let [x, y, modifiers] = global.get_pointer();       
         let monitor = this._activeMonitor;
         this.actor.set_position(monitor.x, monitor.y);
         this.actor.set_size(monitor.width, monitor.height);
@@ -78,7 +78,10 @@ AppSwitcher3D.prototype = {
 
         this._initialDelayTimeoutId = 0;
 
-        this._next();
+        if (modifiers & Clutter.ModifierType.SHIFT_MASK)
+            this._previous();
+        else
+            this._next();
     },
     
     _hidePreviews: function(endOpacity) {

--- a/js/ui/appSwitcher/appSwitcher3D.js
+++ b/js/ui/appSwitcher/appSwitcher3D.js
@@ -55,7 +55,6 @@ AppSwitcher3D.prototype = {
 
     _show: function() {
         this._enableMonitorFix();
-        
         let monitor = this._activeMonitor;
         this.actor.set_position(monitor.x, monitor.y);
         this.actor.set_size(monitor.width, monitor.height);
@@ -78,7 +77,11 @@ AppSwitcher3D.prototype = {
 
         this._initialDelayTimeoutId = 0;
 
-        this._next();
+        let backward = this._binding.is_reversed();
+        if (backward)
+            this._previous();
+        else
+            this._next();
     },
     
     _hidePreviews: function(endOpacity) {

--- a/js/ui/appSwitcher/classicSwitcher.js
+++ b/js/ui/appSwitcher/classicSwitcher.js
@@ -139,10 +139,14 @@ ClassicSwitcher.prototype = {
 
     _show: function() {
         Main.panelManager.panels.forEach(function(panel) { panel.actor.set_reactive(false); });
-        
+        let [x, y, modifiers] = global.get_pointer();       
         this.actor.opacity = 255;
         this._initialDelayTimeoutId = 0;
-        this._next();
+
+        if (modifiers & Clutter.ModifierType.SHIFT_MASK)
+            this._previous();
+        else
+            this._next();
     },
     
     _hide: function() {

--- a/js/ui/appSwitcher/classicSwitcher.js
+++ b/js/ui/appSwitcher/classicSwitcher.js
@@ -139,10 +139,15 @@ ClassicSwitcher.prototype = {
 
     _show: function() {
         Main.panelManager.panels.forEach(function(panel) { panel.actor.set_reactive(false); });
-        
+
         this.actor.opacity = 255;
         this._initialDelayTimeoutId = 0;
-        this._next();
+
+        let backward = this._binding.is_reversed();
+        if (backward)
+            this._previous();
+        else
+            this._next();
     },
     
     _hide: function() {


### PR DESCRIPTION
Fixes #13717.

Previously, `_show` and `_keyReleaseEvent` always incremented the `currentIndex` value without taking the alt+shift+tab into account.

- Update `_show` and `_keyReleaseEvent` to detect backward keybindings.

- Adjust `_currentIndex` calculation to decrement for Alt+Shift+Tab.