### PR TITLE
Applets/grouped-window-list: Fix spacing calculation to allow for values of 0px

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -279,7 +279,7 @@ var AppGroup = class AppGroup {
         const direction = this.state.isHorizontal ? 'right' : 'bottom';
         const existingStyle = this.actor.style ? this.actor.style : '';
         let spacing = parseInt(appletActor.get_theme_node().get_length('spacing'));
-        if (!spacing) {
+        if (isNaN(spacing)) {
             spacing = 6;
         }
         this.actor.style = existingStyle + 'margin-' + direction + ':' + spacing + 'px;';


### PR DESCRIPTION
When adding app icons to the taskbar, since `!spacing` will return true if it is 0, this will prevent themes from setting icon spacing to 0 pixels via `cinnamon.css`. Modifying it to check if the value is NaN will allow for 0 to count appropriately.