### PR TITLE
screenshot: guard against double _ungrab in area/color/window pickers

### DIFF
--- a/js/ui/screenshot.js
+++ b/js/ui/screenshot.js
@@ -405,6 +405,18 @@ class SelectArea {
     }
 
     _onButtonRelease(actor, event) {
+        // The selection is finished on the first release. Ignore any further
+        // press/release pairs arriving during the 100ms fade-out - each of
+        // them used to overwrite the result and schedule another _ungrab(),
+        // and the second popModal() would take the 'incorrect pop' error path
+        // after tearing down the X grab, aborting _ungrab() before
+        // this._group.destroy(): the fullscreen overlay stayed on screen and
+        // the panel appeared frozen.
+        if (!this.active || this._finishing)
+            return Clutter.EVENT_PROPAGATE;
+
+        this._finishing = true;
+
         this._result = this._getGeometry();
         this._group.ease({
             opacity: 0,
@@ -419,6 +431,12 @@ class SelectArea {
     }
 
     _ungrab() {
+        // One-shot guard, NOT this.active: Escape legitimately calls
+        // _ungrab() before any selection started (active is still false).
+        if (this._ungrabbed)
+            return;
+        this._ungrabbed = true;
+
         this.active = false;
 
         if (this.stage_event_id > 0) {
@@ -522,6 +540,18 @@ class PickColor {
     }
 
     _onButtonRelease(actor, event) {
+        // The selection is finished on the first release. Ignore any further
+        // press/release pairs arriving during the 100ms fade-out - each of
+        // them used to overwrite the result and schedule another _ungrab(),
+        // and the second popModal() would take the 'incorrect pop' error path
+        // after tearing down the X grab, aborting _ungrab() before
+        // this._group.destroy(): the fullscreen overlay stayed on screen and
+        // the panel appeared frozen.
+        if (!this.active || this._finishing)
+            return Clutter.EVENT_PROPAGATE;
+
+        this._finishing = true;
+
         this._result = this._getGeometry();
         this._group.ease({
             opacity: 0,
@@ -535,6 +565,12 @@ class PickColor {
     }
 
     _ungrab() {
+        // One-shot guard, NOT this.active: Escape legitimately calls
+        // _ungrab() before any selection started (active is still false).
+        if (this._ungrabbed)
+            return;
+        this._ungrabbed = true;
+
         this.active = false;
 
         if (this.stage_event_id > 0) {
@@ -657,6 +693,10 @@ class SelectWindow {
         if (window === null)
             return Clutter.EVENT_STOP;
 
+        if (this._finishing)
+            return Clutter.EVENT_STOP;
+        this._finishing = true;
+
         this._result = window;
         this._group.ease({
             opacity: 0,
@@ -671,6 +711,10 @@ class SelectWindow {
     }
 
     _ungrab() {
+        if (this._ungrabbed)
+            return;
+        this._ungrabbed = true;
+
         Main.popModal(this._group);
         global.unset_cursor();
         this.emit('finished', this._result);


### PR DESCRIPTION
**The bug.** A second BUTTON_RELEASE (or BUTTON_PRESS for `SelectWindow`) arriving within the 100ms fade-out animation schedules a second `_ungrab()`, so `Main.popModal()` runs twice for the same actor. The second call takes the `incorrect pop` error path in `main.js`, which first tears down the stage input mode and the X grab and only then throws — the exception aborts `_ungrab()` before `this._group.destroy()`, so the fullscreen selection overlay stays on screen: clicks land on the overlay and the panel appears frozen until the shell is restarted.

**Reproduce.** Take an area screenshot and click once more right after releasing the selection, e.g.:
```
gdbus call -e -d org.gnome.Shell.Screenshot -o /org/gnome/Shell/Screenshot -m org.gnome.Shell.Screenshot.SelectArea &
sleep 1.2
xdotool mousemove 400 400 mousedown 1 mousemove 700 600 mouseup 1 click 1
```
Watch `~/.xsession-errors` for `JS ERROR: Error: incorrect pop` from `screenshot.js` — one affected user had six occurrences in two days of normal use.

**The fix.** Finish the selection on the first release only, ignore extra input during the fade-out, and make `_ungrab()` idempotent in all three pickers (`SelectArea`, `PickColor`, `SelectWindow`).

Verified on Cinnamon 6.6.9 (Mint 22.3): normal area selection still returns the same geometry; the reproducer above no longer throws (3 runs), overlay is destroyed properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
