### PR TITLE
Fix for autofocus when modal dialogs are opened

### DIFF
--- a/js/ui/modalDialog.js
+++ b/js/ui/modalDialog.js
@@ -143,6 +143,12 @@ class ModalDialog extends BaseDialog.BaseDialog {
         if (!this.pushModal(timestamp))
             return false;
 
+        this._openedId = this.connect('opened', () => {
+            this.disconnect(this._openedId);
+            this._openedId = 0;
+            this._grabInitialKeyFocus();
+        });
+
         this._fadeOpen();
 
         if (this._lightbox && !this._keyboardVisibleId) {
@@ -153,12 +159,6 @@ class ModalDialog extends BaseDialog.BaseDialog {
                 });
             this._raiseKeyboardAboveDialog();
         }
-
-        this._openedId = this.connect('opened', () => {
-            this.disconnect(this._openedId);
-            this._openedId = 0;
-            this._grabInitialKeyFocus();
-        });
 
         return true;
     }


### PR DESCRIPTION
This fixes autofocus when modal dialogs are opened by connecting to the 'opened' signal before showing the dialog. When the animation time is greater than zero, the signal emission is delayed, so that it triggers after connecting. When the animation time is 0, signal emission is instant, so that the signal connect happened after the onComplete() function of the animation is called.