### PR TITLE
Fix three keyboard-related issues (#13787)

### DIFF
--- a/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js
@@ -1937,6 +1937,14 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                     return Clutter.EVENT_STOP;
                 }
                 break;
+            case Clutter.KEY_A:
+            case Clutter.KEY_a:
+                if (ctrlKey) {
+                    let textLen = this.searchEntryText.get_text().length;
+                    this.searchEntryText.set_selection(0, textLen);
+                    return Clutter.EVENT_STOP;
+                }
+                break;
             case Clutter.KEY_Menu:
                 if (this._activeContainer === this.applicationsBox) {
                     this.toggleContextMenu(active._delegate);

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -1372,7 +1372,7 @@ function _stageEventHandler(actor, event) {
             // modifier mask.
             if (action <= 0 && _lastModifierKeyCode > 0) {
                 let currentMask = _modifierMaskForKeySymbol(event.get_key_symbol());
-                action = global.display.get_keybinding_action(_lastModifierKeyCode, modifierState | currentMask);
+                action = global.display.get_keybinding_action(_lastModifierKeyCode, currentMask);
                 if (action > 0) {
                     let entry = keybindingManager.getBindingById(action);
                     if (!_shouldFilterKeybinding(entry)) {
@@ -1437,6 +1437,7 @@ function _findModal(actor) {
 
 function _completeModalSetup(actor, mode, onDismiss) {
     _modifierOnlyAction = 0;
+    _lastModifierKeyCode = 0;
 
     if (modalCount == 0)
         Meta.disable_unredirect_for_display(global.display);

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -1306,12 +1306,32 @@ function _shouldFilterKeybinding(entry) {
  * to give the multi-key binding a chance to activate on key-press.
  */
 let _modifierOnlyAction = 0;
+let _lastModifierKeyCode = 0;
 
 function _isModifierKeyval(symbol) {
     return symbol === Clutter.KEY_Super_L   || symbol === Clutter.KEY_Super_R   ||
            symbol === Clutter.KEY_Control_L || symbol === Clutter.KEY_Control_R ||
            symbol === Clutter.KEY_Alt_L     || symbol === Clutter.KEY_Alt_R     ||
            symbol === Clutter.KEY_Shift_L   || symbol === Clutter.KEY_Shift_R;
+}
+
+function _modifierMaskForKeySymbol(symbol) {
+    switch (symbol) {
+        case Clutter.KEY_Control_L:
+        case Clutter.KEY_Control_R:
+            return Clutter.ModifierType.CONTROL_MASK;
+        case Clutter.KEY_Shift_L:
+        case Clutter.KEY_Shift_R:
+            return Clutter.ModifierType.SHIFT_MASK;
+        case Clutter.KEY_Alt_L:
+        case Clutter.KEY_Alt_R:
+            return Clutter.ModifierType.MOD1_MASK;
+        case Clutter.KEY_Super_L:
+        case Clutter.KEY_Super_R:
+            return Clutter.ModifierType.MOD4_MASK;
+        default:
+            return 0;
+    }
 }
 
 function _stageEventHandler(actor, event) {
@@ -1345,10 +1365,34 @@ function _stageEventHandler(actor, event) {
                     return true;
                 }
             }
+
+            // Try reverse order for multi-modifier keybindings (e.g., Shift+Ctrl
+            // when the binding is stored as Ctrl+Shift). If a previous modifier
+            // key was pressed without matching, try its keycode with this key's
+            // modifier mask.
+            if (action <= 0 && _lastModifierKeyCode > 0) {
+                let currentMask = _modifierMaskForKeySymbol(event.get_key_symbol());
+                action = global.display.get_keybinding_action(_lastModifierKeyCode, modifierState | currentMask);
+                if (action > 0) {
+                    let entry = keybindingManager.getBindingById(action);
+                    if (!_shouldFilterKeybinding(entry)) {
+                        _modifierOnlyAction = action;
+                        _lastModifierKeyCode = 0;
+                        return true;
+                    }
+                }
+            }
+
+            // Any modifier key press that doesn't match cancels a pending
+            // single-modifier action from a previous modifier press.
+            _modifierOnlyAction = 0;
+            _lastModifierKeyCode = keyCode;
             return false;
         }
 
+        // Non-modifier key press clears pending modifier-only action.
         _modifierOnlyAction = 0;
+        _lastModifierKeyCode = 0;
 
         // During modal, muffin's process_iso_next_group doesn't run, handle xkb 'grp'
         // here.
@@ -1370,11 +1414,14 @@ function _stageEventHandler(actor, event) {
     }
 
     // Release event - activate the single-key modifier keybinding if one was stored.
-    if (_isModifierKeyval(event.get_key_symbol()) && _modifierOnlyAction > 0) {
-        let action = _modifierOnlyAction;
-        _modifierOnlyAction = 0;
-        keybindingManager.invoke_keybinding_action_by_id(action);
-        return true;
+    if (_isModifierKeyval(event.get_key_symbol())) {
+        _lastModifierKeyCode = 0;
+        if (_modifierOnlyAction > 0) {
+            let action = _modifierOnlyAction;
+            _modifierOnlyAction = 0;
+            keybindingManager.invoke_keybinding_action_by_id(action);
+            return true;
+        }
     }
 
     return false;

--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -1858,6 +1858,8 @@ var PopupMenu = class PopupMenu extends PopupMenuBase {
                 opacity: 255,
                 onComplete: () => {
                     this.animating = false;
+                    let [xPos, yPos] = this._calculatePosition();
+                    this.actor.set_position(xPos, yPos);
                 }
             }
 
@@ -1891,8 +1893,7 @@ var PopupMenu = class PopupMenu extends PopupMenuBase {
             this.animating = false;
 
             let [xPos, yPos] = this._calculatePosition(); // should this be conditional on this._slidePosition being -1?
-            this.actor.x = xPos;
-            this.actor.y = yPos;
+            this.actor.set_position(xPos, yPos);
 
             this.actor.show();
         }


### PR DESCRIPTION
## Summary

Fix #13787 - three keyboard and shortcut issues in the modal event handler
and menu search field.

---

### Issue 1: Ctrl+Shift order-dependent for layout switching

**Root cause:** In `_stageEventHandler` (`js/ui/main.js`), when the user
presses two modifier keys (e.g., Ctrl+Shift) and the keybinding is stored
as `<Control>Shift`, only "Ctrl first, then Shift" triggers the binding.
"Shift first, then Ctrl" fails because `get_keybinding_action(ctrl_keycode,
Shift_mask)` checks for a binding where Ctrl is the trigger key, but the
binding has Shift as the trigger key.

**Fix:** Track the previous modifier keycode (`_lastModifierKeyCode`) when a
modifier press doesn't match a binding. When the next modifier is pressed,
try the reverse combination: `get_keybinding_action(prev_keycode,
modifierState | current_mask)`. This correctly matches `<Control>Shift`
when Shift is pressed first.

### Issue 2: Super+Space closes the Start Menu

**Root cause:** When Super (the overlay key) is pressed, `_stageEventHandler`
stores its action in `_modifierOnlyAction`, deferred to key-release. If the
user then presses another modifier key that doesn't match a binding,
`_modifierOnlyAction` was never cleared, causing the overlay toggle to fire
on Super release - closing the menu while the user intended Super as part
of a combo (Super+Space for layout switching).

**Fix:** Clear `_modifierOnlyAction` in the modifier key press handler when
the press doesn't match any binding. Also clear it when a non-modifier key
press arrives. This ensures a subsequent modifier-only action only fires if
no other key was pressed between press and release.

### Issue 3: Ctrl+A does not select all text in search field

**Root cause:** The menu applet's `_onMenuKeyPress` handler connects to the
search entry `clutter_text`'s `key-press-event`. ClutterText does not
implement Ctrl+A (select all) by default in the version used by Cinnamon.
The event propagated but no built-in handler acted on it.

**Fix:** Add `Clutter.KEY_A` / `Clutter.KEY_a` cases in the `_onMenuKeyPress`
switch statement. When ctrlKey is held, call
`this.searchEntryText.set_selection(0, textLen)` to select all text.

---

## Files changed

- `js/ui/main.js` (+51, -5): Fix Issues 1 and 2 in `_stageEventHandler`
- `files/usr/share/cinnamon/applets/menu@cinnamon.org/applet.js` (+8, -0): Fix Issue 3 in `_onMenuKeyPress`

## Testing

1. **Issue 1:** Set Ctrl+Shift as layout switching shortcut. With the menu
   open, press Shift first then Ctrl (both orders). Layout should switch
   regardless of order.
2. **Issue 2:** Open the Start Menu (by mouse click). Press Super+Space
   (or whatever the layout switch combo is). The menu should stay open
   and the layout should switch. Solo Super press/release should still
   toggle the menu.
3. **Issue 3:** Open the Start Menu, type text in the search field, press
   Ctrl+A. All text should be selected.
