### PR TITLE
keyboard applet: never ellipsize the layout code in the panel

### DIFF
--- a/files/usr/share/cinnamon/applets/keyboard@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/keyboard@cinnamon.org/applet.js
@@ -1,5 +1,6 @@
 const Applet = imports.ui.applet;
 const St = imports.gi.St;
+const Pango = imports.gi.Pango;
 const Main = imports.ui.main;
 const PopupMenu = imports.ui.popupMenu;
 const Util = imports.misc.util;
@@ -232,6 +233,11 @@ class CinnamonKeyboardApplet extends Applet.Applet {
             });
             // Enforce a constant width and center the text
             actor.set_style("min-width: 2.5em; text-align: center;");
+            // Never ellipsize the two-letter layout code: when the panel is
+            // packed St would shrink the label and render "…", which is as
+            // wide as the code itself - the layout gets hidden without
+            // saving any space.
+            actor.clutter_text.ellipsize = Pango.EllipsizeMode.NONE;
         }
 
         this._panel_icon_box.set_child(actor);
@@ -253,6 +259,8 @@ class CinnamonKeyboardApplet extends Applet.Applet {
 
         // Enforce a constant width and center the text
         actor.set_style("min-width: 2.5em; text-align: center;");
+        // See _syncGroup: never ellipsize the short code.
+        actor.clutter_text.ellipsize = Pango.EllipsizeMode.NONE;
 
         this._panel_icon_box.set_child(actor);
     }


### PR DESCRIPTION
When the panel runs out of space St shrinks the keyboard applet's label and renders the two-letter layout code ("En", "Ru") as "…". The ellipsis is as wide as the code itself, so nothing is saved — the current layout just becomes invisible, which defeats the applet's purpose.

The recently added `min-width: 2.5em` stabilizes the width in the normal case, but under real panel pressure St can still allocate below the natural size and Pango ellipsizes. This change additionally disables ellipsizing on the label (`Pango.EllipsizeMode.NONE`), so the code stays readable however tight the panel gets.

Spotted by a user with a full window list: the applet collapsed to "…" while barely changing width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)