### PR TITLE
st-theme-node: Allow unitless integers for background-blur property

### DIFF
--- a/src/st/st-theme-node.c
+++ b/src/st/st-theme-node.c
@@ -1960,6 +1960,16 @@ _st_theme_node_ensure_background (StThemeNode *node)
           else
             node->background_position_set = TRUE;
         }
+      else if (strcmp (property_name, "-blur") == 0)
+        {
+          CRTerm *term = decl->value;
+          if (term != NULL &&
+              term->type == TERM_NUMBER &&
+              term->content.num->type == NUM_GENERIC)
+            node->background_blur = (int) term->content.num->val;
+          else
+            get_length_from_term_int (node, decl->value, FALSE, &node->background_blur);
+        }
       else if (strcmp (property_name, "-repeat") == 0)
         {
           if (decl->value->type == TERM_IDENT)


### PR DESCRIPTION
Previously, theme developers might encounter parsing issues or strict requirements if they attempted to define blur radii without explicit length units (like px). By supporting NUM_GENERIC types for the -blur property, this change improves developer ergonomics and makes the theme parser more forgiving and robust. It aligns the parser more closely with expected CSS/SASS behaviors where unitless integers are frequently used for scaling or rendering properties.

How was this implemented?
Added a new property check for -blur inside _st_theme_node_ensure_background.

The parser now explicitly checks if the CSS declaration value (decl->value) is a raw number (TERM_NUMBER & NUM_GENERIC).

If it is a unitless integer, it safely casts and assigns it directly to node->background_blur.

If it is not a generic number (e.g., it has a px or em unit), it smoothly falls back to the existing get_length_from_term_int helper function to resolve the value.