### PR TITLE
keyboard: fall back to tecla for layout preview, hide menu actions for missing tools

### DIFF
--- a/files/usr/share/cinnamon/applets/keyboard@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/keyboard@cinnamon.org/applet.js
@@ -4,6 +4,8 @@ const Main = imports.ui.main;
 const PopupMenu = imports.ui.popupMenu;
 const Util = imports.misc.util;
 const Gio = imports.gi.Gio;
+const GLib = imports.gi.GLib;
+const Meta = imports.gi.Meta;
 const Signals = imports.signals;
 const KeyboardManager = imports.ui.keyboardManager;
 const IBus = imports.gi.IBus;
@@ -86,7 +88,9 @@ class CinnamonKeyboardApplet extends Applet.Applet {
             this._propSection = new PopupMenu.PopupMenuSection();
             this.menu.addMenuItem(this._propSection);
             this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-            this.showLayoutAction = this.menu.addAction(_("Show Keyboard Layout"), () => this._showActiveLayout());
+            this.showLayoutAction = null;
+            if (this._getLayoutDisplayProgram() !== null)
+                this.showLayoutAction = this.menu.addAction(_("Show Keyboard Layout"), () => this._showActiveLayout());
             this.menu.addAction(_("Show Character Table"), () => {
                 Main.overview.hide();
                 Util.spawn(['gucharmap']);
@@ -104,16 +108,36 @@ class CinnamonKeyboardApplet extends Applet.Applet {
         }
     }
 
+    _getLayoutDisplayProgram() {
+        // gkbd-keyboard-display (libgnomekbd) is X11-only, so on Wayland only
+        // tecla is usable. On X11 keep gkbd-keyboard-display preferred where
+        // still available (tecla only shows a standard pc105 geometry).
+        const candidates = Meta.is_wayland_compositor() ?
+            ['tecla'] : ['gkbd-keyboard-display', 'tecla'];
+        for (const program of candidates) {
+            if (GLib.find_program_in_path(program))
+                return program;
+        }
+        return null;
+    }
+
     _showActiveLayout() {
         Main.overview.hide();
 
         let source = this._inputSourcesManager.currentSource;
 
         let description = source.xkbLayout;
-        if (source.variant.length > 0)
-            description = '%s\t%s'.format(description, source.variant);
-
-        Util.spawn(['gkbd-keyboard-display', '-l', description]);
+        if (this._getLayoutDisplayProgram() === 'tecla') {
+            // '+' is the layout/variant separator accepted by every tecla
+            // version (space and tab only since tecla 48)
+            if (source.variant.length > 0)
+                description = '%s+%s'.format(description, source.variant);
+            Util.spawn(['tecla', description]);
+        } else {
+            if (source.variant.length > 0)
+                description = '%s\t%s'.format(description, source.variant);
+            Util.spawn(['gkbd-keyboard-display', '-l', description]);
+        }
     }
 
     _onCurrentSourceChanged() {
@@ -233,7 +257,8 @@ class CinnamonKeyboardApplet extends Applet.Applet {
             this.actor.hide();
         }
 
-        this.showLayoutAction.setSensitive(selected.type === 'xkb');
+        if (this.showLayoutAction !== null)
+            this.showLayoutAction.setSensitive(selected.type === 'xkb');
 
         this._updatePropertySection(selected.properties);
     }

--- a/files/usr/share/cinnamon/applets/keyboard@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/keyboard@cinnamon.org/applet.js
@@ -87,14 +87,19 @@ class CinnamonKeyboardApplet extends Applet.Applet {
             this.menu.addMenuItem(this._propSeparator);
             this._propSection = new PopupMenu.PopupMenuSection();
             this.menu.addMenuItem(this._propSection);
-            this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
             this.showLayoutAction = null;
-            if (this._getLayoutDisplayProgram() !== null)
+            const haveLayoutDisplay = this._getLayoutDisplayProgram() !== null;
+            const haveCharmap = GLib.find_program_in_path('gucharmap') !== null;
+            if (haveLayoutDisplay || haveCharmap)
+                this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+            if (haveLayoutDisplay)
                 this.showLayoutAction = this.menu.addAction(_("Show Keyboard Layout"), () => this._showActiveLayout());
-            this.menu.addAction(_("Show Character Table"), () => {
-                Main.overview.hide();
-                Util.spawn(['gucharmap']);
-            });
+            if (haveCharmap) {
+                this.menu.addAction(_("Show Character Table"), () => {
+                    Main.overview.hide();
+                    Util.spawn(['gucharmap']);
+                });
+            }
             this._applet_context_menu.addSettingsAction(_("Manage keyboard layouts"), 'keyboard', "layouts");
 
             this._inputSourcesManager = KeyboardManager.getInputSourceManager();

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/AddKeyboardLayout.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/AddKeyboardLayout.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 
 import gettext
-import os
 import subprocess
 
 import cairo
@@ -12,6 +11,7 @@ gi.require_version('IBus', '1.0')
 gi.require_version('Pango', '1.0')
 from gi.repository import GLib, Gio, Gtk, GObject, CinnamonDesktop, IBus, Pango
 
+from bin import util
 from bin.SettingsWidgets import Keybinding
 from xapp.SettingsWidgets import SettingsPage
 from xapp.GSettingsWidgets import PXGSettingsBackend, GSettingsSwitch
@@ -21,11 +21,28 @@ MAX_LAYOUTS_PER_GROUP = 4
 INPUT_SOURCE_SETTINGS = "org.cinnamon.desktop.input-sources"
 SHOW_ALL_SOURCES_KEY="show-all-sources"
 
-def make_gkbd_keyboard_args(layout, variant):
-    if variant:
-        return ["gkbd-keyboard-display", "-l", f"{layout}\t{variant}"]
+def get_layout_preview_program():
+    # gkbd-keyboard-display (libgnomekbd) is X11-only, so on Wayland only tecla
+    # is usable. On X11 keep gkbd-keyboard-display preferred where still
+    # available (tecla only shows a standard pc105 geometry).
+    if util.get_session_type() == "wayland":
+        candidates = ("tecla",)
     else:
-        return ["gkbd-keyboard-display", "-l", layout]
+        candidates = ("gkbd-keyboard-display", "tecla")
+    for program in candidates:
+        if GLib.find_program_in_path(program):
+            return program
+    return None
+
+def make_layout_preview_args(layout, variant):
+    program = get_layout_preview_program()
+    if program == "tecla":
+        # '+' is the layout/variant separator accepted by every tecla version
+        # (space and tab only since tecla 48)
+        return [program, f"{layout}+{variant}" if variant else layout]
+    if variant:
+        return [program, "-l", f"{layout}\t{variant}"]
+    return [program, "-l", layout]
 
 def make_ibus_display_name(engine):
     name = engine.get_longname()
@@ -99,7 +116,7 @@ class AddKeyboardLayoutDialog():
 
         self.response_id = None
 
-        if not GLib.find_program_in_path("gkbd-keyboard-display"):
+        if get_layout_preview_program() is None:
             self.preview_button.set_visible(False)
 
         self._ibus = IBus.Bus.new_async()
@@ -167,7 +184,7 @@ class AddKeyboardLayoutDialog():
         display_name = self.layouts_sort_store.get_value(iter, LAYOUT_DISPLAY_NAME_COLUMN)
         layout_layout = self.layouts_sort_store.get_value(iter, LAYOUT_LAYOUT_COLUMN)
         layout_variant = self.layouts_sort_store.get_value(iter, LAYOUT_VARIANT_COLUMN)
-        args = make_gkbd_keyboard_args(layout_layout, layout_variant)
+        args = make_layout_preview_args(layout_layout, layout_variant)
         subprocess.Popen(args)
 
     def _on_all_sources_changed(self, button, data=None):

--- a/files/usr/share/cinnamon/cinnamon-settings/bin/InputSources.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/InputSources.py
@@ -41,9 +41,7 @@ class InputSourceSettingsPage(SettingsPage):
 
         self.test_layout_button = builder.get_object("test_layout")
         self.test_layout_button.connect("clicked", self.on_test_layout_clicked)
-        # TODO: maybe use tecla as an alternative for wayland, if we don't roll something ourselves.
-        # btw there's no plan for tecla to support different keyboard geometries than a standard pc105.
-        if not GLib.find_program_in_path("gkbd-keyboard-display"):
+        if AddKeyboardLayout.get_layout_preview_program() is None:
             self.test_layout_button.set_visible(False)
 
         self.engine_config_button = builder.get_object("engine_config_button")
@@ -218,7 +216,7 @@ class InputSourceSettingsPage(SettingsPage):
     def on_test_layout_clicked(self, button, data=None):
         source = self._get_selected_source()
 
-        args = AddKeyboardLayout.make_gkbd_keyboard_args(source.xkb_layout, source.xkb_variant)
+        args = AddKeyboardLayout.make_layout_preview_args(source.xkb_layout, source.xkb_variant)
         subprocess.Popen(args)
 
     def on_engine_config_clicked(self, button, data=None):


### PR DESCRIPTION
### Background

`gkbd-keyboard-display` comes from **libgnomekbd**, which is unmaintained and being removed from distributions: GNOME replaced it with [tecla](https://gitlab.gnome.org/GNOME/tecla) in GNOME 45, and Debian is in the process of removing libgnomekbd entirely. It is also an X11-only GTK3 program, so the keyboard layout preview was already unavailable under Wayland.

### 1. Layout preview: fall back to tecla

The layout preview button (in the "Add layout" dialog) and the "Test layout" button were already hidden when `gkbd-keyboard-display` was missing — the feature was simply lost. This PR makes them fall back to `tecla`, hiding the buttons only when *neither* program is available. `gkbd-keyboard-display` stays preferred when installed, since tecla only renders a standard pc105 geometry (this addresses the `TODO` comment removed from `InputSources.py`). Because tecla is a GTK4 program it also works under Wayland, restoring the preview there.

tecla is invoked with a single `layout+variant` argument. `+` is accepted as the layout/variant separator by **every** tecla version (verified against the tecla 46 and 50 sources, `tecla_model_new_from_layout_name`); space and tab were only added in tecla 48, so `+` is used unconditionally for backward compatibility (Ubuntu 24.04 / Mint 22 ship tecla 46).

### 2. Applet: hide actions when the target program is missing

The keyboard applet added its **"Show Keyboard Layout"** menu entry unconditionally: with no preview program installed, clicking it just popped an *"Execution of 'gkbd-keyboard-display' failed"* error notification. It now uses the same lookup/fallback as cinnamon-settings and the entry is hidden when no preview program is available.

A second commit applies the same guard to **"Show Character Table"** (`gucharmap`), which has the identical failure mode when gucharmap is not installed.

### Possible future improvement

tecla ≥ 47 accepts a `--parent-handle` option to attach the preview window to a parent as a modal dialog. This could be used from the two cinnamon-settings dialogs (it doesn't apply to the applet, which has no parent GTK window), but it requires exporting the GTK window handle on Wayland/X11 and has no `gkbd-keyboard-display` equivalent, so it's left out of this PR to keep the fallback simple.