### PR TITLE
popupMenu: allow modal grab when a compositor grab is active

### DIFF
--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -10,6 +10,7 @@ const Cinnamon = imports.gi.Cinnamon;
 const Signals = imports.signals;
 const St = imports.gi.St;
 const Atk = imports.gi.Atk;
+const Meta = imports.gi.Meta;
 
 const BoxPointer = imports.ui.boxpointer;
 const DND = imports.ui.dnd;
@@ -3506,7 +3507,8 @@ var PopupMenuManager = class PopupMenuManager {
     }
 
     _grab() {
-        if (!Main.pushModal(this._owner.actor)) {
+        if (!Main.pushModal(this._owner.actor, undefined,
+                            Meta.ModalOptions.POINTER_ALREADY_GRABBED)) {
             return;
         }
         this._signals.connect(global.stage, 'captured-event', this._onEventCapture, this);


### PR DESCRIPTION
***This fix is done by AI.***

### Summary

Right-clicking the titlebar of client-side-decorated (CSD) applications
(VS Code, Opera, etc.) on Cinnamon 6.6.x can leave the window menu
completely frozen: it appears but never responds to clicks. Right-clicking 
another window's titlebar clears the ghost menu and displays a new one
but that new menu can also be a frozen one if you right-clicked the 
titlebar of the same window; cinnamon --replace reliably recovers.

### Root cause

When a CSD app's titlebar is right-clicked, the app forwards the request
to muffin, which is still holding a grab op when Cinnamon's popup machinery
runs. `PopupMenu.open()` succeeds and the menu actor is shown, but the
synchronous `open-state-changed(true)` dispatch reaches
`PopupMenuManager._grab()`, whose `Main.pushModal()` -> `global.begin_modal()`
is refused by muffin because a grab op is already in effect:

```
JS LOG: pushModal: invocation of begin_modal failed
```

The grab is silently skipped (`grabbed` stays false), no code path rolls
the menu back, and muffin releases its own grab a moment later — leaving a
visible menu with no modal grab and no event capture.

State captured while frozen:

```
modal: 0
menuStack: [ { name: "WindowMenu", open: true } ]
_manager.grabbed: false
```

Non-CSD windows don't hit this: muffin serves their titlebar right-click
synchronously, inside its own grab lifecycle.

### Fix

Pass `Meta.ModalOptions.POINTER_ALREADY_GRABBED` to `pushModal` in
`PopupMenuManager._grab()`. Popup menus go modal through Clutter stage
capture and don't require an X pointer grab, which is exactly what this
flag signals to muffin. It only changes behavior when a grab op is already
active, so normal menu paths are unaffected.

### Verification

- Hot-swapped the fix into a live Cinnamon 6.6.9 session: CSD titlebar
  menu opens, accepts clicks, closes on outside click, and reopens
  correctly every time.
- Without the fix, the same steps reproduce the frozen menu with
  `pushModal: invocation of begin_modal failed` in ~/.xsession-errors.

Fixes #13931