### PR TITLE
global: Don't create a scope for D-Bus activated applications

### DIFF
--- a/src/cinnamon-global.c
+++ b/src/cinnamon-global.c
@@ -1681,6 +1681,11 @@ cinnamon_global_app_launched_cb (GAppLaunchContext *context,
   if (!g_variant_lookup (platform_data, "pid", "i", &pid))
     return;
 
+  /* If pid == 0 the application was launched through D-Bus
+   * activation, therefore it's already in its own unit */
+  if (pid == 0)
+    return;
+
   app_name = g_app_info_get_id (info);
   if (app_name == NULL)
     app_name = g_app_info_get_executable (info);


### PR DESCRIPTION
When an application is started through D-Bus activation, the launch context reports pid 0: the process is spawned by the bus, not by us. Passing that on to `gnome_start_systemd_scope()` creates an empty scope that never has any process in it and stays active forever:

```
app-cinnamon-org.gnome.DiskUtility-0.scope  loaded active running  Application launched by cinnamon
```

It is also pointless, since a D-Bus activated service already runs in its own unit. gnome-shell has the same guard in `shell_global_app_launched_cb()` for the same reason.

This has no visible effect today, only because `gnome_start_systemd_scope()` never gets far enough to create anything — see linuxmint/cinnamon-desktop#275. It does as soon as that is fixed, which is why it is worth landing the two together.

### Testing

Mint 23, Cinnamon 6.7.4 with the cinnamon-desktop fix applied. Launching a `DBusActivatable=true` application from the menu creates no scope, while regular launches keep getting theirs:

```
  app-cinnamon-debian-xterm-18470.scope  loaded active running  Application launched by cinnamon
  app-cinnamon-nemo-18782.scope          loaded active running  Application launched by cinnamon
```