### PR TITLE
cs_themes: hide the simplified settings button when no styles are installed

### DIFF
--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
+++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_themes.py
@@ -218,6 +218,7 @@ class Module:
             self.active_style = None
             self.active_mode_name = None
             self.active_variant = None
+            self.simplified_button = None
 
             # HiDPI support
             for mode in ["mixed", "dark", "light"]:
@@ -261,6 +262,11 @@ class Module:
             button.set_label(_("Simplified settings..."))
             button.set_halign(Gtk.Align.END)
             button.connect("clicked", self.on_simplified_button_clicked)
+            # no_show_all, or the show_all() done on the page would reveal the
+            # button again after update_simplified_button() hid it
+            button.set_no_show_all(True)
+            self.simplified_button = button
+            self.update_simplified_button()
             page.add(button)
 
             page = DownloadSpicesPage(self, 'theme', self.spices, self.window)
@@ -525,7 +531,13 @@ class Module:
             # Position style combo on "Custom"
             self.style_combo.append_text(_("Custom"))
             self.style_combo.set_active(len(self.styles.keys()))
+        self.update_simplified_button()
         self.ui_ready = True
+
+    def update_simplified_button(self):
+        # With no styles installed the simplified page has nothing to offer
+        if self.simplified_button is not None:
+            self.simplified_button.set_visible(len(self.styles) > 0)
 
     def on_customize_button_clicked(self, widget):
         self.set_button_chooser(self.icon_chooser, self.settings.get_string("icon-theme"), 'icons', 'icons', ICON_SIZE)


### PR DESCRIPTION
Fixes #13962.

The simplified page needs at least one style from `/usr/share/cinnamon/styles.d` whose themes are all installed. Where nothing ships such a file — Cinnamon itself dropped `00_cinnamon.styles` in 13b1ad10 — the page has only "Custom" in the style combo, the three appearance buttons are insensitive, and the stack switcher is hidden there, so the only way out is "Customize".

Startup already avoids that page when no variant is active, but the "Simplified settings..." button of the advanced page still offers it.

This keeps a reference to that button and drives its visibility from the number of styles found, when it is built and at the end of `reset_look_ui()`, so it follows if the styles change. `set_no_show_all()` is needed because the page is shown with `show_all()`, which would otherwise make the button visible again.

Tested on Debian unstable (Cinnamon 6.6.9), which ships no styles file: the button is gone and the rest of the page is unchanged. Adding a valid styles file brings the button back and the simplified page works as before.