### PR TITLE
fix(calendar-server): support ICal 4.0 with fallback from 3.0

### DIFF
--- a/calendar-server/cinnamon-calendar-server.py
+++ b/calendar-server/cinnamon-calendar-server.py
@@ -13,7 +13,10 @@ import signal
 import gi
 gi.require_version('EDataServer', '1.2')
 gi.require_version('ECal', '2.0')
-gi.require_version('ICal', '3.0')
+try:
+    gi.require_version('ICal', '3.0')
+except ValueError:
+    gi.require_version('ICal', '4.0')
 gi.require_version('Cinnamon', '0.1')
 from gi.repository import GLib, Gio, GObject
 from gi.repository import EDataServer, ECal, ICal, ICalGLib

--- a/calendar-server/cinnamon-calendar-server.py
+++ b/calendar-server/cinnamon-calendar-server.py
@@ -13,10 +13,14 @@ import signal
 import gi
 gi.require_version('EDataServer', '1.2')
 gi.require_version('ECal', '2.0')
-try:
+for ical_version in ('3.0', '4.0'):
+    try:
+        gi.require_version('ICal', ical_version)
+        break
+    except ValueError:
+        continue
+else:
     gi.require_version('ICal', '3.0')
-except ValueError:
-    gi.require_version('ICal', '4.0')
 gi.require_version('Cinnamon', '0.1')
 from gi.repository import GLib, Gio, GObject
 from gi.repository import EDataServer, ECal, ICal, ICalGLib


### PR DESCRIPTION
## Description

`cinnamon-calendar-server.py` hardcodes `gi.require_version('ICal', '3.0')`, which fails on systems with libical 4.0 (e.g. Manjaro) where the GIR namespace is `ICal-4.0`.

### Fix

Try known ICal versions (3.0, then 4.0) in a for/else loop. Falls back to the original `require_version('ICal', '3.0')` if neither is found, preserving the original error behavior.

### Related issue

Closes #13763