### PR TITLE
input methods: Add support for fcitx5.

### DIFF
--- a/files/usr/share/cinnamon/applets/keyboard@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/keyboard@cinnamon.org/applet.js
@@ -8,6 +8,7 @@ const Signals = imports.signals;
 const KeyboardManager = imports.ui.keyboardManager;
 const IBus = imports.gi.IBus;
 const IBusManager = imports.misc.ibusManager;
+const IMFramework = imports.misc.imFramework;
 const SignalManager = imports.misc.signalManager;
 
 const PANEL_EDIT_MODE_KEY = "panel-edit-mode";
@@ -57,11 +58,16 @@ class CinnamonKeyboardApplet extends Applet.Applet {
         this._selectedLayout = null;
         this._layoutItems = new Map();
 
+        // Under fcitx, layout/IME state and indication belong to fcitx's own tray
+        // icon. Stay hidden and don't suppress the external IM's tray icon.
+        this._imIsFcitx = IMFramework.getFramework() === IMFramework.FRAMEWORK_FCITX;
 
         try {
             this.metadata = metadata;
-            Main.systrayManager.registerTrayIconReplacement("keyboard", metadata.uuid);
-            Main.systrayManager.registerTrayIconReplacement("input-method", metadata.uuid);
+            if (!this._imIsFcitx) {
+                Main.systrayManager.registerTrayIconReplacement("keyboard", metadata.uuid);
+                Main.systrayManager.registerTrayIconReplacement("input-method", metadata.uuid);
+            }
 
             this.menuManager = new PopupMenu.PopupMenuManager(this);
             this.menu = new Applet.AppletPopupMenu(this, orientation);
@@ -119,7 +125,8 @@ class CinnamonKeyboardApplet extends Applet.Applet {
     }
 
     _onPanelEditModeChanged() {
-        this.actor.visible = global.settings.get_boolean(PANEL_EDIT_MODE_KEY) || this._inputSourcesManager.multipleSources;
+        this.actor.visible = !this._imIsFcitx &&
+            (global.settings.get_boolean(PANEL_EDIT_MODE_KEY) || this._inputSourcesManager.multipleSources);
     }
 
     on_applet_added_to_panel() {
@@ -180,7 +187,7 @@ class CinnamonKeyboardApplet extends Applet.Applet {
             this._layoutSection.addMenuItem(menuItem);
         }
 
-        if (!this._inputSourcesManager.multipleSources) {
+        if (this._imIsFcitx || !this._inputSourcesManager.multipleSources) {
             this.menu.close();
             this.actor.hide();
         } else {
@@ -220,7 +227,7 @@ class CinnamonKeyboardApplet extends Applet.Applet {
 
         this._panel_icon_box.set_child(actor);
 
-        if (!this._inputSourcesManager.multipleSources) {
+        if (this._imIsFcitx || !this._inputSourcesManager.multipleSources) {
             this.actor.hide();
         }
 

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/InputSources.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/InputSources.py
@@ -15,6 +15,7 @@ from xapp.SettingsWidgets import SettingsPage
 from xapp.GSettingsWidgets import PXGSettingsBackend, GSettingsSwitch
 
 from bin import AddKeyboardLayout
+from bin.util import using_fcitx
 
 MAX_LAYOUTS_PER_GROUP = 4
 
@@ -47,6 +48,10 @@ class InputSourceSettingsPage(SettingsPage):
 
         self.engine_config_button = builder.get_object("engine_config_button")
         self.engine_config_button.connect("clicked", self.on_engine_config_clicked)
+        # Configure is ibus-engine-specific; fcitx engines are configured in fcitx.
+        if using_fcitx():
+            self.engine_config_button.set_no_show_all(True)
+            self.engine_config_button.set_visible(False)
         self.add_layout_button = builder.get_object("add_layout")
         self.add_layout_button.connect("clicked", self.on_add_layout_clicked)
         self.remove_layout_button = builder.get_object("remove_layout")
@@ -57,6 +62,31 @@ class InputSourceSettingsPage(SettingsPage):
         self.move_layout_down_button.connect("clicked", self.on_move_layout_down_clicked)
 
         self.update_widgets()
+
+        if using_fcitx():
+            # Under fcitx, layout switching, the applet and per-window memory are
+            # owned by fcitx, and input methods are configured in fcitx's own
+            # tools. Explain that, with handoffs to those tools, in place of our
+            # options/shortcuts.
+            infobar = Gtk.InfoBar()
+            infobar.set_message_type(Gtk.MessageType.INFO)
+            label = Gtk.Label(
+                _("In Fcitx mode, input methods, additional layouts and their "
+                  "switching shortcuts are managed by Fcitx. Only the first "
+                  "layout configured here is used.")
+            )
+            label.set_line_wrap(True)
+            label.set_xalign(0.0)
+            infobar.get_content_area().add(label)
+
+            manage_button = Gtk.Button(label=_("Manage Fcitx"))
+            manage_button.connect("clicked", lambda widget: subprocess.Popen(["fcitx5-configtool"]))
+            infobar.get_action_area().pack_start(manage_button, False, False, 0)
+
+            infobar.show_all()
+            self.pack_start(infobar, False, False, 0)
+            self.reorder_child(infobar, 0)
+            return
 
         section = self.add_section(_("Options"))
         widget = GSettingsSwitch(

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/InputSources.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/InputSources.py
@@ -48,6 +48,12 @@ class InputSourceSettingsPage(SettingsPage):
 
         self.engine_config_button = builder.get_object("engine_config_button")
         self.engine_config_button.connect("clicked", self.on_engine_config_clicked)
+
+        self.im_launch_button = builder.get_object("im_launch_button")
+        self.im_launch_button.connect("clicked", lambda widget: subprocess.Popen(["mintlocale-im"]))
+        if not GLib.find_program_in_path("mintlocale-im"):
+            self.im_launch_button.set_visible(False)
+
         # Configure is ibus-engine-specific; fcitx engines are configured in fcitx.
         if using_fcitx():
             self.engine_config_button.set_no_show_all(True)

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/KeybindingTable.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/KeybindingTable.py
@@ -12,6 +12,8 @@ import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, Gdk, Gio, GObject, GLib
 
+from bin import util
+
 gettext.install("cinnamon", "/usr/share/locale")
 
 # Keybindings page - check if we need to store custom
@@ -591,6 +593,10 @@ class KeybindingTable(GObject.Object):
                 category.add(kb)
 
         for category in STATIC_KEYBINDINGS:
+            # The "Keyboard" category is just the layout-switch shortcuts; under
+            # fcitx, switching is owned by fcitx, so hide the whole category.
+            if category[1] == "keyboard" and util.using_fcitx():
+                continue
             _load_category(category)
 
     def _on_enabled_spices_changed(self, settings, key, data=None):

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/input-sources-list.ui
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/input-sources-list.ui
@@ -351,6 +351,11 @@
     <property name="can-focus">False</property>
     <property name="icon-name">xsi-go-down-symbolic</property>
   </object>
+  <object class="GtkImage" id="image3">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">mintlocale-im</property>
+  </object>
   <object class="GtkBox" id="input_sources_list_box">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
@@ -482,6 +487,23 @@
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <child>
+              <object class="GtkButton" id="im_launch_button">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="no-show-all">True</property>
+                <property name="tooltip-text" translatable="yes">Change framework or install language support.</property>
+                <property name="image">image3</property>
+                <property name="always-show-image">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="pack-type">end</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkButton" id="test_layout">
                 <property name="label" translatable="yes">View layout</property>
                 <property name="visible">True</property>
@@ -492,7 +514,7 @@
                 <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="pack-type">end</property>
-                <property name="position">0</property>
+                <property name="position">1</property>
               </packing>
             </child>
             <child>
@@ -505,7 +527,8 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">1</property>
+                <property name="pack-type">end</property>
+                <property name="position">2</property>
               </packing>
             </child>
             <style>

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/util.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/util.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 import os
+import shutil
 
 import gi
 gi.require_version('GSound', '1.0')
@@ -47,3 +48,8 @@ def get_session_type():
         pass
 
     return None
+
+def using_fcitx():
+    # Mirror js/misc/imFramework.js
+    mod = (os.environ.get("GTK_IM_MODULE") or os.environ.get("XMODIFIERS") or "").lower()
+    return "fcitx" in mod and shutil.which("fcitx5") is not None

--- a/js/misc/fcitxInputMethod.js
+++ b/js/misc/fcitxInputMethod.js
@@ -1,0 +1,298 @@
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+/* exported FcitxInputMethod */
+
+// Clutter.InputMethod backend that feeds Cinnamon's own Clutter actors (menu
+// search, run dialog, Looking Glass, ...) through fcitx5 instead of ibus, used
+// when fcitx is the active framework on X11 (see misc/imFramework.js).
+//
+// This mirrors misc/inputMethod.js (the ibus backend) one-to-one, but talks to
+// fcitx's dbusfrontend over plain Gio DBus (there is no fcitx gobject-
+// introspection binding the way there is for IBus):
+//
+//   service    org.fcitx.Fcitx5
+//   InputMethod1  /org/freedesktop/portal/inputmethod  org.fcitx.Fcitx.InputMethod1
+//   InputContext1 (path returned by CreateInputContext) org.fcitx.Fcitx.InputContext1
+//
+// fcitx draws its own candidate popup; we only bridge input and report the
+// caret rectangle so that popup lands in the right place. We deliberately do
+// NOT request ClientSideInputPanel, so candidates are never drawn in-process.
+
+const { Clutter, Gio, GLib, GObject } = imports.gi;
+
+const KeyboardManager = imports.ui.keyboardManager;
+
+var HIDE_PANEL_TIME = 50;
+
+const FCITX_SERVICE = 'org.fcitx.Fcitx5';
+const FCITX_IM_PATH = '/org/freedesktop/portal/inputmethod';
+const FCITX_IM_IFACE = 'org.fcitx.Fcitx.InputMethod1';
+const FCITX_IC_IFACE = 'org.fcitx.Fcitx.InputContext1';
+
+// fcitx CapabilityFlag bits (src/lib/fcitx-utils/capabilityflags.h)
+const CAP_PREEDIT = 1 << 1;
+const CAP_FORMATTED_PREEDIT = 1 << 4;
+const CAP_SURROUNDING_TEXT = 1 << 6;
+
+var FcitxInputMethod = GObject.registerClass(
+class FcitxInputMethod extends Clutter.InputMethod {
+    _init() {
+        super._init();
+        this._hints = 0;
+        this._purpose = 0;
+        this._currentFocus = null;
+        this._preeditStr = '';
+        this._preeditPos = 0;
+        this._preeditVisible = false;
+        this._hidePanelId = 0;
+
+        this._connection = null;
+        this._icPath = null;
+        this._signalIds = [];
+        this._cancellable = new Gio.Cancellable();
+
+        this.connect('notify::can-show-preedit', this._updateCapabilities.bind(this));
+
+        this._inputSourceManager = KeyboardManager.getInputSourceManager();
+        this._inputSourceManager.reload();
+        this._sourceChangedId = this._inputSourceManager.connect('current-source-changed',
+                                                                 this._onSourceChanged.bind(this));
+        this._currentSource = this._inputSourceManager.currentSource;
+        this._currentSource.activate(true);
+
+        this._watchId = Gio.bus_watch_name(Gio.BusType.SESSION, FCITX_SERVICE,
+                                           Gio.BusNameWatcherFlags.NONE,
+                                           this._onNameAppeared.bind(this),
+                                           this._onNameVanished.bind(this));
+    }
+
+    get currentFocus() {
+        return this._currentFocus;
+    }
+
+    _onSourceChanged() {
+        this._currentSource = this._inputSourceManager.currentSource;
+    }
+
+    _onNameAppeared(connection, _name, _owner) {
+        this._connection = connection;
+        this._createContext();
+    }
+
+    _onNameVanished() {
+        this._clear();
+    }
+
+    _createContext() {
+        // CreateInputContext(a(ss)) -> (o path, ay uuid)
+        let args = new GLib.Variant('(a(ss))', [[['program', 'cinnamon']]]);
+        this._connection.call(FCITX_SERVICE, FCITX_IM_PATH, FCITX_IM_IFACE,
+                              'CreateInputContext', args,
+                              new GLib.VariantType('(oay)'),
+                              Gio.DBusCallFlags.NONE, -1, this._cancellable,
+                              this._onContextCreated.bind(this));
+    }
+
+    _onContextCreated(connection, res) {
+        let path;
+        try {
+            [path] = connection.call_finish(res).deepUnpack();
+        } catch (e) {
+            if (!e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED))
+                logError(e, 'fcitx: CreateInputContext failed');
+            return;
+        }
+
+        this._icPath = path;
+
+        let subscribe = (signal, callback) => {
+            return this._connection.signal_subscribe(FCITX_SERVICE, FCITX_IC_IFACE,
+                                                     signal, this._icPath, null,
+                                                     Gio.DBusSignalFlags.NONE, callback);
+        };
+        this._signalIds.push(subscribe('CommitString', this._onCommitString.bind(this)));
+        this._signalIds.push(subscribe('UpdateFormattedPreedit', this._onUpdatePreedit.bind(this)));
+        this._signalIds.push(subscribe('ForwardKey', this._onForwardKey.bind(this)));
+        this._signalIds.push(subscribe('DeleteSurroundingText', this._onDeleteSurrounding.bind(this)));
+
+        this._updateCapabilities();
+
+        if (this._currentFocus)
+            this._icCall('FocusIn', null);
+    }
+
+    _icCall(method, params, replyType = null, callback = null) {
+        if (!this._connection || !this._icPath)
+            return;
+        this._connection.call(FCITX_SERVICE, this._icPath, FCITX_IC_IFACE, method,
+                              params, replyType, Gio.DBusCallFlags.NONE, -1,
+                              this._cancellable, callback);
+    }
+
+    _updateCapabilities() {
+        let caps = CAP_PREEDIT | CAP_FORMATTED_PREEDIT | CAP_SURROUNDING_TEXT;
+        // SetCapability(t) — note: we never set ClientSideInputPanel, so fcitx
+        // keeps drawing its own candidate popup.
+        this._icCall('SetCapability', new GLib.Variant('(t)', [caps]));
+    }
+
+    _clear() {
+        if (this._connection && this._signalIds.length > 0) {
+            for (let id of this._signalIds)
+                this._connection.signal_unsubscribe(id);
+        }
+        this._signalIds = [];
+
+        if (this._connection && this._icPath)
+            this._icCall('DestroyIC', null);
+
+        this._icPath = null;
+        this._connection = null;
+        this._hints = 0;
+        this._purpose = 0;
+        this._preeditStr = '';
+        this._preeditPos = 0;
+        this._preeditVisible = false;
+    }
+
+    _onCommitString(_conn, _sender, _path, _iface, _signal, params) {
+        let [text] = params.deepUnpack();
+        if (text)
+            this.commit(text);
+    }
+
+    _onUpdatePreedit(_conn, _sender, _path, _iface, _signal, params) {
+        // UpdateFormattedPreedit(a(si) strings, i cursor)
+        let [strings, pos] = params.deepUnpack();
+        let preedit = strings.map(s => s[0]).join('');
+
+        if (preedit.length > 0)
+            this.set_preedit_text(preedit, pos);
+        else if (this._preeditVisible)
+            this.set_preedit_text(null, pos);
+
+        this._preeditStr = preedit;
+        this._preeditPos = pos;
+        this._preeditVisible = preedit.length > 0;
+    }
+
+    _onForwardKey(_conn, _sender, _path, _iface, _signal, params) {
+        // ForwardKey(u keyval, u state, b isRelease)
+        let [keyval, state, isRelease] = params.deepUnpack();
+        let press = !isRelease;
+
+        let curEvent = Clutter.get_current_event();
+        let time;
+        if (curEvent)
+            time = curEvent.get_time();
+        else
+            time = global.display.get_current_time_roundtrip();
+
+        // fcitx doesn't give us a keycode on forwarded keys; 0 is acceptable.
+        this.forward_key(keyval, 0, state & Clutter.ModifierType.MODIFIER_MASK, time, press);
+    }
+
+    _onDeleteSurrounding(_conn, _sender, _path, _iface, _signal, params) {
+        // DeleteSurroundingText(i offset, u nchars)
+        let [offset, nchars] = params.deepUnpack();
+        try {
+            this.delete_surrounding(offset, nchars);
+        } catch (e) {
+            this.delete_surrounding(0, nchars + offset);
+        }
+    }
+
+    vfunc_focus_in(focus) {
+        this._currentFocus = focus;
+        this._icCall('FocusIn', null);
+
+        if (this._hidePanelId) {
+            GLib.source_remove(this._hidePanelId);
+            this._hidePanelId = 0;
+        }
+    }
+
+    vfunc_focus_out() {
+        this._currentFocus = null;
+        this._icCall('FocusOut', null);
+
+        if (this._preeditStr) {
+            this.set_preedit_text(null, 0);
+            this._preeditStr = null;
+        }
+
+        this._hidePanelId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, HIDE_PANEL_TIME, () => {
+            this.set_input_panel_state(Clutter.InputPanelState.OFF);
+            this._hidePanelId = 0;
+            return GLib.SOURCE_REMOVE;
+        });
+    }
+
+    vfunc_reset() {
+        this._icCall('Reset', null);
+
+        if (this._preeditStr) {
+            this.set_preedit_text(null, 0);
+            this._preeditStr = null;
+        }
+    }
+
+    vfunc_set_cursor_location(rect) {
+        // fcitx positions its own candidate popup from this. On X11 the stage
+        // covers the screen, so stage coords double as screen coords.
+        this._icCall('SetCursorRect',
+                     new GLib.Variant('(iiii)', [rect.get_x(), rect.get_y(),
+                                                 rect.get_width(), rect.get_height()]));
+    }
+
+    vfunc_set_surrounding(text, cursor, anchor) {
+        if (!text)
+            return;
+        // SetSurroundingText(s text, u cursor, u anchor)
+        this._icCall('SetSurroundingText',
+                     new GLib.Variant('(suu)', [text, cursor, anchor]));
+    }
+
+    vfunc_update_content_hints(hints) {
+        // fcitx expresses hints/purpose through capability flags differently from
+        // ibus; the base capabilities are sufficient for v1. Track for parity.
+        this._hints = hints;
+    }
+
+    vfunc_update_content_purpose(purpose) {
+        this._purpose = purpose;
+    }
+
+    vfunc_filter_key_event(event) {
+        if (!this._connection || !this._icPath)
+            return false;
+        if (!this._currentSource)
+            return false;
+
+        let isRelease = event.type() == Clutter.EventType.KEY_RELEASE;
+        let keyval = event.get_key_symbol();
+        // fcitx's own GTK frontend passes the X hardware keycode (evdev + 8),
+        // which is exactly what Clutter.get_key_code() returns — so no -8 here.
+        let keycode = event.get_key_code();
+        let state = event.get_state() & Clutter.ModifierType.MODIFIER_MASK;
+        let time = event.get_time();
+
+        // ProcessKeyEvent(u keyval, u keycode, u state, b isRelease, u time) -> (b handled)
+        this._connection.call(FCITX_SERVICE, this._icPath, FCITX_IC_IFACE,
+                              'ProcessKeyEvent',
+                              new GLib.Variant('(uuubu)', [keyval, keycode, state, isRelease, time]),
+                              new GLib.VariantType('(b)'),
+                              Gio.DBusCallFlags.NONE, -1, this._cancellable,
+                              (connection, res) => {
+                                  let handled = false;
+                                  try {
+                                      [handled] = connection.call_finish(res).deepUnpack();
+                                  } catch (e) {
+                                      if (e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED))
+                                          return;
+                                      log(`Error processing key on fcitx: ${e.message}`);
+                                  }
+                                  this.notify_key_event(event, handled);
+                              });
+        return true;
+    }
+});

--- a/js/misc/ibusManager.js
+++ b/js/misc/ibusManager.js
@@ -5,6 +5,7 @@ const { Gio, GLib, IBus, Meta } = imports.gi;
 const Signals = imports.signals;
 
 const IBusCandidatePopup = imports.ui.ibusCandidatePopup;
+const IMFramework = imports.misc.imFramework;
 
 // Ensure runtime version matches
 _checkIBusVersion(1, 5, 2);
@@ -47,6 +48,11 @@ var IBusManager = class {
         this._registerPropertiesId = 0;
         this._currentEngineName = null;
         this._preloadEnginesId = 0;
+        this._ibus = null;
+
+        if (IMFramework.getFramework() !== IMFramework.FRAMEWORK_IBUS) {
+            return;
+        }
 
         this._ibus = IBus.Bus.new_async();
         this._ibus.connect('connected', this._onConnected.bind(this));

--- a/js/misc/imFramework.js
+++ b/js/misc/imFramework.js
@@ -1,0 +1,43 @@
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+/* exported getFramework, FRAMEWORK_IBUS, FRAMEWORK_FCITX, FRAMEWORK_NONE */
+
+// Which input-method framework is active for this session.
+//
+// On X11 the choice is made by the user via mintlocale-im / im-config, which
+// exports GTK_IM_MODULE / XMODIFIERS at session start. We trust those: they are
+// the live truth for this session and need no subprocess to query.
+//
+// On Wayland, muffin routes app text-input (text-input-v3) through the in-process
+// ClutterInputMethod, which only has an ibus backend; there is no path for an
+// external fcitx to connect. So Wayland is always treated as ibus for now.
+//
+// Only an explicit fcitx selection changes behaviour; everything else stays on
+// the historical ibus path, so non-fcitx sessions are unaffected.
+
+const { GLib, Meta } = imports.gi;
+
+var FRAMEWORK_IBUS = 'ibus';
+var FRAMEWORK_FCITX = 'fcitx';
+var FRAMEWORK_NONE = 'none';
+
+let _framework = null;
+
+function getFramework() {
+    if (_framework != null)
+        return _framework;
+
+    if (Meta.is_wayland_compositor()) {
+        _framework = FRAMEWORK_IBUS;
+        return _framework;
+    }
+
+    // im-config sets GTK_IM_MODULE=fcitx from ~/.xinputrc without checking that
+    // fcitx is installed, so a stale config after uninstalling fcitx would still
+    // claim fcitx. Require the fcitx5 binary to actually be present (this also
+    // pins us to fcitx5, never fcitx4).
+    let mod = (GLib.getenv('GTK_IM_MODULE') || GLib.getenv('XMODIFIERS') || '').toLowerCase();
+    let isFcitx = mod.includes('fcitx') && GLib.find_program_in_path('fcitx5') != null;
+    _framework = isFcitx ? FRAMEWORK_FCITX : FRAMEWORK_IBUS;
+
+    return _framework;
+}

--- a/js/ui/keyboardManager.js
+++ b/js/ui/keyboardManager.js
@@ -7,6 +7,7 @@ const Signals = imports.signals;
 const ByteArray = imports.byteArray;
 
 const IBusManager = imports.misc.ibusManager;
+const IMFramework = imports.misc.imFramework;
 const LoginManager = imports.misc.loginManager;
 const Main = imports.ui.main;
 const PopupMenu = imports.ui.popupMenu;
@@ -165,6 +166,13 @@ var KeyboardManager = class {
     }
 
     _buildGroupStrings(_group) {
+        if (IMFramework.getFramework() === IMFramework.FRAMEWORK_FCITX) {
+            // Under fcitx, Cinnamon owns only the base layout; fcitx manages any
+            // alternate layouts itself. Send a single-group keymap.
+            let base = _group[0] || this._localeLayoutInfo;
+            return [base.layout, base.variant];
+        }
+
         let alreadyIncluded = _group.some(g => g.layout === this._localeLayoutInfo.layout &&
                                                 g.variant === this._localeLayoutInfo.variant);
         let group = alreadyIncluded ? _group : _group.concat(this._localeLayoutInfo);
@@ -550,6 +558,9 @@ var InputSourceManager = class {
     }
 
     _setupKeybindings() {
+        if (IMFramework.getFramework() === IMFramework.FRAMEWORK_FCITX)
+            return;
+
         let kb = this._kb_settings.get_strv("switch-input-source");
         Main.keybindingManager.addHotKeyArray(
             "switch-input-source", kb,

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -131,6 +131,8 @@ const Systray = imports.ui.systray;
 const Accessibility = imports.ui.accessibility;
 const ModalDialog = imports.ui.modalDialog;
 const InputMethod = imports.misc.inputMethod;
+const FcitxInputMethod = imports.misc.fcitxInputMethod;
+const IMFramework = imports.misc.imFramework;
 const ScreenRecorder = imports.ui.screenRecorder;
 const {GesturesManager} = imports.ui.gestures.gesturesManager;
 const {MonitorLabeler} = imports.ui.monitorLabeler;
@@ -524,7 +526,10 @@ function start() {
 
     _loadOskLayouts();
     keyboardManager = new KeyboardManager();
-    inputMethod = new InputMethod.InputMethod();
+    if (IMFramework.getFramework() === IMFramework.FRAMEWORK_FCITX)
+        inputMethod = new FcitxInputMethod.FcitxInputMethod();
+    else
+        inputMethod = new InputMethod.InputMethod();
     Clutter.get_default_backend().set_input_method(inputMethod);
     virtualKeyboardManager = new VirtualKeyboard.VirtualKeyboardManager();
     virtualKeyboardManager.connect("enabled-changed", () => {


### PR DESCRIPTION
- Don't launch ibus if it's not the session-preferred engine
- Add fcitx5 implementation of ClutterInputMethod, allowing
  integration with clutter entries.
- fcitx provides all popups and indicators and shortcut handling.

We probably shouldn't actively break a user's preferred engine,
and there are gaps in ibus' language support.

Requires:
https://github.com/linuxmint/cinnamon-session/commit/f8836e8208b719e
https://github.com/linuxmint/cinnamon-settings-daemon/commit/de97f127
https://github.com/linuxmint/mintlocale/commit/87d55141378

Fixes https://github.com/linuxmint/cinnamon/issues/12851

Ref: https://github.com/linuxmint/cinnamon/issues/11115, https://github.com/linuxmint/cinnamon/issues/13387, https://github.com/linuxmint/cinnamon/issues/13622

Related: https://github.com/linuxmint/mintlocale/issues/85, https://github.com/linuxmint/mintlocale/issues/89, https://github.com/linuxmint/mintlocale/issues/93