### PR TITLE
keyboard: fix flag icons being half-size and squashed on HiDPI

### DIFF
--- a/files/usr/share/cinnamon/applets/keyboard@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/keyboard@cinnamon.org/applet.js
@@ -178,7 +178,7 @@ class CinnamonKeyboardApplet extends Applet.Applet {
             let actor = null;
 
             if (source.type === 'ibus' || this._inputSourcesManager.showFlags) {
-                actor = this._inputSourcesManager.createFlagIcon(source, POPUP_MENU_ICON_STYLE_CLASS, 22);
+                actor = this._inputSourcesManager.createFlagIcon(source, POPUP_MENU_ICON_STYLE_CLASS, 22 * global.ui_scale);
             }
 
             if (actor == null) {
@@ -217,7 +217,7 @@ class CinnamonKeyboardApplet extends Applet.Applet {
         this.set_applet_tooltip(selected.displayName);
 
         let actor = null;
-        const iconSize = this.getPanelIconSize(St.IconType.FULLCOLOR);
+        const iconSize = this.getPanelIconSize(St.IconType.FULLCOLOR) * global.ui_scale;
 
         // IBus engines always show their own icon (flags are an xkb concept); xkb
         // layouts show a flag only when the user opted into flags.

--- a/js/ui/keyboardManager.js
+++ b/js/ui/keyboardManager.js
@@ -319,6 +319,13 @@ var SubscriptableFlagIcon = GObject.registerClass({
                         return;
                     }
 
+                    // On HiDPI the texture cache hands back an actor that is
+                    // pre-scaled by the ui scale.  Without correcting its size
+                    // the surrounding St.Bin clamps only the height, so the
+                    // flag renders squashed (twice as wide as it should be).
+                    actor.set_size(actor.width / global.ui_scale,
+                                   actor.height / global.ui_scale);
+
                     this._image = actor;
                     this._imageBin.set_child(actor);
                     this._drawingArea.queue_repaint();


### PR DESCRIPTION
With "show flags" enabled the keyboard applet's flag icons render **squashed (2x too wide) and at half the intended size** on HiDPI.

Two related causes:

1. `St.TextureCache.load_image_from_file_async()` returns an actor **pre-scaled by the ui scale**. `SubscriptableFlagIcon` puts it into its `St.Bin` without correcting the size, so the bin clamps only the height: with ui scale 2 a 320×240 (4:3) `iso-flag-png` file renders at twice its proper width — e.g. **64×24** for a requested height of 24. Fixed by scaling the returned actor back to the logical size (a no-op at ui scale 1).

2. The applet requests the flag at the logical icon size, so on HiDPI the image is half the intended size. Fixed by multiplying by `global.ui_scale` at both call sites (the menu path used to have this multiplication and lost it at some point).

Verified live on a 3000×2000 laptop panel (ui scale 2): the panel flag went from a squashed 64×24 to a correct 4:3 image at the intended size; layouts menu flags likewise. At ui scale 1 both changes are no-ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)