### PR TITLE
keybindings: allow screenshot keys while a menu is open

### DIFF
--- a/js/ui/keybindings.js
+++ b/js/ui/keybindings.js
@@ -43,13 +43,15 @@ const MEDIA_KEYS = [
     { key: MK.REPEAT,                     mode: Cinnamon.ActionMode.ALL },
     { key: MK.RANDOM,                     mode: Cinnamon.ActionMode.ALL },
 
-    // Screenshots
+    // Screenshots: ALL, not NORMAL - taking a screenshot is useful precisely
+    // while a menu or applet popup is open, and full-screen Print already
+    // worked there.
     { key: MK.SCREENSHOT,                 mode: Cinnamon.ActionMode.ALL },
-    { key: MK.SCREENSHOT_CLIP,            mode: Cinnamon.ActionMode.NORMAL },
-    { key: MK.WINDOW_SCREENSHOT,          mode: Cinnamon.ActionMode.NORMAL },
-    { key: MK.WINDOW_SCREENSHOT_CLIP,     mode: Cinnamon.ActionMode.NORMAL },
-    { key: MK.AREA_SCREENSHOT,            mode: Cinnamon.ActionMode.NORMAL },
-    { key: MK.AREA_SCREENSHOT_CLIP,       mode: Cinnamon.ActionMode.NORMAL },
+    { key: MK.SCREENSHOT_CLIP,            mode: Cinnamon.ActionMode.ALL },
+    { key: MK.WINDOW_SCREENSHOT,          mode: Cinnamon.ActionMode.ALL },
+    { key: MK.WINDOW_SCREENSHOT_CLIP,     mode: Cinnamon.ActionMode.ALL },
+    { key: MK.AREA_SCREENSHOT,            mode: Cinnamon.ActionMode.ALL },
+    { key: MK.AREA_SCREENSHOT_CLIP,       mode: Cinnamon.ActionMode.ALL },
 
     // Touchpad
     { key: MK.TOUCHPAD,                   mode: Cinnamon.ActionMode.NORMAL },


### PR DESCRIPTION
Pressing <kbd>Shift</kbd>+<kbd>Print</kbd> (area screenshot) with any menu or applet popup open does nothing: the area/window/clipboard screenshot keys are registered with `ActionMode.NORMAL`, so the modal filter swallows them. Meanwhile the full-screen `SCREENSHOT` key is already `ALL` and works in the same situation, as do the volume keys — which makes the dead <kbd>Shift</kbd>+<kbd>Print</kbd> feel like a bug to the user (that's exactly how it was reported to me).

Capturing the screen while a popup is open is a legitimate and common request, and the pickers in `js/ui/screenshot.js` handle starting on top of an existing modal (verified live: the picker opens, Escape cancels cleanly, selection completes cleanly).

This registers all six screenshot media keys with `ActionMode.ALL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)