### PR TITLE
Add State property to Power D-Bus interface

### DIFF
--- a/js/misc/interfaces.js
+++ b/js/misc/interfaces.js
@@ -98,6 +98,7 @@ xml['org.cinnamon.SettingsDaemon.Power'] =
     "<node> \
         <interface name='org.cinnamon.SettingsDaemon.Power'> \
             <property name='Icon' type='s' access='read'/> \
+            <property name='State' type='u' access='read'/> \
             <property name='Tooltip' type='s' access='read'/> \
             <method name='GetPrimaryDevice'> \
                 <arg name='device' type='(sssusduut)' direction='out' /> \


### PR DESCRIPTION
Companion change to linuxmint/cinnamon-settings-daemon#468 to make it so power applet is updated immediately when "state" changes.  More details can be found in that pull request. 