### PR TITLE
printers@cinnamon.org: Update the applet when the printer list is empty or unavailable, and check for system-config-printer

### DIFF
--- a/files/usr/share/cinnamon/applets/printers@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/printers@cinnamon.org/applet.js
@@ -1,4 +1,5 @@
 const Applet = imports.ui.applet;
+const Cinnamon = imports.gi.Cinnamon;
 const CinnamonDesktop = imports.gi.CinnamonDesktop;
 const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
@@ -11,6 +12,8 @@ const Tooltips = imports.ui.tooltips;
 const Util = imports.misc.util;
 
 const PANEL_EDIT_MODE_KEY = "panel-edit-mode";
+
+const CONFIG_TOOL = 'system-config-printer';
 
 const PRINTER_STATE_STOPPED = 5;
 
@@ -141,9 +144,13 @@ class CinnamonPrintersApplet extends Applet.TextIconApplet {
         this.set_applet_tooltip(_("Printers"));
         this.set_applet_icon_symbolic_name('xsi-printer');
 
-        let printersContextItem = new PopupMenu.PopupIconMenuItem(_("Printers"), 'xsi-printer', St.IconType.SYMBOLIC);
-        printersContextItem.connect('activate', () => Util.spawn(['system-config-printer']));
-        this._applet_context_menu.addMenuItem(printersContextItem);
+        // Kept hidden until the asynchronous lookup below says the program is
+        // there; the separator finalizeContextMenu() adds hides itself along
+        // with it.
+        this._printersContextItem = new PopupMenu.PopupIconMenuItem(_("Printers"), 'xsi-printer', St.IconType.SYMBOLIC);
+        this._printersContextItem.connect('activate', () => Util.spawn([CONFIG_TOOL]));
+        this._applet_context_menu.addMenuItem(this._printersContextItem);
+        this._printersContextItem.actor.hide();
 
         this.menu = new Applet.AppletPopupMenu(this, orientation);
         this.menu.connect('open-state-changed', (menu, open) => {
@@ -163,6 +170,7 @@ class CinnamonPrintersApplet extends Applet.TextIconApplet {
 
         this._printers = new Map();
         this._hasPrinterConfig = false;
+        this._hasConfigTool = false;
         this._cupsSubscription = null;
         this._rebuildId = 0;
         this._menuDirty = false;
@@ -170,6 +178,16 @@ class CinnamonPrintersApplet extends Applet.TextIconApplet {
         this._wallClock = new CinnamonDesktop.WallClock();
 
         this._cancellable = new Gio.Cancellable();
+
+        Cinnamon.find_program_in_path(CONFIG_TOOL, (path) => {
+            if (path == null || !this._cancellable || this._cancellable.is_cancelled())
+                return;
+
+            this._hasConfigTool = true;
+            this._printersContextItem.actor.show();
+            this._scheduleMenuRebuild();
+        });
+
         Gio.DBus.session.call(
             'org.freedesktop.DBus', '/org/freedesktop/DBus',
             'org.freedesktop.DBus', 'ListActivatableNames',
@@ -480,8 +498,12 @@ class CinnamonPrintersApplet extends Applet.TextIconApplet {
         this.menu.removeAll();
 
         if (this._printers.size === 0) {
-            let printersItem = new PopupMenu.PopupIconMenuItem(_("Printers"), 'xsi-printer', St.IconType.SYMBOLIC);
-            printersItem.connect('activate', () => Util.spawn(['system-config-printer']));
+            let printersItem = new PopupMenu.PopupIconMenuItem(_("Printers"), 'xsi-printer', St.IconType.SYMBOLIC,
+                                                              { reactive: this._hasConfigTool });
+            if (this._hasConfigTool)
+                printersItem.connect('activate', () => Util.spawn([CONFIG_TOOL]));
+            else
+                printersItem.actor.add_style_class_name('popup-inactive-menu-item');
             this.menu.addMenuItem(printersItem);
         }
 
@@ -502,9 +524,11 @@ class CinnamonPrintersApplet extends Applet.TextIconApplet {
             printerItem.setButton(0, null, null, null);
             if (warning || printer.state === PRINTER_STATE_STOPPED || printer.jobs.size > 0)
                 printerItem.label.add_style_class_name('popup-device-menu-item');
-            printerItem.connect('activate', () => {
-                Util.spawn(['system-config-printer', '--show-jobs', name]);
-            });
+            if (this._hasConfigTool) {
+                printerItem.connect('activate', () => {
+                    Util.spawn([CONFIG_TOOL, '--show-jobs', name]);
+                });
+            }
 
             if (this._hasPrinterConfig) {
                 printerItem.setButton(1, 'xsi-emblem-system', _("Show properties"), () => {

--- a/files/usr/share/cinnamon/applets/printers@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/printers@cinnamon.org/applet.js
@@ -243,19 +243,25 @@ class CinnamonPrintersApplet extends Applet.TextIconApplet {
 
     _bootstrapPrinters() {
         try {
-            Util.spawn_async(['/usr/bin/lpstat', '-e'], (out) => {
-                if (!out || !this._cancellable || this._cancellable.is_cancelled())
+            Util.spawnAsyncIO(['lpstat', '-e'], (out, err, exitCode) => {
+                if (!this._cancellable || this._cancellable.is_cancelled())
                     return;
 
-                for (const name of out.trim().split('\n')) {
-                    if (name.trim())
-                        this._getOrCreatePrinter(name.trim());
+                if (exitCode !== 0) {
+                    global.logWarning(`printers@cinnamon.org: could not list printers: ${err ? err.trim() : `lpstat exited with ${exitCode}`}`);
+                } else if (out) {
+                    for (const name of out.trim().split('\n')) {
+                        if (name.trim())
+                            this._getOrCreatePrinter(name.trim());
+                    }
                 }
 
                 this._updateApplet();
             });
         } catch (e) {
+            // lpstat is missing (no cups client installed) - nothing to list.
             global.logWarning(`printers@cinnamon.org: could not list printers: ${e.message}`);
+            this._updateApplet();
         }
     }
 


### PR DESCRIPTION
The applet assumes that the CUPS command line tools and `system-config-printer` are always there. On a system installed without the printing stack neither is true, and the applet ends up in a broken state instead of quietly staying out of the way. Two commits, each usable on its own.

### 1. Update the applet even when lpstat fails

On a system where `lpstat` is not available the printers applet never updates itself, and with the default settings its icon stays in the panel forever.

`_bootstrapPrinters()` fetches the initial printer list with `Util.spawn_async()`, which runs the command through `cinnamon-subprocess-wrapper` and pushes the output back over DBus. `PushSubprocessResult()` only invokes the callback when the command succeeded:

```js
    PushSubprocessResult(process_id, result, success) {
        if (Util.subprocess_callbacks[process_id]) {
            if (success)
                Util.subprocess_callbacks[process_id](result);
            delete Util.subprocess_callbacks[process_id];
        }
    }
```

So if `lpstat` is missing, or exits non-zero, the callback is silently dropped: `_updateApplet()` is never reached, and neither is the `_updateVisibility()` it calls. The `try`/`catch` around the call cannot help, since the failure happens in the wrapper process, not in Cinnamon. The result is that the applet keeps whatever visibility it had when it was created — with the default `show-icon` value (`printers`, i.e. "when printers exist") and no printers configured, the icon is shown even though it should be hidden. The same happened when `lpstat` did run but printed nothing, because the callback returned early on empty output.

This is not an exotic case: the applet is enabled by default in `panel1:right`, and `lpstat` is packaged separately from CUPS on Debian and derivatives (`cups-client`), so it can easily be absent on a machine with no printing setup. It was the cause of Debian bug [#993152](https://bugs.debian.org/993152), which used to be worse before the rework — with the old code the missing command broke the nested `spawn_async` chain and left `updating = true`, so the menu would not open at all.

### Fix

Use `Util.spawnAsyncIO()` instead: it passes the exit status and stderr to the callback, and it throws immediately (`Gio.Subprocess.init()` fails with `G_SPAWN_ERROR_NOENT`) when the binary cannot be executed at all. Both failure paths now log a warning and still call `_updateApplet()`, so the applet ends up in a consistent state — hidden, with the default setting and no printers. The hardcoded `/usr/bin` path is dropped as well, so `lpstat` is looked up in `PATH`.

### Testing

Tested on Cinnamon 6.7.5, `show-icon` left at its default (`printers`), asking the applet itself for its state over `org.Cinnamon.Eval`:

| case | before | after |
| --- | --- | --- |
| `lpstat` not installed | `{visible: true, printers: 0}` — icon stuck in the panel, nothing logged | `{visible: false, printers: 0}` + `printers@cinnamon.org: could not list printers: Failed to execute child process “lpstat” (No such file or directory)` |
| `lpstat` installed, no printer configured | `{visible: true, printers: 0}` | `{visible: false, printers: 0}` |
| one printer configured | `{visible: true, printers: 1}` | `{visible: true, printers: 1}`, menu opens and lists the printer |

### 2. Don't offer system-config-printer when it is missing

Three places spawn `system-config-printer` unconditionally: the context menu entry, the item shown when no printer is configured, and the activation of a printer row. Where the printing stack was never installed that program is not there either, so those actions can only end in an `Execution of 'system-config-printer' failed` error notification. Cinnamon's own settings already handle this properly — the Printers entry of System Settings is a standalone module, and `SAModule.process()` only lists it when the executable is found in `PATH`.

The commit looks the binary up with `GLib.find_program_in_path()` and, when it is missing, leaves the context menu entry out, does not connect the activation handler of the printer rows, and shows the placeholder item as insensitive instead of pretending it can open something. No new translatable strings.

Same test setup, this time with the applet's menus inspected over `org.Cinnamon.Eval`:

| case | menu | context menu |
| --- | --- | --- |
| `system-config-printer` missing, one printer | printer row present, no activation handler | no `Printers` entry |
| `system-config-printer` missing, no printer | `Printers` placeholder, `reactive: false` | no `Printers` entry |
| `system-config-printer` installed, one printer | printer row with its activation handler | `Printers` entry, as before |