### PR TITLE
Update classicSwitcher.js

### DIFF
--- a/js/ui/appSwitcher/classicSwitcher.js
+++ b/js/ui/appSwitcher/classicSwitcher.js
@@ -582,6 +582,7 @@ SwitcherList.prototype = {
     },
 
     _onItemClicked: function (index) {
+        this._itemEntered(index);
         this._itemActivated(index);
     },
 


### PR DESCRIPTION
PLLEEEEEEESEEEE merge this PR!!!! This ONE LINE make me crazy each update... 

THIS IS SO EASY to reproduce this bug - just move mouse to the middle of the screen and try to switch between windows and thats all - in focus bacame WRONG window, not the window that you clicked... This is so small and so borring bug, ONE LINE, PLEEESSSEEEE, one line of code... PLEEEEEESEEEE merge this line...please...