### PR TITLE
backgrounds: Add 'wallpaper' to keywords

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_backgrounds.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_backgrounds.py
@@ -166,7 +166,7 @@ class Module:
     comment = _("Change your desktop's background")
 
     def __init__(self, content_box):
-        keywords = _("background, picture, slideshow")
+        keywords = _("background, picture, slideshow, wallpaper")
         self.sidePage = SidePage(_("Backgrounds"), "cs-backgrounds", keywords, content_box, module=self)
 
     def on_module_selected(self):


### PR DESCRIPTION
Updates the backgrounds .desktop file to include 'wallpaper' in its keywords.  This improves searchability in the menu, as users often use this  term interchangeably with 'background'.