### PR TITLE
network applet: six correctness fixes, incl. multiple active WireGuard connections

### DIFF
--- a/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
@@ -2604,6 +2604,8 @@ CinnamonNetworkApplet.prototype = {
         if (this._activeConnections.some(con => con.get_connection_type() === "wireguard")) {
             return NM.ConnectivityState.FULL;
         }
+
+        return state;
     },
 
     _proxyConnectivityCheckCallback(new_state) {

--- a/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
@@ -2532,10 +2532,9 @@ CinnamonNetworkApplet.prototype = {
                     let iconName = 'xsi-network-vpn';
                     if (mc._section == NMConnectionCategory.WIRELESS) {
                         const dev = mc._primaryDevice;
-                        if (dev) {
-                            const ap = dev.device.active_access_point;
-                            iconName = 'xsi-network-wireless-signal-' + signalToIcon(ap.strength) + '-secure-symbolic';
-                        }
+                        const ap = dev ? dev.device.active_access_point : null;
+                        if (ap)
+                            iconName = 'xsi-network-wireless-signal-' + signalToIcon(ap.strength) + '-secure';
                     }
                     this._setIcon(iconName);
                     this.set_applet_tooltip(_("Connected to the VPN"));

--- a/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
@@ -168,7 +168,7 @@ NMNetworkMenuItem.prototype = {
         accessPoints = sortAccessPoints(accessPoints);
         this.bestAP = accessPoints[0];
         this._accessPoints = [ ];
-        for (let i = 0; i < accessPoints; i++) {
+        for (let i = 0; i < accessPoints.length; i++) {
             let ap = accessPoints[i];
             let apObj = {
                 ap: ap,

--- a/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
@@ -1041,7 +1041,8 @@ NMDeviceVPN.prototype = {
         for (let obj of this._connections) {
             if (!obj.item) {
                 obj.item = new PopupMenu.PopupMenuItem(obj.name);
-                this._updateConnectionItemView(obj.item, obj.connection);
+                this._updateConnectionItemView(obj.item, obj.connection,
+                                               this._activeConnections.some(ac => ac.connection == obj.connection));
                 obj.item.connect('activate', Lang.bind(this, function() {
                     let activeConnection = this._activeConnections.find(ac => ac.connection === obj.connection);
                     if (activeConnection) {

--- a/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
@@ -2301,7 +2301,7 @@ CinnamonNetworkApplet.prototype = {
     _connectionRemoved: function(client, connection) {
         let pos = this._connections.indexOf(connection);
         if (pos != -1)
-            this._connections.splice(pos);
+            this._connections.splice(pos, 1);
 
         let section = connection._section;
 

--- a/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
@@ -1073,6 +1073,8 @@ NMDeviceWIREGUARD.prototype = {
         this.category = NMConnectionCategory.WIREGUARD;
         this._type = NM.SETTING_WIREGUARD_SETTING_NAME;
 
+        this._activeConnections = [];
+
         NMDevice.prototype._init.call(this, client, null, [ ]);
 
         // Tests:
@@ -1089,16 +1091,14 @@ NMDeviceWIREGUARD.prototype = {
     },
 
     get connected() {
-        return !!this._activeConnection;
+        return this._activeConnections.length > 0;
     },
 
-    setActiveConnection: function(activeConnection) {
-        if (activeConnection) {
-            activeConnection._type = NM.SETTING_WIREGUARD_SETTING_NAME;
-        }
-        NMDevice.prototype.setActiveConnection.call(this, activeConnection);
+    setActiveConnections: function(activeConnections) {
+        this._activeConnections = activeConnections || [];
 
-        this.emit('active-connection-changed');
+        this._createSection();
+        this.emit('active-connections-changed');
     },
 
     _shouldShowConnectionList: function() {
@@ -1106,8 +1106,48 @@ NMDeviceWIREGUARD.prototype = {
     },
 
     deactivate: function() {
-        if (this._activeConnection)
-            this._client.deactivate_connection(this._activeConnection, null);
+        for (let ac of this._activeConnections)
+            this._client.deactivate_connection(ac, null);
+
+        this._activeConnections = [];
+    },
+
+    _clearSection: function() {
+        if (this.section && this.section.removeAll)
+            this.section.removeAll();
+
+        this._autoConnectionItem = null;
+        this._overflowItem = null;
+
+        for (let i = 0; i < this._connections.length; i++) {
+            if (this._connections[i].item && this._connections[i].item.destroy)
+                this._connections[i].item.destroy();
+
+            this._connections[i].item = null;
+        }
+    },
+
+    /* A switch per tunnel: WireGuard connections are independent of one another,
+       so they are not a pick-one list. */
+    _createSection: function() {
+        for (let obj of this._connections) {
+            let active = this._activeConnections.some(ac => ac.connection == obj.connection);
+
+            if (!obj.item) {
+                obj.item = new PopupMenu.PopupSwitchMenuItem(obj.name, active);
+                obj.item.connect('toggled', (item, state) => {
+                    let activeConnection = this._activeConnections.find(ac => ac.connection === obj.connection);
+
+                    if (!state && activeConnection)
+                        this._client.deactivate_connection(activeConnection, null);
+                    else if (state && !activeConnection)
+                        this._client.activate_connection_async(obj.connection, this.device, null, null, null);
+                });
+                this.section.addMenuItem(obj.item);
+            } else {
+                obj.item.setToggleState(active);
+            }
+        }
     },
 
     statusLabel: null,
@@ -1905,9 +1945,9 @@ CinnamonNetworkApplet.prototype = {
                 device: new NMDeviceWIREGUARD(this._client),
                 item: new NMWiredSectionTitleMenuItem(_("WIREGUARD Connections"))
             };
-            this._devices.wireguard.device.connect('active-connection-changed', Lang.bind(this, function() {
+            this._devices.wireguard.device.connect('active-connections-changed', () => {
                 this._devices.wireguard.item.updateForDevice(this._devices.wireguard.device);
-            }));
+            });
             this._devices.wireguard.item.updateForDevice(this._devices.wireguard.device);
             this._devices.wireguard.section.addMenuItem(this._devices.wireguard.item);
             this._devices.wireguard.section.addMenuItem(this._devices.wireguard.device.section);
@@ -2149,6 +2189,8 @@ CinnamonNetworkApplet.prototype = {
             if (active._primaryDevice) {
                 if (active._type == NM.SETTING_VPN_SETTING_NAME)
                     this._devices.vpn.device.setActiveConnections([]);
+                else if (active._type == NM.SETTING_WIREGUARD_SETTING_NAME)
+                    this._devices.wireguard.device.setActiveConnections([]);
                 else
                     active._primaryDevice.setActiveConnection(null);
 
@@ -2170,6 +2212,7 @@ CinnamonNetworkApplet.prototype = {
         let default_ip6 = null;
 
         let vpnConnections = [];
+        let wireguardConnections = [];
 
         for (let a of this._activeConnections) {
             if (!a._inited) {
@@ -2246,16 +2289,20 @@ CinnamonNetworkApplet.prototype = {
             }
 
             if (a._primaryDevice) {
-                if (a._type == NM.SETTING_VPN_SETTING_NAME) {
+                if (a._type == NM.SETTING_VPN_SETTING_NAME)
                     vpnConnections.push(a);
-                } else {
+                else if (a._type == NM.SETTING_WIREGUARD_SETTING_NAME)
+                    wireguardConnections.push(a);
+                else
                     a._primaryDevice.setActiveConnection(a);
-                }
             }
         }
 
         if (this._devices.vpn && this._devices.vpn.device)
             this._devices.vpn.device.setActiveConnections(vpnConnections);
+
+        if (this._devices.wireguard && this._devices.wireguard.device)
+            this._devices.wireguard.device.setActiveConnections(wireguardConnections);
 
         this._mainConnection = activated || activating || default_ip4 || default_ip6 || null;
     },


### PR DESCRIPTION
Six independent correctness fixes in `network@cinnamon.org`, one per commit so they can be taken or dropped individually. No new UI.

### The bugs

**1. `updateAccessPoints()` never loops** — `for (let i = 0; i < accessPoints; i++)` compares the index to the *array* rather than its length, so the body never runs. `_accessPoints` is left empty and the `notify::strength` handlers are never reconnected, silently stopping signal-strength updates for that network.

**2. `splice(pos)` truncates the connection list** — `Array.splice(pos)` with no delete count removes everything from `pos` to the end, so removing one connection dropped every connection after it from `_connections`.

**3. The VPN-over-wireless icon never resolves** — `set_applet_icon_symbolic_name()` passes the name through unchanged and sets `St.IconType.SYMBOLIC`; St appends `-symbolic` itself at lookup time. The name built here already carried the suffix, so it asked for `xsi-network-wireless-signal-<level>-secure-symbolic-symbolic`, which does not exist. The panel icon renders as nothing while a VPN is active over wireless. Verified against the shipped icon set:

```
FOUND    xsi-network-wireless-signal-good-secure-symbolic
MISSING  xsi-network-wireless-signal-good-secure-symbolic-symbolic
```

The same commit guards `active_access_point`, which is null on a wireless device that is still activating.

**4. `_correctStateForTunnel()` returns `undefined`** — it falls through without a return when no tun/wireguard connection is active. Only reached from the currently-disabled connectivity check, but wrong either way.

**5. An already-connected VPN draws no dot when its row is first built** — `_updateConnectionItemView()` takes `active` as its third argument, but the first-build call omits it, so `active` is `undefined`. The row corrects itself on the next redraw, which is why it reads as intermittent. This is likely what #12550 is seeing.

**6. Only one WireGuard connection can be active in the UI** (#12178) — `NMDeviceWIREGUARD` kept a single `_activeConnection` slot, but every WireGuard connection is handed the *same* pseudo-device and `_syncActiveConnections()` calls `setActiveConnection()` once per connection, so each activation overwrites the previous one. With two tunnels up the menu shows one as connected and draws the other as if it were down; the section switch tears down only one and then flips straight back on.

This last one mirrors what #12930 did for `NMDeviceVPN` — keep a list, assign it once after the sync loop rather than per connection, and deactivate all of them. The VPN section got that treatment; the WireGuard section was left behind.

Rows become a switch each rather than a pick-one list, since WireGuard connections are independent of one another. That is the behaviour asked for in #12178 ("checkboxes instead of the radio items to toggle the Networks independently") and re-confirmed there in February.

### Testing

Honest about what was and wasn't done:

- Built and `node --check`ed against `master`.
- Smoke-tested by running this branch's `applet.js` on **Cinnamon 6.6.9**, which differs from master only by the four lines of #13847. With two WireGuard tunnels up simultaneously the applet reported both, each with its own working switch:
  ```
  wg active list: [wg-devvps, wg-lab-inet]
  rows: wg-devvps=ON  wg-lab-inet=ON  wg-lab=off  wg-home=off
  ```
- **Not** run on master itself — I don't have a master build here.
- Bugs 1-5 are reasoned from the code and verified by inspection; 1, 2 and 4 are single-expression fixes.

Closes #12178


---

**Disclosure:** I worked on this with Claude (Anthropic's Claude Code). It did the bulk of the code reading, diagnosis and patch authoring, and drafted this write-up; I reviewed the changes and ran them on my own machine before filing. The commits carry a `Co-Authored-By: Claude` trailer to the same effect. Flagging it so you can weight the review accordingly.
