### PR TITLE
cinnamon-settings: open applet configuration on the selected panel's instance

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/bin/ExtensionCore.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/bin/ExtensionCore.py
@@ -161,10 +161,11 @@ def sanitize_html(string):
 
 
 class ManageSpicesRow(Gtk.ListBoxRow):
-    def __init__(self, extension_type, metadata, size_groups):
+    def __init__(self, extension_type, metadata, size_groups, instance_id_getter=None):
         super().__init__()
         self.extension_type = extension_type
         self.metadata = metadata
+        self.instance_id_getter = instance_id_getter
 
         self.status_ids = {}
 
@@ -357,7 +358,12 @@ class ManageSpicesRow(Gtk.ListBoxRow):
         if self.ext_config_app:
             subprocess.Popen([self.ext_config_app])
         else:
-            subprocess.Popen(['xlet-settings', self.extension_type, self.uuid])
+            command = ['xlet-settings', self.extension_type, self.uuid]
+            if self.instance_id_getter is not None:
+                instance_id = self.instance_id_getter(self.uuid)
+                if instance_id is not None:
+                    command += ['-i', instance_id]
+            subprocess.Popen(command)
 
     def add_status(self, status_id, icon_name, tooltip_text=''):
         if status_id in self.status_ids:
@@ -646,6 +652,10 @@ class ManageSpicesPage(SettingsPage):
         row = self.list_box.get_selected_row()
         subprocess.Popen(['xlet-about-dialog', self.collection_type + 's', row.uuid])
 
+    def get_instance_id(self, uuid):
+        # Overridden by pages that can tell which xlet instance the user means
+        return None
+
     def load_extensions(self, *args):
         for row in self.extension_rows:
             row.destroy()
@@ -656,7 +666,7 @@ class ManageSpicesPage(SettingsPage):
 
         for uuid, metadata in self.spices.get_installed().items():
             try:
-                extension_row = ManageSpicesRow(self.collection_type, metadata, size_groups)
+                extension_row = ManageSpicesRow(self.collection_type, metadata, size_groups, self.get_instance_id)
                 self.list_box.add(extension_row)
                 self.extension_rows.append(extension_row)
                 extension_row.set_enabled(self.spices.get_enabled(uuid))

--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_applets.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_applets.py
@@ -112,6 +112,14 @@ class ManageAppletsPage(ManageSpicesPage):
 
         self.spices.send_proxy_signal('highlightPanel', '(ib)', self.panel_id, True)
 
+    def get_instance_id(self, uuid):
+        # Let xlet-settings open on the instance located on the selected panel
+        for definition in self.spices.settings.get_strv('enabled-applets'):
+            parts = definition.split(':')
+            if len(parts) > 4 and parts[3] == uuid and parts[0] == f'panel{self.panel_id}':
+                return parts[4]
+        return None
+
     def panels_changed(self, *args):
         self.panels = []
         n_mons = Gdk.Screen.get_default().get_n_monitors()

--- a/files/usr/share/cinnamon/cinnamon-settings/xlet-settings.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/xlet-settings.py
@@ -95,7 +95,7 @@ class MainWindow(object):
         self.type = args.type
         self.uuid = args.uuid
         self.tab = 0
-        self.instance_id = str(args.id)
+        self.instance_id = str(args.id) if args.id is not None else None
         if args.tab is not None:
             self.tab = int(args.tab)
 
@@ -112,6 +112,8 @@ class MainWindow(object):
                 if info["id"] == self.instance_id:
                     self.set_instance(info)
                     break
+            else:
+                self.set_instance(self.instance_info[0])
         else:
             self.set_instance(self.instance_info[0])
         try:


### PR DESCRIPTION
Fixes multi-instance applet configuration opening the wrong instance — on multi-monitor setups, visibly the wrong panel/monitor.  Closes #13882

### The user-facing problem

`ExtensionCore.py` launches `xlet-settings applet <uuid>` with no `-i`, so xlet-settings falls back to the first instance (lowest id) — even though the applets page knows exactly which panel is selected (`panel_id`, from the panel context-menu argument and the Previous/Next Panel buttons). Repro on a multi-monitor setup, applet on panels A and B with different settings:

1. Right-click panel B → Applets → Configure the applet.
2. The manager highlights panel B, but xlet-settings shows (and highlights) the instance    on panel A — two different highlights on two different monitors, and edits land on panel A.

**Fix (commit 1):** pass an instance resolver to `ManageSpicesRow`; `configure()` appends `-i <instance>` when the applet has an instance on the selected panel. `ManageAppletsPage` resolves it from `enabled-applets` `panel<id>:zone:pos:uuid:instance`). Desklet/extension/action pages keep the previous behavior (base resolver returns `None`).

### The related latent bug (commit 2)

`self.instance_id = str(args.id)` turns a missing `-i` into the truthy string `"None"`, so the selection code enters the match loop, matches nothing, and never calls `set_instance()`:

```python
if self.instance_id and len(self.instance_info) > 1:   # "None" is truthy
    for info in self.instance_info:
        if info["id"] == self.instance_id:             # never matches
            self.set_instance(info)
            break
else:
    self.set_instance(self.instance_info[0])           # intended fallback, never reached
```

This is currently masked by `load_instances()` defaulting `selected_instance` to the first instance, so the dialog still works — but `-t <tab>` is silently ignored for no-`-i` launches (regression from 769a754), and the code only works by accident of that default. Commit 2 keeps `instance_id` as `None` when absent and adds a `for`/`else` fallback for stale/unmatched ids.

### Testing

On Cinnamon 6.6.7 (Mint 22.3), 2 monitors, multi-instance applet on two panels with
visibly different settings ("grouped" vs "one-to-one" window list behavior):

- Right-click panel → Applets → Configure: before — dialog showed the *other* panel's instance while the panel highlight and the applet highlight pointed at different monitors; after — dialog opens on the selected panel's instance, and the panel and   applet highlights agree.
- `xlet-settings applet <uuid> -i <id>`: unchanged, opens the given instance.
- `xlet-settings applet <uuid> -i <bogus-id>`: now explicitly falls back to the first instance via set_instance() instead of relying on the load_instances() default.
- `xlet-settings applet <uuid> -t 2` (no `-i`): tab argument is honored again.

Claude Fable 5 was used to fix these issues.