### PR TITLE
issue-13868

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/Spices.py
@@ -420,7 +420,8 @@ class Spice_Harvester(GObject.Object):
             response = requests.get(url, proxies=proxy_info, stream=True, timeout=15)
             assert response.ok
 
-            totalSize = int(response.headers.get('content-length'))
+            content_length = response.headers.get('content-length')
+            totalSize = int(content_length) if content_length is not None else -1
 
             for data in response.iter_content(chunk_size=blockSize):
                 count += 1


### PR DESCRIPTION
- content length extraction fails if for some reasone the content-length header is missing from the remote response
- fix it by means of a none type fallback to length of -1
- this is the recommended patch from the ticket comments - i just took the time to build the patch pr for it
- ai: gemini helped but mostly with github process stuff - the development i did myself
- tested locally by manually adjusting the locally installed copy of Spices.py
- fixes #13868