### PR TITLE
xapp-status applet: harden against misbehaving clients and fix icon lifecycle issues

### DIFF
--- a/files/usr/share/cinnamon/applets/xapp-status@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/xapp-status@cinnamon.org/applet.js
@@ -110,6 +110,7 @@ class XAppStatusIcon {
         this.proxy = proxy;
 
         this.iconName = null;
+        this.icon_loader_handle = null;
 
         this.actor = new St.BoxLayout({
             style_class: "applet-box",
@@ -231,6 +232,9 @@ class XAppStatusIcon {
                 return;
             }
             else {
+                // Invalidate any in-flight image load
+                this.icon_loader_handle = null;
+
                 icon = new St.Icon( { "icon-type": type, "icon-size": this.iconSize, "icon-name": iconName });
                 this.icon_holder.show();
                 this.icon_holder.child = icon;
@@ -238,16 +242,19 @@ class XAppStatusIcon {
         }
         else {
             this.iconName = null;
+            this.icon_loader_handle = null;
             this.icon_holder.hide();
         }
     }
 
     _onImageLoaded(cache, handle, actor, data=null) {
+        /* The icon changed again (or this icon was destroyed) while the
+         * image was loading - discard the result. */
         if (handle !== this.icon_loader_handle) {
-            global.logError(`xapp-status@cinnamon.org: Icon or image seems out of sync (${this.name}`);
             return;
         }
 
+        this.icon_loader_handle = null;
         this.icon_holder.child = actor;
         this.icon_holder.show();
     }
@@ -276,7 +283,7 @@ class XAppStatusIcon {
         }
 
         this.show_label = (this.applet.orientation == St.Side.TOP || this.applet.orientation == St.Side.BOTTOM) &&
-                           this.proxy.label.length > 0;
+                           (label != null && label.length > 0);
 
         this.label.visible = this.show_label;
     }
@@ -384,7 +391,9 @@ class XAppStatusIcon {
     destroy() {
         this.proxy.disconnect(this._proxy_prop_change_id);
         this._proxy_prop_change_id = 0;
+        this.icon_loader_handle = null;
         this._tooltip.destroy();
+        this.actor.destroy();
     }
 }
 
@@ -538,7 +547,7 @@ class CinnamonXAppStatusApplet extends Applet.Applet {
     shouldIgnoreStatusIcon(icon_proxy) {
         let hiddenIcons = Main.systrayManager.getRoles();
 
-        let name = icon_proxy.name.toLowerCase();
+        let name = (icon_proxy.name || "").toLowerCase();
 
         if (hiddenIcons.indexOf(name) != -1 ) {
             return true;
@@ -548,8 +557,12 @@ class CinnamonXAppStatusApplet extends Applet.Applet {
     }
 
     _sortFunc(a, b) {
-        let asym = a.proxy.icon_name.includes("-symbolic");
-        let bsym = b.proxy.icon_name.includes("-symbolic");
+        /* These properties belong to another process and can't be assumed to be strings. */
+        let aname = a.proxy.name || "";
+        let bname = b.proxy.name || "";
+
+        let asym = (a.proxy.icon_name || "").includes("-symbolic");
+        let bsym = (b.proxy.icon_name || "").includes("-symbolic");
 
         if (asym && !bsym) {
             return 1;
@@ -559,8 +572,8 @@ class CinnamonXAppStatusApplet extends Applet.Applet {
             return -1;
         }
 
-        return GLib.utf8_collate(a.proxy.name.replace("org.x.StatusIcon.", "").toLowerCase(),
-                                 b.proxy.name.replace("org.x.StatusIcon.", "").toLowerCase());
+        return GLib.utf8_collate(aname.replace("org.x.StatusIcon.", "").toLowerCase(),
+                                 bname.replace("org.x.StatusIcon.", "").toLowerCase());
     }
 
     sortIcons() {
@@ -613,6 +626,11 @@ class CinnamonXAppStatusApplet extends Applet.Applet {
     }
 
     on_applet_removed_from_panel() {
+        if (this._scaleUpdateId > 0) {
+            Mainloop.source_remove(this._scaleUpdateId);
+            this._scaleUpdateId = 0;
+        }
+
         this.signalManager.disconnectAllSignals();
 
         for (let key in this.statusIcons) {


### PR DESCRIPTION
The Electron 43.3.x tray regression (https://github.com/electron/electron/issues/52674,
https://github.com/signalapp/Signal-Desktop/issues/7995) surfaced several ways a
single misbehaving status icon client can degrade the whole XApp tray. The Electron
bug itself is fixed upstream in 43.4.1, but the weaknesses it exposed in the applet
are worth fixing regardless.

Three groups of changes, all in the xapp-status applet:

**Null-guard proxy properties.** Name, IconName, and Label belong to another process
and can be null. `_sortFunc()` called `.includes()` on icon_name and `.replace()` on
name, `setLabel()` read `proxy.label.length` after already establishing the label was
falsy, and `shouldIgnoreStatusIcon()` called `.toLowerCase()` on name. A TypeError in
any of these propagates out of a signal handler, leaving the panel with a half-sorted
tray or an icon that never finishes being added.

**Discard stale async image loads.** When an icon switched from a file path to a
themed name (or was cleared or destroyed) while a file load was still in flight, the
load's completion callback would overwrite the newer icon, or touch a destroyed
actor. The texture cache handle is now invalidated at each of those points and stale
callbacks are discarded. The logError on handle mismatch is removed since a mismatch
is now the expected result of deliberate invalidation rather than an anomaly.

**Lifecycle fixes.** `XAppStatusIcon.destroy()` never destroyed its actor, leaking
actors every time an app quit (RecorderIcon in the same file already does this
correctly). The ui-scale debounce timer was also left running when the applet was
removed from the panel, so a pending `refreshIcons()` could fire against destroyed
icons.

No behavior change for well-behaved clients.
