### PR TITLE
Change spinbutton and scale validation to inclusive

### DIFF
--- a/js/ui/settings.js
+++ b/js/ui/settings.js
@@ -862,7 +862,7 @@ XletSettingsBase.prototype = {
         switch (setting["type"]) {
             case "spinbutton":
             case "scale":
-                return (val < setting["max"] && val > setting["min"]);
+                return (val <= setting["max"] && val >= setting["min"]);
                 break;
             case "combobox":
             case "radiogroup":


### PR DESCRIPTION
`_checkSanity: function(val, setting)` returns false when `setting` is "scale" and `val` is equal to min or max allowed value. Changing line 865 fixes this issue.