### PR TITLE
power applet: debounce device menu rebuilds

### DIFF
--- a/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/power@cinnamon.org/applet.js
@@ -579,6 +579,33 @@ class CinnamonPowerApplet extends Applet.TextIconApplet {
     }
 
     _devicesChanged() {
+        // Coalesce bursts of change notifications into one rebuild per 500ms.
+        // csd-power emits g-properties-changed for every UPower device update;
+        // a flapping AC adapter (loose plug) produces a storm of them (measured
+        // 126 signals in 3 minutes), and rebuilding the device menu - destroying
+        // and recreating every DeviceItem - on each signal floods GJS with
+        // garbage.  The resulting high-frequency GC blocks JS callbacks,
+        // including the shell's own paint path, so the whole screen goes black
+        // for seconds at a time (and pending actor destroys leak, leaving stuck
+        // notification banners).  The first signal is handled immediately, the
+        // rest of the burst is folded into one trailing rebuild.
+        if (this._rebuildGate === undefined)
+            this._rebuildGate = 0;
+        if (this._rebuildGate > 0) {
+            this._rebuildDirty = true;
+            return;
+        }
+        this._rebuildDirty = false;
+        this._rebuildGate = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 500, () => {
+            this._rebuildGate = 0;
+            if (this._rebuildDirty)
+                this._devicesChanged();
+            return GLib.SOURCE_REMOVE;
+        });
+        this._devicesChangedReal();
+    }
+
+    _devicesChangedReal() {
 
         this._devices = [];
         this._primaryDevice = null;


### PR DESCRIPTION
**The bug.** `_devicesChanged()` is connected to the csd-power proxy's `g-properties-changed` and rebuilds the whole device menu — destroying and recreating every `DeviceItem` — on each signal. With a flapping AC adapter (loose plug / failing cable) csd-power emits a storm of signals: measured **126 in 3 minutes** against ~18 at idle. The flood of destroyed/recreated actors drives GJS into high-frequency incremental GC; while it runs, GJS blocks JS callbacks from C — including the shell's own paint vfunc (`UiActor.vfunc_paint` in `layout.js`, which paints *everything*). Result: every time the charger blinks, the entire screen freezes or goes black for seconds (`Attempting to run a JS callback during garbage collection ... The offending callback was paint(), a vfunc` at exactly the frame rate in `.xsession-errors`), and blocked destroy callbacks leave zombie notification banners floating over all windows.

**Measurements** (Cinnamon 6.6.9, 3000x2000 eDP): deliberately flapping the charger produced 200 unpainted frames over 9s with the stock applet; removing the applet from the panel dropped it to 29; with this debounce the blackouts are gone entirely (user-confirmed over many plug/unplug cycles).

**The fix.** Coalesce bursts into one rebuild per 500ms: the first signal is handled immediately (icon still reacts instantly), the rest of a burst is folded into a single trailing rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
