### PR TITLE
fix scrolling in notifications applet by setting a maximum height

### DIFF
--- a/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/notifications@cinnamon.org/applet.js
@@ -109,6 +109,7 @@ class CinnamonNotificationsApplet extends Applet.TextIconApplet {
         this.scrollview.add_actor(this._notificationbin);
         this.scrollview.set_policy(St.PolicyType.NEVER, St.PolicyType.AUTOMATIC);
         this.scrollview.set_clip_to_allocation(true);
+        this.scrollview.set_style('max-height: 600px;');
 
         let vscroll = this.scrollview.get_vscroll_bar();
         vscroll.connect('scroll-start', Lang.bind(this, function() {


### PR DESCRIPTION
This will Fix #13761 by setting a maximum height for the notification applet, beyond which, the scrollbar will appear. Previously, the height was growing beyond the screen size, and the scrollbar never appeared.