### PR TITLE
Fix menu misalignment on first open after login

### DIFF
--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -1858,6 +1858,8 @@ var PopupMenu = class PopupMenu extends PopupMenuBase {
                 opacity: 255,
                 onComplete: () => {
                     this.animating = false;
+                    let [xPos, yPos] = this._calculatePosition();
+                    this.actor.set_position(xPos, yPos);
                 }
             }
 
@@ -1891,8 +1893,7 @@ var PopupMenu = class PopupMenu extends PopupMenuBase {
             this.animating = false;
 
             let [xPos, yPos] = this._calculatePosition(); // should this be conditional on this._slidePosition being -1?
-            this.actor.x = xPos;
-            this.actor.y = yPos;
+            this.actor.set_position(xPos, yPos);
 
             this.actor.show();
         }


### PR DESCRIPTION
## Summary

Fix #13780 - the menu appears at the wrong horizontal position on the
first click after login, then snaps to the correct position ~1 second
later.

## Root cause

Two interacting defects in `js/ui/popupMenu.js` `open()`:

### 1. Animation path: `_allocationChanged` blocked during animation

The `_allocationChanged` handler is guarded by `!this.animating` (line 2128).
When animation is enabled and `open()` runs:

1. `this.animating = true` is set (line 1851)
2. `_calculatePosition()` runs but the menu layout is incomplete - the
   applet's `_onOpenStateChanged` only shows `INITIAL_BUTTON_LOAD` buttons
   synchronously and defers the rest via `Mainloop.idle_add` (applet.js:1554)
3. When deferred buttons appear, the allocation changes, but
   `_allocationChanged` bails because `animating` is still `true`
4. Only after animation completes and `animating = false` does the next
   allocation change trigger `_allocationChanged` - the ~1 second snap

### 2. Non-animation path: separate x/y assignment races

With `this.actor.x = xPos; this.actor.y = yPos;`, setting `x` fires
`notify::allocation` -> `_allocationChanged` -> `set_position(x', y')`,
then `this.actor.y = yPos` overwrites the corrected Y with the stale value.

## Fix (3 insertions, 2 deletions in popupMenu.js)

### Change 1 - Animation path onComplete (line 1859-1862)

```js
onComplete: () => {
    this.animating = false;
    let [xPos, yPos] = this._calculatePosition();
    this.actor.set_position(xPos, yPos);
}
```

Recalculates and sets the correct position the instant the animation
finishes, no longer relying on a delayed `_allocationChanged`.

### Change 2 - Non-animation path (line 1893-1896)

```js
this.actor.set_position(xPos, yPos);
```

Atomic set eliminates the race between separate x/y assignments and the
synchronous `_allocationChanged` they trigger.

## Testing

1. Centre menu button on panel, reboot, click menu - correct on first click
2. No visual diff on subsequent opens
3. Test with animations enabled and disabled
4. Test with side-panel layouts

## Side effects

None. Adds a position recalibration at the natural completion point of the
animation (idempotent). Replaces racy two-step assignment with an atomic
call already used in this class (`shiftToPosition`, `_allocationChanged`).
