### PR TITLE
cinnamon-desktop-editor: Fix panel launcher edits hanging the dialog and not refreshing the panel

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-desktop-editor/cinnamon-desktop-editor.py
+++ b/files/usr/share/cinnamon/cinnamon-desktop-editor/cinnamon-desktop-editor.py
@@ -415,20 +415,29 @@ class Main:
         self.end()
 
     def panel_launcher_cb(self, success, dest_path):
-        if success:
-            settings = JsonSettingsWidgets.JSONSettingsHandler(self.json_path)
-            launchers = settings.get_value("launcherList")
-            if self.desktop_file is None:
-                launchers.append(os.path.split(dest_path)[1])
-            else:
-                i = launchers.index(self.desktop_file)
-                if i >= 0:
-                    del launchers[i]
-                    launchers.insert(i, os.path.split(dest_path)[1])
-            settings.save_settings()
-            if self.desktop_file is None:
-                self.ask_menu_launcher(dest_path)
-        self.end()
+        try:
+            if success:
+                settings = JsonSettingsWidgets.JSONSettingsHandler(self.json_path)
+                launchers = settings.get_value("launcherList")
+                new_name = os.path.split(dest_path)[1]
+                if self.desktop_file is None:
+                    launchers.append(new_name)
+                else:
+                    try:
+                        i = launchers.index(self.desktop_file)
+                    except ValueError:
+                        # The entry we were asked to edit is no longer in the
+                        # list (a previous edit may have already replaced it) -
+                        # add the new launcher instead of dropping the edit.
+                        if new_name not in launchers:
+                            launchers.append(new_name)
+                    else:
+                        launchers[i] = new_name
+                settings.save_settings()
+                if self.desktop_file is None:
+                    self.ask_menu_launcher(dest_path)
+        finally:
+            self.end()
 
     def nemo_launcher_cb(self, success, dest_path):
         if success:

--- a/files/usr/share/cinnamon/cinnamon-desktop-editor/cinnamon-desktop-editor.py
+++ b/files/usr/share/cinnamon/cinnamon-desktop-editor/cinnamon-desktop-editor.py
@@ -4,6 +4,7 @@ import sys
 import os
 import gettext
 import glob
+import json
 from optparse import OptionParser
 import shutil
 import subprocess
@@ -434,10 +435,23 @@ class Main:
                     else:
                         launchers[i] = new_name
                 settings.save_settings()
+                self.notify_cinnamon(launchers)
                 if self.desktop_file is None:
                     self.ask_menu_launcher(dest_path)
         finally:
             self.end()
+
+    def notify_cinnamon(self, launchers):
+        # Cinnamon does not monitor the settings file for external changes -
+        # tell it to reload, the same way xlet-settings.py does after saving.
+        uuid = os.path.basename(os.path.dirname(self.json_path))
+        instance_id = os.path.splitext(os.path.basename(self.json_path))[0]
+        try:
+            proxy = Gio.DBusProxy.new_for_bus_sync(Gio.BusType.SESSION, Gio.DBusProxyFlags.NONE, None,
+                                                   "org.Cinnamon", "/org/Cinnamon", "org.Cinnamon", None)
+            proxy.updateSetting('(ssss)', uuid, instance_id, "launcherList", json.dumps(launchers))
+        except GLib.Error as e:
+            print("Could not notify Cinnamon of launcher list change: %s" % e.message)
 
     def nemo_launcher_cb(self, success, dest_path):
         if success:


### PR DESCRIPTION
Fixes #13895

Two small fixes to the panel launcher edit flow:

* `panel_launcher_cb` assumed `launchers.index()` returns -1 when the entry is missing (see the `if i >= 0:` right after it), but it raises ValueError. The unhandled exception meant `Gtk.main_quit()` was never reached, so the dialog hung on OK and an orphaned cinnamon-custom-launcher-N.desktop was left behind on every attempt. The callback now handles the missing entry (the edited launcher gets appended instead of dropped) and always closes the dialog.

* After saving, the editor now tells Cinnamon to reload the applet settings via the org.Cinnamon `updateSetting` dbus call, the same way xlet-settings.py does after it saves. Without this the panel didn't reflect an add/edit until Cinnamon was restarted - which is also what baited users into editing a second time and hitting the hang above.

Tested on Mint 22.3 / Cinnamon 6.6.9: editing a launcher now updates the panel within a second or two, repeated edits don't hang, and no orphan files pile up.

One pre-existing wart deliberately left alone to keep this small: editing an already-custom launcher overwrites its .desktop file in place, so launcherList doesn't change and the panel won't show the new name/icon until a restart. Fixing that would need the applet to reload launchers whose files changed on disk, which seemed out of scope here.
