### PR TITLE
network@cinnamon.org: don't show the offline icon when online through an unmanaged device

### DIFF
--- a/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
@@ -2409,7 +2409,7 @@ CinnamonNetworkApplet.prototype = {
                     // /etc/network/interfaces): there is no active connection
                     // to describe, but we are not offline either.
                     this._setIcon('xsi-network-wired');
-                    this.set_applet_tooltip(_("Connected to the network"));
+                    this.set_applet_tooltip(_("Connected through an unmanaged device"));
                 } else {
                     this._setIcon('xsi-network-offline');
                     this.set_applet_tooltip(_("No connection"));

--- a/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/network@cinnamon.org/applet.js
@@ -2403,8 +2403,17 @@ CinnamonNetworkApplet.prototype = {
             let mc = this._mainConnection;
 
             if (!mc) {
-                this._setIcon('xsi-network-offline');
-                this.set_applet_tooltip(_("No connection"));
+                if (this._client.state == NM.State.CONNECTED_GLOBAL) {
+                    // We are online through a device NetworkManager does not
+                    // manage (for instance one configured in
+                    // /etc/network/interfaces): there is no active connection
+                    // to describe, but we are not offline either.
+                    this._setIcon('xsi-network-wired');
+                    this.set_applet_tooltip(_("Connected to the network"));
+                } else {
+                    this._setIcon('xsi-network-offline');
+                    this.set_applet_tooltip(_("No connection"));
+                }
             } else if (mc.state == NM.ActiveConnectionState.ACTIVATING) {
                 new_delay = FAST_PERIODIC_UPDATE_FREQUENCY_SECONDS;
                 switch (mc._section) {


### PR DESCRIPTION
The network applet shows the offline icon, and a "No connection" tooltip, whenever `_mainConnection` is null. That also happens on a machine that is perfectly online, when the only connectivity comes from a device NetworkManager does not manage — typically an interface configured in `/etc/network/interfaces`, with the ifupdown plugin set to `managed=false`, which is the default on Debian. There is no active connection for the applet to describe, so it concludes the machine is offline.

NetworkManager still reports `NM_STATE_CONNECTED_GLOBAL` in that situation, so this uses it as the fallback: when there is no main connection but the global state is `CONNECTED_GLOBAL`, show the generic wired icon and the `Connected to the network` tooltip that `_updateIcon()` already uses for active connections it cannot classify. Everything else is unchanged, and when the machine really is offline the global state is not `CONNECTED_GLOBAL`, so the offline icon is still shown.

Both the icons and both the strings are already used elsewhere in the same function, so there is nothing new to translate.

### Testing

Debian sid VM, cinnamon 6.6.9, NetworkManager 1.58.0, `enp1s0` configured in `/etc/network/interfaces` with `[ifupdown] managed=false` (Debian default):

```
$ nmcli device
DEVICE  TYPE      STATE                   CONNECTION
lo      loopback  connected (externally)  lo
enp1s0  ethernet  unmanaged               --

$ gdbus call --system --dest org.freedesktop.NetworkManager \
    --object-path /org/freedesktop/NetworkManager \
    --method org.freedesktop.DBus.Properties.Get \
    org.freedesktop.NetworkManager State
(<uint32 70>,)     # NM_STATE_CONNECTED_GLOBAL
```

The only active connection is the loopback one, which `_syncActiveConnections()` skips because it has no `_section`, so `_mainConnection` ends up null. Inspecting the live applet before the patch:

```
icon=xsi-network-offline  tooltip="No connection"  _mainConnection=null  client.state=70
```

and after it:

```
icon=xsi-network-wired    tooltip="Connected to the network"  _mainConnection=null  client.state=70
```

Bringing the interface down gives `state=20` and the offline icon is shown again, as expected.

| before | after |
| --- | --- |
| <img width="840" height="80" alt="cinnamon-network-unmanaged-before" src="https://github.com/user-attachments/assets/db4bcfa7-9af3-485d-9b62-82fa36750934" /> | <img width="840" height="80" alt="cinnamon-network-unmanaged-after" src="https://github.com/user-attachments/assets/1a723231-55a8-401b-918d-712c4825215f" /> |

This has been reported on the Debian side since 2013, https://bugs.debian.org/699773 — GNOME Shell used to carry a Debian-specific patch doing exactly this, which is what that bug asked us to port.