### PR TITLE
Grouped Window List Window Association Enhancements

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -639,6 +639,56 @@ class GroupedWindowListApplet extends Applet.Applet {
         this.state.set({lastTitleDisplay: titleDisplay});
     }
 
+    _matchFavoriteToWindow(fav, wmClass, wmInstance, gtkAppId) {
+        if (!fav || !fav.app) {
+            return false;
+        }
+
+        let favId = fav.id.toLowerCase();
+        // Get base name without path and .desktop
+        let baseName = favId.substring(favId.lastIndexOf('/') + 1).replace('.desktop', '');
+
+        // 1. Direct match on desktop ID base name (case-insensitive)
+        if (baseName === wmClass || baseName === wmInstance || (gtkAppId && baseName === gtkAppId)) {
+            return true;
+        }
+
+        // 2. Match on StartupWMClass from the app info
+        let appInfo = fav.app.get_app_info();
+        if (appInfo) {
+            let startupClass = appInfo.get_startup_wm_class ? appInfo.get_startup_wm_class() : null;
+            if (!startupClass) {
+                try {
+                    startupClass = appInfo.get_string("StartupWMClass");
+                } catch (e) {}
+            }
+            if (startupClass) {
+                startupClass = startupClass.toLowerCase();
+                if (startupClass === wmClass || startupClass === wmInstance) {
+                    return true;
+                }
+            }
+
+            // 3. Match executable/command name
+            let exec = appInfo.get_executable ? appInfo.get_executable() : null;
+            if (!exec) {
+                try {
+                    let cmd = appInfo.get_commandline ? appInfo.get_commandline() : "";
+                    if (cmd) {
+                        exec = cmd.split(' ')[0];
+                    }
+                } catch (e) {}
+            }
+            if (exec) {
+                let execBase = exec.substring(exec.lastIndexOf('/') + 1).toLowerCase();
+                if (execBase === wmClass || execBase === wmInstance) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     _matchWindowToPinnedApp(metaWindow) {
         if (!this.pinnedFavorites || !this.pinnedFavorites._favorites) {
             return null;
@@ -654,49 +704,8 @@ class GroupedWindowListApplet extends Applet.Applet {
 
         // Iterate through pinned favorites
         for (let fav of this.pinnedFavorites._favorites) {
-            if (!fav || !fav.app) continue;
-
-            let favId = fav.id.toLowerCase();
-            // Get base name without path and .desktop
-            let baseName = favId.substring(favId.lastIndexOf('/') + 1).replace('.desktop', '');
-
-            // 1. Direct match on desktop ID base name (case-insensitive)
-            if (baseName === wmClass || baseName === wmInstance || (gtkAppId && baseName === gtkAppId)) {
+            if (this._matchFavoriteToWindow(fav, wmClass, wmInstance, gtkAppId)) {
                 return fav.app;
-            }
-
-            // 2. Match on StartupWMClass from the app info
-            let appInfo = fav.app.get_app_info();
-            if (appInfo) {
-                let startupClass = appInfo.get_startup_wm_class ? appInfo.get_startup_wm_class() : null;
-                if (!startupClass) {
-                    try {
-                        startupClass = appInfo.get_string("StartupWMClass");
-                    } catch (e) {}
-                }
-                if (startupClass) {
-                    startupClass = startupClass.toLowerCase();
-                    if (startupClass === wmClass || startupClass === wmInstance) {
-                        return fav.app;
-                    }
-                }
-
-                // 3. Match executable/command name
-                let exec = appInfo.get_executable ? appInfo.get_executable() : null;
-                if (!exec) {
-                    try {
-                        let cmd = appInfo.get_commandline ? appInfo.get_commandline() : "";
-                        if (cmd) {
-                            exec = cmd.split(' ')[0];
-                        }
-                    } catch (e) {}
-                }
-                if (exec) {
-                    let execBase = exec.substring(exec.lastIndexOf('/') + 1).toLowerCase();
-                    if (execBase === wmClass || execBase === wmInstance) {
-                        return fav.app;
-                    }
-                }
             }
         }
         return null;

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/applet.js
@@ -639,7 +639,80 @@ class GroupedWindowListApplet extends Applet.Applet {
         this.state.set({lastTitleDisplay: titleDisplay});
     }
 
+    _matchWindowToPinnedApp(metaWindow) {
+        if (!this.pinnedFavorites || !this.pinnedFavorites._favorites) {
+            return null;
+        }
+
+        let wmClass = metaWindow.get_wm_class();
+        let wmInstance = metaWindow.get_wm_class_instance();
+        let gtkAppId = metaWindow.get_gtk_application_id ? metaWindow.get_gtk_application_id() : null;
+
+        wmClass = wmClass ? wmClass.toLowerCase() : "";
+        wmInstance = wmInstance ? wmInstance.toLowerCase() : "";
+        gtkAppId = gtkAppId ? gtkAppId.toLowerCase() : "";
+
+        // Iterate through pinned favorites
+        for (let fav of this.pinnedFavorites._favorites) {
+            if (!fav || !fav.app) continue;
+
+            let favId = fav.id.toLowerCase();
+            // Get base name without path and .desktop
+            let baseName = favId.substring(favId.lastIndexOf('/') + 1).replace('.desktop', '');
+
+            // 1. Direct match on desktop ID base name (case-insensitive)
+            if (baseName === wmClass || baseName === wmInstance || (gtkAppId && baseName === gtkAppId)) {
+                return fav.app;
+            }
+
+            // 2. Match on StartupWMClass from the app info
+            let appInfo = fav.app.get_app_info();
+            if (appInfo) {
+                let startupClass = appInfo.get_startup_wm_class ? appInfo.get_startup_wm_class() : null;
+                if (!startupClass) {
+                    try {
+                        startupClass = appInfo.get_string("StartupWMClass");
+                    } catch (e) {}
+                }
+                if (startupClass) {
+                    startupClass = startupClass.toLowerCase();
+                    if (startupClass === wmClass || startupClass === wmInstance) {
+                        return fav.app;
+                    }
+                }
+
+                // 3. Match executable/command name
+                let exec = appInfo.get_executable ? appInfo.get_executable() : null;
+                if (!exec) {
+                    try {
+                        let cmd = appInfo.get_commandline ? appInfo.get_commandline() : "";
+                        if (cmd) {
+                            exec = cmd.split(' ')[0];
+                        }
+                    } catch (e) {}
+                }
+                if (exec) {
+                    let execBase = exec.substring(exec.lastIndexOf('/') + 1).toLowerCase();
+                    if (execBase === wmClass || execBase === wmInstance) {
+                        return fav.app;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
     getAppFromWindow(metaWindow) {
+        if (!metaWindow) {
+            return null;
+        }
+
+        // Try matching against pinned favorites first to prevent duplicate icons
+        let pinnedMatch = this._matchWindowToPinnedApp(metaWindow);
+        if (pinnedMatch) {
+            return pinnedMatch;
+        }
+
         const tracker = this.state.trigger('getTracker');
         if (!tracker) {
           return null;
@@ -651,6 +724,20 @@ class GroupedWindowListApplet extends Applet.Applet {
         if (!app) {
           app = tracker.get_app_from_pid(metaWindow.get_client_pid());
         }
+
+        // Fallback: If the tracker returned a transient app, check if its ID matches a pinned favorite
+        if (app && this.pinnedFavorites && this.pinnedFavorites._favorites) {
+            let appId = app.get_id().toLowerCase();
+            for (let fav of this.pinnedFavorites._favorites) {
+                if (!fav || !fav.app) continue;
+                let favId = fav.id.toLowerCase();
+                let baseName = favId.substring(favId.lastIndexOf('/') + 1).replace('.desktop', '');
+                if (appId === baseName || appId === favId) {
+                    return fav.app;
+                }
+            }
+        }
+
         return app;
     }
 
@@ -1030,6 +1117,9 @@ class GroupedWindowListApplet extends Applet.Applet {
 
     onWindowSkipTaskbarChanged(display, metaWindow) {
         const currentWorkspace = this.getCurrentWorkspace();
+        if (!currentWorkspace) {
+            return;
+        }
 
         if (metaWindow.is_skip_taskbar()) {
             currentWorkspace.windowRemoved(currentWorkspace.metaWorkspace, metaWindow);


### PR DESCRIPTION
## Problem
In Cinnamon, the **Grouped Window List (GWL)** applet relies on `Cinnamon.WindowTracker` to associate running windows with their corresponding launcher `.desktop` files. This association frequently fails for applications that:
1. Do not define a `StartupWMClass` key in their `.desktop` files.
2. Have casing discrepancies between their X11 `WM_CLASS` values and their `.desktop` file names (e.g. `Brave-browser` vs `brave-browser.desktop` or `GitKraken` vs `GitKraken.desktop`).
3. Are launched via wrapper scripts or subprocess execution models (e.g. Electron apps, Java applications, or multi-process systems), which obscures the mapping process.

When this failure occurs, the window is classified as a transient or generic application. The GWL applet then spawns a duplicate, unpinned icon on the panel rather than nesting/grouping the window under its existing pinned launcher.

Additionally, a potential early-startup race condition existed in `onWindowSkipTaskbarChanged` where `getCurrentWorkspace()` could return `null` before workspaces were fully loaded, causing a fatal JS TypeError (`TypeError: currentWorkspace is null`) that broke subsequent applet event handling.

## Changes Included

### 1. Pinned Launcher Fallback Matching (`_matchWindowToPinnedApp`)
Introduced a helper method `_matchWindowToPinnedApp(metaWindow)` that proactively queries the pinned favorites list to resolve window associations if the standard `WindowTracker` lookup fails or returns a transient app. It matches a window's `WM_CLASS` (both class name and instance name) and GTK application ID against:
*   **Desktop file base names:** Case-insensitively matches the base name of the pinned desktop launcher (e.g., `gitkraken` derived from `GitKraken.desktop`).
*   **StartupWMClass Key:** Retrieves the `StartupWMClass` key from the `.desktop` file metadata (using `Gio.AppInfo` APIs) and compares it case-insensitively.
*   **Executable/Command Line:** Extracts the executable name/command line specified in the `.desktop` entry's `Exec` field to match against the running process's window class.

### 2. TypeError Null-Check
Added a null-check check for `currentWorkspace` at the entry point of `onWindowSkipTaskbarChanged` in `applet.js`:
```javascript
    onWindowSkipTaskbarChanged(display, metaWindow) {
        const currentWorkspace = this.getCurrentWorkspace();
        if (!currentWorkspace) {
            return;
        }
        // ...
    }
```
This safely prevents early-startup crashes when taskbar skip events are fired before the workspace array is fully initialized.

## Rationale & Benefits
*   **Zero-Configuration Grouping:** Users no longer need to manually modify system-wide or user-space `.desktop` entries to add `StartupWMClass` keys or fix casing to prevent duplicate icons.
*   **Electron & Wrapper Compatibility:** Automatically corrects mapping for popular Electron-based applications (like GitKraken, Slack, VS Code, Discord) and standard applications with wrapper binaries.
*   **Robust Shell Reliability:** Eliminates a known startup-time JS crash, ensuring that window tracker callbacks are consistently registered and handled.