### PR TITLE
looking-glass: replace pyinotify with Gio.FileMonitor

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -4,7 +4,6 @@
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code
 extension-pkg-whitelist=gi,
-                        pyinotify,
                         setproctitle
 
 # Add files or directories to the blacklist. They should be base names, not

--- a/debian/control
+++ b/debian/control
@@ -99,7 +99,6 @@ Depends:
  python3-pam | python3-pampy,
  python3-pexpect,
  python3-pil,
- python3-pyinotify,
  python3-requests,
  python3-setproctitle,
  python3-tinycss2,

--- a/files/usr/share/cinnamon/cinnamon-looking-glass/cinnamon-looking-glass.py
+++ b/files/usr/share/cinnamon/cinnamon-looking-glass/cinnamon-looking-glass.py
@@ -15,7 +15,6 @@
 import os
 import signal
 import sys
-import pyinotify
 import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gio, Gtk, GObject, Gdk, GLib
@@ -224,22 +223,6 @@ class NewLogDialog(Gtk.Dialog):
 
         return result
 
-class FileWatchHandler(pyinotify.ProcessEvent):
-    def my_init(self, view):
-        self.view = view
-
-    def process_IN_CLOSE_WRITE(self, event):
-        self.view.get_updates()
-
-    def process_IN_CREATE(self, event):
-        self.view.get_updates()
-
-    def process_IN_DELETE(self, event):
-        self.view.get_updates()
-
-    def process_IN_MODIFY(self, event):
-        self.view.get_updates()
-
 class FileWatcherView(Gtk.ScrolledWindow):
     def __init__(self, filename):
         Gtk.ScrolledWindow.__init__(self)
@@ -259,21 +242,18 @@ class FileWatcherView(Gtk.ScrolledWindow):
         self.show_all()
         self.get_updates()
 
-        handler = FileWatchHandler(view=self)
-        watch_manager = pyinotify.WatchManager()
-        self.notifier = pyinotify.ThreadedNotifier(watch_manager, handler)
-        watch_manager.add_watch(filename, (pyinotify.IN_CLOSE_WRITE |
-                                           pyinotify.IN_CREATE |
-                                           pyinotify.IN_DELETE |
-                                           pyinotify.IN_MODIFY))
-        self.notifier.start()
+        self.monitor = Gio.File.new_for_path(filename).monitor_file(Gio.FileMonitorFlags.NONE, None)
+        self.monitor.connect("changed", self.on_file_changed)
         self.connect("destroy", self.on_destroy)
         self.connect("size-allocate", self.on_size_changed)
 
+    def on_file_changed(self, monitor, gfile, other_file, event_type):
+        self.get_updates()
+
     def on_destroy(self, widget):
-        if self.notifier:
-            self.notifier.stop()
-            self.notifier = None
+        if self.monitor:
+            self.monitor.cancel()
+            self.monitor = None
 
     def on_size_changed(self, widget, bla):
         if self.changed > 0:


### PR DESCRIPTION
`cinnamon-looking-glass.py` is the only thing in Cinnamon still using **pyinotify**, for the file watcher tabs ("Actions → Add File Watcher") that tail a log file.

pyinotify is a problem now:

* upstream is dead — last release 0.9.6 in **2015**, no commits since, see [seb-m/pyinotify](https://github.com/seb-m/pyinotify);
* it does `import asyncore` at module level, and `asyncore` was **removed from the Python standard library in 3.12**. It still imports today only because distributions ship a third-party backport of that module as an extra dependency (Debian added `python3-pyasyncore` to `python3-pyinotify` for exactly this reason);
* distributions have started filing bugs against every reverse dependency to get rid of it — for Cinnamon this is [Debian #1075948](https://bugs.debian.org/1075948), part of [#1004387](https://bugs.debian.org/1004387).

`Gio.FileMonitor` does the same job and comes from **python3-gi**, which Cinnamon already depends on, so this drops a dependency rather than trading it for another one — no new build or runtime requirement, and `Gio` was already imported in this file.

There is a second, smaller benefit. `pyinotify.ThreadedNotifier` runs its own thread and called `get_updates()` from there, so the log view — and therefore `Gtk.TextBuffer.set_text()` in `update()` — was being driven from outside the main loop. `Gio.FileMonitor` emits `changed` on the thread-default main context, so everything now stays on the main loop.

## What changed

* `FileWatchHandler` (the `pyinotify.ProcessEvent` subclass) is gone; its four `process_IN_*` methods all did the same thing and collapse into a single `on_file_changed()` callback.
* `FileWatcherView` monitors the file with `Gio.File.new_for_path(filename).monitor_file()` and cancels the monitor on destroy, instead of starting/stopping a `ThreadedNotifier`.
* `pyinotify` dropped from `debian/control` and from the pylint `extension-pkg-whitelist`.

The `IN_CLOSE_WRITE | IN_CREATE | IN_DELETE | IN_MODIFY` mask maps onto the default `GFileMonitor` events (`changed`, `changes-done-hint`, `created`, `deleted`), all of which just trigger a refresh. The existing 500 ms rate limiting in `get_updates()` is untouched and also absorbs the `changed` + `changes-done-hint` pair that `GFileMonitor` emits for a single write.

## Testing

Tested on a Debian sid VM with Cinnamon 6.6.8, driving `FileWatcherView` directly on the running session: appending to the watched file refreshes the text buffer exactly as before, and the monitor is cancelled when the view is destroyed. Running the same test against the unmodified file shows the thread count going from 1 to 2 (the `ThreadedNotifier`), while with `Gio.FileMonitor` it stays at 1.

Also checked manually from the UI: Looking Glass → Actions → Add File Watcher on a log file, the tab updates and auto-scrolls as before.