### PR TITLE
network: Remove stale wireguard connections

### DIFF
--- a/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
@@ -2309,6 +2309,10 @@ CinnamonNetworkApplet.prototype = {
             this._devices.vpn.device.removeConnection(connection);
             if (this._devices.vpn.device.empty)
                 this._devices.vpn.section.actor.hide();
+        } else if (section == NMConnectionCategory.WIREGUARD) {
+            this._devices.wireguard.device.removeConnection(connection);
+            if (this._devices.wireguard.device.empty)
+                this._devices.wireguard.section.actor.hide();
         } else if (section != NMConnectionCategory.INVALID) {
             let devices = this._devices[section].devices;
             for (let i = 0; i < devices.length; i++)


### PR DESCRIPTION
Fixes WireGuard connections lingering in the Cinnamon Network Manager applet by ensuring WireGuard entries are removed and the WireGuard section is hidden when it becomes empty.

Changes:

Handle NMConnectionCategory.WIREGUARD in _connectionRemoved() by removing the connection from the WireGuard device list.
Hide the WireGuard menu section when no WireGuard connections remain.

Fixes #12581 