### PR TITLE
network@cinnamon.org: guard against null modem device path in _createAutomaticConnection

### DIFF
--- a/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
@@ -912,8 +912,16 @@ NMDeviceModem.prototype = {
     _createAutomaticConnection: function() {
         // Mobile wizard is too complex for Cinnamon UI and
         // is handled by the network panel
-        Util.spawn(['cinnamon-settings', 'network',
-                    'connect-3g', this.device.get_path()]);
+        let path = this.device.get_path();
+        if (path) {
+            Util.spawn(['cinnamon-settings', 'network', 'connect-3g', path]);
+        } else {
+            // Some modems (e.g. MBIM/eSIM devices) do not expose a device
+            // path, so get_path() returns null. Passing null to Util.spawn()
+            // throws "array element (type filename) may not be null", so fall
+            // back to just opening the network panel.
+            Util.spawn(['cinnamon-settings', 'network']);
+        }
         return null;
     }
 };


### PR DESCRIPTION
Clicking a mobile broadband device's auto-connect item calls `Util.spawn(['cinnamon-settings', 'network', 'connect-3g', this.device.get_path()])`. For MBIM/eSIM modems (e.g. Dell Snapdragon X62 on `mhi-pci-generic`), `NM.Device.get_path()` returns `null`, so `GLib.spawn_async()` throws `array element (type filename) may not be null` and the user sees an error notification instead of the network panel opening.

This adds a null check: if the device path is available it is passed to `connect-3g` as before; otherwise the network panel is opened without it.

Fixes #13885.
