### PR TITLE
Automatic volume decrease to 100% after disabling overamplification with higher volume set.

### DIFF
--- a/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/sound@cinnamon.org/applet.js
@@ -1115,6 +1115,11 @@ class CinnamonSoundApplet extends Applet.TextIconApplet {
         else {
             this._volumeMax = this._volumeNorm;
             this._outputVolumeSection.set_mark(0);
+
+            if (this._output && this._output.volume > this._volumeMax) {
+                this._output.volume = this._volumeMax;
+                this._output.push_volume();
+            }
         }
         this._outputVolumeSection._update();
     }


### PR DESCRIPTION
The sound applet kept users original volume over 100% after turning off overamplification (untill lowering it manually). The fix makes the volume go to 100% if it was higher than that before turning overamplification off.

Behaviour before fix:

<img width="801" height="413" alt="before" src="https://github.com/user-attachments/assets/243013c9-d638-40bc-afea-7cbd2da075f5" />

<img width="801" height="413" alt="after" src="https://github.com/user-attachments/assets/fc675f29-c330-4f8f-b7a1-7ee38382562b" />


Behaviour after fix:
<img width="755" height="383" alt="before2" src="https://github.com/user-attachments/assets/12c188c6-205b-418f-a793-9f3d1ca92b87" />



<img width="791" height="393" alt="after2" src="https://github.com/user-attachments/assets/fe90d44a-f304-4150-9398-a0e08e04be4b" />

