### PR TITLE
grouped-window-list: fix four panel button layout bugs

### DIFF
--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -472,11 +472,15 @@ var AppGroup = class AppGroup {
             childBox.y1 = box.y1 + labelYPadding;
             childBox.y2 = childBox.y1 + Math.min(labelNaturalHeight, allocHeight);
 
+            // The same 6 px getPreferredWidth adds to natural_size - without it the label ends flush
+            // with the button edge and the ellipsis touches the border.
+            const labelPadding = 6 * global.ui_scale;
+
             if (direction === Clutter.TextDirection.LTR) {
                 childBox.x1 = Math.min(this.iconBox.x + this.iconBox.width, box.x2);
-                childBox.x2 = box.x2;
+                childBox.x2 = Math.max(childBox.x1, box.x2 - labelPadding);
             } else {
-                childBox.x1 = box.x1;
+                childBox.x1 = Math.min(box.x1 + labelPadding, this.iconBox.x);
                 childBox.x2 = this.iconBox.x;
             }
 

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -382,12 +382,18 @@ var AppGroup = class AppGroup {
                             this.workspaceState.lastFocusedApp === appId);
 
         if (this.state.orientation === St.Side.TOP || this.state.orientation === St.Side.BOTTOM) {
-            if (allocateForLabel) {
-                const max = this.labelVisiblePref && this.groupState.metaWindows.length > 0 ?
-                    labelNaturalSize + iconNaturalSize + 6 : 0;
+            // With no open window there is nothing to label (allocate() draws the label only when
+            // metaWindows.length > 0), so the button is icon only. Counting labelNaturalSize in here
+            // gave pinned apps arbitrarily different widths: an empty label reports 1 px or 5 px
+            // depending on its state.
+            if (allocateForLabel && this.groupState.metaWindows.length > 0) {
+                const max = this.labelVisiblePref ? labelNaturalSize + iconNaturalSize + 6 : 0;
                 alloc.natural_size = Math.min(iconNaturalSize + Math.max(max, labelNaturalSize), MAX_BUTTON_WIDTH * global.ui_scale);
             } else {
-                alloc.natural_size = iconNaturalSize + 6 * global.ui_scale;
+                // Width from the panel icon size instead of the actor's natural width, so buttons with
+                // no label stay equal no matter what a particular image reports.
+                const iconWidth = this.iconSize ? this.iconSize * global.ui_scale : iconNaturalSize;
+                alloc.natural_size = iconWidth + 6 * global.ui_scale;
             }
             alloc.min_size = alloc.natural_size;
         } else {

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -502,6 +502,13 @@ var AppGroup = class AppGroup {
                     this.label.set_style('text-align: right;');
 
             this.label.allocate(childBox);
+        } else {
+            // An actor that is not allocated keeps its previous allocation and is still painted.
+            // A button that shrinks to icon size therefore left the old, wide label box behind and
+            // the text spilled over the neighbouring buttons. Collapse the box instead of skipping it.
+            childBox.x1 = childBox.x2 = box.x1;
+            childBox.y1 = childBox.y2 = box.y1;
+            this.label.allocate(childBox);
         }
 
         // Call set_icon_geometry for support of Cinnamon's minimize animation

--- a/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
+++ b/files/usr/share/cinnamon/applets/grouped-window-list@cinnamon.org/appGroup.js
@@ -517,9 +517,15 @@ var AppGroup = class AppGroup {
         if (this.labelVisiblePref
             || !this.label
             || !this.state.isHorizontal
-            || this.label.is_finalized()
-            || !this.label.realized) {
+            || this.label.is_finalized()) {
             return;
+        }
+
+        // hideLabel() hides the label, so unrealized is the normal state of a pinned app with no
+        // windows. Bailing out here left such a button titleless once a window was opened.
+        // An unrealized actor is shown right away instead of being animated.
+        if (!this.label.realized) {
+            animate = false;
         }
 
         const width = MAX_BUTTON_WIDTH * global.ui_scale;


### PR DESCRIPTION
Four independent layout fixes for the `grouped-window-list` applet, all in `appGroup.js`. Each one was found on a horizontal panel (Cinnamon 6.6.4, `global.ui_scale = 1`) and verified live by reading back actor and label allocations.

### 1. Keep a gap between the label and the button edge

`getPreferredWidth()` reserves `iconNaturalSize + labelNaturalSize + 6`, but `allocate()` used to stretch the label all the way to `box.x2`. The 6 px were silently swallowed, so a truncated title had its ellipsis flush against the button border. The label box now stops `6 px` short on the trailing side (mirrored for RTL).

### 2. Show the title when a pinned app opens a window

`showLabel()` bailed out on `!this.label.realized`. For a pinned app with no windows that is the normal state — `hideLabel()` hides the label, and a hidden actor is never realized. Opening a window from such a button therefore produced a button with an icon and no title until something else forced a refresh. The unrealized case now skips the width animation instead of skipping the whole method.

### 3. Equal width for buttons without a label

`allocate()` only draws the label when `metaWindows.length > 0`, but `getPreferredWidth()` counted `labelNaturalSize` regardless. An empty label reports 1 px or 5 px depending on whether it went through `hideLabel()` or an interrupted `showLabel()` ease, so two pinned apps with no windows ended up different widths, and the width changed as other buttons were pinned or unpinned.

The label size is now excluded when there is no window to label, and the icon-only width is derived from `this.iconSize` (the panel icon size) rather than the icon actor's natural width — icon files whose artwork does not fill the requested box otherwise made their button narrower than its neighbours.

### 4. Stop painting the label after the button shrinks

`allocate()` called `this.label.allocate()` only inside `if (this.drawLabel)`. Clutter keeps the previous allocation of an actor that is skipped during a layout pass and still paints it. A button that lost its last window shrank to icon size, `drawLabel` became false, and the old wide label box stayed behind — the stale title was painted outside the button and over its neighbours.

Measured before the fix, on a button that had shrunk to 30 px:

```
actor=624-654   labelBox=30-150   drawLabel=false   label.visible=true
```

and after:

```
actor=624-654   labelBox=0-0      drawLabel=false
```

The `else` branch now allocates a collapsed box instead of leaving the label unallocated.
