### PR TITLE
Add some options to cinnamon-screenshot

### DIFF
--- a/data/org.cinnamon.gschema.xml
+++ b/data/org.cinnamon.gschema.xml
@@ -1066,6 +1066,18 @@
       <description>When enabled, opens the file manager with the saved screenshot pre-selected after a successful save.</description>
     </key>
 
+    <key name="autosave-to-file" type="b">
+      <default>false</default>
+      <summary>Autosave screenshot to file</summary>
+      <description>When enabled, saves the screenshot to file without showing the application's interactive window</description>
+    </key>
+
+    <key name="autosave-to-clipboard" type="b">
+      <default>false</default>
+      <summary>Autosave screenshot to file</summary>
+      <description>When enabled, saves the screenshot to the clipboard without showing the application's interactive window</description>
+    </key>
+
   </schema>
 
 </schemalist>

--- a/files/usr/share/cinnamon/cinnamon-screenshot/application.py
+++ b/files/usr/share/cinnamon/cinnamon-screenshot/application.py
@@ -29,6 +29,15 @@ class ScreenshotApplication(Gtk.Application):
             self._run_clipboard()
         elif args.file and not args.interactive:
             self._run_save_to_file(args.file)
+        elif (prefs.get_autosave_to_file() or prefs.get_autosave_to_clipboard()) and not args.interactive:
+            if prefs.get_autosave_to_file():
+                filename = util.build_filename(
+                    prefs.get_save_directory(),
+                    file_type=prefs.get_default_file_type(),
+                )
+                self._run_save_to_file(filename)
+            if prefs.get_autosave_to_clipboard():
+                self._run_clipboard()
         else:
             self._run_window()
 

--- a/files/usr/share/cinnamon/cinnamon-screenshot/prefs.py
+++ b/files/usr/share/cinnamon/cinnamon-screenshot/prefs.py
@@ -12,6 +12,8 @@ INCLUDE_SHADOW_KEY = 'include-shadow'
 SAVE_DIRECTORY_KEY = 'save-directory'
 DEFAULT_FILE_TYPE_KEY = 'default-file-type'
 LAUNCH_FILE_MANAGER_KEY = 'launch-file-manager-after-save'
+AUTOSAVE_TO_FILE_KEY = 'autosave-to-file'
+AUTOSAVE_TO_CLIPBOARD_KEY = 'autosave-to-clipboard'
 
 settings = Gio.Settings.new(SCHEMA_ID)
 if not settings.get_string(SAVE_DIRECTORY_KEY):
@@ -58,6 +60,12 @@ def set_default_file_type(value):
 
 def get_launch_file_manager():
     return settings.get_boolean(LAUNCH_FILE_MANAGER_KEY)
+
+def get_autosave_to_file():
+    return settings.get_boolean(AUTOSAVE_TO_FILE_KEY)
+
+def get_autosave_to_clipboard():
+    return settings.get_boolean(AUTOSAVE_TO_CLIPBOARD_KEY)
 
 _current_window = None
 
@@ -107,6 +115,16 @@ class PreferencesWindow:
         section.add_row(GSettingsSwitch(
             _('Launch file manager after saving'),
             SCHEMA_ID, LAUNCH_FILE_MANAGER_KEY,
+        ))
+
+        section_behavior = page.add_section(_('Behavior'))
+        section_behavior.add_row(GSettingsSwitch(
+            _('Autosave to file'),
+            SCHEMA_ID, AUTOSAVE_TO_FILE_KEY,
+        ))
+        section_behavior.add_row(GSettingsSwitch(
+            _('Autosave to clipboard'),
+            SCHEMA_ID, AUTOSAVE_TO_CLIPBOARD_KEY,
         ))
 
         self.window.show_all()


### PR DESCRIPTION
This adds two option to cinnamon-screenshot:

- autosave-to-file
- autosave-to-clipboard

These options do what they're called, without opening the interactive window. Both options can be used at the same time.