### PR TITLE
cs_themes: Set value of xsettings on gtk theme selected

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
@@ -985,6 +985,17 @@ class Module:
         try:
             self.settings.set_string("gtk-theme", theme)
             self.set_button_chooser_text(self.theme_chooser, theme)
+            theme_lower = theme.lower()
+
+            if "darker" in theme_lower:
+                new_pref = 0
+            elif "dark" in theme_lower:
+                new_pref = 1
+            else:
+                new_pref = 2
+
+            self.xsettings.set_enum("color-scheme", new_pref)
+
         except Exception as detail:
             print(detail)
         return True


### PR DESCRIPTION
# Problem
Related to #12994, see my [comment](https://github.com/linuxmint/cinnamon/issues/12994#issuecomment-4321136962).

When the GTK theme is changed from advanced option it is not reflected on apps like firefox/libadwaita/flatpack apps.
I have to manually set prefer dark or light in the setting.
 
[theme-not-working-properly.webm](https://github.com/user-attachments/assets/6e2c2fb6-28a1-42ae-b7e2-b7c97fe9e15d)

I modified `_on_gtk_theme_selected` to set the xsettings value, the value of `org.x.apps.portal color-scheme` is decided and set based on theme's name.
After applying changes:

[cinnamon-2026-05-03T151933+0530.webm](https://github.com/user-attachments/assets/8e525b74-6549-42c2-a008-1ebd013017c8)

