### PR TITLE
menu: restore places order after search

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -2866,6 +2866,10 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         for (let i = 0; i < this._recentButtons.length; i++) {
             this.applicationsBox.set_child_at_index(this._recentButtons[i].actor, pos++);
         }
+
+        for (let i = 0; i < this._placesButtons.length; i++) {
+            this.placesBox.set_child_at_index(this._placesButtons[i].actor, i);
+        }
     }
 
     _select_category (name = null) {


### PR DESCRIPTION
Fixes #13757

The menu already restores the original order for application, favorite, and recent items via `_resetSortOrder()`, but `placesBox` items were not restored.

This patch restores the original order of `_placesButtons` after search state changes by resetting their child indices in `placesBox`.

I was not able to test this directly in a Cinnamon desktop environment, but the issue appears to be caused by places ordering not being reset when leaving search mode.
