### PR TITLE
systray: fix icon loss on redisplay, timeout races, and teardown errors

### DIFF
--- a/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/systray@cinnamon.org/applet.js
@@ -66,6 +66,11 @@ class CinnamonSystrayApplet extends Applet.Applet {
     }
 
     on_applet_removed_from_panel() {
+        if (this._scaleUpdateId > 0) {
+            Mainloop.source_remove(this._scaleUpdateId);
+            this._scaleUpdateId = 0;
+        }
+
         this._signalManager.disconnectAllSignals();
 
         this._clearIcons();
@@ -93,6 +98,11 @@ class CinnamonSystrayApplet extends Applet.Applet {
 
     _clearIcons() {
         this.button_box.get_children().forEach((button) => {
+            if (button._showTimeoutId > 0) {
+                GLib.source_remove(button._showTimeoutId);
+                button._showTimeoutId = 0;
+            }
+
             // button.set_size(-1, -1);
             button.remove_actor(button.child);
             button.destroy();
@@ -156,7 +166,9 @@ class CinnamonSystrayApplet extends Applet.Applet {
 
             icon.visible = false;
             icon.opacity = 0;
-            GLib.timeout_add(GLib.PRIORITY_DEFAULT, 1000, () => {
+            button._showTimeoutId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 1000, () => {
+                button._showTimeoutId = 0;
+
                 if (icon.is_finalized()) {
                     button.destroy();
                     return GLib.SOURCE_REMOVE;
@@ -212,6 +224,15 @@ class CinnamonSystrayApplet extends Applet.Applet {
 
     _onTrayIconRemoved(o, icon) {
         const parent = icon.get_parent();
+
+        if (parent == null) {
+            return;
+        }
+
+        if (parent._showTimeoutId > 0) {
+            GLib.source_remove(parent._showTimeoutId);
+            parent._showTimeoutId = 0;
+        }
 
         parent.remove_actor(icon);
         parent.destroy()

--- a/src/cinnamon-tray-manager.c
+++ b/src/cinnamon-tray-manager.c
@@ -383,6 +383,9 @@ void
 cinnamon_tray_manager_set_orientation (CinnamonTrayManager *manager,
                                        ClutterOrientation   orientation)
 {
+  if (manager->priv->na_manager == NULL)
+    return;
+
   if (orientation == CLUTTER_ORIENTATION_HORIZONTAL)
     {
       na_tray_manager_set_orientation (manager->priv->na_manager, GTK_ORIENTATION_HORIZONTAL);
@@ -400,7 +403,12 @@ cinnamon_tray_manager_child_redisplay (gpointer socket_pointer, gpointer child_p
 
   g_return_if_fail(child != NULL);
 
-  if (child->actor && CLUTTER_IS_ACTOR(child->actor)) {
+  /* No actor means the plug never arrived. Leave the child alone so the
+   * pending plug-added handler can still create its icon. */
+  if (child->actor == NULL)
+    return;
+
+  if (CLUTTER_IS_ACTOR(child->actor)) {
     clutter_actor_destroy(child->actor);
     g_clear_object (&child->actor);
   }
@@ -410,5 +418,8 @@ cinnamon_tray_manager_child_redisplay (gpointer socket_pointer, gpointer child_p
 
 void cinnamon_tray_manager_redisplay (CinnamonTrayManager *manager)
 {
+  if (manager->priv->icons == NULL)
+    return;
+
   g_hash_table_foreach(manager->priv->icons, cinnamon_tray_manager_child_redisplay, manager);
 }


### PR DESCRIPTION
Follow-up to the xapp-status applet hardening PR; this covers the XEmbed
side of the tray. Two files, four fixes, each with a concrete trigger.

**Never-plugged icons were permanently lost on redisplay**
(cinnamon-tray-manager.c). `cinnamon_tray_manager_child_redisplay()` called
`on_plug_added()` for every child, including sockets whose plug had not
arrived yet. For those, it created a CinnamonTrayIcon for an unplugged
window and emitted tray-icon-added for it, and worse, disconnected the
pending plug-added handler, so the real icon could never appear once the
app finished embedding. Redisplay runs on icon size changes, panel edit
mode, UI scale changes, role registration, and applet reload, so any
slow-embedding client was exposed. Skip children with no actor and leave
their plug-added handler in place.

**TypeError on removal of hidden-role icons** (systray applet). Icons whose
role is claimed by an applet (nm-applet with the network applet loaded, for
example) never get a button, so `icon.get_parent()` is null in
`_onTrayIconRemoved()` and the handler threw on every such removal.

**Races in the 1-second delayed-show timeout** (systray applet). The
timeout in `_onTrayIconAdded()` was untracked. If the icon was removed or a
redisplay ran within that second, the surviving callback could call
`button.destroy()` on an already-destroyed button, or animate an orphaned
icon. The source id is now stored on the button and cancelled from both
`_clearIcons()` and `_onTrayIconRemoved()`.

**Teardown cleanups.** `cinnamon_tray_manager_redisplay()` and
`_set_orientation()` now tolerate the released-resources state after
x11-display-closing instead of hitting g_return_if_fail criticals, and the
applet cancels its pending ui-scale debounce timer when removed from the
panel.

No behavior change for icons that embed promptly and clients that exit
cleanly.
