### PR TITLE
Grouped window list: fix missing window title during transition of app between workspaces

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/workspace.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/workspace.js
@@ -322,9 +322,15 @@ var Workspace = class Workspace {
         if (refApp === -1) {
             initApp(-1);
         } else if (metaWindow) {
-            if (this.state.settings.groupApps) {
-                this.appGroups[refApp].windowAdded(metaWindow);
-            } else if (transientFavorite && this.appGroups[refApp].groupState.metaWindows.length === 0) {
+            if ((this.state.settings.groupApps || transientFavorite) && this.appGroups[refApp].groupState.metaWindows.length === 0) {
+                if (this.state.settings.groupApps && this.appGroups[refApp].groupState.isFavoriteApp) {
+                    isFavoriteApp = true;
+                }
+                this.appGroups[refApp].destroy();
+                this.appGroups.splice(refApp, 1);
+
+                initApp(refApp);
+            } else if (this.state.settings.groupApps) {
                 this.appGroups[refApp].windowAdded(metaWindow);
             } else if (refWindow === -1) {
                 initApp(refApp+1);


### PR DESCRIPTION
Fixes https://github.com/linuxmint/cinnamon/issues/12891.

Modified windowAdded, in case when a window moves to another workspace and arrives at an empty pinned app's panel group we now destroy and recreate the group in order to force UI refresh.