### PR TITLE
Fix issue #12641- invisible panel on second display

### DIFF
--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -942,6 +942,7 @@ var PanelManager = GObject.registerClass({
     }
 
     _onMonitorsChanged() {
+        this._fullPanelLoad();
         const oldCount = this.monitorCount;
         this.monitorCount = global.display.get_n_monitors();
 


### PR DESCRIPTION
If a secondary monitor is connected after cinnamon starts, the panels on the secondary monitor is not displayed. Calling the fullPanelLoad inside onMonitorsChanged fixes the issue.

fixes #12641 and fixes #12467